### PR TITLE
DELIA-45558 : For CS thunder, dont' return error for 0 remotes for ge…

### DIFF
--- a/ControlService/ControlService.cpp
+++ b/ControlService/ControlService.cpp
@@ -2096,8 +2096,9 @@ namespace WPEFramework {
 
             if (netStatus.status.rf4ce.controller_qty == 0)
             {
-                LOGERR("ERROR - No RF4CE controllers found!");
-                return false;
+                LOGWARN("No RF4CE controllers found!");
+                m_numOfBindRemotes = 0;
+                return true;
             }
             // Make sure we don't overrrun the m_remoteInfo array.
             if (netStatus.status.rf4ce.controller_qty > CTRLM_MAIN_MAX_BOUND_CONTROLLERS)


### PR DESCRIPTION
…tAllRem...

Reason for change: 0 remotes is a valid scenario.
Test Procedure: Verify using thunder plugin test app.
Risks: None.
Signed-off-by: jschmidt <Jeff_Schmidt@cable.comcast>