### PR TITLE
XRE-14362: Updating Readme files of Infoplugins

### DIFF
--- a/DisplayInfo/DisplayInfoPlugin.json
+++ b/DisplayInfo/DisplayInfoPlugin.json
@@ -9,6 +9,6 @@
     "version": "1.0"
   },
   "interface": {
-    "$ref": "{interfacedir}/DisplayInfo.json#"
+    "$cppref": "{cppinterfacedir}/IDisplayInfo.h"
   }
 }

--- a/DisplayInfo/doc/DisplayInfoPlugin.md
+++ b/DisplayInfo/doc/DisplayInfoPlugin.md
@@ -4,7 +4,7 @@
 
 **Version: 1.0**
 
-**Status: :black_circle::black_circle::white_circle:**
+**Status: :black_circle::black_circle::black_circle:**
 
 DisplayInfo plugin for Thunder framework.
 
@@ -28,7 +28,7 @@ This document describes purpose and functionality of the DisplayInfo plugin. It 
 <a name="head.Case_Sensitivity"></a>
 ## Case Sensitivity
 
-All identifiers on the interface described in this document are case-sensitive. Thus, unless stated otherwise, all keywords, entities, properties, relations and actions should be treated as such.
+All identifiers on the interfaces described in this document are case-sensitive. Thus, unless stated otherwise, all keywords, entities, properties, relations and actions should be treated as such.
 
 <a name="head.Acronyms,_Abbreviations_and_Terms"></a>
 ## Acronyms, Abbreviations and Terms
@@ -61,7 +61,7 @@ The table below provides and overview of terms and abbreviations used in this do
 <a name="head.Description"></a>
 # Description
 
-The Display Info plugin allows retrieving of various display-related information.
+The DisplayInfo plugin allows retrieving of various display-related information.
 
 The plugin is designed to be loaded and executed within the Thunder framework. For more information about the framework refer to [[Thunder](#ref.Thunder)].
 
@@ -139,22 +139,35 @@ TV's Extended Display Identification Data.
 
 The following properties are provided by the DisplayInfo plugin:
 
+GraphicsProperties interface properties:
+
+| Property | Description |
+| :-------- | :-------- |
+| [totalgpuram](#property.totalgpuram) <sup>RO</sup> | Total GPU DRAM memory (in bytes) |
+| [freegpuram](#property.freegpuram) <sup>RO</sup> | Free GPU DRAM memory (in bytes) |
 ConnectionProperties interface properties:
 
 | Property | Description |
 | :-------- | :-------- |
-| [isaudiopassthrough](#property.isaudiopassthrough) <sup>RO</sup> | Is audioPassthrough on HDMI |
-| [connected](#property.connected) <sup>RO</sup> | Is HDMI connected |
+| [isaudiopassthrough](#property.isaudiopassthrough) <sup>RO</sup> | Current audio passthrough status on HDMI |
+| [connected](#property.connected) <sup>RO</sup> | Current HDMI connection status |
 | [width](#property.width) <sup>RO</sup> | Horizontal resolution of TV |
 | [height](#property.height) <sup>RO</sup> | Vertical resolution of TV |
 | [verticalfreq](#property.verticalfreq) <sup>RO</sup> | Vertical Frequency |
 | [hdcpprotection](#property.hdcpprotection) | HDCP protocol used for transmission |
 | [portname](#property.portname) <sup>RO</sup> | Video output port on the STB used for connection to TV |
+HDRProperties interface properties:
 
-<a name="property.isaudiopassthrough"></a>
-## *isaudiopassthrough <sup>property</sup>*
+| Property | Description |
+| :-------- | :-------- |
+| [tvcapabilities](#property.tvcapabilities) <sup>RO</sup> | HDR formats supported by TV |
+| [stbcapabilities](#property.stbcapabilities) <sup>RO</sup> | HDR formats supported by STB |
+| [hdrsetting](#property.hdrsetting) <sup>RO</sup> | HDR format in use |
 
-Provides access to the is audioPassthrough on HDMI.
+<a name="property.totalgpuram"></a>
+## *totalgpuram <sup>property</sup>*
+
+Provides access to the total GPU DRAM memory (in bytes).
 
 > This property is **read-only**.
 
@@ -162,7 +175,73 @@ Provides access to the is audioPassthrough on HDMI.
 
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
-| (property) | boolean | Is audioPassthrough on HDMI |
+| (property) | integer | Total GPU DRAM memory (in bytes) |
+
+### Example
+
+#### Get Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "DisplayInfo.1.totalgpuram"
+}
+```
+#### Get Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": 0
+}
+```
+<a name="property.freegpuram"></a>
+## *freegpuram <sup>property</sup>*
+
+Provides access to the free GPU DRAM memory (in bytes).
+
+> This property is **read-only**.
+
+### Value
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| (property) | integer | Free GPU DRAM memory (in bytes) |
+
+### Example
+
+#### Get Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "DisplayInfo.1.freegpuram"
+}
+```
+#### Get Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": 0
+}
+```
+<a name="property.isaudiopassthrough"></a>
+## *isaudiopassthrough <sup>property</sup>*
+
+Provides access to the current audio passthrough status on HDMI.
+
+> This property is **read-only**.
+
+### Value
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| (property) | boolean | Current audio passthrough status on HDMI |
 
 ### Example
 
@@ -187,7 +266,7 @@ Provides access to the is audioPassthrough on HDMI.
 <a name="property.connected"></a>
 ## *connected <sup>property</sup>*
 
-Provides access to the is HDMI connected.
+Provides access to the current HDMI connection status.
 
 > This property is **read-only**.
 
@@ -195,7 +274,7 @@ Provides access to the is HDMI connected.
 
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
-| (property) | boolean | Is HDMI connected |
+| (property) | boolean | Current HDMI connection status |
 
 ### Example
 
@@ -247,7 +326,7 @@ Provides access to the horizontal resolution of TV.
 {
     "jsonrpc": "2.0",
     "id": 1234567890,
-    "result": 0
+    "result": 1280
 }
 ```
 <a name="property.height"></a>
@@ -280,7 +359,7 @@ Provides access to the vertical resolution of TV.
 {
     "jsonrpc": "2.0",
     "id": 1234567890,
-    "result": 0
+    "result": 720
 }
 ```
 <a name="property.verticalfreq"></a>
@@ -399,10 +478,115 @@ Provides access to the video output port on the STB used for connection to TV.
     "result": ""
 }
 ```
+<a name="property.tvcapabilities"></a>
+## *tvcapabilities <sup>property</sup>*
+
+Provides access to the HDR formats supported by TV.
+
+> This property is **read-only**.
+
+### Value
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| (property) | array | HDR formats supported by TV |
+| (property)[#] | string |  (must be one of the following: *HdrOff*, *Hdr10*, *Hdr10Plus*, *HdrHlg*, *HdrDolbyvision*, *HdrTechnicolor*) |
+
+### Example
+
+#### Get Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "DisplayInfo.1.tvcapabilities"
+}
+```
+#### Get Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": [
+        "HdrOff"
+    ]
+}
+```
+<a name="property.stbcapabilities"></a>
+## *stbcapabilities <sup>property</sup>*
+
+Provides access to the HDR formats supported by STB.
+
+> This property is **read-only**.
+
+### Value
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| (property) | array | HDR formats supported by STB |
+| (property)[#] | string |  (must be one of the following: *HdrOff*, *Hdr10*, *Hdr10Plus*, *HdrHlg*, *HdrDolbyvision*, *HdrTechnicolor*) |
+
+### Example
+
+#### Get Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "DisplayInfo.1.stbcapabilities"
+}
+```
+#### Get Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": [
+        "HdrOff"
+    ]
+}
+```
+<a name="property.hdrsetting"></a>
+## *hdrsetting <sup>property</sup>*
+
+Provides access to the HDR format in use.
+
+> This property is **read-only**.
+
+### Value
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| (property) | string | HDR format in use (must be one of the following: *HdrOff*, *Hdr10*, *Hdr10Plus*, *HdrHlg*, *HdrDolbyvision*, *HdrTechnicolor*) |
+
+### Example
+
+#### Get Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "DisplayInfo.1.hdrsetting"
+}
+```
+#### Get Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": "HdrOff"
+}
+```
 <a name="head.Notifications"></a>
 # Notifications
 
-Notifications are autonomous events, triggered by the internals of the implementation, and broadcasted via JSON-RPC to all registered observers.Refer to [[Thunder](#ref.Thunder)] for information on how to register for a notification.
+Notifications are autonomous events, triggered by the internals of the implementation, and broadcasted via JSON-RPC to all registered observers. Refer to [[Thunder](#ref.Thunder)] for information on how to register for a notification.
 
 The following events are provided by the DisplayInfo plugin:
 
@@ -420,7 +604,7 @@ ConnectionProperties interface events:
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
 | params | object |  |
-| params.event | string |  (must be one of the following: *PreResolutionChange*, *PostResolutionChange*, *HdcpChange*) |
+| params.event | string |  (must be one of the following: *PreResolutionChange*, *PostResolutionChange*, *HdmiChange*, *HdcpChange*) |
 
 ### Example
 

--- a/PlayerInfo/PlayerInfoPlugin.json
+++ b/PlayerInfo/PlayerInfoPlugin.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "plugin.schema.json",
+  "info": {
+    "title": "Player Info Plugin",
+    "callsign": "PlayerInfo",
+    "locator": "libWPEPlayerInfo.so",
+    "status": "beta",
+    "description": "The PlayerInfo plugin helps to get system supported Audio Video codecs",
+    "version": "1.0"
+  },
+  "interface": {
+    "$cppref": "{cppinterfacedir}/IPlayerInfo.h"
+  }
+}

--- a/PlayerInfo/doc/PlayerInfoPlugin.md
+++ b/PlayerInfo/doc/PlayerInfoPlugin.md
@@ -15,7 +15,6 @@ PlayerInfo plugin for Thunder framework.
 - [Configuration](#head.Configuration)
 - [Methods](#head.Methods)
 - [Properties](#head.Properties)
-- [Notifications](#head.Notifications)
 
 <a name="head.Introduction"></a>
 # Introduction
@@ -23,12 +22,12 @@ PlayerInfo plugin for Thunder framework.
 <a name="head.Scope"></a>
 ## Scope
 
-This document describes purpose and functionality of the PlayerInfo plugin. It includes detailed specification of its configuration, methods and properties provided, as well as notifications sent.
+This document describes purpose and functionality of the PlayerInfo plugin. It includes detailed specification of its configuration, methods and properties provided.
 
 <a name="head.Case_Sensitivity"></a>
 ## Case Sensitivity
 
-All identifiers on the interface described in this document are case-sensitive. Thus, unless stated otherwise, all keywords, entities, properties, relations and actions should be treated as such.
+All identifiers on the interfaces described in this document are case-sensitive. Thus, unless stated otherwise, all keywords, entities, properties, relations and actions should be treated as such.
 
 <a name="head.Acronyms,_Abbreviations_and_Terms"></a>
 ## Acronyms, Abbreviations and Terms
@@ -61,7 +60,7 @@ The table below provides and overview of terms and abbreviations used in this do
 <a name="head.Description"></a>
 # Description
 
-The PlayerInfo plugin allows retrieving of various player-related information.
+The PlayerInfo plugin helps to get system supported Audio Video codecs
 
 The plugin is designed to be loaded and executed within the Thunder framework. For more information about the framework refer to [[Thunder](#ref.Thunder)].
 
@@ -74,7 +73,7 @@ The table below lists configuration options of the plugin.
 | :-------- | :-------- | :-------- |
 | callsign | string | Plugin instance name (default: *PlayerInfo*) |
 | classname | string | Class name: *PlayerInfo* |
-| locator | string | Library name: *libWPEFrameworkPlayerInfo.so* |
+| locator | string | Library name: *libWPEPlayerInfo.so* |
 | autostart | boolean | Determines if the plugin is to be started automatically along with the framework |
 
 <a name="head.Methods"></a>
@@ -401,10 +400,9 @@ Provides access to the dolby Mode.
 <a name="head.Notifications"></a>
 # Notifications
 
-Notifications are autonomous events, triggered by the internals of the implementation, and broadcasted via JSON-RPC to all registered observers.Refer to [[Thunder](#ref.Thunder)] for information on how to register for a notification.
+Notifications are autonomous events, triggered by the internals of the implementation, and broadcasted via JSON-RPC to all registered observers. Refer to [[Thunder](#ref.Thunder)] for information on how to register for a notification.
 
 The following events are provided by the PlayerInfo plugin:
-
 
 Dolby Output interface events:
 


### PR DESCRIPTION
Reason for change: Updating the readme files for Infoplugins
1. Added markdown files for PlayerInfo and DisplayInfo plugins
2. Added JSON files from which README files can be re-generated if required
Test Procedure: none
Risks: None
Signed-off-by: Vinod Jacob <vinod_jacob@comcast.com>