### PR TITLE
RDKCOM-1705 getPreviousRebootReason fails on Raspberry Pi

### DIFF
--- a/helpers/SystemServicesHelper.h
+++ b/helpers/SystemServicesHelper.h
@@ -32,8 +32,7 @@
 #include "utils.h"
 
 /* Status-keeper files */
-
-#ifdef PLATFORM_BROADCOM
+#if defined (PLATFORM_BROADCOM) || defined (PLATFORM_BROADCOM_REF)
 #define SYSTEM_SERVICE_REBOOT_INFO_FILE             "/opt/secure/reboot/reboot.info"
 #define SYSTEM_SERVICE_PREVIOUS_REBOOT_INFO_FILE    "/opt/secure/reboot/previousreboot.info"
 #define SYSTEM_SERVICE_HARD_POWER_INFO_FILE         "/opt/secure/reboot/hardpower.info"

--- a/raspberrypi.cmake
+++ b/raspberrypi.cmake
@@ -15,6 +15,7 @@
 message("Building for raspberrypi...")
 
 add_definitions (-DUSE_SOUND_PLAYER)
+add_definitions (-DPLATFORM_BROADCOM_REF)
 
 
 #DeadCodeStrip(DCS)...forRNG150sizereduction


### PR DESCRIPTION
RDKCOM-1705 RDK Services: org.rdk.System.1.getPreviousRebootReason is giving a false response. 

Reason for change: In RPI, getPreviousRebootReason method
in System returns wrong
response because the wrong log file is looked up. Changes
in https://github.com/rdkcentral/rdkservices/pull/406
Test Procedure:
Command : curl --header "Content-Type: application/json"
--request POST --data '{"jsonrpc":"2.0","id":"3",
"method":"org.rdk.System.1.getPreviousRebootReason","params":{}}'
http://192.168.1.8:9998/jsonrpc
Response :
{"jsonrpc":"2.0","id":3,"result":{"reason":"HARD_POWER",
"success":true}}
Risks: NA

Signed-off-by: Simi Mathew <simim@tataelxsi.co.in>

Jenkins verification at https://gerrit.teamccp.com/#/c/449199/