### PR TITLE
RDK-28250 : Adding argument 'age' for Warehouse.isClean

### DIFF
--- a/Warehouse/Warehouse.h
+++ b/Warehouse/Warehouse.h
@@ -86,7 +86,7 @@ namespace WPEFramework {
             void setFrontPanelState(int state, JsonObject& response);
             void internalReset(JsonObject& response);
             void lightReset(JsonObject& response);
-            void isClean(JsonObject& response);
+            void isClean(int age, JsonObject& response);
 
             //Begin methods
             uint32_t resetDeviceWrapper(const JsonObject& parameters, JsonObject& response);

--- a/helpers/utils.cpp
+++ b/helpers/utils.cpp
@@ -110,3 +110,41 @@ std::string Utils::cRunScript(const char *cmd)
     return totalStr;
 }
 
+using namespace WPEFramework;
+
+/***
+ * @brief	: Checks that file exists
+ * @param1[in]	: pFileName name of file
+ * @return		: true if file exists.
+ */
+bool Utils::fileExists(const char *pFileName)
+{
+    struct stat fileStat;
+    return 0 == stat(pFileName, &fileStat);
+}
+
+/***
+ * @brief	: Checks that file exists and modified at least pointed seconds ago
+ * @param1[in]	: pFileName name of file
+ * @param1[in]	: age modification age in seconds
+ * @return		: true if file exists and modifies 'age' seconds ago.
+ */
+bool Utils::isFileExistsAndOlderThen(const char *pFileName, long age /*= -1*/)
+{
+    struct stat fileStat;
+    int res = stat(pFileName, &fileStat);
+    if (0 != res)
+        return false;
+
+    if (-1 == age)
+        return true;
+
+    time_t currentTime = time(nullptr);
+    //LOGWARN("current time of %s: %lu", pFileName, currentTime);
+
+    time_t modifiedSecondsAgo = difftime(currentTime, fileStat.st_mtime);
+    //LOGWARN("elapsed time is %lu, %s", modifiedSecondsAgo, modifiedSecondsAgo <= age ? "updated recently (doesn't exists)" : "updated long time ago (exists)");
+
+    return modifiedSecondsAgo > age;
+}
+

--- a/helpers/utils.h
+++ b/helpers/utils.h
@@ -123,6 +123,16 @@
         catch (...) { param = 0; }\
 }
 
+#define getDefaultNumberParameter(paramName, param, default) {\
+    if (parameters.HasLabel(paramName)) { \
+        if (Core::JSON::Variant::type::NUMBER == parameters[paramName].Content()) \
+            param = parameters[paramName].Number(); \
+        else \
+            try { param = std::stoi( parameters[paramName].String()); } \
+            catch (...) { param = default; } \
+    } else param = default; \
+}
+
 #define getNumberParameterObject(parameters, paramName, param) {\
     if (Core::JSON::Variant::type::NUMBER == parameters[paramName].Content()) \
         param = parameters[paramName].Number();\
@@ -274,9 +284,13 @@ namespace Utils
      * @param1[in]	: pFileName name of file
      * @return		: true if file exists.
      */
-    inline bool fileExists(const char *pFileName)
-    {
-        struct stat fileStat;
-        return stat(pFileName, &fileStat) == 0;
-    }
+    bool fileExists(const char *pFileName);
+
+    /***
+     * @brief	: Checks that file exists and modified at least pointed seconds ago
+     * @param1[in]	: pFileName name of file
+     * @param1[in]	: age modification age in seconds
+     * @return		: true if file exists and modifies 'age' seconds ago.
+     */
+    bool isFileExistsAndOlderThen(const char *pFileName, long age = -1);
 }


### PR DESCRIPTION
Reason for change: implementing
Test Procedure: isClean should return 'true' status after warehouse reset with used
                value of age argument in seconds. And this value should be more
                then time, starting from warehouse reset till moment of testing.
Risks: Low
Signed-off-by: Savchenko Maksym <Maksym_Savchenko@cable.comcast.com>