### PR TITLE
RDK-29733:TTS Service for PCM audio playback

### DIFF
--- a/TextToSpeech/impl/TTSSpeaker.h
+++ b/TextToSpeech/impl/TTSSpeaker.h
@@ -41,6 +41,10 @@ namespace TTS {
 #define DEFAULT_WPM 200
 #define MAX_VOLUME 100
 
+//Nuance Endpoint
+#define NUANCE_LOOPBACK_ADDR "http://127.0.0.1:50050/nuanceEve"
+#define NUANCE_LOCALHOST_ADDR "http://localhost:50050/nuanceEve"
+
 // --- //
 
 class TTSConfiguration {
@@ -162,6 +166,7 @@ private:
     bool        m_busThread;
     bool        m_flushed;
     bool        m_isEOS;
+    bool        m_pcmAudioEnabled;
     bool        m_ensurePipeline;
     std::thread *m_gstThread;
     guint       m_busWatch;


### PR DESCRIPTION
Reason for change:
* TTS service will play raw PCM audio for local speech synthesis(nuance) output of  raw PCM audio.
* Endpoint defined as nuanceEve,then only PCM audio will be enabled
Test Procedure:
* Set End point to nuanceEve
* run TTSThunderAPITest app, send text to nuance, will play PCM audio

Risks: None

Signed-off-by: Manoj Bhatta <manoj_bhatta@Comcast.Com>