### PR TITLE
XIONE-1468: getPreviousRebootReason fails on Realtek devices

### DIFF
--- a/helpers/SystemServicesHelper.h
+++ b/helpers/SystemServicesHelper.h
@@ -33,7 +33,7 @@
 
 /* Status-keeper files */
 
-#ifdef PLATFORM_BROADCOM
+#if defined (PLATFORM_BROADCOM) || defined (PLATFORM_REALTEK)
 #define SYSTEM_SERVICE_REBOOT_INFO_FILE             "/opt/secure/reboot/reboot.info"
 #define SYSTEM_SERVICE_PREVIOUS_REBOOT_INFO_FILE    "/opt/secure/reboot/previousreboot.info"
 #define SYSTEM_SERVICE_HARD_POWER_INFO_FILE         "/opt/secure/reboot/hardpower.info"


### PR DESCRIPTION
Reason for change: getPreviousRebootReason fails on Realtek devices
Risks: Low
Test Procedure: getPreviousRebootReason starts working on Realtek devices

Signed-off-by: Rohith Damodaran <Rohith_Damodaran@comcast.com>