### PR TITLE
RDK-29259 : HDMI In switching support

### DIFF
--- a/HdmiInput/HdmiInput.h
+++ b/HdmiInput/HdmiInput.h
@@ -55,6 +55,8 @@ namespace WPEFramework {
             uint32_t getHDMIInputDevicesWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t writeEDIDWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t readEDIDWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t startHdmiInput(const JsonObject& parameters, JsonObject& response);
+            uint32_t stopHdmiInput(const JsonObject& parameters, JsonObject& response);
             //End methods
 
             JsonArray getHDMIInputDevices();


### PR DESCRIPTION
Reason for change: Added APIs to start/stop HDMI
In display
Test Procedure: Verify HDMI In switching using curl
commands
Risks: None

Signed-off-by: Deekshit Devadas <deekshit.devadasy@sky.uk>