### PR TITLE
DELIA-43686 : Add quirk to CS Thunder Plugin to add Security type to …

### DIFF
--- a/ControlService/ControlService.h
+++ b/ControlService/ControlService.h
@@ -41,6 +41,14 @@ typedef enum {
     STATUS_METHOD_NOT_FOUND
 } StatusCode;
 
+typedef enum
+{
+    RF4CE_CHIP_CONNECTIVITY_NOT_CONNECTED,
+    RF4CE_CHIP_CONNECTIVITY_CONNECTED,
+    RF4CE_CHIP_CONNECTIVITY_NOT_SUPPORTED,
+    RF4CE_CHIP_CONNECTIVITY_IARM_CALL_RESULT_ERROR,
+} eCheckRf4ceChipConnectivity;
+
 namespace WPEFramework {
 
     namespace Plugin {
@@ -90,6 +98,7 @@ namespace WPEFramework {
 
             //Begin methods
             uint32_t getApiVersionNumber(const JsonObject& parameters, JsonObject& response);
+            uint32_t getQuirks(const JsonObject& parameters, JsonObject& response);
 
             uint32_t getAllRemoteDataWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t getSingleRemoteDataWrapper(const JsonObject& parameters, JsonObject& response);
@@ -101,6 +110,7 @@ namespace WPEFramework {
             uint32_t endPairingModeWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t findMyRemoteWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t canFindMyRemoteWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t checkRf4ceChipConnectivityWrapper(const JsonObject& parameters, JsonObject& response);
             //End methods
 
             //Begin events
@@ -138,6 +148,7 @@ namespace WPEFramework {
             StatusCode endPairingMode(int& bindStatus);
             StatusCode findMyRemote(int timeOutPeriod, bool bOnlyLastUsed);
             bool       canFindMyRemote();
+            eCheckRf4ceChipConnectivity checkRf4ceChipConnectivity();
 
             // Local utility methods
             void setApiVersionNumber(uint32_t apiVersionNumber);

--- a/RemoteActionMapping/test/ramTestClient.cpp
+++ b/RemoteActionMapping/test/ramTestClient.cpp
@@ -35,7 +35,7 @@
 
 #include <vector>
 
-#define SYSSRV_CALLSIGN "org.rdk.RemoteActionMapping"
+#define SYSSRV_CALLSIGN "org.rdk.RemoteActionMapping.1"
 #define SERVER_DETAILS  "127.0.0.1:9998"
 
 using namespace std;
@@ -501,11 +501,64 @@ int main(int argc, char** argv)
 
     Core::SystemInfo::SetEnvironment(_T("THUNDER_ACCESS"), (_T(SERVER_DETAILS)));
 
+    // Security Token
+    std::cout << "Retrieving security token" << std::endl;
+    std::string sToken;
+
+    FILE *pSecurity = popen("/usr/bin/WPEFrameworkSecurityUtility", "r");
+    if(pSecurity) {
+        JsonObject pSecurityJson;
+        std::string pSecurityOutput;
+        int         pSecurityOutputTrimIndex;
+        std::array<char, 256> pSecurityBuffer;
+
+        while(fgets(pSecurityBuffer.data(), 256, pSecurity) != NULL) {
+            pSecurityOutput += pSecurityBuffer.data();
+        }
+        pclose(pSecurity);
+
+        pSecurityOutputTrimIndex = pSecurityOutput.find('{');
+        if(pSecurityOutputTrimIndex == std::string::npos) {
+            std::cout << "Security Utility returned unexpected output" << std::endl;
+        } else {
+            if(pSecurityOutputTrimIndex > 0) {
+                 std::cout << "Trimming output from Security Utility" << std::endl;
+                 pSecurityOutput = pSecurityOutput.substr(pSecurityOutputTrimIndex);
+            }
+            pSecurityJson.FromString(pSecurityOutput);
+            if(pSecurityJson["success"].Boolean() == true) {
+                std::cout << "Security Token retrieved successfully!" << std::endl;
+                sToken = "token=" + pSecurityJson["token"].String();
+            } else {
+                std::cout << "Security Token retrieval failed!" << std::endl;
+            }
+        }
+    } else {
+        std::cout << "Failed to open security utility" << std::endl;
+    }
+    // End Security Token
+
+    std::cout << "Using callsign: " << SYSSRV_CALLSIGN << std::endl;
+
     if (NULL == remoteObject) {
-        remoteObject = new JSONRPC::LinkType<Core::JSON::IElement>(_T(SYSSRV_CALLSIGN), _T(""));
+        remoteObject = new JSONRPC::Client(_T(SYSSRV_CALLSIGN), _T(""), false, sToken);
         if (NULL == remoteObject) {
             std::cout << "JSONRPC::Client initialization failed" << std::endl;
+
         } else {
+
+            {
+                // Create a controller client
+                static auto& controllerClient = *new WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>("", "", false, sToken);
+                // In case the plugin isn't activated already, try to start it, BEFORE registering for the events!
+                string strres;
+                JsonObject params;
+                params["callsign"] = SYSSRV_CALLSIGN;
+                JsonObject result;
+                ret = controllerClient.Invoke(2000, "activate", params, result);
+                result.ToString(strres);
+                std::cout<<"\nstartup result : "<< strres <<"\n";
+            }
 
             /* Register handlers for Event reception. */
             std::cout << "\nSubscribing to event handlers\n" << std::endl;


### PR DESCRIPTION
…Remote Data

Reason for change: Security Type was missing
Test Procedure: Verify Security Type is available through CS Thunder Plugin.
Risks: None.
Signed-off-by: jschmidt <Jeff_Schmidt@cable.comcast

DELIA-44559 : Change CS thunder quirk to return array, not string.

Reason for change: Control Service Thunder Quirk should be an array, not a string
Test Procedure: Verify test app gives "result : {"quirks":["DELIA-43686"],"success":true}".
Risks: None.
Signed-off-by: jschmidt <Jeff_Schmidt@cable.comcast

DELIA-44598 : Add Security Token Supprt for RemoteActionMapping Thunder Plugin.

Reason for change: Test won't run without this.
Test Procedure: Verify the ramTestClient tests execute.
Risks: None.
Signed-off-by: jschmidt <Jeff_Schmidt@cable.comcast>

DELIA-45247 : Update SYSSRV_CALLSIGN adding (.1) - CS and RAMs

Reason for change: Thunder Plugin Test Client's calls are failing.
Test Procedure: Verify the Control Servive and RAMs tests are successful.
Risks: None.
Signed-off-by: jschmidt <Jeff_Schmidt@cable.comcast>

RDK-28770 : Thunder Plugin - CS 7 API Quirk for rf4ce chip connectivity test.

Reason for change: Allow App to run rf4ce chip connectivity test.
Test Procedure: Verify rf4ce chip connectivity test using thunder plugin test app.
Risks: None.
Signed-off-by: jschmidt <Jeff_Schmidt@cable.comcast>

DELIA-45558 : For CS thunder, dont' return error for 0 remotes for getAllRem...

Reason for change: 0 remotes is a valid scenario.
Test Procedure: Verify using thunder plugin test app.
Risks: None.
Signed-off-by: jschmidt <Jeff_Schmidt@cable.comcast>