### PR TITLE
AMLOGIC-197: Remove Network precondition for LocationSync Plugin

### DIFF
--- a/LocationSync/LocationSync.config
+++ b/LocationSync/LocationSync.config
@@ -1,7 +1,5 @@
 set (autostart true)
 
-set (preconditions Network)
-
 map()
     kv(interval 10)
     kv(retries 20)


### PR DESCRIPTION
LocationSync also has a precondition for Network which is not currently provided by any plugin in RDKServices. It was provided by the NetworkControl plugin in ThunderNanoServices. Removing this precondition until we can figure out best way to set it up through RDKServices. 
LocationSync plugin will still work and retry sync with the server URL if there is no network connectivity. Default is 20 retries every 10 seconds.