### PR TITLE
XIONE-1025: Do not do wifi signal scans when wifi disabled

### DIFF
--- a/WifiManager/WifiManager.cpp
+++ b/WifiManager/WifiManager.cpp
@@ -300,6 +300,14 @@ namespace WPEFramework
             params["state"] = static_cast<int>(state);
             params["isLNF"] = isLNF;
             sendNotify("onWIFIStateChanged", params);
+            if (state == WifiState::CONNECTED)
+            {
+                wifiSignalThreshold.setSignalThresholdChangeEnabled(true);
+            }
+            else
+            {
+                wifiSignalThreshold.setSignalThresholdChangeEnabled(false);
+            }
         }
 
         /**

--- a/WifiManager/WifiManager.cpp
+++ b/WifiManager/WifiManager.cpp
@@ -268,11 +268,11 @@ namespace WPEFramework
             return result;
         }
 
-        uint32_t WifiManager::setSignalThresholdChangeEnabled(const JsonObject &parameters, JsonObject &response)
+        uint32_t WifiManager::setWifiStateConnected(const JsonObject &parameters, JsonObject &response)
         {
             LOGINFOMETHOD();
 
-            uint32_t result = wifiSignalThreshold.setSignalThresholdChangeEnabled(parameters, response);
+            uint32_t result = wifiSignalThreshold.setWifiStateConnected(parameters, response);
 
             LOGTRACEMETHODFIN();
             return result;
@@ -302,11 +302,11 @@ namespace WPEFramework
             sendNotify("onWIFIStateChanged", params);
             if (state == WifiState::CONNECTED)
             {
-                wifiSignalThreshold.setSignalThresholdChangeEnabled(true);
+                wifiSignalThreshold.setWifiStateConnected(true);
             }
             else
             {
-                wifiSignalThreshold.setSignalThresholdChangeEnabled(false);
+                wifiSignalThreshold.setWifiStateConnected(false);
             }
         }
 

--- a/WifiManager/impl/WifiManagerSignalThreshold.cpp
+++ b/WifiManager/impl/WifiManagerSignalThreshold.cpp
@@ -70,7 +70,7 @@ WifiManagerSignalThreshold::~WifiManagerSignalThreshold()
     stopThread();
 }
 
-uint32_t WifiManagerSignalThreshold::setSignalThresholdChangeEnabled(const JsonObject &parameters, JsonObject &response)
+uint32_t WifiManagerSignalThreshold::setWifiStateConnected(const JsonObject &parameters, JsonObject &response)
 {
     LOGINFOMETHOD();
     returnIfBooleanParamNotFound(parameters, "enabled");
@@ -160,11 +160,11 @@ void WifiManagerSignalThreshold::stopThread()
     }
 }
 
-void WifiManagerSignalThreshold::setSignalThresholdChangeEnabled(bool enable)
+void WifiManagerSignalThreshold::setWifiStateConnected(bool connected)
 {
-    LOGINFO("setSignalThresholdChangeEnabled: enable %s", enable ? "true":"false");
-    running = enable;
-    if (enable)
+    LOGINFO("setSignalThresholdChangeEnabled: enable %s", connected ? "true":"false");
+    running = connected;
+    if (connected)
     {
         cv.notify_one();
     }

--- a/WifiManager/impl/WifiManagerSignalThreshold.cpp
+++ b/WifiManager/impl/WifiManagerSignalThreshold.cpp
@@ -60,7 +60,8 @@ namespace {
 
 WifiManagerSignalThreshold::WifiManagerSignalThreshold(WifiManagerInterface &wifiManager):
     changeEnabled(false),
-    wifiManager(wifiManager)
+    wifiManager(wifiManager),
+    running(false)
 {
 }
 
@@ -101,10 +102,19 @@ uint32_t WifiManagerSignalThreshold::isSignalThresholdChangeEnabled(const JsonOb
 
 void WifiManagerSignalThreshold::setSignalThresholdChangeEnabled(bool enabled, int interval)
 {
+    LOGINFO("setSignalThresholdChangeEnabled: enabled %s, interval %d", enabled ? "true":"false", interval);
+
     stopThread();
 
     changeEnabled = enabled;
-    if(changeEnabled) {
+
+    WifiState state;
+    getWifiState(state);
+
+    if(changeEnabled)
+    {
+        if (state == WifiState::CONNECTED)
+            running = true;
         startThread(interval);
     }
 }
@@ -122,21 +132,68 @@ void WifiManagerSignalThreshold::loop(int interval)
 
         float signalStrength;
         std::string strength;
-        getSignalData(wifiManager, signalStrength, strength);
+        std::string lastStrength = "";
+        if (running)
+        {
+            getSignalData(wifiManager, signalStrength, strength);
 
-        wifiManager.onWifiSignalThresholdChanged(signalStrength, strength);
+            if (strength.compare(lastStrength) != 0)
+            {
+                wifiManager.onWifiSignalThresholdChanged(signalStrength, strength);
+                lastStrength = strength;
+            }
+            cv.wait_for(lk, std::chrono::milliseconds(interval), [this](){ return changeEnabled == false; });
+        } else {
+            cv.wait(lk, [this](){ return running; });
+        }
 
-        cv.wait_for(lk, std::chrono::milliseconds(interval), [this](){ return changeEnabled == false; });
     }
 }
 
 void WifiManagerSignalThreshold::stopThread()
 {
     changeEnabled = false;
+    running = false;
     cv.notify_one();
     if(thread.joinable()) {
         thread.join();
     }
+}
+
+void WifiManagerSignalThreshold::setSignalThresholdChangeEnabled(bool enable)
+{
+    LOGINFO("setSignalThresholdChangeEnabled: enable %s", enable ? "true":"false");
+    running = enable;
+    if (enable)
+    {
+        cv.notify_one();
+    }
+}
+
+void WifiManagerSignalThreshold::getWifiState(WifiState &state)
+{
+    LOGINFO("getWifiState: entered");
+    JsonObject params, parameters;
+
+    uint32_t result = wifiManager.getCurrentState(parameters, parameters);
+    if (result != 0)
+    {
+        LOGINFO("wifiManager.getCurrentState result = %d", result);
+        state = WifiState::FAILED;
+    }
+    else if (parameters.HasLabel("state"))
+    {
+        unsigned int number = 0;
+        getNumberParameter("state", number);
+        state = (WifiState) number;
+        LOGINFO("wifi state = %d", state);
+    }
+    else
+    {
+        LOGINFO("no state attribute");
+        state = WifiState::FAILED;
+    }
+
 }
 
 void WifiManagerSignalThreshold::startThread(int interval)

--- a/WifiManager/impl/WifiManagerSignalThreshold.cpp
+++ b/WifiManager/impl/WifiManagerSignalThreshold.cpp
@@ -144,7 +144,7 @@ void WifiManagerSignalThreshold::loop(int interval)
             }
             cv.wait_for(lk, std::chrono::milliseconds(interval), [this](){ return changeEnabled == false; });
         } else {
-            cv.wait(lk, [this](){ return running; });
+            cv.wait(lk, [this](){ return running || changeEnabled == false; });
         }
 
     }

--- a/WifiManager/impl/WifiManagerSignalThreshold.h
+++ b/WifiManager/impl/WifiManagerSignalThreshold.h
@@ -47,7 +47,7 @@ namespace WPEFramework {
             WifiManagerSignalThreshold& operator=(const WifiManagerSignalThreshold&) = delete;
 
             uint32_t setSignalThresholdChangeEnabled(const JsonObject& parameters, JsonObject& response);
-            void setSignalThresholdChangeEnabled(bool enable);
+            void setWifiStateConnected(bool enable);
             uint32_t isSignalThresholdChangeEnabled(const JsonObject& parameters, JsonObject& response) const;
 
         private:

--- a/WifiManager/impl/WifiManagerSignalThreshold.h
+++ b/WifiManager/impl/WifiManagerSignalThreshold.h
@@ -47,7 +47,7 @@ namespace WPEFramework {
             WifiManagerSignalThreshold& operator=(const WifiManagerSignalThreshold&) = delete;
 
             uint32_t setSignalThresholdChangeEnabled(const JsonObject& parameters, JsonObject& response);
-            void setWifiStateConnected(bool enable);
+            void setWifiStateConnected(bool connected);
             uint32_t isSignalThresholdChangeEnabled(const JsonObject& parameters, JsonObject& response) const;
 
         private:

--- a/WifiManager/impl/WifiManagerSignalThreshold.h
+++ b/WifiManager/impl/WifiManagerSignalThreshold.h
@@ -47,6 +47,7 @@ namespace WPEFramework {
             WifiManagerSignalThreshold& operator=(const WifiManagerSignalThreshold&) = delete;
 
             uint32_t setSignalThresholdChangeEnabled(const JsonObject& parameters, JsonObject& response);
+            void setSignalThresholdChangeEnabled(bool enable);
             uint32_t isSignalThresholdChangeEnabled(const JsonObject& parameters, JsonObject& response) const;
 
         private:
@@ -56,6 +57,7 @@ namespace WPEFramework {
             void loop(int interval);
             void stopThread();
             void startThread(int interval);
+            void getWifiState(WifiState &state);
 
         private:
             std::thread thread;
@@ -63,6 +65,7 @@ namespace WPEFramework {
             std::mutex cv_mutex;
             std::condition_variable cv;
             WifiManagerInterface &wifiManager;
+            bool running;
         };
     }
 }


### PR DESCRIPTION
Reason for change: Prevent thunder restarts, only perform signal scans when configures
Test Procedure: Scans are started when configured, stopped on disconnection or not configures
Risks: Low
Signed-off-by: Kamal Mortoza <kamal.mortoza@sky.uk>