### PR TITLE
DELIA-44559 : Change CS thunder quirk to return array, not string.

### DIFF
--- a/ControlService/ControlService.cpp
+++ b/ControlService/ControlService.cpp
@@ -89,7 +89,6 @@ namespace WPEFramework {
             registerMethod("findMyRemote", &ControlService::findMyRemoteWrapper, this);
 
             setApiVersionNumber(7);
-            setQuirks("DELIA-43686");
         }
 
         ControlService::~ControlService()
@@ -727,7 +726,9 @@ namespace WPEFramework {
         uint32_t ControlService::getQuirks(const JsonObject& parameters, JsonObject& response)
         {
             LOGINFOMETHOD();
-            response["quirks"] = m_quirks;
+            JsonArray array;
+            array.Add("DELIA-43686");
+            response["quirks"] = array;
             returnResponse(true);
         }
 
@@ -1594,12 +1595,6 @@ namespace WPEFramework {
         {
             LOGINFO("setting version: %d", (int)apiVersionNumber);
             m_apiVersionNumber = apiVersionNumber;
-        }
-
-        void ControlService::setQuirks(string quirks)
-        {
-            LOGINFO("setting quirks: %s", quirks);
-            m_quirks = quirks;
         }
 
         int ControlService::numericCtrlm2Int(ctrlm_key_code_t ctrlm_key)

--- a/ControlService/ControlService.h
+++ b/ControlService/ControlService.h
@@ -142,7 +142,6 @@ namespace WPEFramework {
 
             // Local utility methods
             void setApiVersionNumber(uint32_t apiVersionNumber);
-            void setQuirks(string quirks);
             int numericCtrlm2Int(ctrlm_key_code_t ctrlm_key);
 
             char* getRemoteModel(char *remoteType);
@@ -163,7 +162,6 @@ namespace WPEFramework {
             static ControlService* _instance;
         private:
             uint32_t    m_apiVersionNumber;
-            string      m_quirks;
 
             JsonObject  m_remoteInfo[CTRLM_MAIN_MAX_BOUND_CONTROLLERS];
             int         m_numOfBindRemotes;


### PR DESCRIPTION
Reason for change: Control Service Thunder Quirk should be an array, not a string
Test Procedure: Verify test app gives "result : {"quirks":["DELIA-43686"],"success":true}".
Risks: None.
Signed-off-by: jschmidt <Jeff_Schmidt@cable.comcast