### PR TITLE
hdcp2_2RxInfo is not available in nexus v14.4-r0 (MOT7425-11257)

### DIFF
--- a/DisplayInfo/Nexus/PlatformImplementation.cpp
+++ b/DisplayInfo/Nexus/PlatformImplementation.cpp
@@ -468,7 +468,6 @@ private:
                                         , NEXUSHdmiOutputHdcpStateToString(hdcpStatus.hdcpState).c_str()
                                         , hdcpStatus.linkReadyForEncryption ? _T("true") : _T("false")
                                         , hdcpStatus.hdcp1_1Features ? _T("true") : _T("false")
-                                        , hdcpStatus.hdcp2_2RxInfo.hdcp1_xDeviceDownstream ? _T("true") : _T("false")
 #ifdef NEXUS_HDCPVERSION_SUPPORTED
                                         , NEXUSHdcpVersionToString(hdcpStatus.rxMaxHdcpVersion).c_str()
 #endif


### PR DESCRIPTION
Removed reference to hdcp2_2RxInfo as it is not available in one of our platforms (XG1V1)