### PR TITLE
Fixing a runtime issue on platco-adapter platform:

### DIFF
--- a/RDKShell/CMakeLists.txt
+++ b/RDKShell/CMakeLists.txt
@@ -19,17 +19,19 @@ set(PLUGIN_NAME RDKShell)
 set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
 
 find_package(${NAMESPACE}Plugins REQUIRED)
-
+find_package(IARMBus)
+    
 add_library(${MODULE_NAME} SHARED
         RDKShell.cpp
         Module.cpp
+        ../helpers/utils.cpp
 )
 
 set_target_properties(${MODULE_NAME} PROPERTIES
         CXX_STANDARD 11
         CXX_STANDARD_REQUIRED YES)
 
-target_include_directories(${MODULE_NAME} PRIVATE ../helpers)
+target_include_directories(${MODULE_NAME} PRIVATE ../helpers ${IARMBUS_INCLUDE_DIRS} )
 
 set(RDKSHELL_INCLUDES $ENV{RDKSHELL_INCLUDES})
 separate_arguments(RDKSHELL_INCLUDES)


### PR DESCRIPTION
symbol lookup error: /usr/lib/wpeframework/plugins/libWPEFrameworkRDKShell.so: undefined symbol: _ZN5Utils12getRFCConfigEPcR12_RFC_Param_t