### PR TITLE
RDKPI-330: Include ControlService, RemoteActionMapping in RPi Builds

### DIFF
--- a/ControlService/CMakeLists.txt
+++ b/ControlService/CMakeLists.txt
@@ -31,13 +31,14 @@ set_target_properties(${MODULE_NAME} PROPERTIES
         CXX_STANDARD 11
         CXX_STANDARD_REQUIRED YES)
 
-find_package(IARMBus)
-target_include_directories(${MODULE_NAME} PRIVATE ${IARMBUS_INCLUDE_DIRS} ../helpers)
+target_include_directories(${MODULE_NAME} PRIVATE ../helpers)
 
 find_package(CTRLM)
 if (CTRLM_FOUND)
     add_definitions(-DCTRLM_FOUND)
     target_include_directories(${MODULE_NAME} PRIVATE ${CTRLM_INCLUDE_DIRS})
+    find_package(IARMBus)
+    target_include_directories(${MODULE_NAME} PRIVATE ${IARMBUS_INCLUDE_DIRS})
     find_package(IRMGR)
     target_include_directories(${MODULE_NAME} PRIVATE ${IRMGR_INCLUDE_DIRS})
     target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins ${IARMBUS_LIBRARIES})

--- a/ControlService/CMakeLists.txt
+++ b/ControlService/CMakeLists.txt
@@ -31,14 +31,13 @@ set_target_properties(${MODULE_NAME} PROPERTIES
         CXX_STANDARD 11
         CXX_STANDARD_REQUIRED YES)
 
-target_include_directories(${MODULE_NAME} PRIVATE ../helpers)
+find_package(IARMBus)
+target_include_directories(${MODULE_NAME} PRIVATE ${IARMBUS_INCLUDE_DIRS} ../helpers)
 
 find_package(CTRLM)
 if (CTRLM_FOUND)
     add_definitions(-DCTRLM_FOUND)
     target_include_directories(${MODULE_NAME} PRIVATE ${CTRLM_INCLUDE_DIRS})
-    find_package(IARMBus)
-    target_include_directories(${MODULE_NAME} PRIVATE ${IARMBUS_INCLUDE_DIRS})
     find_package(IRMGR)
     target_include_directories(${MODULE_NAME} PRIVATE ${IRMGR_INCLUDE_DIRS})
     target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins ${IARMBUS_LIBRARIES})

--- a/RemoteActionMapping/CMakeLists.txt
+++ b/RemoteActionMapping/CMakeLists.txt
@@ -32,13 +32,14 @@ set_target_properties(${MODULE_NAME} PROPERTIES
         CXX_STANDARD 11
         CXX_STANDARD_REQUIRED YES)
 
-find_package(IARMBus)
-target_include_directories(${MODULE_NAME} PRIVATE ${IARMBUS_INCLUDE_DIRS} ../helpers)
+target_include_directories(${MODULE_NAME} PRIVATE ../helpers)
 
 find_package(CTRLM)
 if (CTRLM_FOUND)
     add_definitions(-DCTRLM_FOUND)
     target_include_directories(${MODULE_NAME} PRIVATE ${CTRLM_INCLUDE_DIRS})
+    find_package(IARMBus)
+    target_include_directories(${MODULE_NAME} PRIVATE ${IARMBUS_INCLUDE_DIRS})
     find_package(IRMGR)
     target_include_directories(${MODULE_NAME} PRIVATE ${IRMGR_INCLUDE_DIRS})
     target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins ${IARMBUS_LIBRARIES})

--- a/RemoteActionMapping/CMakeLists.txt
+++ b/RemoteActionMapping/CMakeLists.txt
@@ -32,14 +32,13 @@ set_target_properties(${MODULE_NAME} PROPERTIES
         CXX_STANDARD 11
         CXX_STANDARD_REQUIRED YES)
 
-target_include_directories(${MODULE_NAME} PRIVATE ../helpers)
+find_package(IARMBus)
+target_include_directories(${MODULE_NAME} PRIVATE ${IARMBUS_INCLUDE_DIRS} ../helpers)
 
 find_package(CTRLM)
 if (CTRLM_FOUND)
     add_definitions(-DCTRLM_FOUND)
     target_include_directories(${MODULE_NAME} PRIVATE ${CTRLM_INCLUDE_DIRS})
-    find_package(IARMBus)
-    target_include_directories(${MODULE_NAME} PRIVATE ${IARMBUS_INCLUDE_DIRS})
     find_package(IRMGR)
     target_include_directories(${MODULE_NAME} PRIVATE ${IRMGR_INCLUDE_DIRS})
     target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins ${IARMBUS_LIBRARIES})


### PR DESCRIPTION
RDKPI-330: Include ControlService, RemoteActionMapping and VREXManager  
Reason for change: Include ControlService, RemoteActionMapping and VREXManager in Pi build
Test Procedure: Activate ControlService, RemoteActionMapping and VREXManager plugins 
Risks: Low 
Signed-off-by: Mohita Singh <Mohita_Singh2@comcast.com>