### PR TITLE
DELIA-43817: CEC is not working after power cycle

### DIFF
--- a/HdmiCec_2/HdmiCec_2.cpp
+++ b/HdmiCec_2/HdmiCec_2.cpp
@@ -67,7 +67,7 @@ static LogicalAddress logicalAddress = 0xF;
 static OSDName osdName = "TV Box";
 static int32_t powerState = 1;
 static PowerStatus tvPowerState = 1;
-static bool isDeviceActiveSource = true;
+static bool isDeviceActiveSource = false;
 static bool isLGTvConnected = false;
 
 namespace WPEFramework
@@ -946,9 +946,9 @@ namespace WPEFramework
             {
                 LOGINFO("Command: sending GiveDevicePowerStatus \r\n");
                 smConnection->sendTo(LogicalAddress(LogicalAddress::TV), MessageEncoder().encode(GiveDevicePowerStatus()), 5000);
-                LOGINFO("Command: sending request active Source\r\n");
+                LOGINFO("Command: sending request active Source isDeviceActiveSource is set to false\r\n");
                 smConnection->sendTo(LogicalAddress(LogicalAddress::BROADCAST), MessageEncoder().encode(RequestActiveSource()), 5000);
-                isDeviceActiveSource = true;
+                isDeviceActiveSource = false;
             }
             return;
         }
@@ -1069,6 +1069,7 @@ namespace WPEFramework
                         LOGINFO("Command: sending ActiveSource  physical_addr :%s \r\n",physical_addr.toString().c_str());
                         smConnection->sendTo(LogicalAddress(LogicalAddress::BROADCAST), MessageEncoder().encode(ActiveSource(physical_addr)), 5000);
                         usleep(10000);
+                        isDeviceActiveSource = true;
                     }
                     LOGINFO("Command: sending GiveDevicePowerStatus \r\n");
                     smConnection->sendTo(LogicalAddress(LogicalAddress::TV), MessageEncoder().encode(GiveDevicePowerStatus()), 5000);


### PR DESCRIPTION
Reason for change: Init isDeviceActiveSource to false.
Test Procedure: Refer JIRA.
Risks: Low

Signed-off-by: apatel859 <amit_patel5@comcast.com>