### PR TITLE
[RDK-29360] Add westerosSocket parameter to OCIContainer start

### DIFF
--- a/OCIContainer/OCIContainer.cpp
+++ b/OCIContainer/OCIContainer.cpp
@@ -238,19 +238,30 @@ uint32_t OCIContainer::startContainer(const JsonObject &parameters, JsonObject &
     std::string id = parameters["containerId"].String();
     std::string bundlePath = parameters["bundlePath"].String();
     std::string command = parameters["command"].String();
+    std::string westerosSocket = parameters["westerosSocket"].String();
 
     // Can be used to pass file descriptors to container construction.
     // Currently unsupported, see DobbyProxy::startContainerFromBundle().
     std::list<int> emptyList;
 
     int descriptor;
-    if (command == "null" || command.empty())
+    // If no additional arguments, start the container
+    if ((command == "null" || command.empty()) && (westerosSocket == "null" || westerosSocket.empty()))
     {
         descriptor = mDobbyProxy->startContainerFromBundle(id, bundlePath, emptyList);
     }
     else
     {
-        descriptor = mDobbyProxy->startContainerFromBundle(id, bundlePath, emptyList, command);
+        // Dobby expects empty strings if values not set
+        if (command == "null" || command.empty())
+        {
+            command = "";
+        }
+        if (westerosSocket == "null" || westerosSocket.empty())
+        {
+            westerosSocket = "";
+        }
+        descriptor = mDobbyProxy->startContainerFromBundle(id, bundlePath, emptyList, command, westerosSocket);
     }
 
     // startContainer returns -1 on failure
@@ -284,6 +295,7 @@ uint32_t OCIContainer::startContainerFromDobbySpec(const JsonObject &parameters,
     std::string id = parameters["containerId"].String();
     JsonObject dobbySpec = parameters["dobbySpec"].Object();
     std::string command = parameters["command"].String();
+    std::string westerosSocket = parameters["westerosSocket"].String();
 
     std::string specString;
     if (!WPEFramework::Core::JSON::IElement::ToString(dobbySpec, specString))
@@ -297,13 +309,23 @@ uint32_t OCIContainer::startContainerFromDobbySpec(const JsonObject &parameters,
     std::list<int> emptyList;
 
     int descriptor;
-    if (command == "null" || command.empty())
+    // If no additional arguments, start the container
+    if ((command == "null" || command.empty()) && (westerosSocket == "null" || westerosSocket.empty()))
     {
         descriptor = mDobbyProxy->startContainerFromSpec(id, specString, emptyList);
     }
     else
     {
-        descriptor = mDobbyProxy->startContainerFromSpec(id, specString, emptyList, command);
+        // Dobby expects empty strings if values not set
+        if (command == "null" || command.empty())
+        {
+            command = "";
+        }
+        if (westerosSocket == "null" || westerosSocket.empty())
+        {
+            westerosSocket = "";
+        }
+        descriptor = mDobbyProxy->startContainerFromSpec(id, specString, emptyList, command, westerosSocket);
     }
 
     // startContainer returns -1 on failure

--- a/OCIContainer/README.md
+++ b/OCIContainer/README.md
@@ -106,11 +106,12 @@ Gets information about a running container such as CPU, memory and GPU uage (GPU
 Starts a new container from an existing OCI bundle.
 
 ### Params
-| Name        | Type   | Description                                                                            |
-| ----------- | ------ | -------------------------------------------------------------------------------------- |
-| containerId | string | ID for the new container                                                               |
-| bundlePath  | string | Path to the OCI bundle containing the rootfs and config to use to create the container |
-| command     | string | Custom command to run inside the container, overriding the command in the container config |
+| Name           | Type   | Description                                                                                |
+| -------------- | ------ | ------------------------------------------------------------------------------------------ |
+| containerId    | string | ID for the new container                                                                   |
+| bundlePath     | string | Path to the OCI bundle containing the rootfs and config to use to create the container     |
+| command        | string | Custom command to run inside the container, overriding the command in the container config |
+| westerosSocket | string | Path to a westeros socket to mount inside the container                                    |
 ---
 
 ### Response
@@ -130,10 +131,10 @@ Starts a new container from an existing OCI bundle.
 Starts a new container from a legacy Dobby json specification
 
 ### Params
-| Name        | Type   | Description                                                                            |
-| ----------- | ------ | -------------------------------------------------------------------------------------- |
-| containerId | string | ID for the new container                                                               |
-| dobbySpec  | object | Dobby specification to use for the container |
+| Name        | Type   | Description                                                                          |
+| ----------- | ------ | ------------------------------------------------------------------------------------ |
+| containerId | string | ID for the new container                                                             |
+| dobbySpec   | object | Dobby specification to use for the container                                         |
 | command     | string | Custom command to run inside the container, overriding the command in the Dobby spec |
 
 ### Response


### PR DESCRIPTION
Add new parameter to OCIContainer Start command to mount westeros socket into container at container start.

Depends on feature added in https://github.com/rdkcentral/Dobby/pull/17