### PR TITLE
DELIA-43230: AVInput issues; DELIA-43082: sendAudioPlaybackCommand (S…

### DIFF
--- a/AVInput/AVInput.cpp
+++ b/AVInput/AVInput.cpp
@@ -106,7 +106,7 @@ namespace WPEFramework {
         uint32_t AVInput::numberOfInputsWrapper(const JsonObject& parameters, JsonObject& response)
         {
             LOGINFOMETHOD();
-            bool success;
+            bool success = false;
             if (getActivatedPluginReady(SUBSCRIPTION_CALLSIGN))
             {
                 response["numberOfInputs"] = numberOfInputs(&success);
@@ -121,10 +121,10 @@ namespace WPEFramework {
         uint32_t AVInput::currentVideoModeWrapper(const JsonObject& parameters, JsonObject& response)
         {
             LOGINFOMETHOD();
-            bool success;
+            bool success = false;
             if (getActivatedPluginReady(SUBSCRIPTION_CALLSIGN))
             {
-                response["currentVideoMode"] = currentVideoMode();
+                response["currentVideoMode"] = currentVideoMode(&success);
                 response["message"] = "Success";
             } else {
                 success = false;
@@ -170,6 +170,7 @@ namespace WPEFramework {
                 if (pSuccess) {
                     *pSuccess = false;
                 }
+                return res;
             }
             if (pSuccess) {
                 *pSuccess = true;
@@ -191,11 +192,11 @@ namespace WPEFramework {
                 if (pSuccess) {
                     *pSuccess = false;
                 }
+                return res;
             }
             if (pSuccess) {
                 *pSuccess = true;
             }
-
             return res;
         }
 

--- a/Bluetooth/Bluetooth.cpp
+++ b/Bluetooth/Bluetooth.cpp
@@ -614,7 +614,7 @@ namespace WPEFramework
                 rc = BTRMGR_MediaControl (0, deviceHandle, BTRMGR_MEDIA_CTRL_PLAY);
             }
             else if (audioCtrlCmd == CMD_AUDIO_CTRL_STOP) {
-                rc = BTRMGR_StopAudioStreamingIn(0, deviceHandle);
+                rc = BTRMGR_MediaControl (0, deviceHandle, BTRMGR_MEDIA_CTRL_STOP);
             }
             else if (audioCtrlCmd == CMD_AUDIO_CTRL_SKIP_NEXT) {
                 rc = BTRMGR_MediaControl (0, deviceHandle, BTRMGR_MEDIA_CTRL_NEXT);


### PR DESCRIPTION
…TOP) update

Reason for change: AVINPUT: success trues instead of false returned in some cases; BLUETOOTH: Phone is disconnected from STB  sendAudioPlaybackCommand (STOP) command
Implements: AVINPUT: correct correct return code in all cases; BLUETOOTH: Phone won't disconnect on sendAudioPlaybackCommand (STOP)
Test Procedure: see README.md for the plugin
Signed-off-by: Sergiy Gladkyy <sgladkyy@productengine.com>
Risks: None