### PR TITLE
[DELIA-43983] [Thunder]-System Plugin Issues - fix

### DIFF
--- a/SystemServices/README.md
+++ b/SystemServices/README.md
@@ -15,7 +15,7 @@
   - **cacheContains**
 
     To check if key value present in cache.  
-  _**Request payload:**_ `{"params":{"param":{"cacheKey":"<string>"}}}`  
+  _**Request payload:**_ `{"params":{"key":"<string>"}}`  
   _**Response payload:**_ `{"result":{"success":<bool>}}`
   - **clearLastDeepSleepReason**
 
@@ -40,7 +40,7 @@
   - **getCachedValue**
 
     To get cached value.  
-  _**Request payload:**_ `{"params":{"param":{"cacheKey":"<string>"}}}`  
+  _**Request payload:**_ `{"params":{"key":"<string>"}}`  
   _**Response payload:**_ `{"result":{"<cachekey>":"<string>","success":<bool>}}`
   - **getCoreTemperature**
 
@@ -170,12 +170,12 @@
   - **reboot**
 
     This method shall be used to request the system to perform `reboot`.  
-  _**Request payload:**_ `{"params":{"param":{"cacheKey":"sampleCache"}}}`  
+  _**Request payload:**_ `{"params":{"key":"sampleCache"}}`  
   _**Response payload:**_ `{"result":{"success":<bool>}}`
   - **removeCacheKey**
 
     To delete the key value present in cache.  
-  _**Request payload:**_ `{"params":{"param":{"cacheKey":"<string>"}}}`  
+  _**Request payload:**_ `{"params":{"key":"<string>"}}`  
   _**Response payload:**_ `{"result":{"success":<bool>}}`
   - **requestSystemUptime**
 
@@ -185,7 +185,7 @@
   - **setCachedValue**
 
     To set cache value.  
-  _**Request payload:**_ `{"params":{"param":{"cacheKey":"<string>","cacheValue":<double>}}}`  
+  _**Request payload:**_ `{"params":{"key":"<string>","value":<double>}}`  
   _**Response payload:**_ `{"result":{"success":<bool>}}`
   - **setDeepSleepTimer**
 
@@ -266,12 +266,12 @@ _Note:_ Here callsign used is `org.rdk.SystemServices` instead of actual `org.rd
 
 Method | Request Payload | Response Payload
 :--- | :--- | :---
-| cacheContains | {"jsonrpc":"2.0","id":"1","method":"org.rdk.SystemServices.1.cacheContains","params":{"param":{"cacheKey":"sampleCache"}}} |  {"jsonrpc":"2.0","id":1,"result":{"success":true}} |  
+| cacheContains | {"jsonrpc":"2.0","id":"1","method":"org.rdk.SystemServices.1.cacheContains","params":{"key":"sampleCache"}} |  {"jsonrpc":"2.0","id":1,"result":{"success":true}} |  
 | clearLastDeepSleepReason | {"jsonrpc":"2.0","id":"29","method":"org.rdk.SystemServices.1.clearLastDeepSleepReason","params":{}} | {"jsonrpc":"2.0","id":29,"result":{"success":true}} |  
 | enableMoca | {"jsonrpc":"2.0","id":"30","method": "org.rdk.SystemServices.1.enableMoca","params":{"value":false}} | {"jsonrpc":"2.0","id":30,"result":{"success":false}} |  
 | enableXREConnectionRetention | {"jsonrpc":"2.0","id":"32","method":"org.rdk.SystemServices.1.enableXREConnectionRetention","params":{"param":true}} | {"jsonrpc":"2.0","id":32,"result":{"success":true}} |  
 | getAvailableStandbyModes | {"jsonrpc":"2.0","id":"2","method":"org.rdk.SystemServices.1.getAvailableStandbyModes","params":{}} | {"jsonrpc":"2.0","id":2,"result":{"supportedStandbyModes":["LIGHT_SLEEP","DEEP_SLEEP"],"success":true}} |  
-| getCachedValue | {"jsonrpc":"2.0","id":"3","method":"org.rdk.SystemServices.1.getCachedValue","params":{"param":{"cacheKey":"sampleCache"}}} | {"jsonrpc":"2.0","id":3,"result":{"sampleCache":"4343.3434","success":true}} |  
+| getCachedValue | {"jsonrpc":"2.0","id":"3","method":"org.rdk.SystemServices.1.getCachedValue","params":{"key":"sampleCache"}} | {"jsonrpc":"2.0","id":3,"result":{"sampleCache":"4343.3434","success":true}} |  
 | getCoreTemperature | {"jsonrpc":"2.0","id":"4","method":"org.rdk.SystemServices.1.getCoreTemperature","params":{}} | {"jsonrpc":"2.0","id":4,"result":{"temperature":"48.000000","success":true}} |  
 | getDeviceInfo | {"jsonrpc":"2.0","id":"5","method":"org.rdk.SystemServices.1.getDeviceInfo","params":{"params":["estb_mac"]}} | {"jsonrpc":"2.0","id":5,"result":{"estb_mac":"20:F1:9E:EE:62:08","success":true}} |  
 | getDownloadedFirmwareInfo | {"jsonrpc":"2.0","id":"6","method":"org.rdk.SystemServices.1.getDownloadedFirmwareInfo","params":{}} | {"jsonrpc":"2.0","id":6,"result":{"currentFWVersion":"AX061AEI_VBN_1911_sprint_20200109040424sdy","downloadedFWVersion":"","downloadedFWLocation":"","isRebootDeferred":false,"success":true}} |  
@@ -298,9 +298,9 @@ Method | Request Payload | Response Payload
 | isGzEnabled | {"jsonrpc":"2.0","id":"26","method":"org.rdk.SystemServices.1.isGzEnabled","params":{}} | {"jsonrpc":"2.0","id":26,"result":{"enabled":false,"success":true}} |  
 | queryMocaStatus | {"jsonrpc":"2.0","id":"27","method": "org.rdk.SystemServices.1.queryMocaStatus","params":{}} | {"jsonrpc":"2.0","id":27,"result":{"mocaEnabled":false,"success":true}} |  
 | reboot | {"jsonrpc":"2.0","id":"100","method":"org.rdk.SystemServices.1.reboot","params":{"params":{"reason":"API Validation"}}} | {"jsonrpc":"2.0","id":3,"result":{"IARM_Bus_Call_STATUS":1,"success":true}} |  
-| removeCacheKey | {"jsonrpc":"2.0","id":"34","method":"org.rdk.SystemServices.1.removeCacheKey","params":{"param":{"cacheKey":"sampleCache"}}} | {"jsonrpc":"2.0","id":34,"result":{"success":true}} |  
+| removeCacheKey | {"jsonrpc":"2.0","id":"34","method":"org.rdk.SystemServices.1.removeCacheKey","params":{"key":"sampleCache"}} | {"jsonrpc":"2.0","id":34,"result":{"success":true}} |  
 | requestSystemUptime | {"jsonrpc":"2.0","id":"28","method":"org.rdk.SystemServices.1.requestSystemUptime","params":{}} | {"jsonrpc":"2.0","id":28,"result":{"systemUptime":"1666.92","success":true}} |  
-| setCachedValue | {"jsonrpc":"2.0","id":"33","method":"org.rdk.SystemServices.1.setCachedValue","params":{"param":{"cacheKey":"sampleCache","cacheValue":4343.3434}}} | {"jsonrpc":"2.0","id":33,"result":{"success":true}} |  
+| setCachedValue | {"jsonrpc":"2.0","id":"33","method":"org.rdk.SystemServices.1.setCachedValue","params":{"key":"sampleCache","value":4343.3434}} | {"jsonrpc":"2.0","id":33,"result":{"success":true}} |  
 | setDeepSleepTimer | {"jsonrpc":"2.0","id":"35","method":"org.rdk.SystemServices.1.setDeepSleepTimer","params":{"param":{"seconds":3}}} | {"jsonrpc":"2.0","id":35,"result":{"success":true}} |  
 | setGzEnabled | {"jsonrpc":"2.0","id":"36","method":"org.rdk.SystemServices.1.setGzEnabled","params":{"param":true}} | {"jsonrpc":"2.0","id":36,"result":{"success":true}} |  
 | setMode | {"jsonrpc":"2.0","id":"37","method":"org.rdk.SystemServices.1.setMode","params":{"modeInfo":{"mode":"NORMAL","duration":20}}} | {"jsonrpc":"2.0","id":37,"result":{"success":true}} |  

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -1603,25 +1603,29 @@ namespace WPEFramework {
 
         /***
          * @brief : To get cashed value .
-         * @param1[in]  : {"params":{"param":{"cacheKey":"<string>"}}}
+         * @param1[in]  : {"params":{"key":"<string>"}}
          * @param2[out] : {"result":{"<cachekey>":"<string>","success":<bool>}}
          * @return      : Core::<StatusCode>
          */
         uint32_t SystemServices::getCachedValue(const JsonObject& parameters,
-                JsonObject& response)
-        {
-            JsonObject param;
-            param.FromString(parameters["param"].String());
-            std::string key = param["cacheKey"].String();
-            LOGWARN("key: %s\n", key.c_str());
-            response[(key.c_str())] = m_cacheService.getValue(key).String();
-            returnResponse(true);
-        }
+			JsonObject& response)
+	{
+		bool retStat = false;
+		std::string key = parameters["key"].String();
+		LOGWARN("key: %s\n", key.c_str());
+		if (key.length()) {
+			response[(key.c_str())] = m_cacheService.getValue(key).String();
+			retStat = true;
+		} else {
+			populateResponseWithError(SysSrv_UnSupportedFormat, response);
+		}
+		returnResponse(retStat);
+	}
 
         /***
          * @brief : To set cache value.
-         * @param1[in]  : {"params":{"param":{"cacheKey":"<string>",
-         *                 "cacheValue":<double>}}}
+         * @param1[in]  : {"params":{"key":"<string>",
+         *                 "cacheValue":<double>}}
          * @param2[out] : {"jsonrpc":"2.0","id":3,"result":{"success":<bool>}}
          * @return      : Core::<StatusCode>
          */
@@ -1629,59 +1633,66 @@ namespace WPEFramework {
                 JsonObject& response)
         {
             bool retStat = false;
-            JsonObject param;
-            param.FromString(parameters["param"].String());
-            std::string key = param["cacheKey"].String();
-            std::string value = param["cacheValue"].String();
+            std::string key = parameters["key"].String();
+            std::string value = parameters["value"].String();
 
-            if (m_cacheService.setValue(key, value)) {
-                retStat = true;
-            } else {
-                LOGERR("Accessing m_cacheService.setValue failed\n.");
-            }
-            returnResponse(retStat);
+	    if (key.length() && value.length()) {
+		    if (m_cacheService.setValue(key, value)) {
+			    retStat = true;
+		    } else {
+			    LOGERR("Accessing m_cacheService.setValue failed\n.");
+		    }
+	    } else {
+		    populateResponseWithError(SysSrv_UnSupportedFormat, response);
+	    }
+	    returnResponse(retStat);
         }
 
         /***
          * @brief : To check if key value present in cache.
-         * @param1[in]  : {"params":{"param":{"cacheKey":"<string>"}}}
+         * @param1[in]  : {"params":{"key":"<string>"}}
          * @param2[out] : {"jsonrpc":"2.0","id":3,"result":{"success":<bool>}}
          * @return      : Core::<StatusCode>
          */
         uint32_t SystemServices::cacheContains(const JsonObject& parameters,
                 JsonObject& response)
         {
-            bool retStat = false;
-            JsonObject param;
-            param.FromString(parameters["param"].String());
-            std::string key = param["cacheKey"].String();
-            if (m_cacheService.contains(key)) {
-                retStat = true;
-            } else {
-                LOGERR("Accessing m_cacheService.contains failed\n.");
-            }
-            returnResponse(retStat);
+		bool retStat = false;
+		std::string key = parameters["key"].String();
+		if (key.length()) {
+			if (m_cacheService.contains(key)) {
+				retStat = true;
+			} else {
+				LOGERR("Accessing m_cacheService.contains failed\n.");
+			}
+		} else {
+			populateResponseWithError(SysSrv_UnSupportedFormat, response);
+		}
+		returnResponse(retStat);
         }
 
         /***
          * @brief : To delete the key value present in cache.
-         * @param1[in]  : {"params":{"param":{"cacheKey":"<string>"}}}
+         * @param1[in]  : {"params":{"key":"<string>"}}
          * @param2[out] : {"jsonrpc":"2.0","id":3,"result":{"success":<bool>}}
          * @return      : Core::<StatusCode>
          */
         uint32_t SystemServices::removeCacheKey(const JsonObject& parameters,
                 JsonObject& response)
         {
-            bool retStat = false;
-            JsonObject param;
-            param.FromString(parameters["param"].String());
-            std::string key = param["cacheKey"].String();
-            if (m_cacheService.remove(key)) {
-                retStat = true;
-            } else {
-                LOGERR("Accessing m_cacheService.remove failed\n.");
-            }
-            returnResponse(retStat);
+		bool retStat = false;
+		std::string key = parameters["key"].String();
+		if (key.length()) {
+			if (m_cacheService.remove(key)) {
+				retStat = true;
+			} else {
+				LOGERR("Accessing m_cacheService.remove failed\n.");
+				populateResponseWithError(SysSrv_Unexpected, response);
+			}
+		} else {
+			populateResponseWithError(SysSrv_UnSupportedFormat, response);
+		}
+		returnResponse(retStat);
         }
 
         /***
@@ -1750,28 +1761,30 @@ namespace WPEFramework {
          */
         uint32_t SystemServices::getLastDeepSleepReason(const JsonObject& parameters,
                 JsonObject& response)
-        {
-            bool retAPIStatus = false;
-            string reason;
+	{
+		bool retAPIStatus = false;
+		string reason;
 
-            if (Utils::fileExists(STANDBY_REASON_FILE)) {
-                    std::ifstream inFile(STANDBY_REASON_FILE);
-                    if (inFile) {
-                        std::getline(inFile, reason);
-                        inFile.close();
-                        retAPIStatus = true;
-                    } else {
-                        populateResponseWithError(SysSrv_FileAccessFailed, response);
-                    }
-                } else {
-                    populateResponseWithError(SysSrv_FileNotPresent, response);
-                }
+		if (Utils::fileExists(STANDBY_REASON_FILE)) {
+			std::ifstream inFile(STANDBY_REASON_FILE);
+			if (inFile) {
+				std::getline(inFile, reason);
+				inFile.close();
+				retAPIStatus = true;
+			} else {
+				populateResponseWithError(SysSrv_FileAccessFailed, response);
+			}
+		} else {
+			populateResponseWithError(SysSrv_FileNotPresent, response);
+		}
 
-                if (retAPIStatus && reason.length()) {
-                    response["lastDeepSleepReason"] = reason;
-            }
-            returnResponse(retAPIStatus);
-        }
+		if (retAPIStatus && reason.length()) {
+			response["reason"] = reason;
+		} else {
+			response["reason"] = "";
+		}
+		returnResponse(retAPIStatus);
+	}
 
         /***
          * @brief : Used to clear last deep sleep reason.
@@ -2039,24 +2052,24 @@ namespace WPEFramework {
 
         /***
          * @brief : Enables XRE Connection Retension option.
-         * @param1[in]  : {"params":{"param":<bool>}}
+         * @param1[in]  : {"params":{"enable":<bool>}}
          * @param2[out] : "result":{"success":<bool>}
          * @return      : Core::<StatusCode>
          */
         uint32_t SystemServices::enableXREConnectionRetention(const JsonObject& parameters,
                 JsonObject& response)
-        {
-            bool enable = false, retstatus = false;
-            int status = SysSrv_Unexpected;
+	{
+		bool enable = false, retstatus = false;
+		int status = SysSrv_Unexpected;
 
-                enable = parameters["param"].Boolean();
-                if ((status = enableXREConnectionRetentionHelper(enable)) == SysSrv_OK) {
-                    retstatus = true;
-                } else {
-                    populateResponseWithError(status, response);
-            }
-            returnResponse(retstatus);
-        }
+		enable = parameters["enable"].Boolean();
+		if ((status = enableXREConnectionRetentionHelper(enable)) == SysSrv_OK) {
+			retstatus = true;
+		} else {
+			populateResponseWithError(status, response);
+		}
+		returnResponse(retstatus);
+	}
 
         /***
          * @brief : collect device state info.

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -1259,7 +1259,7 @@ namespace WPEFramework {
                 response["downloadPercent"] = m_downloadPercent;
                 retStatus = true;
             } else {
-                response["downloadPercent"] = 0;
+                response["downloadPercent"] = -1;
                 retStatus = true;
             }
             returnResponse(retStatus);

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -2217,59 +2217,45 @@ namespace WPEFramework {
          */
         uint32_t SystemServices::setDevicePowerState(const JsonObject& parameters,
                 JsonObject& response)
-        {
-            bool retVal = false;
-            string sleepMode;
-            ofstream outfile;
-            outfile.open(STANDBY_REASON_FILE, ios::out);
-                JsonObject paramIn, paramOut;
-                string state = parameters["powerState"].String();
-                string reason = parameters["standbyReason"].String();
+	{
+		bool retVal = false;
+		string sleepMode;
+		ofstream outfile;
+		JsonObject paramIn, paramOut;
+		string state = parameters["powerState"].String();
+		string reason = parameters["standbyReason"].String();
+		/* Power state defaults standbyReason is "application". */
+		reason = ((reason.length()) ? reason : "application");
 
-
-                if(state=="STANDBY")
-                {
-
-
-                    if (SystemServices::_instance) {
-                        SystemServices::_instance->getPreferredStandbyMode(paramIn, paramOut);
-                        /* TODO: parse abd get the sleepMode from paramOut */
-                        sleepMode= paramOut["preferredStandbyMode"].String();
-
-
-                    LOGWARN("Output of preferredStandbyMode: '%s'", sleepMode.c_str());
-
-                    }
-                    else {
-                        LOGWARN("SystemServices::_instance is NULL.\n");
-                    }
-                    if(convert("DEEP_SLEEP",sleepMode))
-                    {
-
-                        retVal = CPowerState::instance()->setPowerState(sleepMode);
-                    }
-                    else{
-
-                        retVal = CPowerState::instance()->setPowerState(state);
-                    }
-
-
-                    if (outfile) {
-                        outfile << reason;
-                        outfile.close();
-
-                    }
-                    else {
-                        printf(" GZ_FILE_ERROR: Can't open file for write mode\n");
-                    }
-
-                }
-                else {
-                    retVal = CPowerState::instance()->setPowerState(state);
-                    LOGERR("this platform has no API System and/or Powerstate\n");
-            }
-            returnResponse(retVal);
-        }//end of setPower State
+		if (state == "STANDBY") {
+			if (SystemServices::_instance) {
+				SystemServices::_instance->getPreferredStandbyMode(paramIn, paramOut);
+				/* TODO: parse abd get the sleepMode from paramOut */
+				sleepMode= paramOut["preferredStandbyMode"].String();
+				LOGWARN("Output of preferredStandbyMode: '%s'", sleepMode.c_str());
+			} else {
+				LOGWARN("SystemServices::_instance is NULL.\n");
+			}
+			if (convert("DEEP_SLEEP", sleepMode)) {
+				retVal = CPowerState::instance()->setPowerState(sleepMode);
+			} else {
+				retVal = CPowerState::instance()->setPowerState(state);
+			}
+			if (outfile) {
+				outfile.open(STANDBY_REASON_FILE, ios::out);
+				if (outfile.is_open()) {
+					outfile << reason;
+					outfile.close();
+				}
+			} else {
+				printf(" GZ_FILE_ERROR: Can't open file for write mode\n");
+			}
+		} else {
+			retVal = CPowerState::instance()->setPowerState(state);
+			LOGERR("this platform has no API System and/or Powerstate\n");
+		}
+		returnResponse(retVal);
+	}//end of setPower State
 #endif /* HAS_API_SYSTEM && HAS_API_POWERSTATE */
 
         /***

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -1624,8 +1624,7 @@ namespace WPEFramework {
 
         /***
          * @brief : To set cache value.
-         * @param1[in]  : {"params":{"key":"<string>",
-         *                 "cacheValue":<double>}}
+         * @param1[in]  : {"params":{"key":"<string>","value":<double>}}
          * @param2[out] : {"jsonrpc":"2.0","id":3,"result":{"success":<bool>}}
          * @return      : Core::<StatusCode>
          */

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -1640,6 +1640,7 @@ namespace WPEFramework {
 			    retStat = true;
 		    } else {
 			    LOGERR("Accessing m_cacheService.setValue failed\n.");
+			    populateResponseWithError(SysSrv_Unexpected, response);
 		    }
 	    } else {
 		    populateResponseWithError(SysSrv_UnSupportedFormat, response);
@@ -1663,6 +1664,7 @@ namespace WPEFramework {
 				retStat = true;
 			} else {
 				LOGERR("Accessing m_cacheService.contains failed\n.");
+				populateResponseWithError(SysSrv_Unexpected, response);
 			}
 		} else {
 			populateResponseWithError(SysSrv_UnSupportedFormat, response);


### PR DESCRIPTION
This PR includes fixes for below APIs.

- **enableXREConnectionRetention**: updated key as **_enable_** in **_params_** object.
`{"jsonrpc":"2.0","id":"3","method":"org.rdk.System.1.enableXREConnectionRetention","params":{"enable":true}}`
- **getCachedValue**: updated key as **_key_** in **_params_** object.
`{"jsonrpc":"2.0","id":"3","method":"org.rdk.System.1.getCachedValue","params":{"key":"TestKey"}}`
- **setCachedValue**: updated keys as **_key_** and **_value_** in **_params_** object.
`{"jsonrpc":"2.0","id":"3","method":"org.rdk.System.1.setCachedValue","params":{"key":"TestKey","value":"Sample Value"}}`
- **cacheContains**: updated key as **_key_** in **_params_** object.
`{"jsonrpc":"2.0","id":"3","method":"org.rdk.System.1.cacheContains","params":{"key":"TestKey"}}`
- **removeCacheKey**: updated key as **_key_** in **_params_** object.
`{"jsonrpc":"2.0","id":"3","method":"org.rdk.System.1.removeCacheKey","params":{"key":"TestKey"}}`
- **getLastDeepSleepReason**: updated key as **_reason_** in **_params_** object.
`{"jsonrpc":"2.0","id":"3","method":"org.rdk.System.1.getLastDeepSleepReason"}`
- **getFirmwareDownloadPercent**: updated to match with SM output.
`{"jsonrpc":"2.0","id":"3","method":"org.rdk.System.1.getFirmwareDownloadPercent"}`