### PR TITLE
DELIA-44326 : [Thunder][Dis[laySettings] - HDMI Audio Delay Issues

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -1593,7 +1593,7 @@ namespace WPEFramework {
                 }
 
                 device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
-                aPort.setAudioDelay (audioDelayOffsetMs);
+                aPort.setAudioDelayOffset (audioDelayOffsetMs);
             }
             catch (const device::Exception& err)
             {


### PR DESCRIPTION
Fixed setAudioDelayOffset call, used device::AudioOutputPort::setAudioDelayOffset().