### PR TITLE
CPC-2684: Fix FrontPanel callsign and documentation

### DIFF
--- a/FrontPanel/FrontPanel.config
+++ b/FrontPanel/FrontPanel.config
@@ -1,0 +1,3 @@
+set (autostart false)
+set (preconditions Platform)
+set (callsign "org.rdk.FrontPanel")

--- a/FrontPanel/doc/FrontPanel.md
+++ b/FrontPanel/doc/FrontPanel.md
@@ -1,0 +1,1 @@
+[FrontPanel](https://wiki.rdkcentral.com/display/RDK/FrontPanel)


### PR DESCRIPTION
Restore the FrontPanel.config and doc files that were removed in https://github.com/rdkcentral/rdkservices/commit/d8332c6a60fa0cc0924d31295b6332dc075456d8