### PR TITLE
RDKShell API v3

### DIFF
--- a/RDKShell/CMakeLists.txt
+++ b/RDKShell/CMakeLists.txt
@@ -1,0 +1,42 @@
+# If not stated otherwise in this file or this component's license file the
+# following copyright and licenses apply:
+#
+# Copyright 2020 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set(PLUGIN_NAME RDKShell)
+set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
+
+find_package(${NAMESPACE}Plugins REQUIRED)
+
+add_library(${MODULE_NAME} SHARED
+        RDKShell.cpp
+        Module.cpp
+)
+
+set_target_properties(${MODULE_NAME} PROPERTIES
+        CXX_STANDARD 11
+        CXX_STANDARD_REQUIRED YES)
+
+target_include_directories(${MODULE_NAME} PRIVATE ../helpers)
+
+set(RDKSHELL_INCLUDES $ENV{RDKSHELL_INCLUDES})
+separate_arguments(RDKSHELL_INCLUDES)
+include_directories(BEFORE ${RDKSHELL_INCLUDES})
+target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins -lrdkshell rfcapi)
+
+install(TARGETS ${MODULE_NAME}
+        DESTINATION lib/${STORAGE_DIRECTORY}/plugins)
+
+write_config(${PLUGIN_NAME})

--- a/RDKShell/Module.cpp
+++ b/RDKShell/Module.cpp
@@ -1,0 +1,22 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2020 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+#include "Module.h"
+
+MODULE_NAME_DECLARATION(BUILD_REFERENCE)

--- a/RDKShell/Module.h
+++ b/RDKShell/Module.h
@@ -1,0 +1,29 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2020 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+#pragma once
+#ifndef MODULE_NAME
+#define MODULE_NAME RDKShell
+#endif
+
+#include <plugins/plugins.h>
+#include <tracing/tracing.h>
+
+#undef EXTERNAL
+#define EXTERNAL

--- a/RDKShell/RDKShell.config
+++ b/RDKShell/RDKShell.config
@@ -1,0 +1,3 @@
+set (autostart true)
+set (preconditions Platform)
+set (callsign "org.rdk.RDKShell")

--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -1,0 +1,2592 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2020 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+#include "RDKShell.h"
+#include <string>
+#include <iostream>
+#include <mutex>
+#include <thread>
+#include <securityagent/SecurityTokenUtil.h>
+#include <curl/curl.h>
+#include <rdkshell/compositorcontroller.h>
+#include <rdkshell/application.h>
+#include <interfaces/IMemory.h>
+#include "rfcapi.h"
+
+const short WPEFramework::Plugin::RDKShell::API_VERSION_NUMBER_MAJOR = 1;
+const short WPEFramework::Plugin::RDKShell::API_VERSION_NUMBER_MINOR = 0;
+const string WPEFramework::Plugin::RDKShell::SERVICE_NAME = "org.rdk.RDKShell";
+//methods
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_MOVE_TO_FRONT = "moveToFront";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_MOVE_TO_BACK = "moveToBack";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_MOVE_BEHIND = "moveBehind";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_SET_FOCUS = "setFocus";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_KILL = "kill";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_ADD_KEY_INTERCEPT = "addKeyIntercept";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_REMOVE_KEY_INTERCEPT = "removeKeyIntercept";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_ADD_KEY_LISTENER = "addKeyListener";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_REMOVE_KEY_LISTENER = "removeKeyListener";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_ADD_KEY_METADATA_LISTENER = "addKeyMetadataListener";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_REMOVE_KEY_METADATA_LISTENER = "removeKeyMetadataListener";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_INJECT_KEY = "injectKey";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_GENERATE_KEYS = "generateKey";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_GET_SCREEN_RESOLUTION = "getScreenResolution";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_SET_SCREEN_RESOLUTION = "setScreenResolution";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_CREATE_DISPLAY = "createDisplay";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_GET_CLIENTS = "getClients";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_GET_Z_ORDER = "getZOrder";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_GET_BOUNDS = "getBounds";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_SET_BOUNDS = "setBounds";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_GET_VISIBILITY = "getVisibility";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_SET_VISIBILITY = "setVisibility";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_GET_OPACITY = "getOpacity";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_SET_OPACITY = "setOpacity";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_GET_SCALE = "getScale";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_SET_SCALE = "setScale";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_REMOVE_ANIMATION = "removeAnimation";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_ADD_ANIMATION = "addAnimation";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_ENABLE_INACTIVITY_REPORTING = "enableInactivityReporting";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_SET_INACTIVITY_INTERVAL = "setInactivityInterval";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_SCALE_TO_FIT = "scaleToFit";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_LAUNCH = "launch";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_SUSPEND = "suspend";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_DESTROY = "destroy";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_GET_AVAILABLE_TYPES = "getAvailableTypes";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_GET_STATE = "getState";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_GET_SYSTEM_MEMORY = "getSystemMemory";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_GET_SYSTEM_RESOURCE_INFO = "getSystemResourceInfo";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_SET_MEMORY_MONITOR = "setMemoryMonitor";
+
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_EVENT_ON_USER_INACTIVITY = "onUserInactivity";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_EVENT_ON_APP_LAUNCHED = "onApplicationLaunched";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_EVENT_ON_APP_CONNECTED = "onApplicationConnected";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_EVENT_ON_APP_DISCONNECTED = "onApplicationDisconnected";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_EVENT_ON_APP_TERMINATED = "onApplicationTerminated";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_EVENT_ON_APP_FIRST_FRAME = "onApplicationFirstFrame";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_EVENT_ON_APP_SUSPENDED = "onApplicationSuspended";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_EVENT_ON_APP_RESUMED = "onApplicationResumed";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_EVENT_ON_LAUNCHED = "onLaunched";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_EVENT_ON_SUSPENDED = "onSuspended";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_EVENT_ON_DESTROYED = "onDestroyed";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_EVENT_DEVICE_LOW_RAM_WARNING = "onDeviceLowRamWarning";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_EVENT_DEVICE_CRITICALLY_LOW_RAM_WARNING = "onDeviceCriticallyLowRamWarning";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_EVENT_DEVICE_LOW_RAM_WARNING_CLEARED = "onDeviceLowRamWarningCleared";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_EVENT_DEVICE_CRITICALLY_LOW_RAM_WARNING_CLEARED = "onDeviceCriticallyLowRamWarningCleared";
+
+using namespace std;
+using namespace RdkShell;
+extern int gCurrentFramerate;
+bool receivedResolutionRequest = false;
+unsigned int resolutionWidth = 1280;
+unsigned int resolutionHeight = 720;
+
+
+#define ANY_KEY 65536
+#define MAX_STRING_LENGTH 2048
+
+enum RDKShellLaunchType
+{
+    UNKNOWN = 0,
+    CREATE,
+    ACTIVATE,
+    SUSPEND,
+    RESUME
+};
+
+namespace WPEFramework {
+    namespace Plugin {
+
+        size_t writeCurlResponse(void *ptr, size_t size, size_t nmemb, string stream)
+        {
+            size_t realsize = size * nmemb;
+            string temp(static_cast<const char*>(ptr), realsize);
+            stream.append(temp);
+            return realsize;
+        }
+
+        string RDKShell::m_sToken;
+        bool RDKShell::m_sThunderSecurityChecked = false;
+
+        uint32_t getKeyFlag(std::string modifier)
+        {
+          uint32_t flag = 0;
+          if (0 == modifier.compare("ctrl"))
+          {
+            flag = RDKSHELL_FLAGS_CONTROL;
+          }
+          else if (0 == modifier.compare("shift"))
+          {
+            flag = RDKSHELL_FLAGS_SHIFT;
+          }
+          else if (0 == modifier.compare("alt"))
+          {
+            flag = RDKSHELL_FLAGS_ALT;
+          }
+          return flag;
+        }
+
+        bool getRFCConfig(char* paramName, RFC_ParamData_t& paramOutput)
+        {
+          WDMP_STATUS wdmpStatus = getRFCParameter("RDKShell", paramName, &paramOutput);
+          if (wdmpStatus == WDMP_SUCCESS || wdmpStatus == WDMP_ERR_DEFAULT_VALUE)
+          {
+            return true;
+          }
+          return false;
+        }
+
+        SERVICE_REGISTRATION(RDKShell, 1, 0);
+
+        RDKShell* RDKShell::_instance = nullptr;
+        std::mutex gRdkShellMutex;
+
+        static std::thread shellThread;
+
+        void RDKShell::MonitorClients::StateChange(PluginHost::IShell* service)
+        {
+            if (service)
+            {
+                PluginHost::IShell::state currentState(service->State());
+                if (currentState == PluginHost::IShell::ACTIVATION)
+                {
+                   std::string configLine = service->ConfigLine();
+                   if (configLine.empty())
+                   {
+                       return;
+                   }
+                   JsonObject serviceConfig = JsonObject(configLine.c_str());
+                   if (serviceConfig.HasLabel("clientidentifier"))
+                   {
+                       std::string clientidentifier = serviceConfig["clientidentifier"].String();
+                       gRdkShellMutex.lock();
+                       RdkShell::CompositorController::createDisplay(service->Callsign(), clientidentifier);
+                       RdkShell::CompositorController::addListener(clientidentifier, mShell.mEventListener);
+                       gRdkShellMutex.unlock();
+                   }
+                }
+                else if (currentState == PluginHost::IShell::ACTIVATED && service->Callsign() == WPEFramework::Plugin::RDKShell::SERVICE_NAME)
+                {
+                    PluginHost::ISubSystem* subSystems(service->SubSystems());
+                    if (subSystems != nullptr)
+                    {
+                        subSystems->Set(PluginHost::ISubSystem::PLATFORM, nullptr);
+                        subSystems->Set(PluginHost::ISubSystem::GRAPHICS, nullptr);
+                        subSystems->Release();
+                    }
+                }
+                else if (currentState == PluginHost::IShell::DEACTIVATED)
+                {
+                    std::string configLine = service->ConfigLine();
+                    if (configLine.empty())
+                    {
+                        return;
+                    }
+                    JsonObject serviceConfig = JsonObject(configLine.c_str());
+                    if (serviceConfig.HasLabel("clientidentifier"))
+                    {
+                        std::string clientidentifier = serviceConfig["clientidentifier"].String();
+                        gRdkShellMutex.lock();
+                        RdkShell::CompositorController::kill(clientidentifier);
+                        RdkShell::CompositorController::removeListener(clientidentifier, mShell.mEventListener);
+                        gRdkShellMutex.unlock();
+                    }
+                }
+            }
+        }
+
+        RDKShell::RDKShell()
+                : AbstractPlugin(), mClientsMonitor(Core::Service<MonitorClients>::Create<MonitorClients>(this)), mEnableUserInactivityNotification(false), mCurrentService(nullptr)
+        {
+            LOGINFO("ctor");
+            RDKShell::_instance = this;
+            mEventListener = std::make_shared<RdkShellListener>(this);
+
+            mRemoteShell = false;
+            registerMethod(RDKSHELL_METHOD_MOVE_TO_FRONT, &RDKShell::moveToFrontWrapper, this);
+            registerMethod(RDKSHELL_METHOD_MOVE_TO_BACK, &RDKShell::moveToBackWrapper, this);
+            registerMethod(RDKSHELL_METHOD_MOVE_BEHIND, &RDKShell::moveBehindWrapper, this);
+            registerMethod(RDKSHELL_METHOD_SET_FOCUS, &RDKShell::setFocusWrapper, this);
+            registerMethod(RDKSHELL_METHOD_KILL, &RDKShell::killWrapper, this);
+            registerMethod(RDKSHELL_METHOD_ADD_KEY_INTERCEPT, &RDKShell::addKeyInterceptWrapper, this);
+            registerMethod(RDKSHELL_METHOD_REMOVE_KEY_INTERCEPT, &RDKShell::removeKeyInterceptWrapper, this);
+            registerMethod(RDKSHELL_METHOD_ADD_KEY_LISTENER, &RDKShell::addKeyListenersWrapper, this);
+            registerMethod(RDKSHELL_METHOD_REMOVE_KEY_LISTENER, &RDKShell::removeKeyListenersWrapper, this);
+            registerMethod(RDKSHELL_METHOD_ADD_KEY_METADATA_LISTENER, &RDKShell::addKeyMetadataListenerWrapper, this);
+            registerMethod(RDKSHELL_METHOD_REMOVE_KEY_METADATA_LISTENER, &RDKShell::removeKeyMetadataListenerWrapper, this);
+            registerMethod(RDKSHELL_METHOD_INJECT_KEY, &RDKShell::injectKeyWrapper, this);
+            registerMethod(RDKSHELL_METHOD_GENERATE_KEYS, &RDKShell::generateKeyWrapper, this);
+            registerMethod(RDKSHELL_METHOD_GET_SCREEN_RESOLUTION, &RDKShell::getScreenResolutionWrapper, this);
+            registerMethod(RDKSHELL_METHOD_SET_SCREEN_RESOLUTION, &RDKShell::setScreenResolutionWrapper, this);
+            registerMethod(RDKSHELL_METHOD_CREATE_DISPLAY, &RDKShell::createDisplayWrapper, this);
+            registerMethod(RDKSHELL_METHOD_GET_CLIENTS, &RDKShell::getClientsWrapper, this);
+            registerMethod(RDKSHELL_METHOD_GET_Z_ORDER, &RDKShell::getZOrderWrapper, this);
+            registerMethod(RDKSHELL_METHOD_GET_BOUNDS, &RDKShell::getBoundsWrapper, this);
+            registerMethod(RDKSHELL_METHOD_SET_BOUNDS, &RDKShell::setBoundsWrapper, this);
+            registerMethod(RDKSHELL_METHOD_GET_VISIBILITY, &RDKShell::getVisibilityWrapper, this);
+            registerMethod(RDKSHELL_METHOD_SET_VISIBILITY, &RDKShell::setVisibilityWrapper, this);
+            registerMethod(RDKSHELL_METHOD_GET_OPACITY, &RDKShell::getOpacityWrapper, this);
+            registerMethod(RDKSHELL_METHOD_SET_OPACITY, &RDKShell::setOpacityWrapper, this);
+            registerMethod(RDKSHELL_METHOD_GET_SCALE, &RDKShell::getScaleWrapper, this);
+            registerMethod(RDKSHELL_METHOD_SET_SCALE, &RDKShell::setScaleWrapper, this);
+            registerMethod(RDKSHELL_METHOD_REMOVE_ANIMATION, &RDKShell::removeAnimationWrapper, this);
+            registerMethod(RDKSHELL_METHOD_ADD_ANIMATION, &RDKShell::addAnimationWrapper, this);
+            registerMethod(RDKSHELL_METHOD_ENABLE_INACTIVITY_REPORTING, &RDKShell::enableInactivityReportingWrapper, this);
+            registerMethod(RDKSHELL_METHOD_SET_INACTIVITY_INTERVAL, &RDKShell::setInactivityIntervalWrapper, this);
+            registerMethod(RDKSHELL_METHOD_SCALE_TO_FIT, &RDKShell::scaleToFitWrapper, this);
+            registerMethod(RDKSHELL_METHOD_LAUNCH, &RDKShell::launchWrapper, this);
+            registerMethod(RDKSHELL_METHOD_SUSPEND, &RDKShell::suspendWrapper, this);
+            registerMethod(RDKSHELL_METHOD_DESTROY, &RDKShell::destroyWrapper, this);
+            registerMethod(RDKSHELL_METHOD_GET_AVAILABLE_TYPES, &RDKShell::getAvailableTypesWrapper, this);
+            registerMethod(RDKSHELL_METHOD_GET_STATE, &RDKShell::getState, this);
+            registerMethod(RDKSHELL_METHOD_GET_SYSTEM_MEMORY, &RDKShell::getSystemMemoryWrapper, this);
+            registerMethod(RDKSHELL_METHOD_GET_SYSTEM_RESOURCE_INFO, &RDKShell::getSystemResourceInfoWrapper, this);
+            registerMethod(RDKSHELL_METHOD_SET_MEMORY_MONITOR, &RDKShell::setMemoryMonitorWrapper, this);
+        }
+
+        RDKShell::~RDKShell()
+        {
+            LOGINFO("dtor");
+            mClientsMonitor->Release();
+            RDKShell::_instance = nullptr;
+            mRemoteShell = false;
+            CompositorController::setEventListener(nullptr);
+            mEventListener = nullptr;
+            mEnableUserInactivityNotification = false;
+        }
+
+        const string RDKShell::Initialize(PluginHost::IShell* service )
+        {
+            LOGINFO();
+
+            mCurrentService = service;
+            CompositorController::setEventListener(mEventListener);
+            RFC_ParamData_t param;
+            bool ret = getRFCConfig("Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.Power.UserInactivityNotification.Enable", param);
+            if (true == ret && param.type == WDMP_BOOLEAN && (strncasecmp(param.value,"true",4) == 0))
+            {
+              mEnableUserInactivityNotification = true;
+              ret = getRFCConfig("Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.Power.UserInactivityNotification.TimeMinutes", param);
+              if (true == ret && param.type == WDMP_STRING)
+              {
+                try
+                {
+                  CompositorController::setInactivityInterval(std::stod(param.value));
+                }
+                catch (...)
+                { 
+                  std::cout << "RDKShell unable to set inactivity interval  " << std::endl;
+                }
+              }
+            }
+
+            shellThread = std::thread([]() {
+                gRdkShellMutex.lock();
+                RdkShell::initialize();
+                gRdkShellMutex.unlock();
+                while(true) {
+                  const double maxSleepTime = (1000 / gCurrentFramerate) * 1000;
+                  double startFrameTime = RdkShell::microseconds();
+                  gRdkShellMutex.lock();
+                  if (receivedResolutionRequest)
+                  {
+                    CompositorController::setScreenResolution(resolutionWidth, resolutionHeight);
+                    receivedResolutionRequest = false;
+                  }
+                  RdkShell::draw();
+                  RdkShell::update();
+                  gRdkShellMutex.unlock();
+                  double frameTime = (int)RdkShell::microseconds() - (int)startFrameTime;
+                  if (frameTime < maxSleepTime)
+                  {
+                      int sleepTime = (int)maxSleepTime-(int)frameTime;
+                      usleep(sleepTime);
+                  }
+                }
+            });
+
+            service->Register(mClientsMonitor);
+            return "";
+        }
+
+        void RDKShell::Deinitialize(PluginHost::IShell* service)
+        {
+            LOGINFO();
+
+            mCurrentService = nullptr;
+            service->Unregister(mClientsMonitor);
+        }
+
+        string RDKShell::Information() const
+        {
+            return(string("{\"service\": \"") + SERVICE_NAME + string("\"}"));
+        }
+
+        std::shared_ptr<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement> > RDKShell::getThunderControllerClient(std::string callsign)
+        {
+            Core::SystemInfo::SetEnvironment(_T("THUNDER_ACCESS"), (_T("127.0.0.1:9998")));
+            std::shared_ptr<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement> > thunderClient = make_shared<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement> >(callsign.c_str(), "");
+            return thunderClient;
+        }
+
+        void RDKShell::getSecurityToken(std::string& token)
+        {
+            if(m_sThunderSecurityChecked)
+            {
+                return;
+            }
+            
+            // Thunder Security is enabled by Default.
+            bool thunderSecurityRFCEnabled = true;
+            RFC_ParamData_t param;
+            if (getRFCConfig("Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.ThunderSecurity.Enable", param))
+            {
+                if (param.type == WDMP_BOOLEAN && (strncasecmp(param.value,"false",5) == 0))
+                {
+                    thunderSecurityRFCEnabled = false;
+                }
+            }
+            std::cout << "Thunder Security RFC enabled: " << thunderSecurityRFCEnabled << std::endl;
+            if(!isThunderSecurityConfigured() || !thunderSecurityRFCEnabled)
+            {
+                m_sThunderSecurityChecked = true;
+                std::cout << "Thunder Security is not enabled. Not getting token\n";
+                return;
+            }
+            m_sThunderSecurityChecked = true;
+            unsigned char buffer[MAX_STRING_LENGTH] = {0};
+            
+            int ret = GetSecurityToken(MAX_STRING_LENGTH,buffer);
+            if(ret < 0)
+            {
+                std::cout << "Error in getting token\n";
+            }
+            else
+            {
+                std::cout << "retrieved token successfully\n";
+                token = (char*)buffer;
+            }
+        }
+
+        bool RDKShell::isThunderSecurityConfigured()
+        {
+            bool configured = false;
+            long http_code = 0;
+            std::string jsonResp;
+            CURL *curl_handle = NULL;
+            CURLcode res = CURLE_OK;
+            curl_handle = curl_easy_init();
+            string serialNumber = "";
+            string url = "http://127.0.0.1:9998/Service/Controller/Configuration/Controller";
+            if (curl_handle && 
+                !curl_easy_setopt(curl_handle, CURLOPT_URL, url.c_str()) &&
+                !curl_easy_setopt(curl_handle, CURLOPT_HTTPGET,1) &&
+                !curl_easy_setopt(curl_handle, CURLOPT_FOLLOWLOCATION, 1) && //when redirected, follow the redirections
+                !curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, writeCurlResponse) &&
+                !curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, &jsonResp)) {
+                
+                res = curl_easy_perform(curl_handle);
+                if(curl_easy_getinfo(curl_handle, CURLINFO_RESPONSE_CODE, &http_code) != CURLE_OK)
+                {
+                    std::cout << "curl_easy_getinfo failed\n";
+                }
+                std::cout << "Thunder Controller Configuration ret: " << res << " http response code: " << http_code << std::endl;
+                curl_easy_cleanup(curl_handle);
+            }
+            else
+            {
+                std::cout << "Could not perform curl to read Thunder Controller Configuration\n";
+            }
+            if ((res == CURLE_OK) && (http_code == 200))
+            {
+                //check for "Security" in response
+                JsonObject responseJson = JsonObject(jsonResp);
+                if (responseJson.HasLabel("subsystems"))
+                {
+                    const JsonArray subsystemList = responseJson["subsystems"].Array();
+                    for (int i=0; i<subsystemList.Length(); i++)
+                    {
+                        string subsystem = subsystemList[i].String();
+                        if (subsystem == "Security")
+                        {
+                            configured = true;
+                            break;
+                        }
+                    }
+                }
+            }
+            return configured;
+        }
+
+        void RDKShell::RdkShellListener::onApplicationLaunched(const std::string& client)
+        {
+          std::cout << "RDKShell onApplicationLaunched event received ..." << client << std::endl;
+          JsonObject params;
+          params["client"] = client;
+          mShell.notify(RDKSHELL_EVENT_ON_APP_LAUNCHED, params);
+        }
+
+        void RDKShell::RdkShellListener::onApplicationConnected(const std::string& client)
+        {
+          std::cout << "RDKShell onApplicationConnected event received ..." << client << std::endl;
+          JsonObject params;
+          params["client"] = client;
+          mShell.notify(RDKSHELL_EVENT_ON_APP_CONNECTED, params);
+        }
+
+        void RDKShell::RdkShellListener::onApplicationDisconnected(const std::string& client)
+        {
+          std::cout << "RDKShell onApplicationDisconnected event received ..." << client << std::endl;
+          JsonObject params;
+          params["client"] = client;
+          mShell.notify(RDKSHELL_EVENT_ON_APP_DISCONNECTED, params);
+        }
+
+        void RDKShell::RdkShellListener::onApplicationTerminated(const std::string& client)
+        {
+          std::cout << "RDKShell onApplicationTerminated event received ..." << client << std::endl;
+          JsonObject params;
+          params["client"] = client;
+          mShell.notify(RDKSHELL_EVENT_ON_APP_TERMINATED, params);
+        }
+
+        void RDKShell::RdkShellListener::onApplicationFirstFrame(const std::string& client)
+        {
+          std::cout << "RDKShell onApplicationFirstFrame event received ..." << client << std::endl;
+          JsonObject params;
+          params["client"] = client;
+          mShell.notify(RDKSHELL_EVENT_ON_APP_FIRST_FRAME, params);
+        }
+
+        void RDKShell::RdkShellListener::onApplicationSuspended(const std::string& client)
+        {
+          std::cout << "RDKShell onApplicationSuspended event received for " << client << std::endl;
+          JsonObject params;
+          params["client"] = client;
+          mShell.notify(RDKSHELL_EVENT_ON_APP_SUSPENDED, params);
+        }
+
+        void RDKShell::RdkShellListener::onApplicationResumed(const std::string& client)
+        {
+          std::cout << "RDKShell onApplicationResumed event received for " << client << std::endl;
+          JsonObject params;
+          params["client"] = client;
+          mShell.notify(RDKSHELL_EVENT_ON_APP_RESUMED, params);
+        }
+
+        void RDKShell::RdkShellListener::onUserInactive(const double minutes)
+        {
+          std::cout << "RDKShell onUserInactive event received ..." << minutes << std::endl;
+          JsonObject params;
+          params["minutes"] = std::to_string(minutes);
+          mShell.notify(RDKSHELL_EVENT_ON_USER_INACTIVITY, params);
+        }
+
+        void RDKShell::RdkShellListener::onDeviceLowRamWarning(const int32_t freeKb)
+        {
+          std::cout << "RDKShell onDeviceLowRamWarning event received ..." << freeKb << std::endl;
+          JsonObject params;
+          params["ram"] = freeKb;
+          mShell.notify(RDKSHELL_EVENT_DEVICE_LOW_RAM_WARNING, params);
+        }
+
+        void RDKShell::RdkShellListener::onDeviceCriticallyLowRamWarning(const int32_t freeKb)
+        {
+          std::cout << "RDKShell onDeviceCriticallyLowRamWarning event received ..." << freeKb << std::endl;
+          JsonObject params;
+          params["ram"] = freeKb;
+          mShell.notify(RDKSHELL_EVENT_DEVICE_CRITICALLY_LOW_RAM_WARNING, params);
+        }
+
+        void RDKShell::RdkShellListener::onDeviceLowRamWarningCleared(const int32_t freeKb)
+        {
+          std::cout << "RDKShell onDeviceLowRamWarningCleared event received ..." << freeKb << std::endl;
+          JsonObject params;
+          params["ram"] = freeKb;
+          mShell.notify(RDKSHELL_EVENT_DEVICE_LOW_RAM_WARNING_CLEARED, params);
+        }
+
+        void RDKShell::RdkShellListener::onDeviceCriticallyLowRamWarningCleared(const int32_t freeKb)
+        {
+          std::cout << "RDKShell onDeviceCriticallyLowRamWarningCleared event received ..." << freeKb << std::endl;
+          JsonObject params;
+          params["ram"] = freeKb;
+          mShell.notify(RDKSHELL_EVENT_DEVICE_CRITICALLY_LOW_RAM_WARNING_CLEARED, params);
+        }
+
+        // Registered methods (wrappers) begin
+        uint32_t RDKShell::moveToFrontWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool result = true;
+            if (!parameters.HasLabel("client") && !parameters.HasLabel("callsign"))
+            {
+                result = false;
+                response["message"] = "please specify client";
+            }
+            if (result)
+            {
+                string client;
+                if (parameters.HasLabel("client"))
+                {
+                    client = parameters["client"].String();
+                }
+                else
+                {
+                    client = parameters["callsign"].String();
+                }
+                result = moveToFront(client);
+                if (false == result) {
+                  response["message"] = "failed to move front";
+                }
+            }
+            returnResponse(result);
+        }
+
+        uint32_t RDKShell::moveToBackWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool result = true;
+            if (!parameters.HasLabel("client") && !parameters.HasLabel("callsign"))
+            {
+                result = false;
+                response["message"] = "please specify client";
+            }
+            if (result)
+            {
+                string client;
+                if (parameters.HasLabel("client"))
+                {
+                    client = parameters["client"].String();
+                }
+                else
+                {
+                    client = parameters["callsign"].String();
+                }
+                result = moveToBack(client);
+                if (false == result) {
+                  response["message"] = "failed to move back";
+                }
+            }
+            returnResponse(result);
+        }
+
+        uint32_t RDKShell::moveBehindWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool result = true;
+            if (!parameters.HasLabel("client") && !parameters.HasLabel("callsign"))
+            {
+                result = false;
+                response["message"] = "please specify client";
+            }
+            if (!parameters.HasLabel("target"))
+            {
+                result = false;
+                response["message"] = "please specify target";
+            }
+            if (result)
+            {
+                string client;
+                if (parameters.HasLabel("client"))
+                {
+                    client = parameters["client"].String();
+                }
+                else
+                {
+                    client = parameters["callsign"].String();
+                }
+                const string target  = parameters["target"].String();
+                result = moveBehind(client, target);
+                if (false == result) {
+                  response["message"] = "failed to move behind";
+                }
+            }
+            returnResponse(result);
+        }
+
+        uint32_t RDKShell::setFocusWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool result = true;
+            if (!parameters.HasLabel("client") && !parameters.HasLabel("callsign"))
+            {
+                result = false;
+                response["message"] = "please specify client";
+            }
+            if (result)
+            {
+                string client;
+                if (parameters.HasLabel("client"))
+                {
+                    client = parameters["client"].String();
+                }
+                else
+                {
+                    client = parameters["callsign"].String();
+                }
+                result = setFocus(client);
+                if (false == result) {
+                  response["message"] = "failed to set focus";
+                }
+            }
+            returnResponse(result);
+        }
+
+        uint32_t RDKShell::killWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool result = true;
+            if (!parameters.HasLabel("client") && !parameters.HasLabel("callsign"))
+            {
+                result = false;
+                response["message"] = "please specify client";
+            }
+            if (result)
+            {
+                string client;
+                if (parameters.HasLabel("client"))
+                {
+                    client = parameters["client"].String();
+                }
+                else
+                {
+                    client = parameters["callsign"].String();
+                }
+                result = kill(client);
+                if (false == result) {
+                  response["message"] = "failed to kill client";
+                }
+            }
+            returnResponse(result);
+        }
+
+        uint32_t RDKShell::addKeyInterceptWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool result = true;
+
+            if (!parameters.HasLabel("keyCode"))
+            {
+                result = false;
+                response["message"] = "please specify keyCode";
+            }
+            if (!parameters.HasLabel("client") && !parameters.HasLabel("callsign"))
+            {
+                result = false;
+                response["message"] = "please specify client";
+            }
+            if (result)
+            {
+                //optional param?
+                const JsonArray modifiers = parameters.HasLabel("modifiers") ? parameters["modifiers"].Array() : JsonArray();
+
+                const uint32_t keyCode = parameters["keyCode"].Number();
+                string client;
+                if (parameters.HasLabel("client"))
+                {
+                    client = parameters["client"].String();
+                }
+                else
+                {
+                    client = parameters["callsign"].String();
+                }
+                result = addKeyIntercept(keyCode, modifiers, client);
+                if (false == result) {
+                  response["message"] = "failed to add key intercept";
+                }
+            }
+            returnResponse(result);
+        }
+
+        uint32_t RDKShell::removeKeyInterceptWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool result = true;
+
+            if (!parameters.HasLabel("keyCode"))
+            {
+                result = false;
+                response["message"] = "please specify keyCode";
+            }
+            if (!parameters.HasLabel("client") && !parameters.HasLabel("callsign"))
+            {
+                result = false;
+                response["message"] = "please specify client";
+            }
+            if (result)
+            {
+                //optional param?
+                const JsonArray modifiers = parameters.HasLabel("modifiers") ? parameters["modifiers"].Array() : JsonArray();
+
+                const uint32_t keyCode = parameters["keyCode"].Number();
+                string client;
+                if (parameters.HasLabel("client"))
+                {
+                    client = parameters["client"].String();
+                }
+                else
+                {
+                    client = parameters["callsign"].String();
+                }
+                result = removeKeyIntercept(keyCode, modifiers, client);
+                if (false == result) {
+                  response["message"] = "failed to remove key intercept";
+                }
+            }
+            returnResponse(result);
+        }
+
+        uint32_t RDKShell::addKeyListenersWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool result = true;
+
+            if (!parameters.HasLabel("keys"))
+            {
+                result = false;
+                response["message"] = "please specify keys";
+            }
+            if (!parameters.HasLabel("client") && !parameters.HasLabel("callsign"))
+            {
+                result = false;
+                response["message"] = "please specify client";
+            }
+
+            if (result)
+            {
+                const JsonArray keys = parameters["keys"].Array();
+                string client;
+                if (parameters.HasLabel("client"))
+                {
+                    client = parameters["client"].String();
+                }
+                else
+                {
+                    client = parameters["callsign"].String();
+                }
+                result = addKeyListeners(client, keys);
+                if (false == result) {
+                  response["message"] = "failed to add key listeners";
+                }
+            }
+            returnResponse(result);
+        }
+
+        uint32_t RDKShell::removeKeyListenersWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool result = true;
+
+            if (!parameters.HasLabel("keys"))
+            {
+                result = false;
+                response["message"] = "please specify keys";
+            }
+            if (!parameters.HasLabel("client") && !parameters.HasLabel("callsign"))
+            {
+                result = false;
+                response["message"] = "please specify client";
+            }
+
+            if (result)
+            {
+                const JsonArray keys = parameters["keys"].Array();
+                string client;
+                if (parameters.HasLabel("client"))
+                {
+                    client = parameters["client"].String();
+                }
+                else
+                {
+                    client = parameters["callsign"].String();
+                }
+                result = removeKeyListeners(client, keys);
+                if (false == result) {
+                  response["message"] = "failed to remove key listeners";
+                }
+            }
+            returnResponse(result);
+        }
+
+        uint32_t RDKShell::addKeyMetadataListenerWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool result = true;
+
+            if (!parameters.HasLabel("client") && !parameters.HasLabel("callsign"))
+            {
+                result = false;
+                response["message"] = "please specify client";
+            }
+
+            if (result)
+            {
+                string client;
+                if (parameters.HasLabel("client"))
+                {
+                    client = parameters["client"].String();
+                }
+                else
+                {
+                    client = parameters["callsign"].String();
+                }
+                gRdkShellMutex.lock();
+                result = CompositorController::addKeyMetadataListener(client);
+                gRdkShellMutex.unlock();
+                if (false == result) {
+                  response["message"] = "failed to add key metadata listeners";
+                }
+            }
+            returnResponse(result);
+        }
+
+        uint32_t RDKShell::removeKeyMetadataListenerWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool result = true;
+
+            if (!parameters.HasLabel("client") && !parameters.HasLabel("callsign"))
+            {
+                result = false;
+                response["message"] = "please specify client";
+            }
+
+            if (result)
+            {
+                string client;
+                if (parameters.HasLabel("client"))
+                {
+                    client = parameters["client"].String();
+                }
+                else
+                {
+                    client = parameters["callsign"].String();
+                }
+                gRdkShellMutex.lock();
+                result = CompositorController::removeKeyMetadataListener(client);
+                gRdkShellMutex.unlock();
+                if (false == result) {
+                  response["message"] = "failed to remove key metadata listeners";
+                }
+            }
+            returnResponse(result);
+        }
+
+        uint32_t RDKShell::injectKeyWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool result = true;
+
+            if (!parameters.HasLabel("keyCode"))
+            {
+                result = false;
+                response["message"] = "please specify keyCode";
+            }
+
+            if (result)
+            {
+                //optional param?
+                const JsonArray modifiers = parameters.HasLabel("modifiers") ? parameters["modifiers"].Array() : JsonArray();
+
+                const uint32_t keyCode = parameters["keyCode"].Number();
+                result = injectKey(keyCode, modifiers);
+                if (false == result) {
+                  response["message"] = "failed to inject key";
+                }
+            }
+            returnResponse(result);
+        }
+
+        uint32_t RDKShell::generateKeyWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool result = true;
+
+            if (!parameters.HasLabel("keys"))
+            {
+                result = false;
+                response["message"] = "please specify keyInputs";
+            }
+
+            if (result)
+            {
+                const JsonArray keyInputs = parameters["keys"].Array();
+
+                result = generateKey(keyInputs);
+                if (false == result) {
+                  response["message"] = "failed to generate keys";
+                }
+            }
+            returnResponse(result);
+        }
+
+        uint32_t RDKShell::getScreenResolutionWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            UNUSED(parameters);
+
+            bool result = true;
+            if (!getScreenResolution(response))
+            {
+                response["message"] = "failed to get screen resolution";
+                result = false;
+            }
+            returnResponse(result);
+        }
+
+        uint32_t RDKShell::setScreenResolutionWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool result = true;
+            if (!parameters.HasLabel("w"))
+            {
+                result = false;
+                response["message"] = "please specify w";
+            }
+            if (!parameters.HasLabel("h"))
+            {
+                result = false;
+                response["message"] = "please specify h";
+            }
+            if (result)
+            {
+                const unsigned int w  = parameters["w"].Number();
+                const unsigned int h  = parameters["h"].Number();
+
+                result = setScreenResolution(w, h);
+                // Just realized: we need one more string& param for the the error message in case setScreenResolution() fails internally
+                // Also, we might not need a "non-wrapper" method at all, nothing prevents us from implementing it right here
+                if (false == result) {
+                  response["message"] = "failed to set screen resolution";
+                }
+            }
+            returnResponse(result);
+        }
+
+        uint32_t RDKShell::createDisplayWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool result = true;
+            if (!parameters.HasLabel("client") && !parameters.HasLabel("callsign"))
+            {
+                result = false;
+                response["message"] = "please specify client";
+            }
+            if (result)
+            {
+                string client;
+                if (parameters.HasLabel("client"))
+                {
+                    client = parameters["client"].String();
+                }
+                else
+                {
+                    client = parameters["callsign"].String();
+                }
+                string displayName("");
+                if (parameters.HasLabel("displayName"))
+                {
+                    displayName = parameters["displayName"].String();
+                }
+                result = createDisplay(client, displayName);
+                if (false == result) {
+                  response["message"] = "failed to create display";
+                }
+            }
+            returnResponse(result);
+        }
+
+        uint32_t RDKShell::getClientsWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            UNUSED(parameters);
+            bool result = true;
+            JsonArray clients;
+            if (!getClients(clients))
+            {
+                response["message"] = "failed to get clients";
+                result = false;
+            } else {
+                response["clients"] = clients;
+                result = true;
+            }
+            returnResponse(result);
+        }
+
+        uint32_t RDKShell::getZOrderWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            UNUSED(parameters);
+            bool result = true;
+            JsonArray clients;
+            if (!getZOrder(clients))
+            {
+                response["message"] = "failed to get clients";
+                result = false;
+            } else {
+                response["clients"] = clients;
+                result = true;
+            }
+            returnResponse(result);
+        }
+
+        uint32_t RDKShell::getBoundsWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            UNUSED(parameters);
+            bool result = true;
+            if (!parameters.HasLabel("client") && !parameters.HasLabel("callsign"))
+            {
+                result = false;
+                response["message"] = "please specify client";
+            }
+            if (result) {
+              JsonObject bounds;
+              string client;
+              if (parameters.HasLabel("client"))
+              {
+                client = parameters["client"].String();
+              }
+              else
+              {
+                client = parameters["callsign"].String();
+              }
+              if (!getBounds(client, bounds))
+              {
+                  response["message"] = "failed to get bounds";
+                  result = false;
+              } else {
+                  response["bounds"] = bounds;
+                  result = true;
+              }
+            }
+            returnResponse(result);
+        }
+
+        uint32_t RDKShell::setBoundsWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool result = true;
+            if (!parameters.HasLabel("client") && !parameters.HasLabel("callsign"))
+            {
+                result = false;
+                response["message"] = "please specify client";
+            }
+            if (result)
+            {
+                string client;
+                if (parameters.HasLabel("client"))
+                {
+                    client = parameters["client"].String();
+                }
+                else
+                {
+                    client = parameters["callsign"].String();
+                }
+
+                unsigned int x=0,y=0,w=0,h=0;
+                gRdkShellMutex.lock();
+                CompositorController::getBounds(client, x, y, w, h);
+                gRdkShellMutex.unlock();
+                if (parameters.HasLabel("x"))
+                {
+                    x  = parameters["x"].Number();
+                }
+                if (parameters.HasLabel("y"))
+                {
+                    y  = parameters["y"].Number();
+                }
+                if (parameters.HasLabel("w"))
+                {
+                    w  = parameters["w"].Number();
+                }
+                if (parameters.HasLabel("h"))
+                {
+                    h  = parameters["h"].Number();
+                }
+
+                result = setBounds(client, x, y, w, h);
+                if (false == result) {
+                  response["message"] = "failed to set bounds";
+                }
+            }
+            returnResponse(result);
+        }
+
+        uint32_t RDKShell::getVisibilityWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool result = true;
+            if (!parameters.HasLabel("client") && !parameters.HasLabel("callsign"))
+            {
+                result = false;
+                response["message"] = "please specify client";
+            }
+            if (result)
+            {
+                string client;
+                if (parameters.HasLabel("client"))
+                {
+                    client = parameters["client"].String();
+                }
+                else
+                {
+                    client = parameters["callsign"].String();
+                }
+                bool visible;
+                result = getVisibility(client, visible);
+                if (false == result) {
+                  response["message"] = "failed to get visibility";
+                }
+                else {
+                  response["visible"] = visible;
+                }
+            }
+            returnResponse(result);
+        }
+
+        uint32_t RDKShell::setVisibilityWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool result = true;
+            if (!parameters.HasLabel("client") && !parameters.HasLabel("callsign"))
+            {
+                result = false;
+                response["message"] = "please specify client";
+            }
+            if (!parameters.HasLabel("visible"))
+            {
+                result = false;
+                response["message"] = "please specify visibility (visible = true/false)";
+            }
+            if (result)
+            {
+                string client;
+                if (parameters.HasLabel("client"))
+                {
+                    client = parameters["client"].String();
+                }
+                else
+                {
+                    client = parameters["callsign"].String();
+                }
+                const bool visible  = parameters["visible"].Boolean();
+
+                result = setVisibility(client, visible);
+                // Just realized: we need one more string& param for the the error message in case setScreenResolution() fails internally
+                // Also, we might not need a "non-wrapper" method at all, nothing prevents us from implementing it right here
+
+                if (false == result) {
+                  response["message"] = "failed to set visibility";
+                }
+            }
+            returnResponse(result);
+        }
+
+        uint32_t RDKShell::getOpacityWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            UNUSED(parameters);
+            bool result = true;
+            if (!parameters.HasLabel("client") && !parameters.HasLabel("callsign"))
+            {
+                result = false;
+                response["message"] = "please specify client";
+            }
+
+            if (result)
+            {
+                string client;
+                if (parameters.HasLabel("client"))
+                {
+                    client = parameters["client"].String();
+                }
+                else
+                {
+                    client = parameters["callsign"].String();
+                }
+                unsigned int opacity;
+                if (!getOpacity(client, opacity))
+                {
+                    response["message"] = "failed to get opacity";
+                    result = false;
+                } else {
+                    response["opacity"] = opacity;
+                    result = true;
+                }
+            }
+
+            returnResponse(result);
+        }
+
+        uint32_t RDKShell::setOpacityWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool result = true;
+            if (!parameters.HasLabel("client") && !parameters.HasLabel("callsign"))
+            {
+                result = false;
+                response["message"] = "please specify client";
+            }
+            if (!parameters.HasLabel("opacity"))
+            {
+                result = false;
+                response["message"] = "please specify opacity";
+            }
+            if (result)
+            {
+                string client;
+                if (parameters.HasLabel("client"))
+                {
+                    client = parameters["client"].String();
+                }
+                else
+                {
+                    client = parameters["callsign"].String();
+                }
+                const unsigned int  opacity  = parameters["opacity"].Number();
+
+                result = setOpacity(client, opacity);
+                if (false == result) {
+                  response["message"] = "failed to set opacity";
+                }
+                // handle the result
+            }
+            returnResponse(result);
+        }
+
+        uint32_t RDKShell::getScaleWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            UNUSED(parameters);
+            bool result = true;
+            if (!parameters.HasLabel("client") && !parameters.HasLabel("callsign"))
+            {
+                result = false;
+                response["message"] = "please specify client";
+            }
+
+            if (result)
+            {
+                string client;
+                if (parameters.HasLabel("client"))
+                {
+                    client = parameters["client"].String();
+                }
+                else
+                {
+                    client = parameters["callsign"].String();
+                }
+                double scaleX = 1.0;
+                double scaleY = 1.0;
+                if (!getScale(client, scaleX, scaleY))
+                {
+                    response["message"] = "failed to get scale";
+                    result = false;
+                } else {
+                    response["sx"] = std::to_string(scaleX);
+                    response["sy"] = std::to_string(scaleY);
+                    result = true;
+                }
+            }
+
+            returnResponse(result);
+        }
+
+        uint32_t RDKShell::setScaleWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool result = true;
+            if (!parameters.HasLabel("client") && !parameters.HasLabel("callsign"))
+            {
+                result = false;
+                response["message"] = "please specify client";
+            }
+            if (!parameters.HasLabel("sx") && !parameters.HasLabel("sy"))
+            {
+                result = false;
+                response["message"] = "please specify sx and/or sy";
+            }
+            if (result)
+            {
+                string client;
+                if (parameters.HasLabel("client"))
+                {
+                    client = parameters["client"].String();
+                }
+                else
+                {
+                    client = parameters["callsign"].String();
+                }
+                double scaleX = 1.0;
+                double scaleY = 1.0;
+                getScale(client, scaleX, scaleY);
+                if (parameters.HasLabel("sx"))
+                {
+                    scaleX = std::stod(parameters["sx"].String());
+                }
+                if (parameters.HasLabel("sy"))
+                {
+                    scaleY = std::stod(parameters["sy"].String());
+                }
+
+                result = setScale(client, scaleX, scaleY);
+                if (false == result) {
+                  response["message"] = "failed to set scale";
+                }
+            }
+            returnResponse(result);
+        }
+
+        uint32_t RDKShell::removeAnimationWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            UNUSED(parameters);
+            bool result = true;
+            if (!parameters.HasLabel("client") && !parameters.HasLabel("callsign"))
+            {
+                result = false;
+                response["message"] = "please specify client";
+            }
+
+            if (result)
+            {
+                string client;
+                if (parameters.HasLabel("client"))
+                {
+                    client = parameters["client"].String();
+                }
+                else
+                {
+                    client = parameters["callsign"].String();
+                }
+                if (!removeAnimation(client))
+                {
+                    response["message"] = "failed to remove animation";
+                    result = false;
+                }
+            }
+            returnResponse(result);
+        }
+
+        uint32_t RDKShell::addAnimationWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool result = true;
+
+            if (parameters.HasLabel("animations"))
+            {
+                const JsonArray animations = parameters["animations"].Array();
+                result = addAnimationList(animations);
+                if (false == result) {
+                    response["message"] = "failed to add animation list";
+                }
+            }
+            returnResponse(result);
+        }
+
+        uint32_t RDKShell::enableInactivityReportingWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool result = true;
+            if (false == mEnableUserInactivityNotification)
+            {
+                result = false;
+                response["message"] = "feature is not enabled";
+            }
+
+            if (!parameters.HasLabel("enable"))
+            {
+                result = false;
+                response["message"] = "please specify enable parameter";
+            }
+            if (result)
+            {
+                const bool enable  = parameters["enable"].Boolean();
+
+                result = enableInactivityReporting(enable);
+
+                if (false == result) {
+                  response["message"] = "failed to set inactivity notification";
+                }
+            }
+            returnResponse(result);
+        }
+
+        uint32_t RDKShell::setInactivityIntervalWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool result = true;
+            if (false == mEnableUserInactivityNotification)
+            {
+                result = false;
+                response["message"] = "feature is not enabled";
+            }
+
+            if (!parameters.HasLabel("interval"))
+            {
+                result = false;
+                response["message"] = "please specify interval parameter";
+            }
+            if (result)
+            {
+                const string interval = parameters["interval"].String();
+
+                result = setInactivityInterval(interval);
+                // Just realized: we need one more string& param for the the error message in case setScreenResolution() fails internally
+                // Also, we might not need a "non-wrapper" method at all, nothing prevents us from implementing it right here
+
+                if (false == result) {
+                  response["message"] = "failed to set inactivity interval";
+                }
+            }
+            returnResponse(result);
+        }
+
+        uint32_t RDKShell::scaleToFitWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool result = true;
+            if (!parameters.HasLabel("client") && !parameters.HasLabel("callsign"))
+            {
+                result = false;
+                response["message"] = "please specify client";
+            }
+            if (result)
+            {
+                string client;
+                if (parameters.HasLabel("client"))
+                {
+                    client = parameters["client"].String();
+                }
+                else
+                {
+                    client = parameters["callsign"].String();
+                }
+
+                unsigned int x = 0, y = 0;
+                unsigned int clientWidth = 0, clientHeight = 0;
+                gRdkShellMutex.lock();
+                CompositorController::getBounds(client, x, y, clientWidth, clientHeight);
+                if (parameters.HasLabel("x"))
+                {
+                    x = parameters["x"].Number();
+                }
+                if (parameters.HasLabel("y"))
+                {
+                    y = parameters["y"].Number();
+                }
+                if (parameters.HasLabel("w"))
+                {
+                    clientWidth = parameters["w"].Number();
+                }
+                if (parameters.HasLabel("h"))
+                {
+                    clientHeight = parameters["h"].Number();
+                }
+                result = CompositorController::scaleToFit(client, x, y, clientWidth, clientHeight);
+                gRdkShellMutex.unlock();
+
+                if (!result) {
+                  response["message"] = "failed to scale to fit";
+                }
+            }
+            returnResponse(result);
+        }
+
+        uint32_t RDKShell::launchWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool result = true;
+            if (!parameters.HasLabel("callsign"))
+            {
+                result = false;
+                response["message"] = "please specify callsign";
+            }
+
+            if (result)
+            {
+                RDKShellLaunchType launchType = RDKShellLaunchType::UNKNOWN;
+                const string callsign = parameters["callsign"].String();
+                const string callsignWithVersion = callsign + ".1";
+                string type;
+                string version = "0.0";
+                string uri;
+                int32_t x = 0;
+                int32_t y = 0;
+                uint32_t width = 0;
+                uint32_t height = 0;
+                bool suspend = false;
+                bool visible = true;
+                bool focused = true;
+                string configuration;
+                string behind;
+                string displayName = "wst-" + callsign;
+                bool scaleToFit = false;
+
+                if (parameters.HasLabel("type"))
+                {
+                    type = parameters["type"].String();
+                }
+                if (parameters.HasLabel("version"))
+                {
+                    version = parameters["version"].String();
+                }
+                if (parameters.HasLabel("uri"))
+                {
+                    uri = parameters["uri"].String();
+                }
+                if (parameters.HasLabel("configuration"))
+                {
+                    configuration = parameters["configuration"].String();
+                }
+                if (parameters.HasLabel("behind"))
+                {
+                    behind = parameters["behind"].String();
+                }
+                if (parameters.HasLabel("displayName"))
+                {
+                    displayName = parameters["displayName"].String();
+                }
+                if (parameters.HasLabel("suspend"))
+                {
+                    suspend = parameters["suspend"].Boolean();
+                }
+                if (parameters.HasLabel("visible"))
+                {
+                    visible = parameters["visible"].Boolean();
+                }
+                if (parameters.HasLabel("focused"))
+                {
+                    focused = parameters["focused"].Boolean();
+                }
+                if (parameters.HasLabel("scaleToFit"))
+                {
+                    scaleToFit = parameters["scaleToFit"].Boolean();
+                }
+
+                //check to see if plugin already exists
+                bool newPluginFound = false;
+                bool originalPluginFound = false;
+                {
+                    Core::JSON::ArrayType<PluginHost::MetaData::Service> availablePluginResult;
+                    uint32_t status = getThunderControllerClient()->Get<Core::JSON::ArrayType<PluginHost::MetaData::Service>>(2000, "status", availablePluginResult);
+
+                    for (uint16_t i = 0; i < availablePluginResult.Length(); i++)
+                    {
+                        PluginHost::MetaData::Service service = availablePluginResult[i];
+                        std::string pluginName = service.Callsign.Value();
+                        pluginName.erase(std::remove(pluginName.begin(),pluginName.end(),'\"'),pluginName.end());
+                        if (!pluginName.empty() && pluginName == callsign)
+                        {
+                            newPluginFound = true;
+                            break;
+                        }
+                        else if (!pluginName.empty() && pluginName == type)
+                        {
+                            originalPluginFound = true;
+                        }
+                    }
+                }
+
+                if (!newPluginFound && !originalPluginFound)
+                {
+                    response["message"] = "failed to launch application.  type not found";
+                    returnResponse(false);
+                }
+                else if (!newPluginFound)
+                {
+                    std::cout << "attempting to clone type: " << type << " into " << callsign << std::endl;
+                    JsonObject joParams;
+                    joParams.Set("callsign", type);
+                    joParams.Set("newcallsign",callsign.c_str());
+                    JsonObject joResult;
+                    // setting wait Time to 2 seconds
+                    uint32_t status = getThunderControllerClient()->Invoke(2000, "clone", joParams, joResult);
+
+                    string strParams;
+                    string strResult;
+                    joParams.ToString(strParams);
+                    joResult.ToString(strResult);
+                    launchType = RDKShellLaunchType::CREATE;
+                }
+
+                WPEFramework::Core::JSON::String configString;
+
+                uint32_t status = 0;
+                string method = "configuration@" + callsign;
+                Core::JSON::ArrayType<PluginHost::MetaData::Service> joResult;
+                status = getThunderControllerClient()->Get<WPEFramework::Core::JSON::String>(2000, method.c_str(), configString);
+
+                JsonObject configSet;
+                configSet.FromString(configString.Value());
+
+                if (!configuration.empty())
+                {
+                    JsonObject configurationOverrides;
+                    configurationOverrides.FromString(configuration);
+                    JsonObject::Iterator configurationIterator = configurationOverrides.Variants();
+                    while (configurationIterator.Next())
+                    {
+                        configSet[configurationIterator.Label()] = configurationIterator.Current();
+                    }
+                }
+                configSet["clientidentifier"] = displayName;
+
+                status = getThunderControllerClient()->Set<JsonObject>(2000, method.c_str(), configSet);
+
+                if (launchType == RDKShellLaunchType::UNKNOWN)
+                {
+                    status = 0;
+                    string statusMethod = "status@"+callsign;
+                    Core::JSON::ArrayType<PluginHost::MetaData::Service> serviceResults;
+                    status = getThunderControllerClient()->Get<Core::JSON::ArrayType<PluginHost::MetaData::Service> >(2000, statusMethod.c_str(),serviceResults);
+
+                    if (status == 0 && serviceResults.Length() > 0)
+                    {
+                        PluginHost::MetaData::Service service = serviceResults[0];
+                        if (service.JSONState == PluginHost::MetaData::Service::state::DEACTIVATED ||
+                            service.JSONState == PluginHost::MetaData::Service::state::DEACTIVATION ||
+                            service.JSONState == PluginHost::MetaData::Service::state::PRECONDITION)
+                        {
+                            launchType = RDKShellLaunchType::ACTIVATE;
+                            JsonObject activateParams;
+                            activateParams.Set("callsign",callsign.c_str());
+                            JsonObject activateResult;
+                            status = getThunderControllerClient()->Invoke(2000, "activate", activateParams, joResult);
+                        }
+                    }
+                    else
+                    {
+                        launchType = RDKShellLaunchType::ACTIVATE;
+                        JsonObject activateParams;
+                        activateParams.Set("callsign",callsign.c_str());
+                        JsonObject activateResult;
+                        status = getThunderControllerClient()->Invoke(2000, "activate", activateParams, joResult);
+                    }
+                }
+                else
+                {
+                    JsonObject activateParams;
+                    activateParams.Set("callsign",callsign.c_str());
+                    JsonObject activateResult;
+                    status = getThunderControllerClient()->Invoke(2000, "activate", activateParams, joResult);
+                }
+
+                if (status > 0)
+                {
+                    result = false;
+                    std::cout << "error activating plugin.  status code is " << status << std::endl;
+                }
+                else
+                {
+                    uint32_t tempX = 0;
+                    uint32_t tempY = 0;
+                    uint32_t screenWidth = 0;
+                    uint32_t screenHeight = 0;
+                    gRdkShellMutex.lock();
+                    CompositorController::getBounds(callsign, tempX, tempY, screenWidth, screenHeight);
+                    gRdkShellMutex.unlock();
+                    width = screenWidth;
+                    height = screenHeight;
+                    if (parameters.HasLabel("x"))
+                    {
+                        x = parameters["x"].Number();
+                    }
+                    if (parameters.HasLabel("y"))
+                    {
+                        y = parameters["y"].Number();
+                    }
+                    if (parameters.HasLabel("w"))
+                    {
+                        width = parameters["w"].Number();
+                    }
+                    if (parameters.HasLabel("h"))
+                    {
+                        height = parameters["h"].Number();
+                    }
+                    gRdkShellMutex.lock();
+                    CompositorController::setBounds(callsign, x, y, width, height);
+                    gRdkShellMutex.unlock();
+
+                    if (scaleToFit)
+                    {
+                        std::cout << "scaling app to fit full screen" << std::endl;
+                        double sx = 1.0;
+                        double sy = 1.0;
+                        if (width != screenWidth)
+                        {
+                            sx = (double)screenWidth / (double)width;
+                        }
+                        if (height != screenHeight)
+                        {
+                            sy = (double)screenHeight / (double)height;
+                        }
+                        setScale(callsign, sx, sy);
+                    }
+
+                    if (!behind.empty())
+                    {
+                        //check to ensure behind is a active client
+                        std::cout << "moving " << callsign << " behind " << behind << std::endl;
+                        bool moveBehindResult = moveBehind(callsign, behind);
+                        if (!moveBehindResult)
+                        {
+                            std::cout << "unable to move behind " << behind << std::endl;
+                        }
+                    }
+                    if (suspend)
+                    {
+
+                        WPEFramework::Core::JSON::String stateString;
+                        stateString = "suspended";
+                        status = getThunderControllerClient(callsignWithVersion)->Set<WPEFramework::Core::JSON::String>(2000, "state", stateString);
+                        
+                        std::cout << "setting the state to suspended\n";
+                        if (launchType == RDKShellLaunchType::UNKNOWN)
+                        {
+                            launchType = RDKShellLaunchType::SUSPEND;
+                        }
+                        visible = false;
+                    }
+                    else
+                    {
+                        WPEFramework::Core::JSON::String stateString;
+                        stateString = "resumed";
+                        status = getThunderControllerClient(callsignWithVersion)->Set<WPEFramework::Core::JSON::String>(2000, "state", stateString);
+                        if (launchType == RDKShellLaunchType::UNKNOWN)
+                        {
+                            launchType = RDKShellLaunchType::RESUME;
+                        }
+                        
+                        std::cout << "setting the state to resumed\n";
+                    }
+                    setVisibility(callsign, visible);
+                    if (!visible)
+                    {
+                        focused = false;
+                    }
+                    if (focused)
+                    {
+                        std::cout << "setting the focused app to " << callsign << std::endl;
+                        setFocus(callsign);
+                    }
+
+                    JsonObject urlResult;
+                    if (!uri.empty())
+                    {
+                        WPEFramework::Core::JSON::String urlString;
+                        urlString = uri;
+                        status = getThunderControllerClient(callsignWithVersion)->Set<WPEFramework::Core::JSON::String>(2000, "url",urlString);
+                        if (status > 0)
+                        {
+                            std::cout << "failed to set url to " << uri << " with status code " << status << std::endl;
+                        }
+                    }
+                }
+
+                if (status > 0 || !result)
+                {
+                    result = false;
+                }
+                else
+                {
+                    string launchTypeString;
+                    switch (launchType)
+                    {
+                        case CREATE:
+                            launchTypeString = "create";
+                            break;
+                        case ACTIVATE:
+                            launchTypeString = "activate";
+                            break;
+                        case SUSPEND:
+                            launchTypeString = "suspend";
+                            break;
+                        case RESUME:
+                            launchTypeString = "resume";
+                            break;
+                        default:
+                            launchTypeString = "unknown";
+                            break;
+                    }
+                    onLaunched(callsign, launchTypeString);
+                    response["launchType"] = launchTypeString;
+                }
+                
+            }
+            if (!result) 
+            {
+                response["message"] = "failed to launch application";
+            }
+            returnResponse(result);
+        }
+
+        uint32_t RDKShell::suspendWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool result = true;
+            if (!parameters.HasLabel("callsign"))
+            {
+                result = false;
+                response["message"] = "please specify callsign";
+            }
+            if (result)
+            {
+                const string callsign = parameters["callsign"].String();
+                std::cout << "about to suspend " << callsign << std::endl;
+
+                WPEFramework::Core::JSON::String stateString;
+                stateString = "suspended";
+                const string callsignWithVersion = callsign + ".1";
+                uint32_t status = getThunderControllerClient(callsignWithVersion)->Set<WPEFramework::Core::JSON::String>(2000, "state", stateString);
+
+                if (status > 0)
+                {
+                    std::cout << "failed to suspend " << callsign << ".  status: " << status << std::endl;
+                    result = false;
+                }
+                else
+                {
+                    setVisibility(callsign, false);
+                    onSuspended(callsign);
+                }
+            }
+            if (!result)
+            {
+                response["message"] = "failed to suspend application";
+            }
+            returnResponse(result);
+        }
+
+        uint32_t RDKShell::destroyWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool result = true;
+            if (!parameters.HasLabel("callsign"))
+            {
+                result = false;
+                response["message"] = "please specify callsign";
+            }
+            if (result)
+            {
+                const string callsign = parameters["callsign"].String();
+                std::cout << "destroying " << callsign << std::endl;
+                JsonObject joParams;
+                joParams.Set("callsign",callsign.c_str());
+                JsonObject joResult;
+                // setting wait Time to 2 seconds
+                uint32_t status = getThunderControllerClient()->Invoke(2000, "deactivate", joParams, joResult);
+                if (status > 0)
+                {
+                    std::cout << "failed to destroy " << callsign << ".  status: " << status << std::endl;
+                    result = false;
+                }
+                else
+                {
+                    onDestroyed(callsign);
+                }
+            }
+            if (!result)
+            {
+                response["message"] = "failed to destroy application";
+            }
+            returnResponse(result);
+        }
+
+        uint32_t RDKShell::getAvailableTypesWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool result = true;
+
+            string method = "status";
+            Core::JSON::ArrayType<PluginHost::MetaData::Service> joResult;
+            uint32_t status = getThunderControllerClient()->Get<Core::JSON::ArrayType<PluginHost::MetaData::Service>>(2000, method.c_str(), joResult);
+
+            JsonArray availableTypes;
+            for (uint16_t i = 0; i < joResult.Length(); i++)
+            {
+                PluginHost::MetaData::Service service = joResult[i];
+                std::string configLine;
+                service.Configuration.ToString(configLine);
+                if (!configLine.empty())
+                {
+                    JsonObject serviceConfig = JsonObject(configLine.c_str());
+                    if (serviceConfig.HasLabel("clientidentifier"))
+                    {
+                        std::string typeName;
+                        service.Callsign.ToString(typeName);
+                        typeName.erase(std::remove(typeName.begin(),typeName.end(),'\"'),typeName.end());
+                        availableTypes.Add(typeName);
+                    }
+                }
+            }
+            response["types"] = availableTypes;
+
+            returnResponse(result);
+        }
+
+        uint32_t RDKShell::getState(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool result = true;
+
+            string method = "status";
+            Core::JSON::ArrayType<PluginHost::MetaData::Service> joResult;
+            uint32_t status = getThunderControllerClient()->Get<Core::JSON::ArrayType<PluginHost::MetaData::Service>>(2000, method.c_str(), joResult);
+
+
+            JsonArray stateArray;
+            for (uint16_t i = 0; i < joResult.Length(); i++)
+            {
+                PluginHost::MetaData::Service service = joResult[i];
+                if (service.JSONState != PluginHost::MetaData::Service::state::DEACTIVATED &&
+                    service.JSONState != PluginHost::MetaData::Service::state::DEACTIVATION &&
+                    service.JSONState != PluginHost::MetaData::Service::state::PRECONDITION)
+                {
+                    std::string configLine;
+                    service.Configuration.ToString(configLine);
+                    if (!configLine.empty())
+                    {
+                        JsonObject serviceConfig = JsonObject(configLine.c_str());
+                        if (serviceConfig.HasLabel("clientidentifier"))
+                        {
+                            std::string callsign;
+                            service.Callsign.ToString(callsign);
+                            callsign.erase(std::remove(callsign.begin(),callsign.end(),'\"'),callsign.end());
+
+                            WPEFramework::Core::JSON::String stateString;
+                            const string callsignWithVersion = callsign + ".1";
+                            uint32_t stateStatus = getThunderControllerClient(callsignWithVersion)->Get<WPEFramework::Core::JSON::String>(2000, "state", stateString);
+
+                            if (stateStatus == 0)
+                            {
+                                WPEFramework::Core::JSON::String urlString;
+                                uint32_t urlStatus = getThunderControllerClient(callsignWithVersion)->Get<WPEFramework::Core::JSON::String>(2000, "url",urlString);
+
+                                JsonObject typeObject;
+                                typeObject["callsign"] = callsign;
+                                typeObject["state"] = stateString.Value();
+                                if (urlStatus == 0)
+                                {
+                                    typeObject["uri"] = urlString.Value();
+                                }
+                                else
+                                {
+                                    typeObject["uri"] = "";
+                                }
+                                stateArray.Add(typeObject);
+                            }
+                        }
+                    }
+                }
+            }
+            response["state"] = stateArray;
+
+            returnResponse(result);
+        }
+
+        uint32_t RDKShell::getSystemMemoryWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool result = true;
+            uint32_t freeKb=0, usedSwapKb=0, totalKb=0;
+            result = systemMemory(freeKb, totalKb, usedSwapKb);
+            if (!result) {
+              response["message"] = "failed to get system Ram";
+            }
+            else
+            {
+              response["freeRam"] = freeKb;
+              response["swapRam"] = usedSwapKb;
+              response["totalRam"] = totalKb;
+            }
+            returnResponse(result);
+        }
+
+        uint32_t RDKShell::getSystemResourceInfoWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool result = true;
+
+            JsonArray memoryInfo;
+
+            string method = "status";
+            Core::JSON::ArrayType<PluginHost::MetaData::Service> joResult;
+            uint32_t status = getThunderControllerClient()->Get<Core::JSON::ArrayType<PluginHost::MetaData::Service>>(2000, method.c_str(), joResult);
+
+            /*std::cout << "DEACTIVATED: " << PluginHost::MetaData::Service::state::DEACTIVATED << std::endl;
+                    std::cout << "DEACTIVATION: " << PluginHost::MetaData::Service::state::DEACTIVATION << std::endl;
+                    std::cout << "ACTIVATED: " << PluginHost::MetaData::Service::state::ACTIVATED << std::endl;
+                    std::cout << "ACTIVATION: " << PluginHost::MetaData::Service::state::ACTIVATION << std::endl;
+                    std::cout << "DESTROYED: " << PluginHost::MetaData::Service::state::DESTROYED << std::endl;
+                    std::cout << "PRECONDITION: " << PluginHost::MetaData::Service::state::PRECONDITION << std::endl;
+                    std::cout << "SUSPENDED: " << PluginHost::MetaData::Service::state::SUSPENDED << std::endl;
+                    std::cout << "RESUMED: " << PluginHost::MetaData::Service::state::RESUMED << std::endl;*/
+
+            JsonArray stateArray;
+            for (uint16_t i = 0; i < joResult.Length(); i++)
+            {
+                PluginHost::MetaData::Service service = joResult[i];
+                if (service.JSONState != PluginHost::MetaData::Service::state::DEACTIVATED &&
+                    service.JSONState != PluginHost::MetaData::Service::state::DEACTIVATION &&
+                    service.JSONState != PluginHost::MetaData::Service::state::PRECONDITION)
+                {
+                    std::string configLine;
+                    service.Configuration.ToString(configLine);
+                    if (!configLine.empty())
+                    {
+                        JsonObject serviceConfig = JsonObject(configLine.c_str());
+                        if (serviceConfig.HasLabel("clientidentifier"))
+                        {
+                            std::string callsign;
+                            service.Callsign.ToString(callsign);
+                            callsign.erase(std::remove(callsign.begin(),callsign.end(),'\"'),callsign.end());
+
+                            WPEFramework::Core::JSON::String stateString;
+                            const string callsignWithVersion = callsign + ".1";
+                            uint32_t stateStatus = getThunderControllerClient(callsignWithVersion)->Get<WPEFramework::Core::JSON::String>(2000, "state", stateString);
+
+                            if (stateStatus == 0)
+                            {
+                                result = pluginMemoryUsage(callsign, memoryInfo);
+                            }
+                        }
+                    }
+                }
+            }
+
+            response["types"] = memoryInfo;
+
+            returnResponse(result);
+        }
+
+        uint32_t RDKShell::setMemoryMonitorWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool result = true;
+            if (!parameters.HasLabel("enable"))
+            {
+                result = false;
+                response["message"] = "please specify enable parameter";
+            }
+            if (result)
+            {
+              bool enable = parameters["enable"].Boolean();
+              if (parameters.HasLabel("interval"))
+              {
+                RdkShell::setMemoryMonitor(enable, std::stod(parameters["interval"].String()));
+              }
+              else
+              {
+                RdkShell::setMemoryMonitor(enable, 5); //default to 5 second interval
+              }
+            }
+            returnResponse(result);
+        }
+
+        // Registered methods begin
+
+        // Events begin
+        void RDKShell::notify(const std::string& event, const JsonObject& parameters)
+        {
+            sendNotify(event.c_str(), parameters);
+        }
+      // Events end
+
+        // Internal methods begin
+        bool RDKShell::moveToFront(const string& client)
+        {
+            bool ret = false;
+            gRdkShellMutex.lock();
+            ret = CompositorController::moveToFront(client);
+            gRdkShellMutex.unlock();
+            return ret;
+        }
+
+        bool RDKShell::moveToBack(const string& client)
+        {
+            bool ret = false;
+            gRdkShellMutex.lock();
+            ret = CompositorController::moveToBack(client);
+            gRdkShellMutex.unlock();
+            return ret;
+        }
+
+        bool RDKShell::moveBehind(const string& client, const string& target)
+        {
+            bool ret = false;
+            gRdkShellMutex.lock();
+            std::vector<std::string> clientList;
+            CompositorController::getClients(clientList);
+            bool targetFound = false;
+            for (size_t i=0; i<clientList.size(); i++)
+            {
+                if (strcasecmp(clientList[i].c_str(),target.c_str()) == 0)
+                {
+                    targetFound = true;
+                    break;
+                }
+            }
+            if (targetFound)
+            {
+                ret = CompositorController::moveBehind(client, target);
+            }
+            gRdkShellMutex.unlock();
+            return ret;
+        }
+
+        bool RDKShell::setFocus(const string& client)
+        {
+            bool ret = false;
+            gRdkShellMutex.lock();
+            ret = CompositorController::setFocus(client);
+            gRdkShellMutex.unlock();
+            return ret;
+        }
+
+        bool RDKShell::kill(const string& client)
+        {
+            bool ret = false;
+            gRdkShellMutex.lock();
+            RdkShell::CompositorController::removeListener(client, mEventListener);
+            ret = CompositorController::kill(client);
+            gRdkShellMutex.unlock();
+            return ret;
+        }
+
+        bool RDKShell::addKeyIntercept(const uint32_t& keyCode, const JsonArray& modifiers, const string& client)
+        {
+            uint32_t flags = 0;
+            for (int i=0; i<modifiers.Length(); i++) {
+              flags |= getKeyFlag(modifiers[i].String());
+            }
+            bool ret = false;
+            gRdkShellMutex.lock();
+            ret = CompositorController::addKeyIntercept(client, keyCode, flags);
+            gRdkShellMutex.unlock();
+            return ret;
+        }
+
+        bool RDKShell::removeKeyIntercept(const uint32_t& keyCode, const JsonArray& modifiers, const string& client)
+        {
+            uint32_t flags = 0;
+            for (int i=0; i<modifiers.Length(); i++) {
+              flags |= getKeyFlag(modifiers[i].String());
+            }
+            bool ret = false;
+            gRdkShellMutex.lock();
+            ret = CompositorController::removeKeyIntercept(client, keyCode, flags);
+            gRdkShellMutex.unlock();
+            return ret;
+        }
+
+        bool RDKShell::addKeyListeners(const string& client, const JsonArray& keys)
+        {
+            gRdkShellMutex.lock();
+            for (int i=0; i<keys.Length(); i++) {
+                const JsonObject& keyInfo = keys[i].Object();
+                if (keyInfo.HasLabel("keyCode"))
+                {
+                    std::string keystring = keyInfo["keyCode"].String();
+                    uint32_t keyCode = 0;
+                    if (keystring.compare("*") == 0)
+                    {
+                      keyCode = ANY_KEY;
+                    }
+                    else
+                    {
+                      keyCode = keyInfo["keyCode"].Number();
+                    }
+                    const JsonArray modifiers = keyInfo.HasLabel("modifiers") ? keyInfo["modifiers"].Array() : JsonArray();
+                    uint32_t flags = 0;
+                    for (int i=0; i<modifiers.Length(); i++) {
+                      flags |= getKeyFlag(modifiers[i].String());
+                    }
+                    std::map<std::string, RdkShellData> properties;
+                    if (keyInfo.HasLabel("activate"))
+                    {
+                        bool activate = keyInfo["activate"].Boolean();
+                        properties["activate"] = activate;
+                    }
+                    if (keyInfo.HasLabel("propagate"))
+                    {
+                        bool propagate = keyInfo["propagate"].Boolean();
+                        properties["propagate"] = propagate;
+                    }
+                    CompositorController::addKeyListener(client, keyCode, flags, properties);
+                }
+            }
+            gRdkShellMutex.unlock();
+            return true;
+        }
+
+        bool RDKShell::removeKeyListeners(const string& client, const JsonArray& keys)
+        {
+            gRdkShellMutex.lock();
+            for (int i=0; i<keys.Length(); i++) {
+                const JsonObject& keyInfo = keys[i].Object();
+                if (keyInfo.HasLabel("keyCode"))
+                {
+                    std::string keystring = keyInfo["keyCode"].String();
+                    uint32_t keyCode = 0;
+                    if (keystring.compare("*") == 0)
+                    {
+                      keyCode = ANY_KEY;
+                    }
+                    else
+                    {
+                      keyCode = keyInfo["keyCode"].Number();
+                    }
+                    const JsonArray modifiers = keyInfo.HasLabel("modifiers") ? keyInfo["modifiers"].Array() : JsonArray();
+                    uint32_t flags = 0;
+                    for (int i=0; i<modifiers.Length(); i++) {
+                      flags |= getKeyFlag(modifiers[i].String());
+                    }
+                    CompositorController::removeKeyListener(client, keyCode, flags);
+                }
+            }
+            gRdkShellMutex.unlock();
+            return true;
+        }
+
+        bool RDKShell::injectKey(const uint32_t& keyCode, const JsonArray& modifiers)
+        {
+            bool ret = false;
+            uint32_t flags = 0;
+            for (int i=0; i<modifiers.Length(); i++) {
+              flags |= getKeyFlag(modifiers[i].String());
+            }
+            gRdkShellMutex.lock();
+            ret = CompositorController::injectKey(keyCode, flags);
+            gRdkShellMutex.unlock();
+            return ret;
+        }
+
+        bool RDKShell::generateKey(const JsonArray& keyInputs)
+        {
+            bool ret = false;
+            for (int i=0; i<keyInputs.Length(); i++) {
+                const JsonObject& keyInputInfo = keyInputs[i].Object();
+                if (keyInputInfo.HasLabel("keyCode"))
+                {
+                  const uint32_t keyCode = keyInputInfo["keyCode"].Number();
+                  const uint32_t delay = keyInputInfo["delay"].Number();
+                  sleep(delay);
+                  const JsonArray modifiers = keyInputInfo.HasLabel("modifiers") ? keyInputInfo["modifiers"].Array() : JsonArray();
+                  uint32_t flags = 0;
+                  for (int k=0; k<modifiers.Length(); k++) {
+                    flags |= getKeyFlag(modifiers[k].String());
+                  }
+                  gRdkShellMutex.lock();
+                  ret = CompositorController::injectKey(keyCode, flags);
+                  gRdkShellMutex.unlock();
+                }
+            }
+            return ret;
+        }
+
+        bool RDKShell::getScreenResolution(JsonObject& out)
+        {
+            unsigned int width=0,height=0;
+            bool ret = false;
+            gRdkShellMutex.lock();
+            ret = CompositorController::getScreenResolution(width, height);
+            gRdkShellMutex.unlock();
+            if (true == ret) {
+              out["w"] = width;
+              out["h"] = height;
+              return true;
+            }
+            return false;
+        }
+
+        bool RDKShell::setScreenResolution(const unsigned int w, const unsigned int h)
+        {
+            gRdkShellMutex.lock();
+            receivedResolutionRequest = true;
+            resolutionWidth = w;
+            resolutionHeight = h;
+            gRdkShellMutex.unlock();
+            return true;
+        }
+
+        bool RDKShell::createDisplay(const string& client, const string& displayName)
+        {
+            bool ret = false;
+            gRdkShellMutex.lock();
+            ret = CompositorController::createDisplay(client, displayName);
+            RdkShell::CompositorController::addListener(client, mEventListener);
+            gRdkShellMutex.unlock();
+            return ret;
+        }
+
+        bool RDKShell::getClients(JsonArray& clients)
+        {
+            std::vector<std::string> clientList;
+            gRdkShellMutex.lock();
+            CompositorController::getClients(clientList);
+            gRdkShellMutex.unlock();
+            for (size_t i=0; i<clientList.size(); i++) {
+              clients.Add(clientList[i]);
+            }
+            return true;
+        }
+
+        bool RDKShell::getZOrder(JsonArray& clients)
+        {
+            std::vector<std::string> zOrderList;
+            gRdkShellMutex.lock();
+            CompositorController::getZOrder(zOrderList);
+            gRdkShellMutex.unlock();
+            for (size_t i=0; i<zOrderList.size(); i++) {
+              clients.Add(zOrderList[i]);
+            }
+            return true;
+        }
+
+        bool RDKShell::getBounds(const string& client, JsonObject& bounds)
+        {
+            unsigned int x=0,y=0,width=0,height=0;
+            bool ret = false;
+            gRdkShellMutex.lock();
+            ret = CompositorController::getBounds(client, x, y, width, height);
+            gRdkShellMutex.unlock();
+            if (true == ret) {
+              bounds["x"] = x;
+              bounds["y"] = y;
+              bounds["w"] = width;
+              bounds["h"] = height;
+              return true;
+            }
+            return false;
+        }
+
+        bool RDKShell::setBounds(const std::string& client, const unsigned int x, const unsigned int y, const unsigned int w, const unsigned int h)
+        {
+            bool ret = false;
+            gRdkShellMutex.lock();
+            ret = CompositorController::setBounds(client, x, y, w, h);
+            gRdkShellMutex.unlock();
+            return ret;
+        }
+
+        bool RDKShell::getVisibility(const string& client, bool& visible)
+        {
+            bool ret = false;
+            gRdkShellMutex.lock();
+            ret = CompositorController::getVisibility(client, visible);
+            gRdkShellMutex.unlock();
+            return ret;
+        }
+
+        bool RDKShell::setVisibility(const string& client, const bool visible)
+        {
+            bool ret = false;
+            gRdkShellMutex.lock();
+            ret = CompositorController::setVisibility(client, visible);
+            gRdkShellMutex.unlock();
+            return ret;
+        }
+
+        bool RDKShell::getOpacity(const string& client, unsigned int& opacity)
+        {
+            bool ret = false;
+            gRdkShellMutex.lock();
+            ret = CompositorController::getOpacity(client, opacity);
+            gRdkShellMutex.unlock();
+            return ret;
+        }
+
+        bool RDKShell::setOpacity(const string& client, const unsigned int opacity)
+        {
+            bool ret = false;
+            gRdkShellMutex.lock();
+            ret = CompositorController::setOpacity(client, opacity);
+            gRdkShellMutex.unlock();
+            return ret;
+        }
+
+        bool RDKShell::getScale(const string& client, double& scaleX, double& scaleY)
+        {
+            bool ret = false;
+            gRdkShellMutex.lock();
+            ret = CompositorController::getScale(client, scaleX, scaleY);
+            gRdkShellMutex.unlock();
+            return ret;
+        }
+
+        bool RDKShell::setScale(const string& client, const double scaleX, const double scaleY)
+        {
+            bool ret = false;
+            gRdkShellMutex.lock();
+            ret = CompositorController::setScale(client, scaleX, scaleY);
+            gRdkShellMutex.unlock();
+            return ret;
+        }
+
+        bool RDKShell::removeAnimation(const string& client)
+        {
+            bool ret = false;
+            gRdkShellMutex.lock();
+            ret = CompositorController::removeAnimation(client);
+            gRdkShellMutex.unlock();
+            return ret;
+        }
+
+        bool RDKShell::addAnimationList(const JsonArray& animations)
+        {
+            gRdkShellMutex.lock();
+            for (int i=0; i<animations.Length(); i++) {
+                const JsonObject& animationInfo = animations[i].Object();
+                if (animationInfo.HasLabel("client") && animationInfo.HasLabel("duration"))
+                {
+                    const string client  = animationInfo["client"].String();
+                    const double duration = std::stod(animationInfo["duration"].String());
+                    std::map<std::string, RdkShellData> animationProperties;
+                    if (animationInfo.HasLabel("x"))
+                    {
+                        int32_t x = animationInfo["x"].Number();
+                        animationProperties["x"] = x;
+                    }
+                    if (animationInfo.HasLabel("y"))
+                    {
+                        int32_t y = animationInfo["y"].Number();
+                        animationProperties["y"] = y;
+                    }
+                    if (animationInfo.HasLabel("w"))
+                    {
+                        uint32_t width = animationInfo["w"].Number();
+                        animationProperties["w"] = width;
+                    }
+                    if (animationInfo.HasLabel("h"))
+                    {
+                        uint32_t height = animationInfo["h"].Number();
+                        animationProperties["h"] = height;
+                    }
+                    if (animationInfo.HasLabel("sx"))
+                    {
+                        double scaleX = std::stod(animationInfo["sx"].String());
+                        animationProperties["sx"] = scaleX;
+                    }
+                    if (animationInfo.HasLabel("sy"))
+                    {
+                        double scaleY = std::stod(animationInfo["sy"].String());
+                        animationProperties["sy"] = scaleY;
+                    }
+                    if (animationInfo.HasLabel("a"))
+                    {
+                        uint32_t opacity = animationInfo["a"].Number();
+                        animationProperties["a"] = opacity;
+                    }
+                    if (animationInfo.HasLabel("tween"))
+                    {
+                        std::string tween = animationInfo["tween"].String();
+                        animationProperties["tween"] = tween;
+                    }
+                    CompositorController::addAnimation(client, duration, animationProperties);
+                }
+            }
+            gRdkShellMutex.unlock();
+            return true;
+        }
+
+        bool RDKShell::enableInactivityReporting(const bool enable)
+        {
+            gRdkShellMutex.lock();
+            CompositorController::enableInactivityReporting(enable);
+            gRdkShellMutex.unlock();
+            return true;
+        }
+
+        bool RDKShell::setInactivityInterval(const string interval)
+        {
+            gRdkShellMutex.lock();
+            try
+            {
+              CompositorController::setInactivityInterval(std::stod(interval));
+            }
+            catch (...) 
+            {
+              std::cout << "RDKShell unable to set inactivity interval  " << std::endl;
+            }
+            gRdkShellMutex.unlock();
+            return true;
+        }
+
+        void RDKShell::onLaunched(const std::string& client, const string& launchType)
+        {
+            std::cout << "RDKShell onLaunched event received for " << client << std::endl;
+            JsonObject params;
+            params["client"] = client;
+            params["launchType"] = launchType;
+            notify(RDKSHELL_EVENT_ON_LAUNCHED, params);
+        }
+
+        void RDKShell::onSuspended(const std::string& client)
+        {
+            std::cout << "RDKShell onSuspended event received for " << client << std::endl;
+            JsonObject params;
+            params["client"] = client;
+
+            notify(RDKSHELL_EVENT_ON_SUSPENDED, params);
+        }
+
+        void RDKShell::onDestroyed(const std::string& client)
+        {
+            std::cout << "RDKShell onDestroyed event received for " << client << std::endl;
+            JsonObject params;
+            params["client"] = client;
+            notify(RDKSHELL_EVENT_ON_DESTROYED, params);
+        }
+
+        bool RDKShell::systemMemory(uint32_t &freeKb, uint32_t & totalKb, uint32_t & usedSwapKb)
+        {
+            gRdkShellMutex.lock();
+            bool ret = RdkShell::systemRam(freeKb, totalKb, usedSwapKb);
+            gRdkShellMutex.unlock();
+            return ret;
+        }
+
+        bool RDKShell::pluginMemoryUsage(const string callsign, JsonArray& memoryInfo)
+        {
+            JsonObject memoryDetails;
+            PluginHost::IShell* plugin(mCurrentService->QueryInterfaceByCallsign<PluginHost::IShell>(callsign.c_str()));
+            memoryDetails["callsign"] = callsign;
+            memoryDetails["ram"] = -1;
+            if (nullptr != plugin)
+            {
+                Exchange::IMemory* memory = plugin->QueryInterface<Exchange::IMemory>();
+
+                if (memory != nullptr)
+                {
+                    memoryDetails["ram"] = memory->Resident()/1024;
+                }
+                else
+                {
+                    std::cout << "Memory information not available for " << callsign << std::endl;
+                }
+                memoryInfo.Add(memoryDetails);
+            }
+            return true;
+        }
+
+        // Internal methods end
+    } // namespace Plugin
+} // namespace WPEFramework

--- a/RDKShell/RDKShell.h
+++ b/RDKShell/RDKShell.h
@@ -1,0 +1,266 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2020 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+#pragma once
+
+#include <mutex>
+#include "Module.h"
+#include "utils.h"
+#include <rdkshell/rdkshellevents.h>
+#include <rdkshell/rdkshell.h>
+#include <rdkshell/linuxkeys.h>
+#include "AbstractPlugin.h"
+
+namespace WPEFramework {
+
+    namespace Plugin {
+
+        class RDKShell :  public AbstractPlugin {
+        public:
+            RDKShell();
+            virtual ~RDKShell();
+            virtual const string Initialize(PluginHost::IShell* service) override;
+            virtual void Deinitialize(PluginHost::IShell* service) override;
+            virtual string Information() const override;
+
+        public/*members*/:
+            static RDKShell* _instance;
+
+        public /*constants*/:
+            static const short API_VERSION_NUMBER_MAJOR;
+            static const short API_VERSION_NUMBER_MINOR;
+            static const string SERVICE_NAME;
+            //methods
+            static const string RDKSHELL_METHOD_MOVE_TO_FRONT;
+            static const string RDKSHELL_METHOD_MOVE_TO_BACK;
+            static const string RDKSHELL_METHOD_MOVE_BEHIND;
+            static const string RDKSHELL_METHOD_SET_FOCUS;
+            static const string RDKSHELL_METHOD_KILL;
+            static const string RDKSHELL_METHOD_ADD_KEY_INTERCEPT;
+            static const string RDKSHELL_METHOD_REMOVE_KEY_INTERCEPT;
+            static const string RDKSHELL_METHOD_ADD_KEY_LISTENER;
+            static const string RDKSHELL_METHOD_REMOVE_KEY_LISTENER;
+            static const string RDKSHELL_METHOD_ADD_KEY_METADATA_LISTENER;
+            static const string RDKSHELL_METHOD_REMOVE_KEY_METADATA_LISTENER;
+            static const string RDKSHELL_METHOD_INJECT_KEY;
+            static const string RDKSHELL_METHOD_GENERATE_KEYS;
+            static const string RDKSHELL_METHOD_GET_SCREEN_RESOLUTION;
+            static const string RDKSHELL_METHOD_SET_SCREEN_RESOLUTION;
+            static const string RDKSHELL_METHOD_CREATE_DISPLAY;
+            static const string RDKSHELL_METHOD_GET_CLIENTS;
+            static const string RDKSHELL_METHOD_GET_Z_ORDER;
+            static const string RDKSHELL_METHOD_GET_BOUNDS;
+            static const string RDKSHELL_METHOD_SET_BOUNDS;
+            static const string RDKSHELL_METHOD_GET_VISIBILITY;
+            static const string RDKSHELL_METHOD_SET_VISIBILITY;
+            static const string RDKSHELL_METHOD_GET_OPACITY;
+            static const string RDKSHELL_METHOD_SET_OPACITY;
+            static const string RDKSHELL_METHOD_GET_SCALE;
+            static const string RDKSHELL_METHOD_SET_SCALE;
+            static const string RDKSHELL_METHOD_ADD_ANIMATION;
+            static const string RDKSHELL_METHOD_REMOVE_ANIMATION;
+            static const string RDKSHELL_METHOD_ENABLE_INACTIVITY_REPORTING;
+            static const string RDKSHELL_METHOD_SET_INACTIVITY_INTERVAL;
+            static const string RDKSHELL_METHOD_SCALE_TO_FIT;
+            static const string RDKSHELL_METHOD_LAUNCH;
+            static const string RDKSHELL_METHOD_SUSPEND;
+            static const string RDKSHELL_METHOD_DESTROY;
+            static const string RDKSHELL_METHOD_GET_AVAILABLE_TYPES;
+            static const string RDKSHELL_METHOD_GET_STATE;
+            static const string RDKSHELL_METHOD_GET_SYSTEM_MEMORY;
+            static const string RDKSHELL_METHOD_GET_SYSTEM_RESOURCE_INFO;
+            static const string RDKSHELL_METHOD_SET_MEMORY_MONITOR;
+
+            // events
+            static const string RDKSHELL_EVENT_ON_USER_INACTIVITY;
+            static const string RDKSHELL_EVENT_ON_APP_LAUNCHED;
+            static const string RDKSHELL_EVENT_ON_APP_CONNECTED;
+            static const string RDKSHELL_EVENT_ON_APP_DISCONNECTED;
+            static const string RDKSHELL_EVENT_ON_APP_TERMINATED;
+            static const string RDKSHELL_EVENT_ON_APP_FIRST_FRAME;
+            static const string RDKSHELL_EVENT_ON_APP_SUSPENDED;
+            static const string RDKSHELL_EVENT_ON_APP_RESUMED;
+            static const string RDKSHELL_EVENT_ON_LAUNCHED;
+            static const string RDKSHELL_EVENT_ON_SUSPENDED;
+            static const string RDKSHELL_EVENT_ON_DESTROYED;
+            static const string RDKSHELL_EVENT_DEVICE_LOW_RAM_WARNING;
+            static const string RDKSHELL_EVENT_DEVICE_CRITICALLY_LOW_RAM_WARNING;
+            static const string RDKSHELL_EVENT_DEVICE_LOW_RAM_WARNING_CLEARED;
+            static const string RDKSHELL_EVENT_DEVICE_CRITICALLY_LOW_RAM_WARNING_CLEARED;
+
+        private/*registered methods (wrappers)*/:
+
+            //methods ("parameters" here is "params" from the curl request)
+            uint32_t moveToFrontWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t moveToBackWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t moveBehindWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t setFocusWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t killWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t addKeyInterceptWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t removeKeyInterceptWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t addKeyListenersWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t removeKeyListenersWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t addKeyMetadataListenerWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t removeKeyMetadataListenerWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t injectKeyWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t generateKeyWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t getScreenResolutionWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t setScreenResolutionWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t createDisplayWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t getClientsWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t getZOrderWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t getBoundsWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t setBoundsWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t getVisibilityWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t setVisibilityWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t getOpacityWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t setOpacityWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t getScaleWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t setScaleWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t addAnimationWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t removeAnimationWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t enableInactivityReportingWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t setInactivityIntervalWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t scaleToFitWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t launchWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t suspendWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t destroyWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t getAvailableTypesWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t getState(const JsonObject& parameters, JsonObject& response);
+            uint32_t getSystemMemoryWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t getSystemResourceInfoWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t setMemoryMonitorWrapper(const JsonObject& parameters, JsonObject& response);
+            void notify(const std::string& event, const JsonObject& parameters);
+
+        private/*internal methods*/:
+            RDKShell(const RDKShell&) = delete;
+            RDKShell& operator=(const RDKShell&) = delete;
+
+            bool moveToFront(const string& client);
+            bool moveToBack(const string& client);
+            bool moveBehind(const string& client, const string& target);
+            bool setFocus(const string& client);
+            bool kill(const string& client);
+            bool addKeyIntercept(const uint32_t& keyCode, const JsonArray& modifiers, const string& client);
+            bool removeKeyIntercept(const uint32_t& keyCode, const JsonArray& modifiers, const string& client);
+            bool addKeyListeners(const string& client, const JsonArray& listeners);
+            bool removeKeyListeners(const string& client, const JsonArray& listeners);
+            bool addAnyKeyListener(const string& client, const JsonArray& listeners);
+            bool injectKey(const uint32_t& keyCode, const JsonArray& modifiers);
+            bool generateKey(const JsonArray& keyInputs);
+            bool getScreenResolution(JsonObject& out);
+            bool setScreenResolution(const unsigned int w, const unsigned int h);
+            bool createDisplay(const string& client, const string& displayName);
+            bool getClients(JsonArray& clients);
+            bool getZOrder(JsonArray& clients);
+            bool getBounds(const string& client, JsonObject& bounds);
+            bool setBounds(const string& client, const unsigned int x, const unsigned int y, const unsigned int w, const unsigned int h);
+            bool getVisibility(const string& client, bool& visibility);
+            bool setVisibility(const string& client, const bool visible);
+            bool getOpacity(const string& client, unsigned int& opacity);
+            bool setOpacity(const string& client, const unsigned int opacity);
+            bool getScale(const string& client, double& scaleX, double& scaleY);
+            bool setScale(const string& client, const double scaleX, const double scaleY);
+            bool removeAnimation(const string& client);
+            bool addAnimationList(const JsonArray& animations);
+            bool enableInactivityReporting(const bool enable);
+            bool setInactivityInterval(const string interval);
+            void onLaunched(const std::string& client, const string& launchType);
+            void onSuspended(const std::string& client);
+            void onDestroyed(const std::string& client);
+            bool systemMemory(uint32_t &freeKb, uint32_t & totalKb, uint32_t & usedSwapKb);
+            bool pluginMemoryUsage(const string callsign, JsonArray& memoryInfo);
+
+            static std::shared_ptr<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement> > getThunderControllerClient(std::string callsign="");
+            static void getSecurityToken(std::string& token);
+            static bool isThunderSecurityConfigured();
+
+            static std::string m_sToken;
+            static bool m_sThunderSecurityChecked;
+
+        private/*classes */:
+
+            class RdkShellListener :  public RdkShell::RdkShellEventListener {
+
+              public:
+                RdkShellListener(RDKShell* shell)
+                    : mShell(*shell)
+                {
+                }
+
+                ~RdkShellListener()
+                {
+                }
+
+                // rdkshell events listeners
+                virtual void onApplicationLaunched(const std::string& client);
+                virtual void onApplicationConnected(const std::string& client);
+                virtual void onApplicationDisconnected(const std::string& client);
+                virtual void onApplicationTerminated(const std::string& client);
+                virtual void onApplicationFirstFrame(const std::string& client);
+                virtual void onApplicationSuspended(const std::string& client);
+                virtual void onApplicationResumed(const std::string& client);
+                virtual void onUserInactive(const double minutes);
+                virtual void onDeviceLowRamWarning(const int32_t freeKb);
+                virtual void onDeviceCriticallyLowRamWarning(const int32_t freeKb);
+                virtual void onDeviceLowRamWarningCleared(const int32_t freeKb);
+                virtual void onDeviceCriticallyLowRamWarningCleared(const int32_t freeKb);
+
+              private:
+                  RDKShell& mShell;
+            };
+
+            class MonitorClients : public PluginHost::IPlugin::INotification {
+              private:
+                  MonitorClients() = delete;
+                  MonitorClients(const MonitorClients&) = delete;
+                  MonitorClients& operator=(const MonitorClients&) = delete;
+
+              public:
+                  MonitorClients(RDKShell* shell)
+                      : mShell(*shell)
+                  {
+                      ASSERT(mShell != nullptr);
+                  }
+                  ~MonitorClients()
+                  {
+                  }
+
+              public:
+                  BEGIN_INTERFACE_MAP(MonitorClients)
+                  INTERFACE_ENTRY(PluginHost::IPlugin::INotification)
+                  END_INTERFACE_MAP
+
+              private:
+                  virtual void StateChange(PluginHost::IShell* shell);
+
+              private:
+                  RDKShell& mShell;
+            };
+
+        private/*members*/:
+            bool mRemoteShell;
+            bool mEnableUserInactivityNotification;
+            MonitorClients* mClientsMonitor;
+            std::shared_ptr<RdkShell::RdkShellEventListener> mEventListener;
+            PluginHost::IShell* mCurrentService;
+            //std::mutex m_callMutex;
+        };
+    } // namespace Plugin
+} // namespace WPEFramework

--- a/RDKShell/RDKShell.json
+++ b/RDKShell/RDKShell.json
@@ -1,0 +1,9 @@
+{
+ "locator":"libWPEFrameworkRDKShell.so",
+ "classname":"RDKShell",
+ "precondition":[
+  "Platform"
+ ],
+ "callsign":"org.rdk.RDKShell",
+ "autostart":true
+}

--- a/RDKShell/README.md
+++ b/RDKShell/README.md
@@ -1,0 +1,91 @@
+-----------------
+# RDKShell
+
+## Versions
+`org.rdk.RDKShell.1`
+
+## Methods:
+```
+curl --header "Content-Type: application/json" --request POST --data '{"jsonrpc":"2.0", "id":3, "method":"org.rdk.RDKShell.1.moveToFront", "params":{ "client": "org.rdk.Netflix"}}' http://127.0.0.1:9998/jsonrpc
+curl --header "Content-Type: application/json" --request POST --data '{"jsonrpc":"2.0", "id":3, "method":"org.rdk.RDKShell.1.moveToBack", "params":{ "client": "org.rdk.Netflix"}}' http://127.0.0.1:9998/jsonrpc
+curl --header "Content-Type: application/json" --request POST --data '{"jsonrpc":"2.0", "id":3, "method":"org.rdk.RDKShell.1.moveBehind", "params":{ "client": "org.rdk.Netflix", "target": "org.rdk.RDKBrowser2"}}' http://127.0.0.1:9998/jsonrpc
+curl --header "Content-Type: application/json" --request POST --data '{"jsonrpc":"2.0", "id":3, "method":"org.rdk.RDKShell.1.setFocus", "params":{ "client": "org.rdk.Netflix"}}' http://127.0.0.1:9998/jsonrpc
+curl --header "Content-Type: application/json" --request POST --data '{"jsonrpc":"2.0", "id":3, "method":"org.rdk.RDKShell.1.kill", "params":{ "client": "org.rdk.Netflix"}}' http://127.0.0.1:9998/jsonrpc
+curl --header "Content-Type: application/json" --request POST --data '{"jsonrpc":"2.0", "id":3, "method":"org.rdk.RDKShell.1.addKeyIntercept", "params":{"keyCode": 10, "modifiers": ["alt", "shift"], "client": "org.rdk.Netflix"}}' http://127.0.0.1:9998/jsonrpc
+curl --header "Content-Type: application/json" --request POST --data '{"jsonrpc":"2.0", "id":3, "method":"org.rdk.RDKShell.1.removeKeyIntercept", "params":{"keyCode": 10, "modifiers": ["alt", "shift"], "client": "org.rdk.Netflix"}}' http://127.0.0.1:9998/jsonrpc
+curl --header "Content-Type: application/json" --request POST --data '{"jsonrpc":"2.0", "id":3, "method":"org.rdk.RDKShell.1.getScreenResolution", "params":{}}' http://127.0.0.1:9998/jsonrpc
+curl --header "Content-Type: application/json" --request POST --data '{"jsonrpc":"2.0", "id":3, "method":"org.rdk.RDKShell.1.setScreenResolution", "params":{ "w": 1920, "h": 1080}}' http://127.0.0.1:9998/jsonrpc
+curl --header "Content-Type: application/json" --request POST --data '{"jsonrpc":"2.0", "id":3, "method":"org.rdk.RDKShell.1.getClients", "params":{}}' http://127.0.0.1:9998/jsonrpc
+curl --header "Content-Type: application/json" --request POST --data '{"jsonrpc":"2.0", "id":3, "method":"org.rdk.RDKShell.1.getZOrder", "params":{}}' http://127.0.0.1:9998/jsonrpc
+curl --header "Content-Type: application/json" --request POST --data '{"jsonrpc":"2.0", "id":3, "method":"org.rdk.RDKShell.1.getBounds", "params":{ "client": "org.rdk.RDKBrowser2"}}' http://127.0.0.1:9998/jsonrpc
+curl --header "Content-Type: application/json" --request POST --data '{"jsonrpc":"2.0", "id":3, "method":"org.rdk.RDKShell.1.setBounds", "params":{"client": "org.rdk.RDKBrowser2", "x": 0, "y": 0, "w": 600, "h": 400}}' http://127.0.0.1:9998/jsonrpc
+curl --header "Content-Type: application/json" --request POST --data '{"jsonrpc":"2.0", "id":3, "method":"org.rdk.RDKShell.1.getVisibility", "params":{ "client": "org.rdk.Netflix"}}' http://127.0.0.1:9998/jsonrpc
+curl --header "Content-Type: application/json" --request POST --data '{"jsonrpc":"2.0", "id":3, "method":"org.rdk.RDKShell.1.setVisibility", "params":{ "client": "org.rdk.Netflix", "visible": true}}' http://127.0.0.1:9998/jsonrpc
+curl --header "Content-Type: application/json" --request POST --data '{"jsonrpc":"2.0", "id":3, "method":"org.rdk.RDKShell.1.getOpacity", "params":{ "client": "org.rdk.Netflix"}}' http://127.0.0.1:9998/jsonrpc
+curl --header "Content-Type: application/json" --request POST --data '{"jsonrpc":"2.0", "id":3, "method":"org.rdk.RDKShell.1.setOpacity", "params":{ "client": "org.rdk.Netflix", "opacity": 100}}' http://127.0.0.1:9998/jsonrpc
+```
+
+## Responses
+```
+moveToFront:
+{"jsonrpc":"2.0", "id":3, "result": {} }
+
+moveToBack:
+{"jsonrpc":"2.0", "id":3, "result": {} }
+
+moveBehind:
+{"jsonrpc":"2.0", "id":3, "result": {} }
+
+setFocus:
+{"jsonrpc":"2.0", "id":3, "result": {} }
+
+kill:
+{"jsonrpc":"2.0", "id":3, "result": {} }
+
+addKeyIntercept:
+{"jsonrpc":"2.0", "id":3, "result": {} }
+
+removeKeyIntercept:
+{"jsonrpc":"2.0", "id":3, "result": {} }
+
+getScreenResolution:
+{"jsonrpc":"2.0", "id":3, "result": {"w": 1920, "h": 1080} }
+
+setScreenResolution:
+{"jsonrpc":"2.0", "id":3, "result": {} }
+
+getClients:
+{"jsonrpc":"2.0", "id":3, "result": { "clients": ["org.rdk.Netflix", "org.rdk.RDKBrowser2"]} }
+
+getZOrder:
+{"jsonrpc":"2.0", "id":3, "result": { "clients": ["org.rdk.Netflix", "org.rdk.RDKBrowser2"]} }
+
+getBounds:
+{"jsonrpc":"2.0", "id":3, "result": {
+             "x": 0,
+             "y": 0,
+             "w": 600,
+             "h": 400} }
+setBounds:
+{"jsonrpc":"2.0", "id":3, "result": {} }
+
+getVisibility:
+{"jsonrpc":"2.0", "id":3, "result": {"visible": true} }
+
+setVisibility:
+{"jsonrpc":"2.0", "id":3, "result": {} }
+
+getOpacity:
+{"jsonrpc":"2.0", "id":3, "result": { "opacity" : 100} }
+
+setOpacity:
+{"jsonrpc":"2.0", "id":3, "result": {} }
+```
+
+## Events
+```
+none
+```
+
+## Full Reference
+https://etwiki.sys.comcast.net/display/RDK/RDKShell


### PR DESCRIPTION
updates

updates

updates

scale and initial animation support

initial event support

key handling, key metadata, inactivity, and animation updates

support for launching native applications and suspend and resume (RDK-28720)

suspend and resume updates

[RDK-28197] updates for inactivity timer RFC

initial support for app lifecycle management

updates

updates for RDK-29085

updates to launch

RDK-29085

updates for memory, events, and configuration (RDK-29085) (#192)

* updates for memory, events, and configuration (RDK-29085)

* updates

* include the launch type and also support for callsign