### PR TITLE
XIONE-818: Resolve thunder network api upcall protocol

### DIFF
--- a/Network/NetUtils.cpp
+++ b/Network/NetUtils.cpp
@@ -241,6 +241,26 @@ namespace WPEFramework {
             out += std::to_string(m_counter++);
         }
 
+        bool NetUtils::isIPV6LinkLocal(const std::string& address)
+        {
+            struct sockaddr_in6 sa6;
+
+            if (inet_pton(AF_INET6, address.c_str(), &(sa6.sin6_addr)) == 0)
+                return false;
+            else
+                return IN6_IS_ADDR_LINKLOCAL(&sa6.sin6_addr);
+        }
+
+        bool NetUtils::isIPV4LinkLocal(const std::string& address)
+        {
+            struct sockaddr_in sa;
+
+            if (inet_pton(AF_INET, address.c_str(), &(sa.sin_addr)) == 0)
+                return false;
+            else
+                return IN_IS_ADDR_LINKLOCAL(sa.sin_addr.s_addr);
+        }
+
         // Not every character can be used for endpoint
         bool NetUtils::_isCharacterIllegal(const int& c)
         {

--- a/Network/NetUtils.h
+++ b/Network/NetUtils.h
@@ -26,6 +26,8 @@
 #include "utils.h"
 #include "NetUtilsNetlink.h"
 
+#define IN_IS_ADDR_LINKLOCAL(a)     (((a) & htonl(0xffff0000)) == htonl (0xa9fe0000))
+
 namespace WPEFramework {
     #define MAX_COMMAND_LENGTH      256
     #define MAX_OUTPUT_LENGTH       128
@@ -46,6 +48,8 @@ namespace WPEFramework {
 
             static bool isIPV4(const std::string &address);
             static bool isIPV6(const std::string &address);
+            static bool isIPV6LinkLocal(const std::string &address);
+            static bool isIPV4LinkLocal(const std::string &address);
             static int execCmd(const char *command, std::string &output, bool *result = NULL, const char *outputfile = NULL);
             static bool getFile(const char *filepath, std::string &contents, bool deleteFile = false);
 

--- a/Network/Network.cpp
+++ b/Network/Network.cpp
@@ -239,8 +239,12 @@ namespace WPEFramework
                     for (int i = 0; i < list.size; i++)
                     {
                         JsonObject interface;
-
-                        interface["interface"] = m_netUtils.getInterfaceDescription(list.interfaces[i].name);
+                        std::string iface = m_netUtils.getInterfaceDescription(list.interfaces[i].name);
+#ifdef NET_DEFINED_INTERFACES_ONLY
+                        if (iface == "")
+                            continue;					// Skip unrecognised interfaces...
+#endif
+                        interface["interface"] = iface;
                         interface["macAddress"] = string(list.interfaces[i].mac);
                         interface["enabled"] = ((list.interfaces[i].flags & IFF_UP) != 0);
                         interface["connected"] = ((list.interfaces[i].flags & IFF_RUNNING) != 0);
@@ -594,8 +598,14 @@ namespace WPEFramework
         {
             JsonObject params;
             params["interface"] = m_netUtils.getInterfaceDescription(interface);
-            params["ip6Address"] = ipv6Addr;
-            params["ip4Address"] = ipv4Addr;
+            if (ipv6Addr != "")
+            {
+                params["ip6Address"] = ipv6Addr;
+            }
+            if (ipv4Addr != "")
+            {
+                params["ip4Address"] = ipv4Addr;
+            }
             params["status"] = string (acquired ? "ACQUIRED" : "LOST");
             sendNotify("onIPAddressStatusChanged", params);
         }
@@ -634,22 +644,44 @@ namespace WPEFramework
             case IARM_BUS_NETWORK_MANAGER_EVENT_INTERFACE_ENABLED_STATUS:
             {
                 IARM_BUS_NetSrvMgr_Iface_EventInterfaceEnabledStatus_t *e = (IARM_BUS_NetSrvMgr_Iface_EventInterfaceEnabledStatus_t*) data;
+#ifdef NET_DEFINED_INTERFACES_ONLY
+                if (m_netUtils.getInterfaceDescription(e->interface) == "")
+                    break;
+#endif
                 onInterfaceEnabledStatusChanged(e->interface, e->status);
                 break;
             }
             case IARM_BUS_NETWORK_MANAGER_EVENT_INTERFACE_CONNECTION_STATUS:
             {
                 IARM_BUS_NetSrvMgr_Iface_EventInterfaceConnectionStatus_t *e = (IARM_BUS_NetSrvMgr_Iface_EventInterfaceConnectionStatus_t*) data;
+#ifdef NET_DEFINED_INTERFACES_ONLY
+                if (m_netUtils.getInterfaceDescription(e->interface) == "")
+                    break;
+#endif
                 onInterfaceConnectionStatusChanged(e->interface, e->status);
                 break;
             }
             case IARM_BUS_NETWORK_MANAGER_EVENT_INTERFACE_IPADDRESS:
             {
                 IARM_BUS_NetSrvMgr_Iface_EventInterfaceIPAddress_t *e = (IARM_BUS_NetSrvMgr_Iface_EventInterfaceIPAddress_t*) data;
+#ifdef NET_DEFINED_INTERFACES_ONLY
+                if (m_netUtils.getInterfaceDescription(e->interface) == "")
+                    break;
+#endif
                 if (e->is_ipv6)
-                    onInterfaceIPAddressChanged(e->interface, e->ip_address, "", e->acquired);
+                {
+#ifdef NET_NO_LINK_LOCAL_ANNOUNCE
+                    if (!m_netUtils.isIPV6LinkLocal(e->ip_address))
+#endif
+                        onInterfaceIPAddressChanged(e->interface, e->ip_address, "", e->acquired);
+                }
                 else
-                    onInterfaceIPAddressChanged(e->interface, "", e->ip_address, e->acquired);
+                {
+#ifdef NET_NO_LINK_LOCAL_ANNOUNCE
+                    if (!m_netUtils.isIPV4LinkLocal(e->ip_address))
+#endif
+                        onInterfaceIPAddressChanged(e->interface, "", e->ip_address, e->acquired);
+                }
                 break;
             }
             case IARM_BUS_NETWORK_MANAGER_EVENT_DEFAULT_INTERFACE:


### PR DESCRIPTION
Reason for change: Adds compile time flags
NET_DEFINED_INTERFACES_ONLY - only show interfaces define in device.properties
NET_NO_LINK_LOCAL_ANNOUNCE - do not advertise link local addresses
Test Procedure: Full network functionality test
Risks: Medium
Signed-off-by: Kamal Mortoza kamal.mortoza@sky.uk