### PR TITLE
DELIA-42724 : FMR API should be supported on multiple networks - Thun…

### DIFF
--- a/ControlService/ControlService.cpp
+++ b/ControlService/ControlService.cpp
@@ -1561,6 +1561,7 @@ namespace WPEFramework {
 #if (CTRLM_MAIN_IARM_BUS_API_REVISION > 8)
             IARM_Result_t retval;
             ctrlm_main_iarm_call_control_service_can_find_my_remote_t call;
+            call.network_type = CTRLM_NETWORK_TYPE_RF4CE;
 
             memset((void*)&call, 0, sizeof(call));
             call.api_revision = CTRLM_MAIN_IARM_BUS_API_REVISION;


### PR DESCRIPTION
…der CS.

Reason for change: Only rf4ce was allowed.
Test Procedure: Verify CanFindMyRemote functionality still works.
Risks: None.
Signed-off-by: jschmidt <Jeff_Schmidt@cable.comcast