### PR TITLE
Delia-46210: Rdkservcies InfoPlugins backward compatibility

### DIFF
--- a/DisplayInfo/CMakeLists.txt
+++ b/DisplayInfo/CMakeLists.txt
@@ -32,6 +32,7 @@ include_directories(${STAGING_INCDIR}/libdrm)
 
 add_library(${MODULE_NAME} SHARED
     DisplayInfo.cpp
+    DisplayInfoJsonRpc.cpp
     Module.cpp)
 
 set_target_properties(${MODULE_NAME} PROPERTIES

--- a/DisplayInfo/DisplayInfo.h
+++ b/DisplayInfo/DisplayInfo.h
@@ -85,10 +85,12 @@ namespace Plugin {
             , _hdrProperties(nullptr)
             , _notification(this)
         {
+            RegisterAll();
         }
 
         virtual ~DisplayInfo()
         {
+            UnregisterAll();
         }
 
         BEGIN_INTERFACE_MAP(DisplayInfo)
@@ -114,6 +116,8 @@ namespace Plugin {
 
     private:
         // JsonRpc
+        void RegisterAll();
+        void UnregisterAll();
         uint32_t get_displayinfo(JsonData::DisplayInfo::DisplayinfoData&) const;
 
         void Info(JsonData::DisplayInfo::DisplayinfoData&) const;

--- a/DisplayInfo/DisplayInfoJsonRpc.cpp
+++ b/DisplayInfo/DisplayInfoJsonRpc.cpp
@@ -1,0 +1,55 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2020 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "DisplayInfo.h"
+
+namespace WPEFramework {
+
+namespace Plugin {
+
+    using namespace JsonData::DisplayInfo;
+
+    // Registration
+    //
+
+    void DisplayInfo::RegisterAll()
+    {
+        Property<DisplayinfoData>(_T("displayinfo"), &DisplayInfo::get_displayinfo, nullptr, this);
+    }
+
+    void DisplayInfo::UnregisterAll()
+    {
+        Unregister(_T("displayinfo"));
+    }
+
+    // API implementation
+    //
+
+    // Property: displayinfo - Display general information
+    // Return codes:
+    //  - ERROR_NONE: Success
+    uint32_t DisplayInfo::get_displayinfo(DisplayinfoData& response) const
+    {
+        Info(response);
+        return Core::ERROR_NONE;
+    }
+
+} // namespace Plugin
+
+}

--- a/PlayerInfo/CMakeLists.txt
+++ b/PlayerInfo/CMakeLists.txt
@@ -24,6 +24,7 @@ find_package(CompileSettingsDebug CONFIG REQUIRED)
 
 add_library(${MODULE_NAME} SHARED
     PlayerInfo.cpp
+    PlayerInfoJsonRpc.cpp
     Module.cpp)
 
 set_target_properties(${MODULE_NAME} PROPERTIES

--- a/PlayerInfo/PlayerInfo.h
+++ b/PlayerInfo/PlayerInfo.h
@@ -84,10 +84,12 @@ namespace Plugin {
             , _videoCodecs(nullptr)
             , _notification(this)
         {
+            RegisterAll();
         }
 
         virtual ~PlayerInfo()
         {
+            UnregisterAll();
         }
 
         BEGIN_INTERFACE_MAP(PlayerInfo)
@@ -110,7 +112,9 @@ namespace Plugin {
         virtual Core::ProxyType<Web::Response> Process(const Web::Request& request) override;
 
     private:
-
+        // JsonRpc
+        void RegisterAll();
+        void UnregisterAll();
         uint32_t get_playerinfo(JsonData::PlayerInfo::CodecsData&) const;
         void Info(JsonData::PlayerInfo::CodecsData&) const;
 

--- a/PlayerInfo/PlayerInfoJsonRpc.cpp
+++ b/PlayerInfo/PlayerInfoJsonRpc.cpp
@@ -1,0 +1,56 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2020 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "PlayerInfo.h"
+
+namespace WPEFramework {
+
+namespace Plugin {
+
+    using namespace JsonData::PlayerInfo;
+
+    // Registration
+    //
+
+    void PlayerInfo::RegisterAll()
+    {
+        Property<CodecsData>(_T("playerinfo"), &PlayerInfo::get_playerinfo, nullptr, this);
+    }
+
+    void PlayerInfo::UnregisterAll()
+    {
+        Unregister(_T("playerinfo"));
+    }
+
+    // API implementation
+    //
+
+    // Property: playerinfo - Player general information
+    // Return codes:
+    //  - ERROR_NONE: Success
+    uint32_t PlayerInfo::get_playerinfo(CodecsData& response) const
+    {
+        Info(response);
+
+        return Core::ERROR_NONE;
+    }
+
+} // namespace Plugin
+
+}


### PR DESCRIPTION
Reason for change: In the process of moving towards autogenerated
JSONRPC interfaces and glue code (Thunder commit
da5f171010371493de62d00720d606c4db1429ba), the following
properties got removed
1. DisplayInfo.1.displayinfo
2. PlayerInfo.1.playerinfo
Re-introducing the above two APIs to maintain backward compatibiltiy
Test Procedure: use curl commands
Risks: None
Signed-off-by: Vinod Jacob <vinod_jacob@comcast.com>