### PR TITLE
RDK-28998

### DIFF
--- a/amlogic.cmake
+++ b/amlogic.cmake
@@ -77,6 +77,11 @@ add_definitions (-DBUILD_ENABLE_THERMAL_PROTECTION)
    add_definitions (-DENABLE_THERMAL_PROTECTION)
 endif()
 
+if (BUILD_ENABLE_DEVICE_MANUFACTURER_INFO)
+    message("Building with device manufacturer info")
+    add_definitions (-DENABLE_DEVICE_MANUFACTURER_INFO)
+endif()
+
 if (AMLOGIC_E2)
     add_definitions (-DAMLOGIC_E2)
 endif()


### PR DESCRIPTION
Reason for change: Enable manufacturer info on amlogic hardware
Test Procedure: Build and test on llama board
Risks: Low

Signed-off-by: Mariusz Strozynski <mariusz.strozynski@consult.red>