### PR TITLE
DELIA-46268 : Fix numVoicePacketsLostCurrentDay in CS Thunder Plugin

### DIFF
--- a/ControlService/ControlService.cpp
+++ b/ControlService/ControlService.cpp
@@ -2017,7 +2017,7 @@ namespace WPEFramework {
             remoteInfo["numVoicePacketsSentPreviousDay"]  = JsonValue((int)ctrlStatus.status.voice_packets_sent_yesterday);
             remoteInfo["numVoicePacketsSentCurrentDay"]   = JsonValue((int)ctrlStatus.status.voice_packets_sent_today);
             remoteInfo["numVoicePacketsLostPreviousDay"]  = JsonValue((int)ctrlStatus.status.voice_packets_lost_yesterday);
-            remoteInfo["numVoicePacketsLostCurrentDay"]   = JsonValue((int)ctrlStatus.status.voice_packet_loss_average_today);
+            remoteInfo["numVoicePacketsLostCurrentDay"]   = JsonValue((int)ctrlStatus.status.voice_packets_lost_today);
             remoteInfo["aveVoicePacketLossPreviousDay"]   = JsonValue(std::to_string(ctrlStatus.status.voice_packet_loss_average_yesterday));   // TODO: Fix problem with FP parameters
             remoteInfo["aveVoicePacketLossCurrentDay"]    = JsonValue(std::to_string(ctrlStatus.status.voice_packet_loss_average_today));       // TODO: Fix problem with FP parameters
             remoteInfo["numVoiceCmdsHighLossPreviousDay"] = JsonValue((int)ctrlStatus.status.utterances_exceeding_packet_loss_threshold_yesterday);


### PR DESCRIPTION
Reason for change: CS Thunder Plugin was returning the wrong value for numVoicePacketsLostCurrentDay.
Test Procedure: Using Control Service plugin test app, verify numVoicePacketsLostCurrentDay.
Risks: None.
Signed-off-by: jschmidt <Jeff_Schmidt@cable.comcast>