### PR TITLE
XRE-14362: Adding properties to VAP plugins

### DIFF
--- a/DisplayInfo/CMakeLists.txt
+++ b/DisplayInfo/CMakeLists.txt
@@ -45,7 +45,25 @@ target_link_libraries(${MODULE_NAME}
         ${NAMESPACE}Plugins::${NAMESPACE}Plugins
         ${NAMESPACE}Definitions::${NAMESPACE}Definitions)
 
-if (NXCLIENT_FOUND AND NEXUS_FOUND)
+if (USE_DEVICESETTINGS)
+    find_package(DS REQUIRED)
+    find_package(IARMBus REQUIRED)
+        target_include_directories(${MODULE_NAME} PRIVATE ${IARMBUS_INCLUDE_DIRS})
+        target_include_directories(${MODULE_NAME} PRIVATE ${DS_INCLUDE_DIRS})
+        target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins ${IARMBUS_LIBRARIES} ${DS_LIBRARIES})
+
+    target_sources(${MODULE_NAME}
+        PRIVATE
+            DeviceSettings/PlatformImplementation.cpp
+            ../helpers/utils.cpp)
+    target_include_directories(${MODULE_NAME} PRIVATE ../helpers)
+    target_link_libraries(${MODULE_NAME}
+        PRIVATE
+            NEXUS::NEXUS
+            NXCLIENT::NXCLIENT)
+    add_definitions( -Wall -O2 -fexceptions )
+
+elseif (NXCLIENT_FOUND AND NEXUS_FOUND)
     target_sources(${MODULE_NAME}
         PRIVATE
             Nexus/PlatformImplementation.cpp)
@@ -77,7 +95,7 @@ else ()
     message(FATAL_ERROR "There is no graphic backend for display info plugin")
 endif ()
 
-install(TARGETS ${MODULE_NAME} 
+install(TARGETS ${MODULE_NAME}
     DESTINATION lib/${STORAGE_DIRECTORY}/plugins)
 
 write_config(${PLUGIN_NAME})

--- a/DisplayInfo/DeviceSettings/PlatformImplementation.cpp
+++ b/DisplayInfo/DeviceSettings/PlatformImplementation.cpp
@@ -1,0 +1,709 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2020 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../Module.h"
+#include <interfaces/IDisplayInfo.h>
+
+#include <nexus_config.h>
+#include <nexus_platform.h>
+#include <nxclient.h>
+
+#include "host.hpp"
+#include "exception.hpp"
+#include "videoOutputPort.hpp"
+#include "videoOutputPortType.hpp"
+#include "videoOutputPortConfig.hpp"
+#include "videoResolution.hpp"
+#include "audioOutputPort.hpp"
+#include "audioOutputPortType.hpp"
+#include "audioOutputPortConfig.hpp"
+#include "manager.hpp"
+#include "utils.h"
+
+#if defined(USE_IARM)
+#include "libIBus.h"
+#include "libIBusDaemon.h"
+#include "dsMgr.h"
+#endif
+
+#include <string.h>
+#include <vector>
+
+namespace WPEFramework {
+namespace Plugin {
+
+class DisplayInfoImplementation : public Exchange::IGraphicsProperties, public Exchange::IConnectionProperties, public Exchange::IDisplayProperties {
+public:
+    DisplayInfoImplementation()
+       : _width(0)
+       , _height(0)
+       , _connected(false)
+       , _major(0)
+       , _minor(0)
+       , _type(HDR_OFF)
+       , _totalGpuRam(0)
+       , _audioPassthrough(false)
+       , _adminLock()
+       , _activity(*this) {
+
+        NEXUS_Error rc = NxClient_Join(NULL);
+        ASSERT(!rc);
+        NxClient_UnregisterAcknowledgeStandby(NxClient_RegisterAcknowledgeStandby());
+        NEXUS_Platform_GetConfiguration(&_platformConfig);
+
+        UpdateTotalGpuRam(_totalGpuRam);
+
+        UpdateDisplayInfo(_connected, _width, _height, _major, _minor, _type);
+        UpdateAudioPassthrough(_audioPassthrough);
+
+        RegisterCallback();
+        DisplayInfoImplementation::_instance = this;
+        try
+        {
+#if defined(USE_IARM)
+            Utils::IARM::init();
+            IARM_Result_t res;
+            IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_RES_PRECHANGE,ResolutionPreChange) );
+            IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_RES_POSTCHANGE, ResolutionPostChange) );
+#endif
+            //TODO: this is probably per process so we either need to be running in our own process or be carefull no other plugin is calling it
+            device::Manager::Initialize();
+            TRACE(Trace::Information, (_T("device::Manager::Initialize success")));
+        }
+        catch(...)
+        {
+           TRACE(Trace::Error, (_T("device::Manager::Initialize failed")));
+        }
+    }
+
+    DisplayInfoImplementation(const DisplayInfoImplementation&) = delete;
+    DisplayInfoImplementation& operator= (const DisplayInfoImplementation&) = delete;
+    virtual ~DisplayInfoImplementation()
+    {
+        NxClient_StopCallbackThread();
+        NxClient_Uninit();
+#if defined(USE_IARM)
+        IARM_Result_t res;
+        IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_RES_PRECHANGE) );
+        IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_RES_POSTCHANGE) );
+#endif
+        DisplayInfoImplementation::_instance = nullptr;
+    }
+
+public:
+    // Graphics Properties interface
+    uint64_t TotalGpuRam() const override
+    {
+        return _totalGpuRam;
+    }
+    uint64_t FreeGpuRam() const override
+    {
+        uint64_t freeRam = 0;
+        NEXUS_MemoryStatus status;
+
+        NEXUS_Error rc = NEXUS_UNKNOWN;
+#if NEXUS_MEMC0_GRAPHICS_HEAP
+        if (_platformConfig.heap[NEXUS_MEMC0_GRAPHICS_HEAP]) {
+            rc = NEXUS_Heap_GetStatus(_platformConfig.heap[NEXUS_MEMC0_GRAPHICS_HEAP], &status);
+            if (rc == NEXUS_SUCCESS) {
+                freeRam = static_cast<uint64_t>(status.free);
+            }
+        }
+#endif
+#if NEXUS_MEMC1_GRAPHICS_HEAP
+        if (_platformConfig.heap[NEXUS_MEMC1_GRAPHICS_HEAP]) {
+            rc = NEXUS_Heap_GetStatus(_platformConfig.heap[NEXUS_MEMC1_GRAPHICS_HEAP], &status);
+            if (rc == NEXUS_SUCCESS) {
+                freeRam += static_cast<uint64_t>(status.free);
+            }
+        }
+#endif
+#if NEXUS_MEMC2_GRAPHICS_HEAP
+        if (_platformConfig.heap[NEXUS_MEMC2_GRAPHICS_HEAP]) {
+            rc = NEXUS_Heap_GetStatus(_platformConfig.heap[NEXUS_MEMC2_GRAPHICS_HEAP], &status);
+            if (rc == NEXUS_SUCCESS) {
+                freeRam  += static_cast<uint64_t>(status.free);
+            }
+        }
+#endif
+        return (freeRam);
+    }
+
+    // Connection Properties interface
+    uint32_t Register(Exchange::IConnectionProperties::INotification* notification) override
+    {
+        _adminLock.Lock();
+
+        // Make sure a sink is not registered multiple times.
+        ASSERT(std::find(_observers.begin(), _observers.end(), notification) == _observers.end());
+
+        _observers.push_back(notification);
+        notification->AddRef();
+
+        _adminLock.Unlock();
+
+        return (Core::ERROR_NONE);
+    }
+    uint32_t Unregister(Exchange::IConnectionProperties::INotification* notification) override
+    {
+        _adminLock.Lock();
+
+        std::list<IConnectionProperties::INotification*>::iterator index(std::find(_observers.begin(), _observers.end(), notification));
+
+        // Make sure you do not unregister something you did not register !!!
+        ASSERT(index != _observers.end());
+
+        if (index != _observers.end()) {
+            (*index)->Release();
+            _observers.erase(index);
+        }
+
+        _adminLock.Unlock();
+
+        return (Core::ERROR_NONE);
+    }
+
+    void Dispatch() const
+    {
+        _adminLock.Lock();
+
+        std::list<IConnectionProperties::INotification*>::const_iterator index = _observers.begin();
+
+        if (index != _observers.end()) {
+            (*index)->Updated();
+        }
+
+        _adminLock.Unlock();
+    }
+
+    bool IsAudioPassthrough () const override
+    {
+        return _audioPassthrough;
+    }
+    bool Connected() const override
+    {
+        return _connected;
+    }
+    uint32_t Width() const override
+    {
+        return _width;
+    }
+    uint32_t Height() const override
+    {
+        return _height;
+    }
+    uint8_t HDCPMajor() const override
+    {
+        return _major;
+    }
+    uint8_t HDCPMinor() const override
+    {
+        return _minor;
+    }
+    HDRType Type() const override
+    {
+        return _type;
+    }
+
+
+    uint32_t Register(Exchange::IDisplayProperties::INotification* sink)
+    {
+        _adminLock.Lock();
+
+        // Make sure a sink is not registered multiple times.
+        ASSERT(std::find(_notificationClients.begin(), _notificationClients.end(), sink) == _notificationClients.end());
+
+        _notificationClients.push_back(sink);
+        sink->AddRef();
+
+        _adminLock.Unlock();
+
+        TRACE_L1("IDisplayProperties : Registered a subscriber %p", sink);
+        return (Core::ERROR_NONE);
+    }
+
+    uint32_t Unregister(Exchange::IDisplayProperties::INotification* sink)
+    {
+        _adminLock.Lock();
+
+        std::list<IDisplayProperties::INotification*>::iterator index(std::find(_notificationClients.begin(), _notificationClients.end(), sink));
+
+        // Make sure you do not unregister something you did not register !!!
+        ASSERT(index != _notificationClients.end());
+
+        if (index != _notificationClients.end()) {
+            (*index)->Release();
+            _notificationClients.erase(index);
+            TRACE_L1("IDisplayProperties : unregistered a subscriber %p", sink);
+        }
+
+        _adminLock.Unlock();
+        return (Core::ERROR_NONE);
+    }
+
+    static void ResolutionPreChange(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
+    {
+        if(DisplayInfoImplementation::_instance)
+        {
+           DisplayInfoImplementation::_instance->ResolutionPreChangeImpl();
+        }
+    }
+
+    void ResolutionPreChangeImpl()
+    {
+        _adminLock.Lock();
+
+        std::list<Exchange::IDisplayProperties::INotification*>::const_iterator index = _notificationClients.begin();
+
+        if (index != _notificationClients.end()) {
+            (*index)->ResolutionPreChange();
+        }
+
+        _adminLock.Unlock();
+    }
+
+    static void ResolutionPostChange(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
+    {
+        int dw = 1280;
+        int dh = 720;
+
+        if (strcmp(owner, IARM_BUS_DSMGR_NAME) == 0)
+        {
+            switch (eventId) {
+                case IARM_BUS_DSMGR_EVENT_RES_POSTCHANGE:
+                    IARM_Bus_DSMgr_EventData_t *eventData = (IARM_Bus_DSMgr_EventData_t *)data;
+                    dw = eventData->data.resn.width;
+                    dh = eventData->data.resn.height;
+                    break;
+            }
+        }
+
+        if(DisplayInfoImplementation::_instance)
+        {
+           DisplayInfoImplementation::_instance->ResolutionPostChangeImpl(dh, dw);
+        }
+    }
+
+    void ResolutionPostChangeImpl(int dh, int dw)
+    {
+        TRACE(Trace::Information, (_T("ResolutionPostChangeImpl width = %d, heght = %d"), dw, dh));
+        string connectedDisplay = getConnectedVideoDisplay();
+        string resolution = getCurrentResolution();
+
+        _adminLock.Lock();
+
+        std::list<Exchange::IDisplayProperties::INotification*>::const_iterator index = _notificationClients.begin();
+
+        if (index != _notificationClients.end()) {
+            (*index)->ResolutionChanged(dh, dw, connectedDisplay, resolution);
+        }
+        _adminLock.Unlock();
+    }
+
+    string getCurrentResolution() const override
+    {
+        string currentResolution = "0";
+        try
+        {
+            device::VideoOutputPort &vPort = device::Host::getInstance().getVideoOutputPort("HDMI0");
+            currentResolution = vPort.getResolution().getName();
+            TRACE(Trace::Information, (_T("Current video playback resolution = %s"), currentResolution));
+        }
+        catch(const device::Exception& err)
+        {
+            TRACE(Trace::Error, (_T("Exception during DeviceSetting library call. code = %d message = %s"), err.getCode(), err.what()));
+        }
+        return currentResolution;
+    }
+
+    string getConnectedVideoDisplay() const override
+    {
+        string displayName;
+        try
+        {
+            device::List<device::VideoOutputPort> vPorts = device::Host::getInstance().getVideoOutputPorts();
+            for (size_t i = 0; i < vPorts.size(); i++)
+            {
+                device::VideoOutputPort &vPort = vPorts.at(i);
+                if (vPort.isDisplayConnected())
+                {
+                    string portName = vPort.getName();
+                    displayName = displayName.empty()?  portName : ", " + portName;
+                }
+            }
+            TRACE(Trace::Information, (_T("Connected Video Display = %s"), displayName));
+        }
+        catch(const device::Exception& err)
+        {
+            TRACE(Trace::Error, (_T("Exception during DeviceSetting library call. code = %d message = %s"), err.getCode(), err.what()));
+        }
+        return displayName;
+    }
+
+    void getTvHdrCapabilities(string& hdrCapabilities, int& capabilities) const override
+    {
+        capabilities = static_cast<int>(dsHDRSTANDARD_NONE);
+        try
+        {
+            device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort("HDMI0");
+            if (vPort.isDisplayConnected()) {
+                vPort.getTVHDRCapabilities(&capabilities);
+            }
+            else {
+                TRACE(Trace::Error, (_T("getTVHDRCapabilities failure: HDMI0 not connected!")));
+            }
+        }
+        catch(const device::Exception& err)
+        {
+            TRACE(Trace::Error, (_T("Exception during DeviceSetting library call. code = %d message = %s"), err.getCode(), err.what()));
+        }
+        if(!capabilities)hdrCapabilities.append("none,");
+        if(capabilities & dsHDRSTANDARD_HDR10)hdrCapabilities.append("HDR10,");
+        if(capabilities & dsHDRSTANDARD_HLG)hdrCapabilities.append("HLG,");
+        if(capabilities & dsHDRSTANDARD_DolbyVision)hdrCapabilities.append("DolbyVision,");
+        if(capabilities & dsHDRSTANDARD_TechnicolorPrime)hdrCapabilities.append("TechnicolorPrime,");
+        if(capabilities & dsHDRSTANDARD_Invalid)hdrCapabilities.append("Invalid,");
+
+        TRACE(Trace::Information, (_T("TV HDR capabilities = %s"), hdrCapabilities.c_str()));
+    }
+
+    void getStbHdrCapabilities(string& hdrCapabilities, int& capabilities) const override
+    {
+        capabilities = static_cast<int>(dsHDRSTANDARD_NONE);
+        try
+        {
+            device::VideoDevice &device = device::Host::getInstance().getVideoDevices().at(0);
+            device.getHDRCapabilities(&capabilities);
+        }
+        catch(const device::Exception& err)
+        {
+            TRACE(Trace::Error, (_T("Exception during DeviceSetting library call. code = %d message = %s"), err.getCode(), err.what()));
+        }
+
+        if(!capabilities)hdrCapabilities.append("none,");
+        if(capabilities & dsHDRSTANDARD_HDR10)hdrCapabilities.append("HDR10,");
+        if(capabilities & dsHDRSTANDARD_HLG)hdrCapabilities.append("HLG,");
+        if(capabilities & dsHDRSTANDARD_DolbyVision)hdrCapabilities.append("DolbyVision,");
+        if(capabilities & dsHDRSTANDARD_TechnicolorPrime)hdrCapabilities.append("TechnicolorPrime,");
+        if(capabilities & dsHDRSTANDARD_Invalid)hdrCapabilities.append("Invalid,");
+
+        TRACE(Trace::Information, (_T("STB HDR capabilities = %s"), hdrCapabilities.c_str()));
+    }
+
+    bool isOutputHDR() const override
+    {
+        bool isHdr = false;
+        try
+        {
+            device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort("HDMI0");
+            if (vPort.isDisplayConnected()) {
+                isHdr = vPort.IsOutputHDR();
+            }
+            else
+            {
+                TRACE(Trace::Information, (_T("IsOutputHDR failure: HDMI0 not connected!")));
+            }
+        }
+        catch(const device::Exception& err)
+        {
+            TRACE(Trace::Error, (_T("Exception during DeviceSetting library call. code = %d message = %s"), err.getCode(), err.what()));
+        }
+        TRACE(Trace::Information, (_T("Output HDR = %s"), isHdr ? "Yes" : "No"));
+        return isHdr;
+    }
+
+    int getHdmiPreferences() const override
+    {
+        int hdcpversion = 0;
+        try
+        {
+            device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort("HDMI0");
+            if (vPort.isDisplayConnected()) {
+                hdcpversion = vPort.GetHdmiPreference();
+            }
+            else
+            {
+                TRACE(Trace::Information, (_T("getHdmiPreferences failure: HDMI0 not connected!")));
+            }
+        }
+        catch(const device::Exception& err)
+        {
+            TRACE(Trace::Error, (_T("Exception during DeviceSetting library call. code = %d message = %s"), err.getCode(), err.what()));
+        }
+        TRACE(Trace::Information, (_T("getHdmiPreferences failure: HDCP protocol in use = %d"), hdcpversion));
+        return hdcpversion;
+    }
+
+    void setHdmiPreferences(const int HdcpProtocol) override
+    {
+        dsHdcpProtocolVersion_t hdcpCurrentProtocol = static_cast<dsHdcpProtocolVersion_t>(HdcpProtocol);
+        try
+        {
+            device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort("HDMI0");
+            if (vPort.isDisplayConnected())
+            {
+                vPort.SetHdmiPreference(hdcpCurrentProtocol);
+            }
+            else
+            {
+                TRACE(Trace::Warning, (_T("setHdmiPreferences failure: HDMI0 not connected!")));
+            }
+        }
+        catch(const device::Exception& err)
+        {
+            TRACE(Trace::Error, (_T("Exception during DeviceSetting library call. code = %d message = %s"), err.getCode(), err.what()));
+        }
+    }
+
+    bool isAudioEquivalenceEnabled() const override
+    {
+        bool isEnbaled = false;
+        try
+        {
+            device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort("HDMI0");
+            if (aPort.isConnected()) {
+                isEnbaled = aPort.GetLEConfig();
+            }
+            else
+            {
+                TRACE(Trace::Information, (_T("isAudioEquivalenceEnabled failure: HDMI0 not connected!")));
+            }
+        }
+        catch(const device::Exception& err)
+        {
+            TRACE(Trace::Error, (_T("Exception during DeviceSetting library call. code = %d message = %s"), err.getCode(), err.what()));
+        }
+        TRACE(Trace::Information, (_T("Audio Equivalence = %d"), isEnbaled? "Enabled":"Disabled"));
+        return isEnbaled;
+    }
+
+    string readEDID() const override
+    {
+        std::vector<uint8_t> edidVec({'u','n','k','n','o','w','n' });
+        try
+        {
+            vector<uint8_t> edidVec2;
+            device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort("HDMI0");
+            if (vPort.isDisplayConnected())
+            {
+                vPort.getDisplay().getEDIDBytes(edidVec2);
+                edidVec = edidVec2;//edidVec must be "unknown" unless we successfully get to this line
+            }
+            else
+            {
+                TRACE(Trace::Warning, (_T("readEDID failure: HDMI0 not connected!")));
+            }
+        }
+        catch (const device::Exception& err)
+        {
+            TRACE(Trace::Error, (_T("Exception during DeviceSetting library call. code = %d message = %s"), err.getCode(), err.what()));
+        }
+        //convert to base64
+        uint16_t size = min(edidVec.size(), (size_t)numeric_limits<uint16_t>::max());
+        if(edidVec.size() > (size_t)numeric_limits<uint16_t>::max())
+            TRACE(Trace::Error, (_T("Size too large to use ToString base64 wpe api")));
+        string edidbase64;
+        Core::ToString((uint8_t*)&edidVec[0], size, false, edidbase64);
+        return edidbase64;
+    }
+
+
+    BEGIN_INTERFACE_MAP(DisplayInfoImplementation)
+        INTERFACE_ENTRY(Exchange::IGraphicsProperties)
+        INTERFACE_ENTRY(Exchange::IDisplayProperties)
+        INTERFACE_ENTRY(Exchange::IConnectionProperties)
+    END_INTERFACE_MAP
+
+private:
+    inline void UpdateTotalGpuRam(uint64_t& totalRam) const
+    {
+        NEXUS_MemoryStatus status;
+        NEXUS_Error rc = NEXUS_UNKNOWN;
+
+#if NEXUS_MEMC0_GRAPHICS_HEAP
+        if (_platformConfig.heap[NEXUS_MEMC0_GRAPHICS_HEAP]) {
+            rc = NEXUS_Heap_GetStatus(_platformConfig.heap[NEXUS_MEMC0_GRAPHICS_HEAP], &status);
+            if (rc == NEXUS_SUCCESS) {
+                totalRam = static_cast<uint64_t>(status.size);
+            }
+        }
+#endif
+#if NEXUS_MEMC1_GRAPHICS_HEAP
+        if (_platformConfig.heap[NEXUS_MEMC1_GRAPHICS_HEAP]) {
+            rc = NEXUS_Heap_GetStatus(_platformConfig.heap[NEXUS_MEMC1_GRAPHICS_HEAP], &status);
+            if (rc == NEXUS_SUCCESS) {
+                totalRam += static_cast<uint64_t>(status.size);
+            }
+        }
+#endif
+#if NEXUS_MEMC2_GRAPHICS_HEAP
+        if (_platformConfig.heap[NEXUS_MEMC2_GRAPHICS_HEAP]) {
+            rc = NEXUS_Heap_GetStatus(_platformConfig.heap[NEXUS_MEMC2_GRAPHICS_HEAP], &status);
+            if (rc == NEXUS_SUCCESS) {
+                totalRam += static_cast<uint64_t>(status.size);
+            }
+        }
+#endif
+    }
+
+    inline void UpdateAudioPassthrough(bool& audioPassthrough)
+    {
+        NxClient_AudioStatus status;
+        NEXUS_Error rc = NEXUS_UNKNOWN;
+        rc = NxClient_GetAudioStatus(&status);
+        if (rc == NEXUS_SUCCESS) {
+            if ((status.hdmi.outputMode != NxClient_AudioOutputMode_eNone) && (status.hdmi.outputMode < NxClient_AudioOutputMode_eMax)) {
+                audioPassthrough = true;
+            }
+        }
+    }
+    inline void UpdateDisplayInfo(bool& connected, uint32_t& width, uint32_t& height, uint8_t& major, uint8_t& minor, HDRType type) const
+    {
+        NEXUS_Error rc = NEXUS_SUCCESS;
+
+        NEXUS_HdmiOutputHandle hdmiOutput;
+        hdmiOutput = NEXUS_HdmiOutput_Open(NEXUS_ALIAS_ID + 0, NULL);
+        if (hdmiOutput) {
+            NEXUS_HdmiOutputStatus status;
+            rc = NEXUS_HdmiOutput_GetStatus(hdmiOutput, &status);
+            if (rc == NEXUS_SUCCESS) {
+                connected = status.connected;
+            }
+
+            NxClient_DisplaySettings displaySettings;
+            NxClient_GetDisplaySettings(&displaySettings);
+#if defined(DISPLAYINFO_BCM_VERSION_MAJOR) && (DISPLAYINFO_BCM_VERSION_MAJOR > 18)
+            // Read HDR status
+            switch (displaySettings.hdmiPreferences.dynamicRangeMode) {
+            case NEXUS_VideoDynamicRangeMode_eHdr10: {
+                type = HDR_10;
+                break;
+            }
+            case NEXUS_VideoDynamicRangeMode_eHdr10Plus: {
+                type = HDR_10PLUS;
+                break;
+            }
+#else
+            switch  (displaySettings.hdmiPreferences.drmInfoFrame.eotf) {
+            case NEXUS_VideoEotf_eHdr10: {
+                type = HDR_10;
+                break;
+            }
+#endif
+            default:
+                break;
+            }
+
+
+            // Check HDCP version
+            NEXUS_HdmiOutputHdcpStatus hdcpStatus;
+            rc = NEXUS_HdmiOutput_GetHdcpStatus(hdmiOutput, &hdcpStatus);
+
+            if (rc  == NEXUS_SUCCESS) {
+#if defined(DISPLAYINFO_BCM_VERSION_MAJOR) && (DISPLAYINFO_BCM_VERSION_MAJOR >= 18)
+                if (hdcpStatus.selectedHdcpVersion == NEXUS_HdcpVersion_e2x) {
+#else
+                if (hdcpStatus.hdcp2_2Features == true) {
+#endif
+                    major = 2;
+                    minor = 2;
+                } else {
+                    major = 1;
+                    minor = 1;
+                }
+            } else {
+                major = 0;
+                minor = 0;
+            }
+        }
+
+        // Read display width and height
+        NEXUS_DisplayCapabilities capabilities;
+        NEXUS_GetDisplayCapabilities(&capabilities);
+        width = capabilities.display[0].graphics.width;
+        height = capabilities.display[0].graphics.height;
+    }
+
+    void RegisterCallback()
+    {
+        NxClient_CallbackThreadSettings settings;
+        NxClient_GetDefaultCallbackThreadSettings(&settings);
+
+        settings.hdmiOutputHotplug.callback = Callback;
+        settings.hdmiOutputHotplug.context = reinterpret_cast<void*>(this);
+        settings.hdmiOutputHotplug.param = 0;
+
+        settings.displaySettingsChanged.callback = Callback;
+        settings.displaySettingsChanged.context = reinterpret_cast<void*>(this);
+        settings.displaySettingsChanged.param = 1;
+
+        if (NxClient_StartCallbackThread(&settings) != NEXUS_SUCCESS) {
+            TRACE_L1(_T("Error in starting nexus callback thread"));
+        }
+    }
+    static void Callback(void *cbData, int param)
+    {
+        DisplayInfoImplementation* platform = static_cast<DisplayInfoImplementation*>(cbData);
+
+        switch (param) {
+        case 0:
+        case 1: {
+            platform->UpdateDisplayInfo();
+            break;
+        }
+        default:
+            break;
+        }
+    }
+    void UpdateDisplayInfo()
+    {
+        _adminLock.Lock();
+        UpdateDisplayInfo(_connected, _width, _height, _major, _minor, _type);
+        _adminLock.Unlock();
+
+        _activity.Submit();
+    }
+
+private:
+    uint32_t _width;
+    uint32_t _height;
+    bool _connected;
+
+    uint8_t _major;
+    uint8_t _minor;
+    HDRType _type;
+
+    uint64_t _totalGpuRam;
+    bool _audioPassthrough;
+
+    std::list<IConnectionProperties::INotification*> _observers;
+    std::list<Exchange::IDisplayProperties::INotification*> _notificationClients;
+
+    NEXUS_PlatformConfiguration _platformConfig;
+
+    mutable Core::CriticalSection _adminLock;
+
+    Core::WorkerPool::JobType<DisplayInfoImplementation&> _activity;
+    public:
+    static DisplayInfoImplementation* _instance;
+};
+    DisplayInfoImplementation* DisplayInfoImplementation::_instance = nullptr;
+    SERVICE_REGISTRATION(DisplayInfoImplementation, 1, 0);
+}
+}

--- a/DisplayInfo/DisplayInfo.cpp
+++ b/DisplayInfo/DisplayInfo.cpp
@@ -16,8 +16,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 #include "DisplayInfo.h"
+#include <string>
 
 namespace WPEFramework {
 namespace Plugin {
@@ -48,6 +49,8 @@ namespace Plugin {
                 _connectionProperties = nullptr;
             } else {
                 _notification.Initialize(_connectionProperties);
+                _displayProperties = _connectionProperties->QueryInterface<Exchange::IDisplayProperties>();
+                if (_displayProperties) _notification.Initialize(_displayProperties);
             }
         }
 
@@ -74,6 +77,12 @@ namespace Plugin {
         if (_connectionProperties != nullptr) {
             _connectionProperties->Release();
             _connectionProperties = nullptr;
+        }
+
+        if (_displayProperties != nullptr)
+        {
+            _displayProperties->Release();
+            _displayProperties = nullptr;
         }
 
         _connectionId = 0;
@@ -133,6 +142,81 @@ namespace Plugin {
         displayInfo.Hdcpminor = _connectionProperties->HDCPMinor();
         displayInfo.Hdrtype = static_cast<JsonData::DisplayInfo::DisplayinfoData::HdrtypeType>(_connectionProperties->Type());
     }
+
+    void DisplayInfo::getCurrentResolution(JsonData::DisplayInfo::VideoPlaybackResolutionData& playbackResolution) const
+    {
+        playbackResolution.VideoPlaybackResolution = _displayProperties->getCurrentResolution();
+    }
+
+    void DisplayInfo::getConnectedVideoDisplay(JsonData::DisplayInfo::VideoOutputPortNameData& connectedDisplay) const
+    {
+        connectedDisplay.VideoOutputPortName = _displayProperties->getConnectedVideoDisplay();
+    }
+
+    void DisplayInfo::getTVHDRCapabilities(JsonData::DisplayInfo::TvHdrCapabilitesData& TvHdrCaps) const
+    {
+        string hdrCaps("");
+        int capabilities = 0;
+        _displayProperties->getTvHdrCapabilities(hdrCaps, capabilities);
+        string delim = ",";
+        size_t pos = 0;
+        string token;
+        while ((pos = hdrCaps.find(delim)) != string::npos)
+        {
+            Core::JSON::String hdrCap;
+            token = hdrCaps.substr(0, pos);
+            hdrCap.FromString(_T(token));
+            TvHdrCaps.TvHdrCapabilites.Add(hdrCap);
+            hdrCaps.erase(0, pos + delim.length());
+        }
+        TvHdrCaps.Capabilities = capabilities;
+    }
+
+    void DisplayInfo::getSettopHDRSupport(JsonData::DisplayInfo::StbHdrCapabilitiesData& StbHdrCaps) const
+    {
+        string hdrCaps("");
+        int capabilities = 0;
+        _displayProperties->getStbHdrCapabilities(hdrCaps, capabilities);
+        string delim = ",";
+        size_t pos = 0;
+        string token;
+        while ((pos = hdrCaps.find(delim)) != string::npos)
+        {
+            Core::JSON::String hdrCap;
+            token = hdrCaps.substr(0, pos);
+            hdrCap.FromString(_T(token));
+            StbHdrCaps.StbHdrCapabilities.Add(hdrCap);
+            hdrCaps.erase(0, pos + delim.length());
+        }
+        StbHdrCaps.Capabilities = capabilities;
+    }
+
+    void DisplayInfo::IsOutputHDR(JsonData::DisplayInfo::OutputHdrStatusData& OutputHdr) const
+    {
+        OutputHdr.IsOutputHDR = _displayProperties->isOutputHDR();
+    }
+
+    void DisplayInfo::getHdmiPreferences(JsonData::DisplayInfo::HdmiPreferencesData& HdmiPref) const
+    {
+        int hdcpversion = _displayProperties->getHdmiPreferences();
+        if(hdcpversion) HdmiPref.CurrentHdcpProtocol = hdcpversion;
+    }
+
+    void DisplayInfo::setHdmiPreferences(const JsonData::DisplayInfo::HdmiPreferencesData& HdmiPref)
+    {
+        _displayProperties->setHdmiPreferences(HdmiPref.CurrentHdcpProtocol.Value());
+    }
+
+    void DisplayInfo::isAudioEquivalenceEnabled(JsonData::DisplayInfo::AudioEquivalenceStatusData& AudioEq) const
+    {
+        AudioEq.IsAudioEquivalenceEnabled = _displayProperties->isAudioEquivalenceEnabled();
+    }
+
+    void DisplayInfo::readEDID(JsonData::DisplayInfo::EDIDData& EDIDData) const
+    {
+        EDIDData.EdidData = _displayProperties->readEDID();
+    }
+
 
 } // namespace Plugin
 } // namespace WPEFramework

--- a/DisplayInfo/DisplayInfo.h
+++ b/DisplayInfo/DisplayInfo.h
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 #pragma once
 
 #include "Module.h"
@@ -28,7 +28,7 @@ namespace Plugin {
 
     class DisplayInfo : public PluginHost::IPlugin, public PluginHost::IWeb, public PluginHost::JSONRPC {
     private:private:
-        class Notification : protected Exchange::IConnectionProperties::INotification {
+        class Notification : protected Exchange::IConnectionProperties::INotification, Exchange::IDisplayProperties::INotification {
         private:
             Notification() = delete;
             Notification(const Notification&) = delete;
@@ -51,6 +51,15 @@ namespace Plugin {
                 _client->AddRef();
                 _client->Register(this);
             }
+
+            void Initialize(Exchange::IDisplayProperties* client)
+            {
+                ASSERT(client != nullptr);
+                _clientDisplay = client;
+                _clientDisplay->AddRef();
+                _clientDisplay->Register(this);
+            }
+
             void Deinitialize()
             {
                 ASSERT(_client != nullptr);
@@ -59,18 +68,38 @@ namespace Plugin {
                     _client->Release();
                     _client = nullptr;
                 }
+
+                ASSERT(_clientDisplay != nullptr);
+                if (_clientDisplay != nullptr) {
+                    _clientDisplay->Unregister(this);
+                    _clientDisplay->Release();
+                    _clientDisplay = nullptr;
+                }
             }
             void Updated() override
             {
                 _parent.Updated();
             }
+
+            void ResolutionPreChange()
+            {
+                _parent.resolutionPreChanged();
+            }
+
+            void ResolutionChanged(const int32_t& height, const int32_t& width, const string& videoOutputPort, const string& resolution) override
+            {
+                _parent.resolutionchanged(height, width, videoOutputPort, resolution);
+            }
+
             BEGIN_INTERFACE_MAP(Notification)
             INTERFACE_ENTRY(Exchange::IConnectionProperties::INotification)
+            INTERFACE_ENTRY(Exchange::IDisplayProperties::INotification)
             END_INTERFACE_MAP
 
         private:
             DisplayInfo& _parent;
             Exchange::IConnectionProperties* _client;
+            Exchange::IDisplayProperties* _clientDisplay;
         };
 
     public:
@@ -82,6 +111,7 @@ namespace Plugin {
             , _connectionId(0)
             , _graphicsProperties(nullptr)
             , _connectionProperties(nullptr)
+            , _displayProperties(nullptr)
             , _notification(this)
         {
             RegisterAll();
@@ -115,20 +145,52 @@ namespace Plugin {
             event_updated();
         }
 
+        void resolutionPreChanged()
+        {
+            resolutionPreChangedJrpc();
+        }
+
+        void resolutionchanged(const int32_t& height, const int32_t& width, const string& videoOutputPort, const string& resolution)
+        {
+            resolutionChangedJrpc(height, width, videoOutputPort, resolution);
+        }
+
     private:
         // JsonRpc
         void RegisterAll();
         void UnregisterAll();
         uint32_t get_displayinfo(JsonData::DisplayInfo::DisplayinfoData&) const;
+        uint32_t getCurrentResolutionJrpc(JsonData::DisplayInfo::VideoPlaybackResolutionData&) const;
+        uint32_t getConnectedVideoDisplayJrpc(JsonData::DisplayInfo::VideoOutputPortNameData&) const;
+        uint32_t getTVHDRCapabilitiesJrpc(JsonData::DisplayInfo::TvHdrCapabilitesData&) const;
+        uint32_t getSettopHDRSupportJrpc(JsonData::DisplayInfo::StbHdrCapabilitiesData&) const;
+        uint32_t IsOutputHDRJrpc(JsonData::DisplayInfo::OutputHdrStatusData&) const;
+        uint32_t getHdmiPreferencesJrpc(JsonData::DisplayInfo::HdmiPreferencesData&) const;
+        uint32_t setHdmiPreferencesJrpc(const JsonData::DisplayInfo::HdmiPreferencesData&);
+        uint32_t isAudioEquivalenceEnabledJrpc(JsonData::DisplayInfo::AudioEquivalenceStatusData&) const;
+        uint32_t readEDIDJrpc(JsonData::DisplayInfo::EDIDData&) const;
+
         void event_updated();
+        void resolutionPreChangedJrpc();
+        void resolutionChangedJrpc(const int32_t& height, const int32_t& width, const string& videoOutputPort, const string& resolution);
 
         void Info(JsonData::DisplayInfo::DisplayinfoData&) const;
+        void getCurrentResolution(JsonData::DisplayInfo::VideoPlaybackResolutionData&) const;
+        void getConnectedVideoDisplay(JsonData::DisplayInfo::VideoOutputPortNameData&) const;
+        void getTVHDRCapabilities(JsonData::DisplayInfo::TvHdrCapabilitesData&) const;
+        void getSettopHDRSupport(JsonData::DisplayInfo::StbHdrCapabilitiesData&) const;
+        void IsOutputHDR(JsonData::DisplayInfo::OutputHdrStatusData&) const;
+        void getHdmiPreferences(JsonData::DisplayInfo::HdmiPreferencesData&) const;
+        void setHdmiPreferences(const JsonData::DisplayInfo::HdmiPreferencesData&);
+        void isAudioEquivalenceEnabled(JsonData::DisplayInfo::AudioEquivalenceStatusData &) const;
+        void readEDID(JsonData::DisplayInfo::EDIDData &) const;
 
     private:
         uint8_t _skipURL;
         uint32_t _connectionId;
         Exchange::IGraphicsProperties* _graphicsProperties;
         Exchange::IConnectionProperties* _connectionProperties;
+        Exchange::IDisplayProperties* _displayProperties;
         Core::Sink<Notification> _notification;
     };
 

--- a/DisplayInfo/DisplayInfoJsonRpc.cpp
+++ b/DisplayInfo/DisplayInfoJsonRpc.cpp
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 #include "DisplayInfo.h"
 
 namespace WPEFramework {
@@ -31,11 +31,27 @@ namespace Plugin {
     void DisplayInfo::RegisterAll()
     {
         Property<DisplayinfoData>(_T("displayinfo"), &DisplayInfo::get_displayinfo, nullptr, this);
+        Property<VideoPlaybackResolutionData>(_T("getCurrentResolution"), &DisplayInfo::getCurrentResolutionJrpc, nullptr, this);
+        Property<VideoOutputPortNameData>(_T("getConnectedVideoDisplays"), &DisplayInfo::getConnectedVideoDisplayJrpc, nullptr, this);
+        Property<TvHdrCapabilitesData>(_T("getTVHDRCapabilities"), &DisplayInfo::getTVHDRCapabilitiesJrpc, nullptr, this);
+        Property<StbHdrCapabilitiesData>(_T("getSettopHDRSupport"), &DisplayInfo::getSettopHDRSupportJrpc, nullptr, this);
+        Property<OutputHdrStatusData>(_T("IsOutputHDR"), &DisplayInfo::IsOutputHDRJrpc, nullptr, this);
+        Property<HdmiPreferencesData>(_T("HdmiPreferences"), &DisplayInfo::getHdmiPreferencesJrpc, &DisplayInfo::setHdmiPreferencesJrpc, this);
+        Property<AudioEquivalenceStatusData>(_T("isAudioEquivalenceEnabled"), &DisplayInfo::isAudioEquivalenceEnabledJrpc, nullptr, this);
+        Property<EDIDData>(_T("readEDID"), &DisplayInfo::readEDIDJrpc, nullptr, this);
     }
 
     void DisplayInfo::UnregisterAll()
     {
         Unregister(_T("displayinfo"));
+        Unregister(_T("getCurrentResolution"));
+        Unregister(_T("getConnectedVideoDisplays"));
+        Unregister(_T("getTVHDRCapabilities"));
+        Unregister(_T("getSettopHDRSupport"));
+        Unregister(_T("IsOutputHDR"));
+        Unregister(_T("HdmiPreferences"));
+        Unregister(_T("isAudioEquivalenceEnabled"));
+        Unregister(_T("readEDID"));
     }
 
     // API implementation
@@ -50,11 +66,82 @@ namespace Plugin {
         return Core::ERROR_NONE;
     }
 
+    uint32_t DisplayInfo::getCurrentResolutionJrpc(VideoPlaybackResolutionData& response) const
+    {
+        getCurrentResolution(response);
+        return Core::ERROR_NONE;
+    }
+
+    uint32_t DisplayInfo::getConnectedVideoDisplayJrpc(VideoOutputPortNameData& response) const
+    {
+        getConnectedVideoDisplay(response);
+        return Core::ERROR_NONE;
+    }
+
+    uint32_t DisplayInfo::getTVHDRCapabilitiesJrpc(TvHdrCapabilitesData& response) const
+    {
+        getTVHDRCapabilities(response);
+        return Core::ERROR_NONE;
+    }
+
+    uint32_t DisplayInfo::getSettopHDRSupportJrpc(StbHdrCapabilitiesData& response) const
+    {
+        getSettopHDRSupport(response);
+        return Core::ERROR_NONE;
+    }
+
+    uint32_t DisplayInfo::IsOutputHDRJrpc(OutputHdrStatusData& response) const
+    {
+        IsOutputHDR(response);
+        return Core::ERROR_NONE;
+    }
+
+    uint32_t DisplayInfo::getHdmiPreferencesJrpc(HdmiPreferencesData& response) const
+    {
+        getHdmiPreferences(response);
+        return Core::ERROR_NONE;
+    }
+
+    uint32_t DisplayInfo::setHdmiPreferencesJrpc(const HdmiPreferencesData& param)
+    {
+        setHdmiPreferences(param);
+        return Core::ERROR_NONE;
+    }
+
+    uint32_t DisplayInfo::isAudioEquivalenceEnabledJrpc(AudioEquivalenceStatusData& response) const
+    {
+        isAudioEquivalenceEnabled(response);
+        return Core::ERROR_NONE;
+    }
+
+    uint32_t DisplayInfo::readEDIDJrpc(EDIDData& response) const
+    {
+        readEDID(response);
+        return Core::ERROR_NONE;
+    }
+
     // Event: updated - Notifies about a change/update in the connection
    void DisplayInfo::event_updated()
    {
         Notify(_T("updated"));
    }
+
+    void DisplayInfo::resolutionPreChangedJrpc()
+   {
+       Notify(_T("ResolutionPreChange"));
+   }
+
+   void DisplayInfo::resolutionChangedJrpc(const int32_t& height, const int32_t& width, const string& videoOutputPort, const string& resolution)
+   {
+       ResolutionChangedParamsData params;
+       params.Height = height;
+       params.Width = width;
+       params.VideoOutputPort = videoOutputPort;
+       params.Resolution = resolution;
+       Notify(_T("ResolutionPostChange"), params);
+   }
+
+
 } // namespace Plugin
 
 }

--- a/PlayerInfo/CMakeLists.txt
+++ b/PlayerInfo/CMakeLists.txt
@@ -39,7 +39,29 @@ target_link_libraries(${MODULE_NAME}
 
 find_package(GSTREAMER REQUIRED)
 
-if (GSTREAMER_FOUND)
+if (USE_DEVICESETTINGS AND GSTREAMER_FOUND)
+    find_package(DS REQUIRED)
+    find_package(IARMBus REQUIRED)
+    target_include_directories(${MODULE_NAME} PRIVATE ${IARMBUS_INCLUDE_DIRS})
+    target_include_directories(${MODULE_NAME} PRIVATE ${DS_INCLUDE_DIRS})
+    target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins ${IARMBUS_LIBRARIES} ${DS_LIBRARIES})
+
+    target_sources(${MODULE_NAME}
+        PRIVATE
+            DeviceSettings/PlatformImplementation.cpp
+            ../helpers/utils.cpp)
+    target_include_directories(${MODULE_NAME} PRIVATE ../helpers)
+
+    target_link_libraries(${MODULE_NAME}
+        PRIVATE
+            ${GSTREAMER_LIBRARIES})
+
+    target_include_directories(${MODULE_NAME}
+        PRIVATE
+            ${GSTREAMER_INCLUDES})
+    add_definitions( -Wall -O2 -fexceptions )
+
+elseif (GSTREAMER_FOUND)
     target_sources(${MODULE_NAME}
         PRIVATE
             GStreamer/PlatformImplementation.cpp)
@@ -53,7 +75,7 @@ if (GSTREAMER_FOUND)
             ${GSTREAMER_INCLUDES})
 endif ()
 
-install(TARGETS ${MODULE_NAME} 
+install(TARGETS ${MODULE_NAME}
     DESTINATION lib/${STORAGE_DIRECTORY}/plugins)
 
 write_config(${PLUGIN_NAME})

--- a/PlayerInfo/DeviceSettings/PlatformImplementation.cpp
+++ b/PlayerInfo/DeviceSettings/PlatformImplementation.cpp
@@ -1,0 +1,550 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2020 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "../Module.h"
+#include <interfaces/IPlayerInfo.h>
+#include <gst/gst.h>
+#include "utils.h"
+
+#include "audioOutputPort.hpp"
+#include "audioOutputPortType.hpp"
+#include "videoOutputPort.hpp"
+#include "manager.hpp"
+#include "host.hpp"
+#include "exception.hpp"
+
+#if defined(USE_IARM)
+#include "libIBus.h"
+#include "libIBusDaemon.h"
+#include "dsMgr.h"
+#endif
+
+namespace WPEFramework {
+namespace Plugin {
+
+class PlayerInfoImplementation : public Exchange::IPlayerProperties, public Exchange::IPlayerAtmosProperties {
+private:
+
+    class GstUtils {
+    private:
+        struct FeatureListDeleter {
+            void operator()(GList* p) { gst_plugin_feature_list_free(p); }
+        };
+
+        struct CapsDeleter {
+            void operator()(GstCaps* p) { gst_caps_unref(p); }
+        };
+        typedef std::unique_ptr<GList, FeatureListDeleter> FeatureList;
+        typedef std::unique_ptr<GstCaps, CapsDeleter> MediaTypes;
+
+   public:
+        GstUtils() = delete;
+        GstUtils(const GstUtils&) = delete;
+        GstUtils& operator= (const GstUtils&) = delete;
+
+        template <typename C, typename CodecIteratorList>
+        static bool GstRegistryCheckElementsForMediaTypes(C caps, CodecIteratorList& codecIteratorList) {
+
+            auto type = std::is_same<C, VideoCaps>::value ? GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO : GST_ELEMENT_FACTORY_TYPE_MEDIA_AUDIO;
+
+            FeatureList decoderFactories{gst_element_factory_list_get_elements(GST_ELEMENT_FACTORY_TYPE_DECODER | type, GST_RANK_MARGINAL)};
+            FeatureList parserFactories{gst_element_factory_list_get_elements(GST_ELEMENT_FACTORY_TYPE_PARSER | type, GST_RANK_MARGINAL)};
+
+            FeatureList elements;
+            for (auto index: caps) {
+
+                MediaTypes mediaType{gst_caps_from_string(index.first.c_str())};
+                if (elements = std::move(GstUtils::GstRegistryGetElementForMediaType(decoderFactories.get(), std::move(mediaType)))) {
+                    codecIteratorList.push_back(index.second);
+
+                } else if (elements = std::move(GstUtils::GstRegistryGetElementForMediaType(parserFactories.get(), std::move(mediaType)))) {
+
+                    for (GList* iterator = elements.get(); iterator; iterator = iterator->next) {
+
+                        GstElementFactory* gstElementFactory = static_cast<GstElementFactory*>(iterator->data);
+                        const GList* padTemplates = gst_element_factory_get_static_pad_templates(gstElementFactory);
+
+                        for (const GList* padTemplatesIterator = padTemplates; padTemplatesIterator; padTemplatesIterator = padTemplatesIterator->next) {
+                            GstStaticPadTemplate* padTemplate = static_cast<GstStaticPadTemplate*>(padTemplatesIterator->data);
+
+                            if (padTemplate->direction == GST_PAD_SRC) {
+                                MediaTypes mediaTypes{gst_static_pad_template_get_caps(padTemplate)};
+                                if (GstUtils::GstRegistryGetElementForMediaType(decoderFactories.get(), std::move(mediaTypes))) {
+                                    codecIteratorList.push_back(index.second);
+                                }
+                            }
+                        }
+                    }
+                 }
+             }
+
+             return (codecIteratorList.size() != 0);
+         }
+
+    private:
+        static inline FeatureList GstRegistryGetElementForMediaType(GList* elementsFactories, MediaTypes&& mediaTypes) {
+            FeatureList candidates{gst_element_factory_list_filter(elementsFactories, mediaTypes.get(), GST_PAD_SINK, false)};
+
+            return std::move(candidates);
+        }
+
+    };
+
+private:
+    class AudioIteratorImplementation : public Exchange::IPlayerProperties::IAudioIterator {
+    public:
+        AudioIteratorImplementation() = delete;
+        AudioIteratorImplementation(const AudioIteratorImplementation&) = delete;
+        AudioIteratorImplementation& operator= (const AudioIteratorImplementation&) = delete;
+
+        AudioIteratorImplementation(const std::list<AudioCodec>& codecs)
+            : _index(0)
+            , _codecs(codecs)
+        {
+        }
+        virtual ~AudioIteratorImplementation()
+        {
+            _codecs.clear();
+        }
+
+    public:
+        bool IsValid() const override
+        {
+            return ((_index != 0) && (_index <= _codecs.size()));
+        }
+        bool Next() override
+        {
+            if (_index == 0) {
+                _index = 1;
+            } else if (_index <= _codecs.size()) {
+                _index++;
+            }
+            return (IsValid());
+        }
+        void Reset() override
+        {
+            _index = 0;
+        }
+        AudioCodec Codec() const
+        {
+            ASSERT(IsValid() == true);
+            std::list<AudioCodec>::const_iterator codec = std::next(_codecs.begin(), _index - 1);
+            ASSERT(*codec != AudioCodec::UNDEFINED);
+
+            return *codec;
+        }
+
+        BEGIN_INTERFACE_MAP(AudioIteratorIImplementation)
+        INTERFACE_ENTRY(Exchange::IPlayerProperties::IAudioIterator)
+        END_INTERFACE_MAP
+
+    private:
+        uint16_t _index;
+        std::list<AudioCodec> _codecs;
+    };
+
+    class VideoIteratorImplementation : public Exchange::IPlayerProperties::IVideoIterator {
+    public:
+        VideoIteratorImplementation() = delete;
+        VideoIteratorImplementation(const VideoIteratorImplementation&) = delete;
+        VideoIteratorImplementation& operator= (const VideoIteratorImplementation&) = delete;
+
+        VideoIteratorImplementation(const std::list<VideoCodec>& codecs)
+            : _index(0)
+            , _codecs(codecs)
+        {
+        }
+        virtual ~VideoIteratorImplementation()
+        {
+            _codecs.clear();
+        }
+
+    public:
+        bool IsValid() const override
+        {
+            return ((_index != 0) && (_index <= _codecs.size()));
+        }
+        bool Next() override
+        {
+            if (_index == 0) {
+                _index = 1;
+            } else if (_index <= _codecs.size()) {
+                _index++;
+            }
+            return (IsValid());
+        }
+        void Reset() override
+        {
+            _index = 0;
+        }
+        VideoCodec Codec() const
+        {
+            ASSERT(IsValid() == true);
+            std::list<VideoCodec>::const_iterator codec = std::next(_codecs.begin(), _index - 1);
+
+            ASSERT(*codec != VideoCodec::UNDEFINED);
+
+            return *codec;
+        }
+
+        BEGIN_INTERFACE_MAP(VideoIteratorIImplementation)
+        INTERFACE_ENTRY(Exchange::IPlayerProperties::IVideoIterator)
+        END_INTERFACE_MAP
+
+    private:
+        uint16_t _index;
+        std::list<VideoCodec> _codecs;
+    };
+
+    typedef std::map<const string, const Exchange::IPlayerProperties::IAudioIterator::AudioCodec> AudioCaps;
+    typedef std::map<const string, const Exchange::IPlayerProperties::IVideoIterator::VideoCodec> VideoCaps;
+
+public:
+    PlayerInfoImplementation() {
+        gst_init(0, nullptr);
+        UpdateAudioCodecInfo();
+        UpdateVideoCodecInfo();
+
+         try
+        {
+#if defined(USE_IARM)
+            Utils::IARM::init();
+            IARM_Result_t res;
+            IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_AUDIO_MODE, AudioModeHandler) );
+#endif
+            //TODO: this is probably per process so we either need to be running in our own process or be carefull no other plugin is calling it
+            device::Manager::Initialize();
+            TRACE(Trace::Information, (_T("device::Manager::Initialize success")));
+        }
+        catch(...)
+        {
+            TRACE(Trace::Error, (_T("device::Manager::Initialize failed")));
+        }
+        PlayerInfoImplementation::_instance = this;
+    }
+
+    PlayerInfoImplementation(const PlayerInfoImplementation&) = delete;
+    PlayerInfoImplementation& operator= (const PlayerInfoImplementation&) = delete;
+    virtual ~PlayerInfoImplementation()
+    {
+        IARM_Result_t res;
+        IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_AUDIO_MODE) );
+        _audioCodecs.clear();
+        _videoCodecs.clear();
+        PlayerInfoImplementation::_instance = nullptr;
+    }
+
+public:
+    Exchange::IPlayerProperties::IAudioIterator* AudioCodec() const override
+    {
+        return (Core::Service<AudioIteratorImplementation>::Create<Exchange::IPlayerProperties::IAudioIterator>(_audioCodecs));
+    }
+    Exchange::IPlayerProperties::IVideoIterator* VideoCodec() const override
+    {
+        return (Core::Service<VideoIteratorImplementation>::Create<Exchange::IPlayerProperties::IVideoIterator>(_videoCodecs));
+    }
+
+    uint32_t Register(Exchange::IPlayerAtmosProperties::INotification* sink)
+    {
+        _adminLock.Lock();
+
+        // Make sure a sink is not registered multiple times.
+        ASSERT(std::find(_notificationClients.begin(), _notificationClients.end(), sink) == _notificationClients.end());
+
+        _notificationClients.push_back(sink);
+        sink->AddRef();
+
+        _adminLock.Unlock();
+
+        TRACE_L1("IPlayerAtmosProperties : Registered a subscriber %p", sink);
+        return (Core::ERROR_NONE);
+    }
+
+    uint32_t Unregister(Exchange::IPlayerAtmosProperties::INotification* sink)
+    {
+        _adminLock.Lock();
+
+        std::list<IPlayerAtmosProperties::INotification*>::iterator index(std::find(_notificationClients.begin(), _notificationClients.end(), sink));
+
+        // Make sure you do not unregister something you did not register !!!
+        ASSERT(index != _notificationClients.end());
+
+        if (index != _notificationClients.end()) {
+            (*index)->Release();
+            _notificationClients.erase(index);
+            TRACE_L1("IPlayerAtmosProperties : unregistered a subscriber %p", sink);
+        }
+
+        _adminLock.Unlock();
+        return (Core::ERROR_NONE);
+    }
+
+    string getSinkAtmosCapability() const override
+    {
+        dsATMOSCapability_t atmosCapability;
+        string ret;
+        try
+        {
+            device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort("HDMI0");
+            if (aPort.isConnected())
+            {
+                aPort.getSinkDeviceAtmosCapability(atmosCapability);
+            }
+            else
+            {
+               TRACE(Trace::Error, (_T("getSinkAtmosCapability failure: HDMI0 not connected!\n")));
+            }
+        }
+        catch(const device::Exception& err)
+        {
+            TRACE(Trace::Error, (_T("Exception during DeviceSetting library call. code = %d message = %s"), err.getCode(), err.what()));
+        }
+
+        switch (atmosCapability)
+        {
+            case 0: ret = "unsupported"; break;
+            case 1: ret = "DDPlus"; break;
+            case 2: ret = "Atmos"; break;
+            default: ret = "Unknown"; break;
+        }
+        return ret;
+    }
+
+    string getSoundMode() const override
+    {
+        string audioPort;
+        string modeString;
+        device::AudioStereoMode mode = device::AudioStereoMode::kStereo;  //default to stereo
+
+        try
+        {
+            /* Return the sound mode of the audio ouput connected to the specified videoDisplay */
+            /* Check if HDMI is connected - Return (default) Stereo Mode if not connected */
+
+            if (device::Host::getInstance().getVideoOutputPort("HDMI0").isDisplayConnected())
+            {
+                audioPort = "HDMI0";
+            }
+            else
+            {
+                /*  * If HDMI is not connected
+                    * Get the SPDIF if it is supported by platform
+                    * If Platform does not have connected ports. Default to HDMI.
+                */
+                audioPort = "HDMI0";
+                device::List<device::VideoOutputPort> vPorts = device::Host::getInstance().getVideoOutputPorts();
+                for (size_t i = 0; i < vPorts.size(); i++)
+                {
+                    device::VideoOutputPort &vPort = vPorts.at(i);
+                    if (vPort.isDisplayConnected())
+                    {
+                        audioPort = "SPDIF0";
+                        break;
+                    }
+                }
+            }
+
+            device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
+
+            if (aPort.isConnected())
+            {
+                mode = aPort.getStereoMode();
+
+                if (aPort.getType().getId() == device::AudioOutputPortType::kHDMI)
+                {
+                    /* In DS5, "Surround" implies "Auto" */
+                    if (aPort.getStereoAuto() || mode == device::AudioStereoMode::kSurround)
+                    {
+                        TRACE(Trace::Information, (_T("HDMI0 is in Auto Mode")));
+                        int surroundMode = device::Host::getInstance().getVideoOutputPort("HDMI0").getDisplay().getSurroundMode();
+                        if ( surroundMode & dsSURROUNDMODE_DDPLUS)
+                        {
+                            TRACE(Trace::Information, (_T("HDMI0 has surround DDPlus")));
+                            modeString.append("AUTO (Dolby Digital Plus)");
+                        }
+                        else if (surroundMode & dsSURROUNDMODE_DD)
+                        {
+                            TRACE(Trace::Information, (_T("HDMI0 has surround DD 5.1")));
+                            modeString.append("AUTO (Dolby Digital 5.1)");
+                        }
+                        else
+                        {
+                            TRACE(Trace::Information, (_T("HDMI0 does not surround")));
+                            modeString.append("AUTO (Stereo)");
+                        }
+                    }
+                    else
+                        modeString.append(mode.toString());
+                }
+                else
+                {
+                    if (mode == device::AudioStereoMode::kSurround)
+                        modeString.append("Surround");
+                    else
+                        modeString.append(mode.toString());
+                }
+            }
+            else
+            {
+                /*
+                * VideoDisplay is not connected. Its audio mode is unknown. Return
+                * "Stereo" as safe default;
+                */
+                mode = device::AudioStereoMode::kStereo;
+                modeString.append("AUTO (Stereo)");
+            }
+        }
+        catch (const device::Exception& err)
+        {
+            TRACE(Trace::Error, (_T("Exception during DeviceSetting library call. code = %d message = %s"), err.getCode(), err.what()));
+            //
+            // Exception
+            // "Stereo" as safe default;
+            //
+            mode = device::AudioStereoMode::kStereo;
+            modeString += "AUTO (Stereo)";
+        }
+
+        TRACE(Trace::Information, (_T("audioPort = %s, mode = %s!"), audioPort.c_str(), modeString.c_str()));
+
+        return modeString;
+    }
+
+    void setAudioAtmosOutputMode(const bool enable) override
+    {
+        try
+        {
+            device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort("HDMI0");
+            if (aPort.isConnected()) {
+                aPort.setAudioAtmosOutputMode (enable);
+            }
+            else {
+                TRACE(Trace::Error, (_T("setAudioAtmosOutputMode failure: HDMI0 not connected!\n")));
+            }
+
+        }
+        catch (const device::Exception& err)
+        {
+            TRACE(Trace::Error, (_T("Exception during DeviceSetting library call. code = %d message = %s"), err.getCode(), err.what()));
+        }
+    }
+
+    static void AudioModeHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
+    {
+        switch (eventId)
+        {
+            case IARM_BUS_DSMGR_EVENT_AUDIO_MODE:
+                {
+                    IARM_Bus_DSMgr_EventData_t *eventData = (IARM_Bus_DSMgr_EventData_t *)data;
+                    string  AudioPortMode;
+                    string AudioPortType;
+                    switch (eventData->data.Audioport.mode)
+                    {
+                        case 1: AudioPortMode = "mono"; break;
+                        case 2: AudioPortMode = "stereo"; break;
+                        case 3: AudioPortMode = "surround"; break;
+                        case 4: AudioPortMode = "passthrough"; break;
+                        case 0: AudioPortMode = "unknown"; break;
+                        default: AudioPortMode = "unknown"; break;
+                    }
+
+                    switch(eventData->data.Audioport.type)
+                    {
+                        case 0: AudioPortType = "unsupported"; break;
+                        case 1: AudioPortType = "DDPlus"; break;
+                        case 2: AudioPortType = "Atmos"; break;
+                        default: AudioPortType = "Unknown"; break;
+                    }
+                    if(PlayerInfoImplementation::_instance)
+                    {
+                        PlayerInfoImplementation::_instance->audiomodeChanged(AudioPortMode, AudioPortType);
+                    }
+                }
+                break;
+            default:
+                break;
+        }
+    }
+
+    void audiomodeChanged(const string AudioPortMode, const string AudioPortType)
+    {
+        _adminLock.Lock();
+        std::list<Exchange::IPlayerAtmosProperties::INotification*>::const_iterator index = _notificationClients.begin();
+        if (index != _notificationClients.end())
+        {
+            (*index)->AudioModeChanged(AudioPortMode, AudioPortType);
+        }
+        _adminLock.Unlock();
+    }
+
+   BEGIN_INTERFACE_MAP(PlayerInfoImplementation)
+        INTERFACE_ENTRY(Exchange::IPlayerProperties)
+        INTERFACE_ENTRY(Exchange::IPlayerAtmosProperties)
+   END_INTERFACE_MAP
+
+private:
+
+
+    void UpdateAudioCodecInfo()
+    {
+        AudioCaps audioCaps = {
+            {"audio/mpeg, mpegversion=(int)1", Exchange::IPlayerProperties::IAudioIterator::AudioCodec::AUDIO_MPEG1},
+            {"audio/mpeg, mpegversion=(int)2", Exchange::IPlayerProperties::IAudioIterator::AudioCodec::AUDIO_MPEG2},
+            {"audio/mpeg, mpegversion=(int)4", Exchange::IPlayerProperties::IAudioIterator::AudioCodec::AUDIO_MPEG4},
+            {"audio/mpeg, mpegversion=(int)1, layer=(int)[1, 3]", Exchange::IPlayerProperties::IAudioIterator::AudioCodec::AUDIO_MPEG3},
+            {"audio/mpeg, mpegversion=(int){2, 4}", Exchange::IPlayerProperties::IAudioIterator::AudioCodec::AUDIO_AAC},
+            {"audio/x-ac3", Exchange::IPlayerProperties::IAudioIterator::AudioCodec::AUDIO_AC3},
+            {"audio/x-eac3", Exchange::IPlayerProperties::IAudioIterator::AudioCodec::AUDIO_AC3_PLUS},
+            {"audio/x-opus", Exchange::IPlayerProperties::IAudioIterator::AudioCodec::AUDIO_OPUS},
+            {"audio/x-dts", Exchange::IPlayerProperties::IAudioIterator::AudioCodec::AUDIO_DTS},
+            {"audio/x-vorbis", Exchange::IPlayerProperties::IAudioIterator::AudioCodec::AUDIO_VORBIS_OGG},
+            {"audio/x-wav", Exchange::IPlayerProperties::IAudioIterator::AudioCodec::AUDIO_WAV},
+        };
+        if (GstUtils::GstRegistryCheckElementsForMediaTypes(audioCaps, _audioCodecs) != true) {
+            TRACE_L1(_T("There is no Audio Codec support available"));
+        }
+
+    }
+    void UpdateVideoCodecInfo()
+    {
+        VideoCaps videoCaps = {
+            {"video/x-h263", Exchange::IPlayerProperties::IVideoIterator::VideoCodec::VIDEO_H263},
+            {"video/x-h264, profile=(string)high", Exchange::IPlayerProperties::IVideoIterator::VideoCodec::VIDEO_H264},
+            {"video/x-h265", Exchange::IPlayerProperties::IVideoIterator::VideoCodec::VIDEO_H265},
+            {"video/mpeg, mpegversion=(int){1,2}, systemstream=(boolean)false", Exchange::IPlayerProperties::IVideoIterator::VideoCodec::VIDEO_MPEG},
+            {"video/x-vp8", Exchange::IPlayerProperties::IVideoIterator::VideoCodec::VIDEO_VP8},
+            {"video/x-vp9", Exchange::IPlayerProperties::IVideoIterator::VideoCodec::VIDEO_VP9},
+            {"video/x-vp10", Exchange::IPlayerProperties::IVideoIterator::VideoCodec::VIDEO_VP10}
+        };
+        if (GstUtils::GstRegistryCheckElementsForMediaTypes(videoCaps, _videoCodecs) != true) {
+            TRACE_L1(_T("There is no Video Codec support available"));
+        }
+    }
+
+private:
+    mutable Core::CriticalSection _adminLock;
+    std::list<Exchange::IPlayerProperties::IAudioIterator::AudioCodec> _audioCodecs;
+    std::list<Exchange::IPlayerProperties::IVideoIterator::VideoCodec> _videoCodecs;
+    std::list<Exchange::IPlayerAtmosProperties::INotification*> _notificationClients;
+public:
+    static PlayerInfoImplementation* _instance;
+};
+    PlayerInfoImplementation* PlayerInfoImplementation::_instance = nullptr;
+    SERVICE_REGISTRATION(PlayerInfoImplementation, 1, 0);
+}
+}

--- a/PlayerInfo/PlayerInfo.cpp
+++ b/PlayerInfo/PlayerInfo.cpp
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 #include "PlayerInfo.h"
 
 namespace WPEFramework {
@@ -53,6 +53,11 @@ namespace Plugin {
                     _player->Release();
                     _player = nullptr;
                 }
+                else
+                {
+                    _atmosproperties = _player->QueryInterface<Exchange::IPlayerAtmosProperties>();
+                    if (_atmosproperties) _notification.Initialize(_atmosproperties);
+                }
             } else {
                 _player->Release();
                 _player = nullptr;
@@ -67,10 +72,18 @@ namespace Plugin {
 
     /* virtual */ void PlayerInfo::Deinitialize(PluginHost::IShell* service)
     {
+        _notification.Deinitialize();
+
         ASSERT(_player != nullptr);
         if (_player != nullptr) {
             _player->Release();
         }
+        if (_atmosproperties != nullptr)
+        {
+            _atmosproperties->Release();
+            _atmosproperties = nullptr;
+        }
+
         _connectionId = 0;
     }
 
@@ -128,6 +141,21 @@ namespace Plugin {
         while(_videoCodecs->Next()) {
             playerInfo.Video.Add(videoCodec = static_cast<JsonData::PlayerInfo::CodecsData::VideocodecsType>(_videoCodecs->Codec()));
         }
+    }
+
+    void PlayerInfo::getSinkAtmosCapability(JsonData::PlayerInfo::SinkAtmosCapabilityData& response) const
+    {
+        response.SinkAtmosCapability = _atmosproperties->getSinkAtmosCapability();
+    }
+
+    void PlayerInfo::getSoundMode(JsonData::PlayerInfo::SoundModeData& response) const
+    {
+        response.SoundMode = _atmosproperties->getSoundMode();
+    }
+
+    void PlayerInfo::setAudioAtmosOutputMode(const JsonData::PlayerInfo::AudioAtmosOutputModeData& param)
+    {
+        _atmosproperties->setAudioAtmosOutputMode(param.AudioAtmosOutputMode.Value());
     }
 
 } // namespace Plugin

--- a/PlayerInfo/PlayerInfoJsonRpc.cpp
+++ b/PlayerInfo/PlayerInfoJsonRpc.cpp
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 #include "PlayerInfo.h"
 
 namespace WPEFramework {
@@ -31,11 +31,17 @@ namespace Plugin {
     void PlayerInfo::RegisterAll()
     {
         Property<CodecsData>(_T("playerinfo"), &PlayerInfo::get_playerinfo, nullptr, this);
+        Property<SinkAtmosCapabilityData>(_T("getSinkAtmosCapability"), &PlayerInfo::getSinkAtmosCapabilityJrpc, nullptr, this);
+        Property<SoundModeData>(_T("getSoundMode"), &PlayerInfo::getSoundModeJrpc, nullptr, this);
+        Property<AudioAtmosOutputModeData>(_T("setAudioAtmosOutputMode"), nullptr, &PlayerInfo::setAudioAtmosOutputModeJrpc, this);
     }
 
     void PlayerInfo::UnregisterAll()
     {
         Unregister(_T("playerinfo"));
+        Unregister(_T("getSinkAtmosCapability"));
+        Unregister(_T("getSoundMode"));
+        Unregister(_T("setAudioAtmosOutputMode"));
     }
 
     // API implementation
@@ -50,6 +56,32 @@ namespace Plugin {
 
         return Core::ERROR_NONE;
     }
+
+    uint32_t PlayerInfo::getSinkAtmosCapabilityJrpc(SinkAtmosCapabilityData& response) const
+    {
+       getSinkAtmosCapability(response);
+        return Core::ERROR_NONE;
+    }
+
+    uint32_t PlayerInfo::getSoundModeJrpc(SoundModeData& response) const
+    {
+        getSoundMode(response);
+        return Core::ERROR_NONE;
+    }
+
+    uint32_t PlayerInfo::setAudioAtmosOutputModeJrpc(const AudioAtmosOutputModeData& param)
+    {
+        setAudioAtmosOutputMode(param);
+        return Core::ERROR_NONE;
+    }
+
+    void PlayerInfo::AudioModeChangedJrpc(const string& audioPortMode, const string&  audioPortType)
+   {
+       AudioModeChangedParamsData params;
+       params.AudioPortMode = audioPortMode;
+       params.AudioPortType = audioPortType;
+       Notify(_T("AudioPortModeChanged"), params);
+   }
 
 } // namespace Plugin
 


### PR DESCRIPTION
Reason for change: Adding properties required by Premium apps
for migration to rdkservices
Changes:
1. Introduced DeviceSettings based platform-implementation
for DisplayInfo & PlayerInfo to isolate IARM calls from
other platforms
Test Procedure: check ticket
Risks: Low
Signed-off-by: Vinod Jacob <vinod_jacob@comcast.com>