### PR TITLE
RDK-28320: Enable Thunder Packager plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ option(PLUGIN_VIDEOAPPLICATIONEVENTS "Include video application events plugin" O
 option(PLUGIN_INACTIVITYNOTIFIER "Include InactivityNotifier plugin" OFF)
 option(PLUGIN_RDKSHELL "Include RDKShell plugin" OFF)
 option(PLUGIN_TEXTTOSPEECH "Include TextToSpeech plugin" OFF)
+option(PLUGIN_PACKAGER "Include Packager plugin" OFF)
 
 # Library installation section
 string(TOLOWER ${NAMESPACE} STORAGE_DIRECTORY)
@@ -55,6 +56,10 @@ string(TOLOWER ${NAMESPACE} STORAGE_DIRECTORY)
 include(CmakeHelperFunctions)
 
 get_directory_property(SEVICES_DEFINES COMPILE_DEFINITIONS)
+
+if(PLUGIN_PACKAGER)
+    add_subdirectory(Packager)
+endif()
 
 if(PLUGIN_BLUETOOTH)
     add_subdirectory(Bluetooth)

--- a/Packager/CMakeLists.txt
+++ b/Packager/CMakeLists.txt
@@ -19,8 +19,6 @@ set(PLUGIN_NAME Packager)
 set(MODULE_NAME WPEFramework${PLUGIN_NAME})
 
 find_package(${NAMESPACE}Plugins REQUIRED)
-find_package(libprovision REQUIRED)
-find_package(LibOPKG REQUIRED)
 find_package(CompileSettingsDebug CONFIG REQUIRED)
 
 add_library(${MODULE_NAME} SHARED
@@ -32,8 +30,6 @@ target_link_libraries(${MODULE_NAME}
     PRIVATE
         CompileSettingsDebug::CompileSettingsDebug
         ${NAMESPACE}Plugins::${NAMESPACE}Plugins
-        libprovision::libprovision
-        LibOPKG::LibOPKG
         )
 
 string(TOLOWER ${NAMESPACE} STORAGENAME)

--- a/Packager/PackagerImplementation.cpp
+++ b/Packager/PackagerImplementation.cpp
@@ -20,11 +20,11 @@
 #include "PackagerImplementation.h"
 
 #if defined (DO_NOT_USE_DEPRECATED_API)
-#include <opkg_cmd.h>
+#include <libopkg/opkg_cmd.h>
 #else
-#include <opkg.h>
+#include <libopkg/opkg.h>
 #endif
-#include <opkg_download.h>
+#include <libopkg/opkg_download.h>
 
 
 namespace WPEFramework {


### PR DESCRIPTION
Reason for change:
1. Modify Makefile to build Packager if enabled
2. Remove libprovision and libopkg dependency. Linking handled in recipe
3. Modify opkg header path
Test Procedure: Packager plugin must build fine if enabled
Risks: None

Signed-off-by: Deva <Deva_Thiyagarajan2@comcast.com>