### PR TITLE
DELIA-43141 : ClassCastException on getCecAddresses call during HdmiCecManager initialization

### DIFF
--- a/HdmiCec/HdmiCec.h
+++ b/HdmiCec/HdmiCec.h
@@ -96,6 +96,8 @@ namespace WPEFramework {
             void setName(std::string name);
             std::string getName();
             JsonObject getCECAddresses();
+
+            uint16_t FromBase64String(const string& newValue, uint8_t object[], uint16_t& length, const TCHAR* ignoreList);
             void sendMessage(std::string message);
             void cecAddressesChanged(int changeStatus);
 


### PR DESCRIPTION
Changed output of getCECAddresses to match legacy service.
Used fixed copy of Core::FromString, which doesn't add exrta zero to the buffer after base64 decoding.
Fixed ClassCastException for PhysicalAddress in cecAddressesChanged event.