### PR TITLE
DELIA-43653 : Add Dolby MS12 APIs to displaysettings plugin

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -142,6 +142,23 @@ namespace WPEFramework {
             registerMethod("getVideoPortStatusInStandby", &DisplaySettings::getVideoPortStatusInStandby, this);
             registerMethod("getCurrentOutputSettings", &DisplaySettings::getCurrentOutputSettings, this);
 
+            registerMethod("getVolumeLeveller", &DisplaySettings::getVolumeLeveller, this);
+            registerMethod("getBassEnhancer", &DisplaySettings::getBassEnhancer, this);
+            registerMethod("isSurroundDecoderEnabled", &DisplaySettings::isSurroundDecoderEnabled, this);
+            registerMethod("getDRCMode", &DisplaySettings::getDRCMode, this);
+            registerMethod("getSurroundVirtualizer", &DisplaySettings::getSurroundVirtualizer, this);
+            registerMethod("setVolumeLeveller", &DisplaySettings::setVolumeLeveller, this);
+            registerMethod("setBassEnhancer", &DisplaySettings::setBassEnhancer, this);
+            registerMethod("enableSurroundDecoder", &DisplaySettings::enableSurroundDecoder, this);
+            registerMethod("setSurroundVirtualizer", &DisplaySettings::setSurroundVirtualizer, this);
+            registerMethod("setMISteering", &DisplaySettings::setMISteering, this);
+            registerMethod("setGain", &DisplaySettings::setGain, this);
+            registerMethod("getGain", &DisplaySettings::getGain, this);
+            registerMethod("setLevel", &DisplaySettings::setLevel, this);
+            registerMethod("getLevel", &DisplaySettings::getLevel, this);
+            registerMethod("setDRCMode", &DisplaySettings::setDRCMode, this);
+            registerMethod("getMISteering", &DisplaySettings::getMISteering, this);
+
             registerMethod("getAudioDelay", &DisplaySettings::getAudioDelay, this);
             registerMethod("setAudioDelay", &DisplaySettings::setAudioDelay, this);
             registerMethod("getAudioDelayOffset", &DisplaySettings::getAudioDelayOffset, this);
@@ -1154,6 +1171,439 @@ namespace WPEFramework {
 
             LOGERR("\nLeaving_ DisplaySettings::%s\n", __FUNCTION__);
             returnResponse(success);
+        }
+
+        uint32_t DisplaySettings::getVolumeLeveller(const JsonObject& parameters, JsonObject& response)
+        {
+                LOGINFOMETHOD();
+
+                bool success = true;
+                string audioPort = parameters.HasLabel("audioPort") ? parameters["audioPort"].String() : "HDMI0";
+                int level = 0;
+
+                try
+                {
+                        device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
+                                if (aPort.isConnected())
+                                {
+                                        level= aPort.getVolumeLeveller();
+                                        response["enable"] = (level ? true : false);
+                                        response["level"] = level;
+                                }
+                }
+                catch (const device::Exception& err)
+                {
+                        LOG_DEVICE_EXCEPTION1(audioPort);
+                        success = false;
+                        response["enable"] = false;
+                        response["mode"] = 0;
+                }
+                returnResponse(success);
+        }
+
+
+        uint32_t DisplaySettings::getBassEnhancer(const JsonObject& parameters, JsonObject& response)
+        {
+                LOGINFOMETHOD();
+                bool success = true;
+                string audioPort = parameters.HasLabel("audioPort") ? parameters["audioPort"].String() : "HDMI0";
+                bool enable = false;
+                try
+                {
+                        device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
+                                if (aPort.isConnected())
+                                {
+                                        enable = aPort.getBassEnhancer();
+                                        response["bassEnhancerEnable"] = enable;
+                                }
+                                else
+                                {
+                                        LOGERR("aport is not connected!");
+                                        success = false;
+                                }
+                }
+                catch (const device::Exception& err)
+                {
+                        LOG_DEVICE_EXCEPTION1(audioPort);
+                        success = false;
+                }
+                returnResponse(success);
+        }
+
+        uint32_t DisplaySettings::isSurroundDecoderEnabled(const JsonObject& parameters, JsonObject& response)
+        {
+                LOGINFOMETHOD();
+                bool success = true;
+                bool surroundDecoderEnable = false;
+                string audioPort = parameters.HasLabel("audioPort") ? parameters["audioPort"].String() : "HDMI0";
+
+                try
+                {
+                        device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
+                                if (aPort.isConnected())
+                                {
+                                        surroundDecoderEnable = aPort.isSurroundDecoderEnabled();
+                                        response["surroundDecoderEnable"] = surroundDecoderEnable;
+                                }
+                                else
+                                {
+                                        LOGERR("aport is not connected!");
+                                        success = false;
+                                }
+                }
+                catch (const device::Exception& err)
+                {
+                        LOG_DEVICE_EXCEPTION1(audioPort);
+                        success = false;
+                }
+                returnResponse(success);
+        }
+
+        uint32_t DisplaySettings::getGain (const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool success = true;
+            float gain = 0;
+
+            string audioPort = parameters.HasLabel("audioPort") ? parameters["audioPort"].String() : "HDMI0";
+            try
+            {
+                device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
+                gain = aPort.getGain();
+                response["gain"] = to_string(gain);
+            }
+            catch(const device::Exception& err)
+            {
+                LOG_DEVICE_EXCEPTION1(audioPort);
+                success = false;
+            }
+            returnResponse(success);
+        }
+
+        uint32_t DisplaySettings::getLevel (const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool success = true;
+            float level = 0;
+
+            string audioPort = parameters.HasLabel("audioPort") ? parameters["audioPort"].String() : "HDMI0";
+            try
+            {
+                device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
+                level = aPort.getLevel();
+                response["level"] = to_string(level);
+            }
+            catch(const device::Exception& err)
+            {
+                LOG_DEVICE_EXCEPTION1(audioPort);
+                success = false;
+            }
+            returnResponse(success);
+        }
+
+        uint32_t DisplaySettings::getDRCMode(const JsonObject& parameters, JsonObject& response)
+        {
+                LOGINFOMETHOD();
+                bool success = true;
+                int mode = 0;
+                string audioPort = parameters.HasLabel("audioPort") ? parameters["audioPort"].String() : "HDMI0";
+                try
+                {
+                       device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
+                                if (aPort.isConnected())
+                                {
+                                        mode = aPort.getDRCMode();
+                                        response["DRCMode"] = mode ? "RF" : "line" ;
+                                }
+                                else
+                                {
+                                        LOGERR("aport is not connected!");
+                                        success = false;
+                                }
+                }
+                catch (const device::Exception& err)
+                {
+                        LOG_DEVICE_EXCEPTION1(audioPort);
+                        success = false;
+                }
+                returnResponse(success);
+        }
+
+        uint32_t DisplaySettings::getSurroundVirtualizer(const JsonObject& parameters, JsonObject& response)
+        {
+                LOGINFOMETHOD();
+                bool success = true;
+                string audioPort = parameters.HasLabel("audioPort") ? parameters["audioPort"].String() : "HDMI0";
+                int boost = 0;
+
+                try
+                {
+                       device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
+                                if (aPort.isConnected())
+                                {
+                                        boost = aPort.getSurroundVirtualizer();
+                                        response["enable"] = boost ? true : false ;
+                                        response["boost"] = boost;
+                                }
+                                else
+                                {
+                                        LOGERR("aport is not connected!");
+                                        success = false;
+                                }
+                }
+                catch (const device::Exception& err)
+                {
+                        LOG_DEVICE_EXCEPTION1(audioPort);
+                        success = false;
+                }
+                returnResponse(success);
+        }
+
+        uint32_t DisplaySettings::getMISteering(const JsonObject& parameters, JsonObject& response)
+        {
+                LOGINFOMETHOD();
+                bool success = true;
+                bool enable = false;
+                string audioPort = parameters.HasLabel("audioPort") ? parameters["audioPort"].String() : "HDMI0";
+                try
+                {
+                       device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
+                                if (aPort.isConnected())
+                                {
+                                        enable = aPort.getMISteering();
+                                        response["MISteeringEnable"] = enable;
+                                }
+                                else
+                                {
+                                        LOGERR("aport is not connected!");
+                                        success = false;
+                                }
+                }
+                catch (const device::Exception& err)
+                {
+                        LOG_DEVICE_EXCEPTION1(audioPort);
+                        success = false;
+                }
+                returnResponse(success);
+        }
+
+        uint32_t DisplaySettings::setVolumeLeveller(const JsonObject& parameters, JsonObject& response)
+        {
+                LOGINFOMETHOD();
+                returnIfParamNotFound(parameters, "level");
+                string sVolumeLeveller = parameters["level"].String();
+                int VolumeLeveller = 0;
+                try {
+                        VolumeLeveller = stoi(sVolumeLeveller);
+                }catch (const device::Exception& err) {
+                        LOG_DEVICE_EXCEPTION1(sVolumeLeveller);
+                        returnResponse(false);
+                }
+                bool success = true;
+                string audioPort = parameters.HasLabel("audioPort") ? parameters["audioPort"].String() : "HDMI0";
+                try
+                {
+                        device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
+                        aPort.setVolumeLeveller(VolumeLeveller);
+                }
+                catch (const device::Exception& err)
+                {
+                        LOG_DEVICE_EXCEPTION2(audioPort, sVolumeLeveller);
+                        success = false;
+                }
+                returnResponse(success);
+        }
+
+        uint32_t DisplaySettings::enableSurroundDecoder(const JsonObject& parameters, JsonObject& response)
+        {
+                LOGINFOMETHOD();
+                returnIfParamNotFound(parameters, "surroundDecoderEnable");
+                string sEnableSurroundDecoder = parameters["surroundDecoderEnable"].String();
+                bool enableSurroundDecoder = false;
+                try {
+                        enableSurroundDecoder= parameters["surroundDecoderEnable"].Boolean();
+                }catch (const device::Exception& err) {
+                        LOG_DEVICE_EXCEPTION1(sEnableSurroundDecoder);
+                        returnResponse(false);
+                }
+                bool success = true;
+                string audioPort = parameters.HasLabel("audioPort") ? parameters["audioPort"].String() : "HDMI0";
+                try
+                {
+                        device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
+                        aPort.enableSurroundDecoder(enableSurroundDecoder);
+                }
+                catch (const device::Exception& err)
+                {
+                        LOG_DEVICE_EXCEPTION2(audioPort, sEnableSurroundDecoder);
+                        success = false;
+                }
+                returnResponse(success);
+        }
+
+        uint32_t DisplaySettings::setBassEnhancer(const JsonObject& parameters, JsonObject& response)
+        {
+                LOGINFOMETHOD();
+                returnIfParamNotFound(parameters, "bassEnhancerEnable");
+                string sBassEnhancer = parameters["bassEnhancerEnable"].String();
+                bool bassEnhancer = false;
+                try {
+                        bassEnhancer = parameters["bassEnhancerEnable"].Boolean();
+                }catch (const device::Exception& err) {
+                        LOG_DEVICE_EXCEPTION1(sBassEnhancer);
+                        returnResponse(false);
+                }
+                bool success = true;
+                string audioPort = parameters.HasLabel("audioPort") ? parameters["audioPort"].String() : "HDMI0";
+                try
+                {
+                        device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
+                        aPort.setBassEnhancer(bassEnhancer);
+                }
+                catch (const device::Exception& err)
+                {
+                        LOG_DEVICE_EXCEPTION2(audioPort, sBassEnhancer);
+                        success = false;
+                }
+                returnResponse(success);
+        }
+
+        uint32_t DisplaySettings::setSurroundVirtualizer(const JsonObject& parameters, JsonObject& response)
+        {
+               LOGINFOMETHOD();
+               returnIfParamNotFound(parameters, "boost");
+               string sSurroundVirtualizer = parameters["boost"].String();
+               int surroundVirtualizer = 0;
+
+               try {
+                  surroundVirtualizer = stoi(sSurroundVirtualizer);
+               }catch (const device::Exception& err) {
+                  LOG_DEVICE_EXCEPTION1(sSurroundVirtualizer);
+                              returnResponse(false);
+               }
+               bool success = true;
+               string audioPort = parameters.HasLabel("audioPort") ? parameters["audioPort"].String() : "HDMI0";
+               try
+               {
+                   device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
+                   aPort.setSurroundVirtualizer(surroundVirtualizer);
+               }
+               catch (const device::Exception& err)
+               {
+                   LOG_DEVICE_EXCEPTION2(audioPort, sSurroundVirtualizer);
+                   success = false;
+               }
+               returnResponse(success);
+        }
+
+        uint32_t DisplaySettings::setMISteering(const JsonObject& parameters, JsonObject& response)
+        {
+                LOGINFOMETHOD();
+                returnIfParamNotFound(parameters, "MISteeringEnable");
+                string sMISteering = parameters["MISteeringEbnable"].String();
+                bool MISteering = false;
+                try {
+                        MISteering = parameters["MISteeringEnable"].Boolean();
+                }catch (const device::Exception& err) {
+                        LOG_DEVICE_EXCEPTION1(sMISteering);
+                        returnResponse(false);
+                }
+                bool success = true;
+                string audioPort = parameters.HasLabel("audioPort") ? parameters["audioPort"].String() : "HDMI0";
+                try
+                {
+                        device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
+                        aPort.setMISteering(MISteering);
+                }
+                catch (const device::Exception& err)
+                {
+                        LOG_DEVICE_EXCEPTION2(audioPort, sMISteering);
+                        success = false;
+                }
+                returnResponse(success)
+        }
+
+        uint32_t DisplaySettings::setGain(const JsonObject& parameters, JsonObject& response)
+        {
+                LOGINFOMETHOD();
+                returnIfParamNotFound(parameters, "gain");
+                string sGain = parameters["gain"].String();
+                float newGain = 0;
+                try {
+                        newGain = stof(sGain);
+                }catch (const device::Exception& err) {
+                        LOG_DEVICE_EXCEPTION1(sGain);
+                        returnResponse(false);
+                }
+                bool success = true;
+                string audioPort = parameters.HasLabel("audioPort") ? parameters["audioPort"].String() : "HDMI0";
+                try
+                {
+                        device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
+                        aPort.setGain(newGain);
+                        success= true;
+                }
+                catch (const device::Exception& err)
+                {
+                        LOG_DEVICE_EXCEPTION2(audioPort, sGain);
+                        success = false;
+                }
+                returnResponse(success);
+        }
+
+        uint32_t DisplaySettings::setLevel(const JsonObject& parameters, JsonObject& response)
+        {
+                LOGINFOMETHOD();
+                returnIfParamNotFound(parameters, "level");
+                string sLevel = parameters["level"].String();
+                float level = 0;
+                try {
+                        level = stof(sLevel);
+                }catch (const device::Exception& err) {
+                        LOG_DEVICE_EXCEPTION1(sLevel);
+                        returnResponse(false);
+                }
+                bool success = true;
+                string audioPort = parameters.HasLabel("audioPort") ? parameters["audioPort"].String() : "HDMI0";
+                try
+                {
+                        device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
+                        aPort.setLevel(level);
+                        success= true;
+                }
+                catch (const device::Exception& err)
+                {
+                        LOG_DEVICE_EXCEPTION2(audioPort, sLevel);
+                        success = false;
+                }
+                returnResponse(success);
+        }
+
+        uint32_t DisplaySettings::setDRCMode(const JsonObject& parameters, JsonObject& response)
+        {
+                LOGINFOMETHOD();
+                returnIfParamNotFound(parameters, "DRCMode");
+                string sDRCMode = parameters["DRCMode"].String();
+                int DRCMode = 0;
+                try {
+                        DRCMode = stoi(sDRCMode);
+                }catch (const device::Exception& err) {
+                        LOG_DEVICE_EXCEPTION1(sDRCMode);
+                        returnResponse(false);
+                }
+                bool success = true;
+                string audioPort = parameters.HasLabel("audioPort") ? parameters["audioPort"].String() : "HDMI0";
+                try
+                {
+                        device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
+                        aPort.setDRCMode(DRCMode);
+                }
+                catch (const device::Exception& err)
+                {
+                        LOG_DEVICE_EXCEPTION2(audioPort, sDRCMode);
+                        success = false;
+                }
+                returnResponse(success);
         }
 
         uint32_t DisplaySettings::getAudioDelay (const JsonObject& parameters, JsonObject& response) 

--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -84,6 +84,22 @@ namespace WPEFramework {
             uint32_t getTVHDRCapabilities(const JsonObject& parameters, JsonObject& response);
             uint32_t getDefaultResolution(const JsonObject& parameters, JsonObject& response);
             uint32_t setScartParameter(const JsonObject& parameters, JsonObject& response);
+            uint32_t getVolumeLeveller(const JsonObject& parameters, JsonObject& response);
+            uint32_t getBassEnhancer(const JsonObject& parameters, JsonObject& response);
+            uint32_t isSurroundDecoderEnabled(const JsonObject& parameters, JsonObject& response);
+            uint32_t getDRCMode(const JsonObject& parameters, JsonObject& response);
+            uint32_t getSurroundVirtualizer(const JsonObject& parameters, JsonObject& response);
+            uint32_t getMISteering(const JsonObject& parameters, JsonObject& response);
+            uint32_t setVolumeLeveller(const JsonObject& parameters, JsonObject& response);
+            uint32_t setBassEnhancer(const JsonObject& parameters, JsonObject& response);
+            uint32_t enableSurroundDecoder(const JsonObject& parameters, JsonObject& response);
+            uint32_t setSurroundVirtualizer(const JsonObject& parameters, JsonObject& response);
+            uint32_t setMISteering(const JsonObject& parameters, JsonObject& response);
+            uint32_t setGain(const JsonObject& parameters, JsonObject& response);
+            uint32_t getGain(const JsonObject& parameters, JsonObject& response);
+            uint32_t setLevel(const JsonObject& parameters, JsonObject& response);
+            uint32_t getLevel(const JsonObject& parameters, JsonObject& response);
+            uint32_t setDRCMode(const JsonObject& parameters, JsonObject& response);
             //End methods
 
             //Begin events


### PR DESCRIPTION
Reason for change: 1) Added dolby APIs mentioned in the ticket
2) Added Volume gain and level adjustment APIs
3) Modified existing dolby APIs to take audioPort arg,
default is HDMI0
Test Procedure: Verify using curl commands
Risks: None

Signed-off-by: Deekshit Devadas <deekshit.devadasy@sky.uk>
(cherry picked from commit 1d549121db48704b8728640ef4e36bf43179218d)