### PR TITLE
DELIA-44598 : Add Security Token Supprt for RemoteActionMapping Thund…

### DIFF
--- a/RemoteActionMapping/test/ramTestClient.cpp
+++ b/RemoteActionMapping/test/ramTestClient.cpp
@@ -501,11 +501,62 @@ int main(int argc, char** argv)
 
     Core::SystemInfo::SetEnvironment(_T("THUNDER_ACCESS"), (_T(SERVER_DETAILS)));
 
+    // Security Token
+    std::cout << "Retrieving security token" << std::endl;
+    std::string sToken;
+
+    FILE *pSecurity = popen("/usr/bin/WPEFrameworkSecurityUtility", "r");
+    if(pSecurity) {
+        JsonObject pSecurityJson;
+        std::string pSecurityOutput;
+        int         pSecurityOutputTrimIndex;
+        std::array<char, 256> pSecurityBuffer;
+
+        while(fgets(pSecurityBuffer.data(), 256, pSecurity) != NULL) {
+            pSecurityOutput += pSecurityBuffer.data();
+        }
+        pclose(pSecurity);
+
+        pSecurityOutputTrimIndex = pSecurityOutput.find('{');
+        if(pSecurityOutputTrimIndex == std::string::npos) {
+            std::cout << "Security Utility returned unexpected output" << std::endl;
+        } else {
+            if(pSecurityOutputTrimIndex > 0) {
+                 std::cout << "Trimming output from Security Utility" << std::endl;
+                 pSecurityOutput = pSecurityOutput.substr(pSecurityOutputTrimIndex);
+            }
+            pSecurityJson.FromString(pSecurityOutput);
+            if(pSecurityJson["success"].Boolean() == true) {
+                std::cout << "Security Token retrieved successfully!" << std::endl;
+                sToken = "token=" + pSecurityJson["token"].String();
+            } else {
+                std::cout << "Security Token retrieval failed!" << std::endl;
+            }
+        }
+    } else {
+        std::cout << "Failed to open security utility" << std::endl;
+    }
+    // End Security Token
+
     if (NULL == remoteObject) {
-        remoteObject = new JSONRPC::LinkType<Core::JSON::IElement>(_T(SYSSRV_CALLSIGN), _T(""));
+        remoteObject = new JSONRPC::Client(_T(SYSSRV_CALLSIGN), _T(""), false, sToken);
         if (NULL == remoteObject) {
             std::cout << "JSONRPC::Client initialization failed" << std::endl;
+
         } else {
+
+            {
+                // Create a controller client
+                static auto& controllerClient = *new WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>("", "", false, sToken);
+                // In case the plugin isn't activated already, try to start it, BEFORE registering for the events!
+                string strres;
+                JsonObject params;
+                params["callsign"] = SYSSRV_CALLSIGN;
+                JsonObject result;
+                ret = controllerClient.Invoke(2000, "activate", params, result);
+                result.ToString(strres);
+                std::cout<<"\nstartup result : "<< strres <<"\n";
+            }
 
             /* Register handlers for Event reception. */
             std::cout << "\nSubscribing to event handlers\n" << std::endl;


### PR DESCRIPTION
…er Plugin.

Reason for change: Test won't run without this.
Test Procedure: Verify the ramTestClient tests execute.
Risks: None.
Signed-off-by: jschmidt <Jeff_Schmidt@cable.comcast>