### PR TITLE
DELIA-45585: WPEFramework crash CCEC_OSAL::Mutex

### DIFF
--- a/HdmiCec/HdmiCec.cpp
+++ b/HdmiCec/HdmiCec.cpp
@@ -77,6 +77,7 @@ namespace WPEFramework
         {
             LOGINFO();
             HdmiCec::_instance = this;
+            smConnection = NULL;
 
             InitializeIARM();
 

--- a/HdmiCec_2/HdmiCec_2.cpp
+++ b/HdmiCec_2/HdmiCec_2.cpp
@@ -314,7 +314,7 @@ namespace WPEFramework
        {
            LOGWARN("Initlaizing CEC_2");
            HdmiCec_2::_instance = this;
-
+           smConnection = NULL;
            InitializeIARM();
 
            registerMethod(HDMICEC2_METHOD_SET_ENABLED, &HdmiCec_2::setEnabledWrapper, this);


### PR DESCRIPTION
Reason for change:  init smConenction in constructor
Test Procedure: refer jira.
Risks: Low

Signed-off-by: apatel859 <amit_patel5@comcast.com>