### PR TITLE
DELIA-43902: system plugin fix onFirmwareUpdateStateChange event

### DIFF
--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -2720,17 +2720,19 @@ namespace WPEFramework {
                 void *data, size_t len)
         {
             LOGINFO("len = %d\n", len);
-            switch (eventId) {
+            /* Only handle state events */
+            if (eventId != IARM_BUS_SYSMGR_EVENT_SYSTEMSTATE) return;
+
+            IARM_Bus_SYSMgr_EventData_t *sysEventData = (IARM_Bus_SYSMgr_EventData_t*)data;
+            IARM_Bus_SYSMgr_SystemState_t stateId = sysEventData->data.systemStates.stateId;
+            int state = sysEventData->data.systemStates.state;
+
+            switch (stateId) {
                 case IARM_BUS_SYSMGR_SYSSTATE_FIRMWARE_UPDATE_STATE:
                     {
-                        int newState = IARM_BUS_SYSMGR_FIRMWARE_UPDATE_STATE_UNINITIALIZED;
-                        IARM_Bus_SYSMgr_EventData_t *eventData = (IARM_Bus_SYSMgr_EventData_t *)data;
-                        LOGWARN("IARM Event: [State/Error/Payload]=[%d/%d/%s]\n",
-                                eventData->data.systemStates.state,
-                                eventData->data.systemStates.error,
-                                eventData->data.systemStates.payload);
+                        LOGWARN("IARMEvt: IARM_BUS_SYSMGR_SYSSTATE_FIRMWARE_UPDATE_STATE = '%d'\n", state);
                         if (SystemServices::_instance) {
-                            SystemServices::_instance->onFirmwareUpdateStateChange(newState);
+                            SystemServices::_instance->onFirmwareUpdateStateChange(state);
                         } else {
                             LOGERR("SystemServices::_instance is NULL.\n");
                         }

--- a/SystemServices/TestClient/systemServiceTestClient.cpp
+++ b/SystemServices/TestClient/systemServiceTestClient.cpp
@@ -872,7 +872,7 @@ void showUsage(char *pName)
 /* This section is related to the event handler implementation for Thunder Plugin Events. */
 namespace Handlers {
 	/* Common Event Handler */
-	static void onEventHandler(const Core::JSON::JsonContainer& parameters) {
+	static void onEventHandler(const JsonObject& parameters) {
 		std::string message;
 		parameters.ToString(message);
 		printf("\n[%llu][System-JSONRPCEvt]: '%s'\n", TimeStamp(), makePretty(message).c_str());
@@ -1015,7 +1015,7 @@ int main(int argc, char** argv)
 		printf("\n[%llu][System-MainFunctn] : Register a common Event Handler for all Events...\n", TimeStamp());
 		/* Experimental: Register a common Event Handler for all Events */
 		for (std::string eventName : SystemEventNames) {
-			if (remoteObject->Subscribe<Core::JSON::JsonContainer>(1000, _T(eventName),
+			if (remoteObject->Subscribe<JsonObject>(1000, _T(eventName),
 						&Handlers::onEventHandler) == Core::ERROR_NONE) {
 				printf("\n[%llu][System-MainFunctn] : Subscribed to '%s'...\n",
 					TimeStamp(), eventName.c_str());


### PR DESCRIPTION
Reason for change: Corrected missing IARM event data retrieval sections.
Test Procedure: Use IARM event sender to invoke event and test System plugin for generating "onFirmwareUpdateStateChange" event.
Risks: Low
Signed-off-by: Arun Madhavan <Arun_Madhavan@comcast.com>