### PR TITLE
DELIA-43636 : Issue in dsHdmiEventHandler (HDCPprofile plugin)

### DIFF
--- a/HdcpProfile/HdcpProfile.cpp
+++ b/HdcpProfile/HdcpProfile.cpp
@@ -71,6 +71,7 @@ namespace WPEFramework
 
             IARM_Result_t res;
             IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_HOTPLUG, dsHdmiEventHandler) );
+            IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDCP_STATUS, dsHdmiEventHandler) );
         }
 
         void HdcpProfile::DeinitializeIARM()
@@ -81,6 +82,7 @@ namespace WPEFramework
             {
                 IARM_Result_t res;
                 IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_HOTPLUG) );
+                IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDCP_STATUS) );
             }
         }
 


### PR DESCRIPTION
Registered for IARM_BUS_DSMGR_EVENT_HDCP_STATUS event, since otherwise notification
with HDCP status will be sent in the case of hot-plug only.