### PR TITLE
DELIA-43686 : Add quirk to CS Thunder Plugin to add Security type to …

### DIFF
--- a/ControlService/ControlService.cpp
+++ b/ControlService/ControlService.cpp
@@ -72,6 +72,7 @@ namespace WPEFramework {
             ControlService::_instance = this;
 
             registerMethod("getApiVersionNumber", &ControlService::getApiVersionNumber, this);
+            registerMethod("getQuirks", &ControlService::getQuirks, this);
 
             registerMethod("getAllRemoteData", &ControlService::getAllRemoteDataWrapper, this);
             registerMethod("getSingleRemoteData", &ControlService::getSingleRemoteDataWrapper, this);
@@ -719,6 +720,15 @@ namespace WPEFramework {
         {
             LOGINFOMETHOD();
             response["version"] = m_apiVersionNumber;
+            returnResponse(true);
+        }
+
+        uint32_t ControlService::getQuirks(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            JsonArray array;
+            array.Add("DELIA-43686");
+            response["quirks"] = array;
             returnResponse(true);
         }
 
@@ -1953,6 +1963,7 @@ namespace WPEFramework {
             remoteInfo["linkQuality"]               = JsonValue((int)ctrlStatus.status.link_quality);
             remoteInfo["bHasCheckedIn"]             = JsonValue((bool)ctrlStatus.status.checkin_for_device_update);
             remoteInfo["bIrdbDownloadSupported"]    = JsonValue((bool)ctrlStatus.status.ir_db_code_download_supported);
+            remoteInfo["securityType"]              = JsonValue((int)ctrlStatus.status.security_type);
 
             remoteInfo["bHasBattery"]                       = JsonValue((bool)ctrlStatus.status.has_battery);
             remoteInfo["batteryChangedTimestamp"]           = JsonValue((long long)(ctrlStatus.status.time_battery_changed * 1000LL));

--- a/ControlService/ControlService.h
+++ b/ControlService/ControlService.h
@@ -90,6 +90,7 @@ namespace WPEFramework {
 
             //Begin methods
             uint32_t getApiVersionNumber(const JsonObject& parameters, JsonObject& response);
+            uint32_t getQuirks(const JsonObject& parameters, JsonObject& response);
 
             uint32_t getAllRemoteDataWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t getSingleRemoteDataWrapper(const JsonObject& parameters, JsonObject& response);

--- a/ControlService/test/controlSvcTestClient.cpp
+++ b/ControlService/test/controlSvcTestClient.cpp
@@ -33,7 +33,7 @@
 #include <stdio.h>
 #include <unistd.h>
 
-#define SYSSRV_CALLSIGN "org.rdk.ControlService"
+#define SYSSRV_CALLSIGN "org.rdk.ControlService.1"
 #define SERVER_DETAILS  "127.0.0.1:9998"
 
 using namespace std;
@@ -318,11 +318,64 @@ int main(int argc, char** argv)
 
     Core::SystemInfo::SetEnvironment(_T("THUNDER_ACCESS"), (_T(SERVER_DETAILS)));
 
+    // Security Token
+    std::cout << "Retrieving security token" << std::endl;
+    std::string sToken;
+
+    FILE *pSecurity = popen("/usr/bin/WPEFrameworkSecurityUtility", "r");
+    if(pSecurity) {
+        JsonObject pSecurityJson;
+        std::string pSecurityOutput;
+        int         pSecurityOutputTrimIndex;
+        std::array<char, 256> pSecurityBuffer;
+
+        while(fgets(pSecurityBuffer.data(), 256, pSecurity) != NULL) {
+            pSecurityOutput += pSecurityBuffer.data();
+        }
+        pclose(pSecurity);
+
+        pSecurityOutputTrimIndex = pSecurityOutput.find('{');
+        if(pSecurityOutputTrimIndex == std::string::npos) {
+            std::cout << "Security Utility returned unexpected output" << std::endl;
+        } else {
+            if(pSecurityOutputTrimIndex > 0) {
+                 std::cout << "Trimming output from Security Utility" << std::endl;
+                 pSecurityOutput = pSecurityOutput.substr(pSecurityOutputTrimIndex);
+            }
+            pSecurityJson.FromString(pSecurityOutput);
+            if(pSecurityJson["success"].Boolean() == true) {
+                std::cout << "Security Token retrieved successfully!" << std::endl;
+                sToken = "token=" + pSecurityJson["token"].String();
+            } else {
+                std::cout << "Security Token retrieval failed!" << std::endl;
+            }
+        }
+    } else {
+        std::cout << "Failed to open security utility" << std::endl;
+    }
+    // End Security Token
+
+    std::cout << "Using callsign: " << SYSSRV_CALLSIGN << std::endl;
+
     if (NULL == remoteObject) {
-        remoteObject = new JSONRPC::LinkType<Core::JSON::IElement>(_T(SYSSRV_CALLSIGN), _T(""));
+        remoteObject = new JSONRPC::Client(_T(SYSSRV_CALLSIGN), _T(""), false, sToken);
         if (NULL == remoteObject) {
             std::cout << "JSONRPC::Client initialization failed" << std::endl;
+
         } else {
+
+            {
+                // Create a controller client
+                static auto& controllerClient = *new WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>("", "", false, sToken);
+                // In case the plugin isn't activated already, try to start it, BEFORE registering for the events!
+                string strres;
+                JsonObject params;
+                params["callsign"] = SYSSRV_CALLSIGN;
+                JsonObject result;
+                ret = controllerClient.Invoke(2000, "activate", params, result);
+                result.ToString(strres);
+                std::cout<<"\nstartup result : "<< strres <<"\n";
+            }
 
             /* Register handlers for Event reception. */
             std::cout << "\nSubscribing to event handlers\n" << std::endl;

--- a/RemoteActionMapping/test/ramTestClient.cpp
+++ b/RemoteActionMapping/test/ramTestClient.cpp
@@ -35,7 +35,7 @@
 
 #include <vector>
 
-#define SYSSRV_CALLSIGN "org.rdk.RemoteActionMapping"
+#define SYSSRV_CALLSIGN "org.rdk.RemoteActionMapping.1"
 #define SERVER_DETAILS  "127.0.0.1:9998"
 
 using namespace std;
@@ -501,11 +501,64 @@ int main(int argc, char** argv)
 
     Core::SystemInfo::SetEnvironment(_T("THUNDER_ACCESS"), (_T(SERVER_DETAILS)));
 
+    // Security Token
+    std::cout << "Retrieving security token" << std::endl;
+    std::string sToken;
+
+    FILE *pSecurity = popen("/usr/bin/WPEFrameworkSecurityUtility", "r");
+    if(pSecurity) {
+        JsonObject pSecurityJson;
+        std::string pSecurityOutput;
+        int         pSecurityOutputTrimIndex;
+        std::array<char, 256> pSecurityBuffer;
+
+        while(fgets(pSecurityBuffer.data(), 256, pSecurity) != NULL) {
+            pSecurityOutput += pSecurityBuffer.data();
+        }
+        pclose(pSecurity);
+
+        pSecurityOutputTrimIndex = pSecurityOutput.find('{');
+        if(pSecurityOutputTrimIndex == std::string::npos) {
+            std::cout << "Security Utility returned unexpected output" << std::endl;
+        } else {
+            if(pSecurityOutputTrimIndex > 0) {
+                 std::cout << "Trimming output from Security Utility" << std::endl;
+                 pSecurityOutput = pSecurityOutput.substr(pSecurityOutputTrimIndex);
+            }
+            pSecurityJson.FromString(pSecurityOutput);
+            if(pSecurityJson["success"].Boolean() == true) {
+                std::cout << "Security Token retrieved successfully!" << std::endl;
+                sToken = "token=" + pSecurityJson["token"].String();
+            } else {
+                std::cout << "Security Token retrieval failed!" << std::endl;
+            }
+        }
+    } else {
+        std::cout << "Failed to open security utility" << std::endl;
+    }
+    // End Security Token
+
+    std::cout << "Using callsign: " << SYSSRV_CALLSIGN << std::endl;
+
     if (NULL == remoteObject) {
-        remoteObject = new JSONRPC::LinkType<Core::JSON::IElement>(_T(SYSSRV_CALLSIGN), _T(""));
+        remoteObject = new JSONRPC::Client(_T(SYSSRV_CALLSIGN), _T(""), false, sToken);
         if (NULL == remoteObject) {
             std::cout << "JSONRPC::Client initialization failed" << std::endl;
+
         } else {
+
+            {
+                // Create a controller client
+                static auto& controllerClient = *new WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>("", "", false, sToken);
+                // In case the plugin isn't activated already, try to start it, BEFORE registering for the events!
+                string strres;
+                JsonObject params;
+                params["callsign"] = SYSSRV_CALLSIGN;
+                JsonObject result;
+                ret = controllerClient.Invoke(2000, "activate", params, result);
+                result.ToString(strres);
+                std::cout<<"\nstartup result : "<< strres <<"\n";
+            }
 
             /* Register handlers for Event reception. */
             std::cout << "\nSubscribing to event handlers\n" << std::endl;


### PR DESCRIPTION
…Remote Data

Reason for change: Security Type was missing
Test Procedure: Verify Security Type is available through CS Thunder Plugin.
Risks: None.
Signed-off-by: jschmidt <Jeff_Schmidt@cable.comcast

DELIA-44559 : Change CS thunder quirk to return array, not string.

Reason for change: Control Service Thunder Quirk should be an array, not a string
Test Procedure: Verify test app gives "result : {"quirks":["DELIA-43686"],"success":true}".
Risks: None.
Signed-off-by: jschmidt <Jeff_Schmidt@cable.comcast

DELIA-44598 : Add Security Token Supprt for RemoteActionMapping Thunder Plugin.

Reason for change: Test won't run without this.
Test Procedure: Verify the ramTestClient tests execute.
Risks: None.
Signed-off-by: jschmidt <Jeff_Schmidt@cable.comcast>

DELIA-45247 : Update SYSSRV_CALLSIGN adding (.1) - CS and RAMs

Reason for change: Thunder Plugin Test Client's calls are failing.
Test Procedure: Verify the Control Servive and RAMs tests are successful.
Risks: None.
Signed-off-by: jschmidt <Jeff_Schmidt@cable.comcast>