### PR TITLE
Revert "XIONE-1468: getPreviousRebootReason call is failing for Realtek devices"

### DIFF
--- a/helpers/SystemServicesHelper.h
+++ b/helpers/SystemServicesHelper.h
@@ -33,7 +33,7 @@
 
 /* Status-keeper files */
 
-#ifdef (PLATFORM_BROADCOM) || defined (PLATFORM_REALTEK)
+#ifdef PLATFORM_BROADCOM
 #define SYSTEM_SERVICE_REBOOT_INFO_FILE             "/opt/secure/reboot/reboot.info"
 #define SYSTEM_SERVICE_PREVIOUS_REBOOT_INFO_FILE    "/opt/secure/reboot/previousreboot.info"
 #define SYSTEM_SERVICE_HARD_POWER_INFO_FILE         "/opt/secure/reboot/hardpower.info"


### PR DESCRIPTION
Reverts rdkcentral/rdkservices#353