### PR TITLE
BCOM-5099: Disable DisplayInfo plugin due to mem leak

### DIFF
--- a/DisplayInfo/DisplayInfo.config
+++ b/DisplayInfo/DisplayInfo.config
@@ -1,4 +1,4 @@
-set(autostart true)
+set(autostart false)
 set(preconditions Platform)
 
 map()


### PR DESCRIPTION
BCOM-5099 - Disable DisplayInfo plugin due to memory leak during HDMI hot plug events.