### PR TITLE
XRE-15671 : warehouse.getDeviceInfo in thunder differs from SM

### DIFF
--- a/Warehouse/Warehouse.cpp
+++ b/Warehouse/Warehouse.cpp
@@ -688,7 +688,7 @@ namespace WPEFramework
 
             resetDevice(suppressReboot);
 
-            response["PARAM_SUCCESS"] = true;
+            response[PARAM_SUCCESS] = true;
             returnResponse(true);
         }
 
@@ -696,11 +696,9 @@ namespace WPEFramework
         {
             LOGINFO();
 
-            JsonObject deviceInfo;
-            getDeviceInfo(deviceInfo);
+            getDeviceInfo(response);
 
-            response["deviceInfo"] = deviceInfo;
-            response["PARAM_SUCCESS"] = true;
+            response[PARAM_SUCCESS] = true;
             returnResponse(true);
         }
 


### PR DESCRIPTION
Got rid of "deviceInfo" container for values in getDeviceInfo call.