### PR TITLE
XRE-15671 : warehouse.getDeviceInfo in thunder differs from SM

### DIFF
--- a/Warehouse/Warehouse.cpp
+++ b/Warehouse/Warehouse.cpp
@@ -655,7 +655,7 @@ namespace WPEFramework
 
             resetDevice(suppressReboot);
 
-            response["PARAM_SUCCESS"] = true;
+            response[PARAM_SUCCESS] = true;
             returnResponse(true);
         }
 
@@ -663,11 +663,9 @@ namespace WPEFramework
         {
             LOGINFO();
 
-            JsonObject deviceInfo;
-            getDeviceInfo(deviceInfo);
+            getDeviceInfo(response);
 
-            response["deviceInfo"] = deviceInfo;
-            response["PARAM_SUCCESS"] = true;
+            response[PARAM_SUCCESS] = true;
             returnResponse(true);
         }
 


### PR DESCRIPTION
Got rid of "deviceInfo" container for values in getDeviceInfo call.