### PR TITLE
[XRE-16308] Change the way OCIContainer imports DobbyProxy

### DIFF
--- a/OCIContainer/CMakeLists.txt
+++ b/OCIContainer/CMakeLists.txt
@@ -40,13 +40,6 @@ target_include_directories(${MODULE_NAME}
         PRIVATE
         ../helpers
 
-        # Dobby includes
-        $<TARGET_PROPERTY:DobbyClientLib,INTERFACE_INCLUDE_DIRECTORIES>
-        $<TARGET_PROPERTY:IpcService,INTERFACE_INCLUDE_DIRECTORIES>
-        $<TARGET_PROPERTY:AppInfraCommon,INTERFACE_INCLUDE_DIRECTORIES>
-        $<TARGET_PROPERTY:AppInfraLogging,INTERFACE_INCLUDE_DIRECTORIES>
-        ${DOBBY_INCLUDE_DIRS}
-
         )
 
 target_link_libraries(${MODULE_NAME}

--- a/OCIContainer/OCIContainer.cpp
+++ b/OCIContainer/OCIContainer.cpp
@@ -1,6 +1,8 @@
 #include "OCIContainer.h"
-#include "IpcFactory.h"
-#include "DobbyProxy.h"
+
+#include <Dobby/DobbyProxy.h>
+#include <Dobby/IpcService/IpcFactory.h>
+
 
 namespace WPEFramework
 {

--- a/OCIContainer/OCIContainer.h
+++ b/OCIContainer/OCIContainer.h
@@ -3,8 +3,8 @@
 #include "Module.h"
 #include "utils.h"
 
-#include <Dobby/IDobbyProxy.h>
-#include "DobbyProtocol.h"
+#include <Dobby/DobbyProtocol.h>
+#include <Dobby/Public/Dobby/IDobbyProxy.h>
 
 #include <vector>
 #include <map>


### PR DESCRIPTION
With Dobby PR#41 (see https://github.com/rdkcentral/Dobby/pull/41)
DobbyProxy no longer needs to be imported via cmake targets.