### PR TITLE
DELIA-44142: wpeframework crash from WifiManager plugin getSignalData()

### DIFF
--- a/WifiManager/impl/WifiManagerSignalThreshold.cpp
+++ b/WifiManager/impl/WifiManagerSignalThreshold.cpp
@@ -34,7 +34,10 @@ namespace {
         JsonObject response;
         wifiManager.getConnectedSSID(JsonObject(), response);
 
-        signalStrengthOut = std::stof(response["signalStrength"].String());
+        signalStrengthOut = 0.0f;
+        if (response.HasLabel("signalStrength")) {
+            signalStrengthOut = std::stof(response["signalStrength"].String());
+        }
 
         if (signalStrengthOut >= signalStrengthThresholdExcellent && signalStrengthOut < 0)
         {


### PR DESCRIPTION
Reason for change: wpeframework crash from WifiManager plugin getSignalData()
Test Procedure: Build and test based on README.md
Risks: Low

Signed-off-by: Mariusz Strozynski <mariusz.strozynski@consult.red>
(cherry picked from commit 91c4dc44d69e5f9d7819330b66476d35c19d2309)