### PR TITLE
DELIA-46582: Cherry-picking infoplugins to 2010 sprint

### DIFF
--- a/DisplayInfo/Amlogic/PlatformImplementation.cpp
+++ b/DisplayInfo/Amlogic/PlatformImplementation.cpp
@@ -401,21 +401,21 @@ private:
 				    case drmMode_4096x2160p25:
 				    case drmMode_4096x2160p30:
 				    case drmMode_4096x2160p50:
-					    height = 4096;
-					    width  = 2160;
+					    height = 2160;
+					    width  = 4096;
 					    break;
 				    case drmMode_3840x2160p60:
 				    case drmMode_4096x2160p60:
-					    height = 4096;
-					    width  = 2160;
+					    height = 2160;
+					    width  = 4096;
 					    break;
 				    default:
 					    break;
 			    }
 		    }
 #else
-		    height = 4096;
-		    width  = 2160;
+		    height = 2160;
+		    width  = 4096;
 #endif
 		    // Read HDR status
 		    type = HDR_DOLBYVISION;

--- a/DisplayInfo/CMakeLists.txt
+++ b/DisplayInfo/CMakeLists.txt
@@ -32,7 +32,6 @@ include_directories(${STAGING_INCDIR}/libdrm)
 
 add_library(${MODULE_NAME} SHARED
     DisplayInfo.cpp
-    DisplayInfoJsonRpc.cpp
     Module.cpp)
 
 set_target_properties(${MODULE_NAME} PROPERTIES
@@ -51,7 +50,21 @@ if (PLUGIN_DISPLAYINFO_BCM_VERSION_MAJOR)
             DISPLAYINFO_BCM_VERSION_MAJOR=${PLUGIN_DISPLAYINFO_BCM_VERSION_MAJOR})
 endif()
 
-if (NXCLIENT_FOUND AND NEXUS_FOUND)
+if (USE_DEVICESETTINGS)
+    find_package(DS REQUIRED)
+    find_package(IARMBus REQUIRED)
+    target_include_directories(${MODULE_NAME} PRIVATE ${IARMBUS_INCLUDE_DIRS}
+        ${DS_INCLUDE_DIRS}
+        ../helpers)
+    target_link_libraries(${MODULE_NAME} PRIVATE
+        ${NAMESPACE}Plugins::${NAMESPACE}Plugins
+        ${IARMBUS_LIBRARIES}
+        ${DS_LIBRARIES})
+    target_sources(${MODULE_NAME}
+        PRIVATE
+            DeviceSettings/PlatformImplementation.cpp
+            ../helpers/utils.cpp)
+elseif (NXCLIENT_FOUND AND NEXUS_FOUND)
     target_sources(${MODULE_NAME}
         PRIVATE
             Nexus/PlatformImplementation.cpp)
@@ -77,7 +90,7 @@ else ()
     message(FATAL_ERROR "There is no graphic backend for display info plugin")
 endif ()
 
-install(TARGETS ${MODULE_NAME} 
+install(TARGETS ${MODULE_NAME}
     DESTINATION lib/${STORAGE_DIRECTORY}/plugins)
 
 write_config(${PLUGIN_NAME})

--- a/DisplayInfo/DeviceSettings/PlatformImplementation.cpp
+++ b/DisplayInfo/DeviceSettings/PlatformImplementation.cpp
@@ -1,0 +1,509 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2020 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "../Module.h"
+#include "../DisplayInfoTracing.h"
+
+#include <interfaces/IDisplayInfo.h>
+
+#include "host.hpp"
+#include "exception.hpp"
+#include "videoOutputPort.hpp"
+#include "videoOutputPortType.hpp"
+#include "videoOutputPortConfig.hpp"
+#include "videoResolution.hpp"
+#include "audioOutputPort.hpp"
+#include "audioOutputPortType.hpp"
+#include "audioOutputPortConfig.hpp"
+#include "manager.hpp"
+#include "utils.h"
+
+#include "libIBus.h"
+#include "libIBusDaemon.h"
+#include "dsMgr.h"
+
+#define EDID_MAX_HORIZONTAL_SIZE 21
+#define EDID_MAX_VERTICAL_SIZE   22
+
+namespace WPEFramework {
+namespace Plugin {
+
+class DisplayInfoImplementation :
+    public Exchange::IGraphicsProperties,
+    public Exchange::IConnectionProperties,
+    public Exchange::IHDRProperties  {
+private:
+    using HdrteratorImplementation = RPC::IteratorType<Exchange::IHDRProperties::IHDRIterator>;
+public:
+    DisplayInfoImplementation()
+    {
+        LOGINFO();
+        DisplayInfoImplementation::_instance = this;
+        try
+        {
+            Utils::IARM::init();
+            IARM_Result_t res;
+            IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_RES_PRECHANGE,ResolutionChange) );
+            IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_RES_POSTCHANGE, ResolutionChange) );
+
+            //TODO: this is probably per process so we either need to be running in our own process or be carefull no other plugin is calling it
+            device::Manager::Initialize();
+            TRACE(Trace::Information, (_T("device::Manager::Initialize success")));
+        }
+        catch(...)
+        {
+           TRACE(Trace::Error, (_T("device::Manager::Initialize failed")));
+        }
+    }
+
+    DisplayInfoImplementation(const DisplayInfoImplementation&) = delete;
+    DisplayInfoImplementation& operator= (const DisplayInfoImplementation&) = delete;
+
+    virtual ~DisplayInfoImplementation()
+    {
+        LOGINFO();
+        IARM_Result_t res;
+        IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_RES_PRECHANGE) );
+        IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_RES_POSTCHANGE) );
+        DisplayInfoImplementation::_instance = nullptr;
+    }
+
+public:
+    // Graphics Properties interface
+    uint32_t TotalGpuRam(uint64_t& total) const override
+    {
+        LOGINFO();
+        total = 0; // TODO: Implement using DeviceSettings
+        return (Core::ERROR_NONE);
+    }
+    uint32_t FreeGpuRam(uint64_t& free ) const override
+    {
+        LOGINFO();
+        free = 0; // TODO: Implement using DeviceSettings
+        return (Core::ERROR_NONE);
+    }
+
+    // Connection Properties interface
+    uint32_t Register(INotification* notification) override
+    {
+        LOGINFO();
+        _adminLock.Lock();
+
+        // Make sure a sink is not registered multiple times.
+        ASSERT(std::find(_observers.begin(), _observers.end(), notification) == _observers.end());
+
+        _observers.push_back(notification);
+        notification->AddRef();
+
+        _adminLock.Unlock();
+
+        return (Core::ERROR_NONE);
+    }
+    uint32_t Unregister(INotification* notification) override
+    {
+        LOGINFO();
+        _adminLock.Lock();
+
+        std::list<IConnectionProperties::INotification*>::iterator index(std::find(_observers.begin(), _observers.end(), notification));
+
+        // Make sure you do not unregister something you did not register !!!
+        ASSERT(index != _observers.end());
+
+        if (index != _observers.end()) {
+            (*index)->Release();
+            _observers.erase(index);
+        }
+
+        _adminLock.Unlock();
+
+        return (Core::ERROR_NONE);
+    }
+
+    static void ResolutionChange(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
+    {
+        LOGINFO();
+        IConnectionProperties::INotification::Source eventtype;
+        if (strcmp(owner, IARM_BUS_DSMGR_NAME) == 0)
+        {
+            switch (eventId) {
+                case IARM_BUS_DSMGR_EVENT_RES_POSTCHANGE:
+                    eventtype = IConnectionProperties::INotification::Source::POST_RESOLUTION_CHANGE;
+                    break;
+                case IARM_BUS_DSMGR_EVENT_RES_PRECHANGE:
+                    eventtype = IConnectionProperties::INotification::Source::PRE_RESOLUTION_CHANGE;
+            }
+        }
+
+        if(DisplayInfoImplementation::_instance)
+        {
+           DisplayInfoImplementation::_instance->ResolutionChangeImpl(eventtype);
+        }
+    }
+
+    void ResolutionChangeImpl(IConnectionProperties::INotification::Source eventtype)
+    {
+        LOGINFO();
+        _adminLock.Lock();
+
+        std::list<IConnectionProperties::INotification*>::const_iterator index = _observers.begin();
+
+        while(index != _observers.end()) {
+            (*index)->Updated(IConnectionProperties::INotification::Source::POST_RESOLUTION_CHANGE);
+            index++;
+        }
+
+        _adminLock.Unlock();
+    }
+
+    uint32_t IsAudioPassthrough (bool& value) const override
+    {
+        LOGINFO("Stubbed function. TODO: Implement using DeviceSettings");
+        value = false; // TODO: Implement using DeviceSettings
+        return (Core::ERROR_NONE);
+    }
+    uint32_t Connected(bool& connected) const override
+    {
+        LOGINFO("Stubbed function. TODO: Implement using DeviceSettings");
+        connected = false; // TODO: Implement using DeviceSettings (or use HDCP Profile plugin for this)
+        return (Core::ERROR_NONE);
+    }
+    uint32_t Width(uint32_t& value) const override
+    {
+        LOGINFO("Stubbed function. TODO: Implement using DeviceSettings");
+        value = 0; // TODO: Implement using DeviceSettings
+        return (Core::ERROR_NONE);
+    }
+    uint32_t Height(uint32_t& value) const override
+    {
+        LOGINFO("Stubbed function. TODO: Implement using DeviceSettings");
+        value = 0; // TODO: Implement using DeviceSettings
+        return (Core::ERROR_NONE);
+    }
+    uint32_t VerticalFreq(uint32_t& value) const override
+    {
+        LOGINFO("Stubbed function. TODO: Implement using DeviceSettings");
+        value = 0; // TODO: Implement using DeviceSettings
+        return (Core::ERROR_NONE);
+    }
+
+    uint32_t HDCPProtection(HDCPProtectionType& value) const override //get
+    {
+        LOGINFO();
+        int hdcpversion = 1;
+        string portname;
+        PortName(portname);
+        if(!portname.empty())
+        {
+            try
+            {
+                device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort(portname);
+                hdcpversion = vPort.GetHdmiPreference();
+                switch(static_cast<dsHdcpProtocolVersion_t>(hdcpversion))
+                {
+                    case dsHDCP_VERSION_1X: value = IConnectionProperties::HDCPProtectionType::HDCP_1X; break;
+                    case dsHDCP_VERSION_2X: value = IConnectionProperties::HDCPProtectionType::HDCP_2X; break;
+                    case dsHDCP_VERSION_MAX: value = IConnectionProperties::HDCPProtectionType::HDCP_AUTO; break;
+                }
+            }
+            catch(const device::Exception& err)
+            {
+                TRACE(Trace::Error, (_T("Exception during DeviceSetting library call. code = %d message = %s"), err.getCode(), err.what()));
+            }
+        }
+        else
+        {
+            TRACE(Trace::Information, (_T("No STB video ouptut ports connected to TV, returning HDCP as unencrypted %d"), hdcpversion));
+        }
+        return (Core::ERROR_NONE);
+    }
+
+    uint32_t HDCPProtection(const HDCPProtectionType value) override //set
+    {
+        LOGINFO();
+        dsHdcpProtocolVersion_t hdcpversion = dsHDCP_VERSION_MAX;
+        string portname;
+        PortName(portname);
+        if(!portname.empty())
+        {
+            switch(value)
+            {
+                case IConnectionProperties::HDCPProtectionType::HDCP_1X : hdcpversion = dsHDCP_VERSION_1X; break;
+                case IConnectionProperties::HDCPProtectionType::HDCP_2X: hdcpversion = dsHDCP_VERSION_2X; break;
+                case IConnectionProperties::HDCPProtectionType::HDCP_AUTO: hdcpversion = dsHDCP_VERSION_MAX; break;
+            }
+            try
+            {
+                device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort(portname);
+                if(!vPort.SetHdmiPreference(hdcpversion))
+                {
+                    TRACE(Trace::Information, (_T("HDCPProtection: SetHdmiPreference failed")));
+                    LOGERR("SetHdmiPreference failed");
+                }
+            }
+            catch(const device::Exception& err)
+            {
+                TRACE(Trace::Error, (_T("Exception during DeviceSetting library call. code = %d message = %s"), err.getCode(), err.what()));
+            }
+        }
+        else
+        {
+            TRACE(Trace::Information, (_T("No STB video ouptut ports connected to TV, returning HDCP as unencrypted %d"), hdcpversion));
+        }
+        return (Core::ERROR_NONE);
+    }
+
+    uint32_t WidthInCentimeters(uint8_t& width /* @out */) const override
+    {
+        LOGINFO();
+        try
+        {
+            ::device::VideoOutputPort vPort = ::device::Host::getInstance().getVideoOutputPort("HDMI0");
+            if (vPort.isDisplayConnected())
+            {
+                std::vector<uint8_t> edidVec;
+
+                vPort.getDisplay().getEDIDBytes(edidVec);
+
+                if(edidVec.size() > EDID_MAX_VERTICAL_SIZE)
+                {
+                    width = edidVec[EDID_MAX_HORIZONTAL_SIZE];
+                    TRACE(Trace::Information, (_T("Width in cm = %d"), width));
+                }
+                else
+                {
+                    LOGWARN("Failed to get Display Size!\n");
+                }
+            }
+        }
+        catch (const device::Exception& err)
+        {
+           TRACE(Trace::Error, (_T("Exception during DeviceSetting library call. code = %d message = %s"), err.getCode(), err.what()));
+        }
+        return (Core::ERROR_NONE);
+    }
+
+    uint32_t HeightInCentimeters(uint8_t& height /* @out */) const override
+    {
+        LOGINFO();
+        try
+        {
+            ::device::VideoOutputPort vPort = ::device::Host::getInstance().getVideoOutputPort("HDMI0");
+            if (vPort.isDisplayConnected())
+            {
+                std::vector<uint8_t> edidVec;
+
+                vPort.getDisplay().getEDIDBytes(edidVec);
+
+                if(edidVec.size() > EDID_MAX_VERTICAL_SIZE)
+                {
+                    height = edidVec[EDID_MAX_VERTICAL_SIZE];
+                    TRACE(Trace::Information, (_T("Height in cm = %d"), height));
+                }
+                else
+                {
+                    LOGWARN("Failed to get Display Size!\n");
+                }
+            }
+        }
+        catch (const device::Exception& err)
+        {
+            TRACE(Trace::Error, (_T("Exception during DeviceSetting library call. code = %d message = %s"), err.getCode(), err.what()));
+        }
+        return (Core::ERROR_NONE);
+    }
+
+    uint32_t EDID (uint16_t& length /* @inout */, uint8_t data[] /* @out @length:length */) const override
+    {
+        LOGINFO();
+        vector<uint8_t> edidVec({'u','n','k','n','o','w','n' });
+        try
+        {
+            vector<uint8_t> edidVec2;
+            device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort("HDMI0");
+            if (vPort.isDisplayConnected())
+            {
+                vPort.getDisplay().getEDIDBytes(edidVec2);
+                edidVec = edidVec2;//edidVec must be "unknown" unless we successfully get to this line
+            }
+            else
+            {
+                LOGWARN("failure: HDMI0 not connected!");
+            }
+        }
+        catch (const device::Exception& err)
+        {
+            LOG_DEVICE_EXCEPTION0();
+        }
+        //convert to base64
+        uint16_t size = min(edidVec.size(), (size_t)numeric_limits<uint16_t>::max());
+        if(edidVec.size() > (size_t)numeric_limits<uint16_t>::max())
+            LOGERR("Size too large to use ToString base64 wpe api");
+        string edidbase64;
+        // Align input string size to multiple of 3
+        int paddingSize = 0;
+        for (; paddingSize < (3-size%3);paddingSize++)
+        {
+            edidVec.push_back(0x00);
+        }
+        size += paddingSize;
+        int i = 0;
+
+        for (i; i < length && i < size; i++)
+        {
+            data[i] = edidVec[i];
+        }
+        length = i;
+        return (Core::ERROR_NONE);
+
+    }
+
+    uint32_t PortName (string& name /* @out */) const
+    {
+        LOGINFO();
+        try
+        {
+            device::List<device::VideoOutputPort> vPorts = device::Host::getInstance().getVideoOutputPorts();
+            for (size_t i = 0; i < vPorts.size(); i++)
+            {
+                device::VideoOutputPort &vPort = vPorts.at(i);
+                if (vPort.isDisplayConnected())
+                {
+                    name = vPort.getName();
+                    TRACE(Trace::Information, (_T("Connected video output port = %s"), name));
+                    break;
+                }
+            }
+        }
+        catch(const device::Exception& err)
+        {
+            TRACE(Trace::Error, (_T("Exception during DeviceSetting library call. code = %d message = %s"), err.getCode(), err.what()));
+        }
+        return (Core::ERROR_NONE);
+    }
+
+    // @property
+    // @brief HDR formats supported by TV
+    // @return HDRType: array of HDR formats
+    uint32_t TVCapabilities(IHDRIterator*& type /* out */) const override
+    {
+        LOGINFO();
+        std::list<Exchange::IHDRProperties::HDRType> hdrCapabilities;
+
+        int capabilities = static_cast<int>(dsHDRSTANDARD_NONE);
+        try
+        {
+            device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort("HDMI0");
+            if (vPort.isDisplayConnected()) {
+                vPort.getTVHDRCapabilities(&capabilities);
+            }
+            else {
+                TRACE(Trace::Error, (_T("getTVHDRCapabilities failure: HDMI0 not connected!")));
+            }
+        }
+        catch(const device::Exception& err)
+        {
+            TRACE(Trace::Error, (_T("Exception during DeviceSetting library call. code = %d message = %s"), err.getCode(), err.what()));
+        }
+        if(!capabilities) hdrCapabilities.push_back(HDR_OFF);
+        if(capabilities & dsHDRSTANDARD_HDR10) hdrCapabilities.push_back(HDR_10);
+        if(capabilities & dsHDRSTANDARD_HLG) hdrCapabilities.push_back(HDR_HLG);
+        if(capabilities & dsHDRSTANDARD_DolbyVision) hdrCapabilities.push_back(HDR_DOLBYVISION);
+        if(capabilities & dsHDRSTANDARD_TechnicolorPrime) hdrCapabilities.push_back(HDR_TECHNICOLOR);
+        if(capabilities & dsHDRSTANDARD_Invalid)hdrCapabilities.push_back(HDR_OFF);
+
+
+        type = Core::Service<HdrteratorImplementation>::Create<Exchange::IHDRProperties::IHDRIterator>(hdrCapabilities);
+        return (type != nullptr ? Core::ERROR_NONE : Core::ERROR_GENERAL);
+    }
+    // @property
+    // @brief HDR formats supported by STB
+    // @return HDRType: array of HDR formats
+    uint32_t STBCapabilities(IHDRIterator*& type /* out */) const override
+    {
+        LOGINFO();
+        std::list<Exchange::IHDRProperties::HDRType> hdrCapabilities;
+
+        int capabilities = static_cast<int>(dsHDRSTANDARD_NONE);
+        try
+        {
+            device::VideoDevice &device = device::Host::getInstance().getVideoDevices().at(0);
+            device.getHDRCapabilities(&capabilities);
+        }
+        catch(const device::Exception& err)
+        {
+            TRACE(Trace::Error, (_T("Exception during DeviceSetting library call. code = %d message = %s"), err.getCode(), err.what()));
+        }
+        if(!capabilities) hdrCapabilities.push_back(HDR_OFF);
+        if(capabilities & dsHDRSTANDARD_HDR10) hdrCapabilities.push_back(HDR_10);
+        if(capabilities & dsHDRSTANDARD_HLG) hdrCapabilities.push_back(HDR_HLG);
+        if(capabilities & dsHDRSTANDARD_DolbyVision) hdrCapabilities.push_back(HDR_DOLBYVISION);
+        if(capabilities & dsHDRSTANDARD_TechnicolorPrime) hdrCapabilities.push_back(HDR_TECHNICOLOR);
+        if(capabilities & dsHDRSTANDARD_Invalid)hdrCapabilities.push_back(HDR_OFF);
+
+
+        type = Core::Service<HdrteratorImplementation>::Create<Exchange::IHDRProperties::IHDRIterator>(hdrCapabilities);
+        return (type != nullptr ? Core::ERROR_NONE : Core::ERROR_GENERAL);
+    }
+    // @property
+    // @brief HDR format in use
+    // @param type: HDR format
+    uint32_t HDRSetting(HDRType& type /* @out */) const override
+    {
+        LOGINFO();
+        LOGINFO();
+        type = IHDRProperties::HDRType::HDR_OFF;
+        bool isHdr = false;
+        try
+        {
+            device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort("HDMI0");
+            if (vPort.isDisplayConnected()) {
+                isHdr = vPort.IsOutputHDR();
+            }
+            else
+            {
+                TRACE(Trace::Information, (_T("IsOutputHDR failure: HDMI0 not connected!")));
+            }
+        }
+        catch(const device::Exception& err)
+        {
+            TRACE(Trace::Error, (_T("Exception during DeviceSetting library call. code = %d message = %s"), err.getCode(), err.what()));
+        }
+        TRACE(Trace::Information, (_T("Output HDR = %s"), isHdr ? "Yes" : "No"));
+
+        type = isHdr? HDR_10 : HDR_OFF;
+        return (Core::ERROR_NONE);
+    }
+
+
+    BEGIN_INTERFACE_MAP(DisplayInfoImplementation)
+        INTERFACE_ENTRY(Exchange::IGraphicsProperties)
+        INTERFACE_ENTRY(Exchange::IConnectionProperties)
+        INTERFACE_ENTRY(Exchange::IHDRProperties)
+    END_INTERFACE_MAP
+
+private:
+    std::list<IConnectionProperties::INotification*> _observers;
+    mutable Core::CriticalSection _adminLock;
+
+public:
+    static DisplayInfoImplementation* _instance;
+};
+    DisplayInfoImplementation* DisplayInfoImplementation::_instance = nullptr;
+    SERVICE_REGISTRATION(DisplayInfoImplementation, 1, 0);
+}
+}

--- a/DisplayInfo/DisplayInfo.cpp
+++ b/DisplayInfo/DisplayInfo.cpp
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 #include "DisplayInfo.h"
 
 namespace WPEFramework {
@@ -42,12 +42,15 @@ namespace Plugin {
         if (_connectionProperties != nullptr) {
 
             _graphicsProperties = _connectionProperties->QueryInterface<Exchange::IGraphicsProperties>();
+            _hdrProperties = _connectionProperties->QueryInterface<Exchange::IHDRProperties>();
             if (_graphicsProperties == nullptr) {
 
                 _connectionProperties->Release();
                 _connectionProperties = nullptr;
             } else {
                 _notification.Initialize(_connectionProperties);
+                Exchange::JConnectionProperties::Register(*this, _connectionProperties);
+                Exchange::JHDRProperties::Register(*this, _hdrProperties);
             }
         }
 
@@ -61,6 +64,9 @@ namespace Plugin {
     /* virtual */ void DisplayInfo::Deinitialize(PluginHost::IShell* service)
     {
         ASSERT(_connectionProperties != nullptr);
+
+        Exchange::JHDRProperties::Unregister(*this);
+        Exchange::JConnectionProperties::Unregister(*this);
 
         _notification.Deinitialize();
 
@@ -76,6 +82,10 @@ namespace Plugin {
             _connectionProperties = nullptr;
         }
 
+        if (_hdrProperties != nullptr) {
+            _hdrProperties->Release();
+            _hdrProperties = nullptr;
+        }
         _connectionId = 0;
     }
 
@@ -122,15 +132,39 @@ namespace Plugin {
 
     void DisplayInfo::Info(JsonData::DisplayInfo::DisplayinfoData& displayInfo) const
     {
-        displayInfo.Totalgpuram = _graphicsProperties->TotalGpuRam();
-        displayInfo.Freegpuram = _graphicsProperties->FreeGpuRam();
+        bool boolean;
+        uint32_t value;
+        Exchange::IHDRProperties::HDRType hdrType;
+        Exchange::IConnectionProperties::HDCPProtectionType hdcpType;
 
-        displayInfo.Audiopassthrough = _connectionProperties->IsAudioPassthrough();
-        displayInfo.Connected = _connectionProperties->Connected();
-        displayInfo.Width = _connectionProperties->Width();
-        displayInfo.Height = _connectionProperties->Height();
-        displayInfo.Hdcpprotection = static_cast<JsonData::DisplayInfo::DisplayinfoData::HdcpprotectionType>(_connectionProperties->HDCPProtection());
-        displayInfo.Hdrtype = static_cast<JsonData::DisplayInfo::DisplayinfoData::HdrtypeType>(_connectionProperties->Type());
+        uint64_t ram = 0;
+        if (_graphicsProperties->TotalGpuRam(ram) == Core::ERROR_NONE) {
+            displayInfo.Totalgpuram = ram;
+        }
+        ram = 0;
+        if (_graphicsProperties->FreeGpuRam(ram) == Core::ERROR_NONE) {
+            displayInfo.Freegpuram = ram;
+        }
+
+        if (_connectionProperties->IsAudioPassthrough(boolean) == Core::ERROR_NONE) {
+            displayInfo.Audiopassthrough = boolean;
+        }
+        if (_connectionProperties->Connected(boolean) == Core::ERROR_NONE) {
+            displayInfo.Connected = boolean;
+        }
+        if (_connectionProperties->Width(value) == Core::ERROR_NONE) {
+            displayInfo.Width = value;
+        }
+        if (_connectionProperties->Height(value) == Core::ERROR_NONE) {
+            displayInfo.Height = value;
+        }
+
+        if (static_cast<const Exchange::IConnectionProperties*>(_connectionProperties)->HDCPProtection(hdcpType) == Core::ERROR_NONE) {
+            displayInfo.Hdcpprotection = static_cast<JsonData::DisplayInfo::DisplayinfoData::HdcpprotectionType>(hdcpType);
+        }
+        if ((_hdrProperties != nullptr) && (_hdrProperties->HDRSetting(hdrType) == Core::ERROR_NONE)) {
+            displayInfo.Hdrtype = static_cast<JsonData::DisplayInfo::DisplayinfoData::HdrtypeType>(hdrType);
+        }
     }
 
 } // namespace Plugin

--- a/DisplayInfo/DisplayInfoPlugin.json
+++ b/DisplayInfo/DisplayInfoPlugin.json
@@ -9,6 +9,6 @@
     "version": "1.0"
   },
   "interface": {
-    "$ref": "{interfacedir}/DisplayInfo.json#"
+    "$cppref": "{cppinterfacedir}/IDisplayInfo.h"
   }
 }

--- a/DisplayInfo/doc/DisplayInfoPlugin.md
+++ b/DisplayInfo/doc/DisplayInfoPlugin.md
@@ -13,6 +13,7 @@ DisplayInfo plugin for Thunder framework.
 - [Introduction](#head.Introduction)
 - [Description](#head.Description)
 - [Configuration](#head.Configuration)
+- [Methods](#head.Methods)
 - [Properties](#head.Properties)
 - [Notifications](#head.Notifications)
 
@@ -22,12 +23,12 @@ DisplayInfo plugin for Thunder framework.
 <a name="head.Scope"></a>
 ## Scope
 
-This document describes purpose and functionality of the DisplayInfo plugin. It includes detailed specification of its configuration, properties provided and notifications sent.
+This document describes purpose and functionality of the DisplayInfo plugin. It includes detailed specification of its configuration, methods and properties provided, as well as notifications sent.
 
 <a name="head.Case_Sensitivity"></a>
 ## Case Sensitivity
 
-All identifiers on the interface described in this document are case-sensitive. Thus, unless stated otherwise, all keywords, entities, properties, relations and actions should be treated as such.
+All identifiers on the interfaces described in this document are case-sensitive. Thus, unless stated otherwise, all keywords, entities, properties, relations and actions should be treated as such.
 
 <a name="head.Acronyms,_Abbreviations_and_Terms"></a>
 ## Acronyms, Abbreviations and Terms
@@ -76,21 +77,97 @@ The table below lists configuration options of the plugin.
 | locator | string | Library name: *libWPEFrameworkDisplayInfo.so* |
 | autostart | boolean | Determines if the plugin is to be started automatically along with the framework |
 
+<a name="head.Methods"></a>
+# Methods
+
+The following methods are provided by the DisplayInfo plugin:
+
+ConnectionProperties interface methods:
+
+| Method | Description |
+| :-------- | :-------- |
+| [edid](#method.edid) | TV's Extended Display Identification Data |
+
+<a name="method.edid"></a>
+## *edid <sup>method</sup>*
+
+TV's Extended Display Identification Data.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.length | integer |  |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.length | integer |  |
+| result.data | string |  |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "DisplayInfo.1.edid",
+    "params": {
+        "length": 0
+    }
+}
+```
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": {
+        "length": 0,
+        "data": ""
+    }
+}
+```
 <a name="head.Properties"></a>
 # Properties
 
 The following properties are provided by the DisplayInfo plugin:
 
-DisplayInfo interface properties:
+GraphicsProperties interface properties:
 
 | Property | Description |
 | :-------- | :-------- |
-| [displayinfo](#property.displayinfo) <sup>RO</sup> | Display general information |
+| [totalgpuram](#property.totalgpuram) <sup>RO</sup> | Total GPU DRAM memory (in bytes) |
+| [freegpuram](#property.freegpuram) <sup>RO</sup> | Free GPU DRAM memory (in bytes) |
+ConnectionProperties interface properties:
 
-<a name="property.displayinfo"></a>
-## *displayinfo <sup>property</sup>*
+| Property | Description |
+| :-------- | :-------- |
+| [isaudiopassthrough](#property.isaudiopassthrough) <sup>RO</sup> | Current audio passthrough status on HDMI |
+| [connected](#property.connected) <sup>RO</sup> | Current HDMI connection status |
+| [width](#property.width) <sup>RO</sup> | Horizontal resolution of TV |
+| [height](#property.height) <sup>RO</sup> | Vertical resolution of TV |
+| [verticalfreq](#property.verticalfreq) <sup>RO</sup> | Vertical Frequency |
+| [hdcpprotection](#property.hdcpprotection) | HDCP protocol used for transmission |
+| [portname](#property.portname) <sup>RO</sup> | Video output port on the STB used for connection to TV |
+HDRProperties interface properties:
 
-Provides access to the display general information.
+| Property | Description |
+| :-------- | :-------- |
+| [tvcapabilities](#property.tvcapabilities) <sup>RO</sup> | HDR formats supported by TV |
+| [stbcapabilities](#property.stbcapabilities) <sup>RO</sup> | HDR formats supported by STB |
+| [hdrsetting](#property.hdrsetting) <sup>RO</sup> | HDR format in use |
+
+<a name="property.totalgpuram"></a>
+## *totalgpuram <sup>property</sup>*
+
+Provides access to the total GPU DRAM memory (in bytes).
 
 > This property is **read-only**.
 
@@ -98,15 +175,7 @@ Provides access to the display general information.
 
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
-| (property) | object | Display general information |
-| (property).totalgpuram | number | Total GPU DRAM memory (in bytes) |
-| (property).freegpuram | number | Free GPU DRAM memory (in bytes) |
-| (property).audiopassthrough | boolean | Audio Pass through is support for this device |
-| (property).connected | boolean | HDMI display connection status |
-| (property).width | number | Width of the connected HDMI display |
-| (property).height | number | Height of the connected HDMI display |
-| (property).hdcpprotection | string | HDCP Protection (must be one of the following: *Unencrypted*, *HDCP1x*, *HDCP2x*) |
-| (property).hdrtype | string | HDR Type used (must be one of the following: *HDROff*, *HDR10*, *HDR10Plus*, *HDRDolbyVision*, *HDRTechnicolor*) |
+| (property) | integer | Total GPU DRAM memory (in bytes) |
 
 ### Example
 
@@ -116,7 +185,7 @@ Provides access to the display general information.
 {
     "jsonrpc": "2.0",
     "id": 1234567890,
-    "method": "DisplayInfo.1.displayinfo"
+    "method": "DisplayInfo.1.totalgpuram"
 }
 ```
 #### Get Response
@@ -125,49 +194,426 @@ Provides access to the display general information.
 {
     "jsonrpc": "2.0",
     "id": 1234567890,
-    "result": {
-        "totalgpuram": 381681664,
-        "freegpuram": 358612992,
-        "audiopassthrough": false,
-        "connected": true,
-        "width": 1280,
-        "height": 720,
-        "hdcpprotection": "HDCP1x",
-        "hdrtype": "HDROff"
-    }
+    "result": 0
+}
+```
+<a name="property.freegpuram"></a>
+## *freegpuram <sup>property</sup>*
+
+Provides access to the free GPU DRAM memory (in bytes).
+
+> This property is **read-only**.
+
+### Value
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| (property) | integer | Free GPU DRAM memory (in bytes) |
+
+### Example
+
+#### Get Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "DisplayInfo.1.freegpuram"
+}
+```
+#### Get Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": 0
+}
+```
+<a name="property.isaudiopassthrough"></a>
+## *isaudiopassthrough <sup>property</sup>*
+
+Provides access to the current audio passthrough status on HDMI.
+
+> This property is **read-only**.
+
+### Value
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| (property) | boolean | Current audio passthrough status on HDMI |
+
+### Example
+
+#### Get Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "DisplayInfo.1.isaudiopassthrough"
+}
+```
+#### Get Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": false
+}
+```
+<a name="property.connected"></a>
+## *connected <sup>property</sup>*
+
+Provides access to the current HDMI connection status.
+
+> This property is **read-only**.
+
+### Value
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| (property) | boolean | Current HDMI connection status |
+
+### Example
+
+#### Get Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "DisplayInfo.1.connected"
+}
+```
+#### Get Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": false
+}
+```
+<a name="property.width"></a>
+## *width <sup>property</sup>*
+
+Provides access to the horizontal resolution of TV.
+
+> This property is **read-only**.
+
+### Value
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| (property) | integer | Horizontal resolution of TV |
+
+### Example
+
+#### Get Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "DisplayInfo.1.width"
+}
+```
+#### Get Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": 1280
+}
+```
+<a name="property.height"></a>
+## *height <sup>property</sup>*
+
+Provides access to the vertical resolution of TV.
+
+> This property is **read-only**.
+
+### Value
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| (property) | integer | Vertical resolution of TV |
+
+### Example
+
+#### Get Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "DisplayInfo.1.height"
+}
+```
+#### Get Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": 720
+}
+```
+<a name="property.verticalfreq"></a>
+## *verticalfreq <sup>property</sup>*
+
+Provides access to the vertical Frequency.
+
+> This property is **read-only**.
+
+### Value
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| (property) | integer | Vertical Frequency |
+
+### Example
+
+#### Get Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "DisplayInfo.1.verticalfreq"
+}
+```
+#### Get Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": 0
+}
+```
+<a name="property.hdcpprotection"></a>
+## *hdcpprotection <sup>property</sup>*
+
+Provides access to the HDCP protocol used for transmission.
+
+### Value
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| (property) | string | HDCP protocol used for transmission (must be one of the following: *HdcpUnencrypted*, *Hdcp1X*, *Hdcp2X*) |
+
+### Example
+
+#### Get Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "DisplayInfo.1.hdcpprotection"
+}
+```
+#### Get Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": "HdcpUnencrypted"
+}
+```
+#### Set Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "DisplayInfo.1.hdcpprotection",
+    "params": "HdcpUnencrypted"
+}
+```
+#### Set Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": "null"
+}
+```
+<a name="property.portname"></a>
+## *portname <sup>property</sup>*
+
+Provides access to the video output port on the STB used for connection to TV.
+
+> This property is **read-only**.
+
+### Value
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| (property) | string | Video output port on the STB used for connection to TV |
+
+### Example
+
+#### Get Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "DisplayInfo.1.portname"
+}
+```
+#### Get Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": ""
+}
+```
+<a name="property.tvcapabilities"></a>
+## *tvcapabilities <sup>property</sup>*
+
+Provides access to the HDR formats supported by TV.
+
+> This property is **read-only**.
+
+### Value
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| (property) | array | HDR formats supported by TV |
+| (property)[#] | string |  (must be one of the following: *HdrOff*, *Hdr10*, *Hdr10Plus*, *HdrHlg*, *HdrDolbyvision*, *HdrTechnicolor*) |
+
+### Example
+
+#### Get Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "DisplayInfo.1.tvcapabilities"
+}
+```
+#### Get Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": [
+        "HdrOff"
+    ]
+}
+```
+<a name="property.stbcapabilities"></a>
+## *stbcapabilities <sup>property</sup>*
+
+Provides access to the HDR formats supported by STB.
+
+> This property is **read-only**.
+
+### Value
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| (property) | array | HDR formats supported by STB |
+| (property)[#] | string |  (must be one of the following: *HdrOff*, *Hdr10*, *Hdr10Plus*, *HdrHlg*, *HdrDolbyvision*, *HdrTechnicolor*) |
+
+### Example
+
+#### Get Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "DisplayInfo.1.stbcapabilities"
+}
+```
+#### Get Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": [
+        "HdrOff"
+    ]
+}
+```
+<a name="property.hdrsetting"></a>
+## *hdrsetting <sup>property</sup>*
+
+Provides access to the HDR format in use.
+
+> This property is **read-only**.
+
+### Value
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| (property) | string | HDR format in use (must be one of the following: *HdrOff*, *Hdr10*, *Hdr10Plus*, *HdrHlg*, *HdrDolbyvision*, *HdrTechnicolor*) |
+
+### Example
+
+#### Get Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "DisplayInfo.1.hdrsetting"
+}
+```
+#### Get Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": "HdrOff"
 }
 ```
 <a name="head.Notifications"></a>
 # Notifications
 
-Notifications are autonomous events, triggered by the internals of the implementation, and broadcasted via JSON-RPC to all registered observers.Refer to [[Thunder](#ref.Thunder)] for information on how to register for a notification.
+Notifications are autonomous events, triggered by the internals of the implementation, and broadcasted via JSON-RPC to all registered observers. Refer to [[Thunder](#ref.Thunder)] for information on how to register for a notification.
 
 The following events are provided by the DisplayInfo plugin:
 
-DisplayInfo interface events:
+ConnectionProperties interface events:
 
 | Event | Description |
 | :-------- | :-------- |
-| [updated](#event.updated) | Notifies about a change/update in the connection |
+| [updated](#event.updated) |  |
 
 <a name="event.updated"></a>
 ## *updated <sup>event</sup>*
 
-Notifies about a change/update in the connection.
-
-### Description
-
-Register to this event to be notified about any change in the connection
-
 ### Parameters
 
-This event carries no parameters.
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.event | string |  (must be one of the following: *PreResolutionChange*, *PostResolutionChange*, *HdmiChange*, *HdcpChange*) |
 
 ### Example
 
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.updated"
+    "method": "client.events.1.updated",
+    "params": {
+        "event": "PreResolutionChange"
+    }
 }
 ```

--- a/PlayerInfo/CMakeLists.txt
+++ b/PlayerInfo/CMakeLists.txt
@@ -24,7 +24,6 @@ find_package(CompileSettingsDebug CONFIG REQUIRED)
 
 add_library(${MODULE_NAME} SHARED
     PlayerInfo.cpp
-    PlayerInfoJsonRpc.cpp
     Module.cpp)
 
 set_target_properties(${MODULE_NAME} PROPERTIES
@@ -40,9 +39,6 @@ target_link_libraries(${MODULE_NAME}
 find_package(GSTREAMER REQUIRED)
 
 if (GSTREAMER_FOUND)
-    target_sources(${MODULE_NAME}
-        PRIVATE
-            GStreamer/PlatformImplementation.cpp)
 
     target_link_libraries(${MODULE_NAME}
         PRIVATE
@@ -51,9 +47,30 @@ if (GSTREAMER_FOUND)
     target_include_directories(${MODULE_NAME}
         PRIVATE
             ${GSTREAMER_INCLUDES})
+
+    if (USE_DEVICESETTINGS)
+        find_package(DS REQUIRED)
+        find_package(IARMBus REQUIRED)
+        target_include_directories(${MODULE_NAME} PRIVATE
+            ${IARMBUS_INCLUDE_DIRS}
+            ${DS_INCLUDE_DIRS}
+            ../helpers)
+        target_link_libraries(${MODULE_NAME} PRIVATE
+            ${NAMESPACE}Plugins::${NAMESPACE}Plugins
+            ${IARMBUS_LIBRARIES}
+            ${DS_LIBRARIES})
+        target_sources(${MODULE_NAME}
+            PRIVATE
+                DeviceSettings/PlatformImplementation.cpp
+                ../helpers/utils.cpp)
+    else()
+        target_sources(${MODULE_NAME}
+            PRIVATE
+                GStreamer/PlatformImplementation.cpp)
+    endif()
 endif ()
 
-install(TARGETS ${MODULE_NAME} 
+install(TARGETS ${MODULE_NAME}
     DESTINATION lib/${STORAGE_DIRECTORY}/plugins)
 
 write_config(${PLUGIN_NAME})

--- a/PlayerInfo/DeviceSettings/PlatformImplementation.cpp
+++ b/PlayerInfo/DeviceSettings/PlatformImplementation.cpp
@@ -1,0 +1,437 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2020 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../Module.h"
+#include <interfaces/IPlayerInfo.h>
+#include <interfaces/IDolby.h>
+#include "host.hpp"
+#include "exception.hpp"
+#include "audioOutputPortType.hpp"
+#include "audioOutputPortConfig.hpp"
+#include "audioOutputPort.hpp"
+#include "utils.h"
+
+#include <gst/gst.h>
+
+#include "libIBus.h"
+#include "libIBusDaemon.h"
+#include "dsMgr.h"
+
+namespace WPEFramework {
+namespace Plugin {
+
+class PlayerInfoImplementation : public Exchange::IPlayerProperties, public Exchange::Dolby::IOutput
+{
+private:
+
+    class GstUtils {
+    private:
+        struct FeatureListDeleter {
+            void operator()(GList* p) { gst_plugin_feature_list_free(p); }
+        };
+
+        struct CapsDeleter {
+            void operator()(GstCaps* p) { gst_caps_unref(p); }
+        };
+        typedef std::unique_ptr<GList, FeatureListDeleter> FeatureList;
+        typedef std::unique_ptr<GstCaps, CapsDeleter> MediaTypes;
+
+   public:
+        GstUtils() = delete;
+        GstUtils(const GstUtils&) = delete;
+        GstUtils& operator= (const GstUtils&) = delete;
+
+        template <typename C, typename CodecIteratorList>
+        static bool GstRegistryCheckElementsForMediaTypes(C caps, CodecIteratorList& codecIteratorList) {
+
+            auto type = std::is_same<C, VideoCaps>::value ? GST_ELEMENT_FACTORY_TYPE_MEDIA_VIDEO : GST_ELEMENT_FACTORY_TYPE_MEDIA_AUDIO;
+
+            FeatureList decoderFactories{gst_element_factory_list_get_elements(GST_ELEMENT_FACTORY_TYPE_DECODER | type, GST_RANK_MARGINAL)};
+            FeatureList parserFactories{gst_element_factory_list_get_elements(GST_ELEMENT_FACTORY_TYPE_PARSER | type, GST_RANK_MARGINAL)};
+
+            FeatureList elements;
+            for (auto index: caps) {
+
+                MediaTypes mediaType{gst_caps_from_string(index.first.c_str())};
+                if (elements = std::move(GstUtils::GstRegistryGetElementForMediaType(decoderFactories.get(), std::move(mediaType)))) {
+                    codecIteratorList.push_back(index.second);
+
+                } else if (elements = std::move(GstUtils::GstRegistryGetElementForMediaType(parserFactories.get(), std::move(mediaType)))) {
+
+                    for (GList* iterator = elements.get(); iterator; iterator = iterator->next) {
+
+                        GstElementFactory* gstElementFactory = static_cast<GstElementFactory*>(iterator->data);
+                        const GList* padTemplates = gst_element_factory_get_static_pad_templates(gstElementFactory);
+
+                        for (const GList* padTemplatesIterator = padTemplates; padTemplatesIterator; padTemplatesIterator = padTemplatesIterator->next) {
+                            GstStaticPadTemplate* padTemplate = static_cast<GstStaticPadTemplate*>(padTemplatesIterator->data);
+
+                            if (padTemplate->direction == GST_PAD_SRC) {
+                                MediaTypes mediaTypes{gst_static_pad_template_get_caps(padTemplate)};
+                                if (GstUtils::GstRegistryGetElementForMediaType(decoderFactories.get(), std::move(mediaTypes))) {
+                                    codecIteratorList.push_back(index.second);
+                                }
+                            }
+                        }
+                    }
+                 }
+             }
+
+             return (codecIteratorList.size() != 0);
+         }
+
+    private:
+        static inline FeatureList GstRegistryGetElementForMediaType(GList* elementsFactories, MediaTypes&& mediaTypes) {
+            FeatureList candidates{gst_element_factory_list_filter(elementsFactories, mediaTypes.get(), GST_PAD_SINK, false)};
+
+            return std::move(candidates);
+        }
+
+    };
+
+private:
+    using AudioIteratorImplementation = RPC::IteratorType<Exchange::IPlayerProperties::IAudioCodecIterator>;
+    using VideoIteratorImplementation = RPC::IteratorType<Exchange::IPlayerProperties::IVideoCodecIterator>;
+
+    typedef std::map<const string, const Exchange::IPlayerProperties::AudioCodec> AudioCaps;
+    typedef std::map<const string, const Exchange::IPlayerProperties::VideoCodec> VideoCaps;
+
+public:
+    PlayerInfoImplementation()
+    {
+        gst_init(0, nullptr);
+        UpdateAudioCodecInfo();
+        UpdateVideoCodecInfo();
+        IARM_Result_t res;
+        IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_AUDIO_MODE, AudioModeHandler) );
+        PlayerInfoImplementation::_instance = this;
+    }
+
+    PlayerInfoImplementation(const PlayerInfoImplementation&) = delete;
+    PlayerInfoImplementation& operator= (const PlayerInfoImplementation&) = delete;
+    ~PlayerInfoImplementation() override
+    {
+        _audioCodecs.clear();
+        _videoCodecs.clear();
+        IARM_Result_t res;
+        IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_AUDIO_MODE) );
+        PlayerInfoImplementation::_instance = nullptr;
+    }
+
+public:
+    uint32_t AudioCodecs(Exchange::IPlayerProperties::IAudioCodecIterator*& iterator) const override
+    {
+        iterator = Core::Service<AudioIteratorImplementation>::Create<Exchange::IPlayerProperties::IAudioCodecIterator>(_audioCodecs);
+        return (iterator != nullptr ? Core::ERROR_NONE : Core::ERROR_GENERAL);
+    }
+    uint32_t VideoCodecs(Exchange::IPlayerProperties::IVideoCodecIterator*& iterator) const override
+    {
+        iterator = Core::Service<VideoIteratorImplementation>::Create<Exchange::IPlayerProperties::IVideoCodecIterator>(_videoCodecs);
+        return (iterator != nullptr ? Core::ERROR_NONE : Core::ERROR_GENERAL);
+    }
+
+    uint32_t Resolution(PlaybackResolution& res /* @out */) const override
+    {
+        LOGINFO();
+        res = RESOLUTION_UNKNOWN;
+
+        string currentResolution = "0";
+        try
+        {
+            device::VideoOutputPort &vPort = device::Host::getInstance().getVideoOutputPort("HDMI0");
+            currentResolution = vPort.getResolution().getName();
+            TRACE(Trace::Information, (_T("Current video playback resolution = %s"), currentResolution));
+        }
+        catch(const device::Exception& err)
+        {
+            TRACE(Trace::Error, (_T("Exception during DeviceSetting library call. code = %d message = %s"), err.getCode(), err.what()));
+        }
+
+        if (currentResolution == "720p") res = RESOLUTION_720P;
+        else if(currentResolution == "1080i") res = RESOLUTION_1080I;
+        else if(currentResolution == "1080p60") res = RESOLUTION_1080P;
+        else if(currentResolution == "2160p30") res = RESOLUTION_2160P30;
+        else if(currentResolution == "2160p60") res = RESOLUTION_2160P60;
+        else res = RESOLUTION_UNKNOWN;
+
+        return (Core::ERROR_NONE);
+    }
+
+    uint32_t IsAudioEquivalenceEnabled(bool& isEnbaled /* @out */) const override
+    {
+        LOGINFO();
+        isEnbaled = false;
+        try
+        {
+            device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort("HDMI0");
+            if (aPort.isConnected()) {
+                isEnbaled = aPort.GetLEConfig();
+                LOGINFO("IsAudioEquivalenceEnabled = %s", isEnbaled? "Enabled":"Disabled");
+            }
+            else
+            {
+                TRACE(Trace::Information, (_T("IsAudioEquivalenceEnabled failure: HDMI0 not connected!")));
+
+                LOGERR("IsAudioEquivalenceEnabled failure: HDMI0 not connected!");
+            }
+        }
+        catch(const device::Exception& err)
+        {
+            TRACE(Trace::Error, (_T("Exception during DeviceSetting library call. code = %d message = %s"), err.getCode(), err.what()));
+        }
+        TRACE(Trace::Information, (_T("Audio Equivalence = %d"), isEnbaled? "Enabled":"Disabled"));
+
+
+        return (Core::ERROR_NONE);
+    }
+
+    uint32_t Register(Exchange::Dolby::IOutput::INotification* notification) override
+    {
+        LOGINFO();
+        _adminLock.Lock();
+
+        // Make sure a sink is not registered multiple times.
+        ASSERT(std::find(_observers.begin(), _observers.end(), notification) == _observers.end());
+
+        _observers.push_back(notification);
+        notification->AddRef();
+
+        _adminLock.Unlock();
+
+        return (Core::ERROR_NONE);
+    }
+
+    uint32_t Unregister(Exchange::Dolby::IOutput::INotification* notification) override
+    {
+        LOGINFO();
+        _adminLock.Lock();
+
+        std::list<Exchange::Dolby::IOutput::INotification*>::iterator index(std::find(_observers.begin(), _observers.end(), notification));
+
+        // Make sure you do not unregister something you did not register !!!
+        ASSERT(index != _observers.end());
+
+        if (index != _observers.end()) {
+            (*index)->Release();
+            _observers.erase(index);
+        }
+
+        _adminLock.Unlock();
+
+        return (Core::ERROR_NONE);
+    }
+
+    static void AudioModeHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
+    {
+        LOGINFO();
+        if(PlayerInfoImplementation::_instance)
+        {
+            PlayerInfoImplementation::_instance->audiomodeChanged(STEREO, true);
+        }
+    }
+
+    void audiomodeChanged(Exchange::Dolby::IOutput::SoundModes mode, bool enable)
+    {
+        LOGINFO();
+        _adminLock.Lock();
+
+        std::list<Exchange::Dolby::IOutput::INotification*>::const_iterator index = _observers.begin();
+
+        while(index != _observers.end()) {
+            (*index)->AudioModeChanged(mode, enable);
+            index++;
+        }
+
+        _adminLock.Unlock();
+
+    }
+
+    uint32_t Mode(const Exchange::Dolby::IOutput::Type& mode) override
+    {
+        LOGINFO();
+        return (Core::ERROR_GENERAL);
+    }
+
+    uint32_t Mode(Exchange::Dolby::IOutput::Type& mode) const override
+    {
+        LOGINFO();
+        return (Core::ERROR_GENERAL);
+    }
+
+
+    uint32_t AtmosMetadata(bool& supported /* @out */) const override
+    {
+        LOGINFO();
+        dsATMOSCapability_t atmosCapability;
+        supported = false;
+        try
+        {
+            device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort("HDMI0");
+            if (aPort.isConnected())
+            {
+                aPort.getSinkDeviceAtmosCapability(atmosCapability);
+            }
+            else
+            {
+               TRACE(Trace::Error, (_T("getSinkAtmosCapability failure: HDMI0 not connected!\n")));
+            }
+        }
+        catch(const device::Exception& err)
+        {
+            TRACE(Trace::Error, (_T("Exception during DeviceSetting library call. code = %d message = %s"), err.getCode(), err.what()));
+        }
+
+        if(atmosCapability == dsAUDIO_ATMOS_ATMOSMETADATA) supported = true;
+        return (Core::ERROR_NONE);
+    }
+
+    uint32_t SoundMode(Exchange::Dolby::IOutput::SoundModes& mode /* @out */) const override
+    {
+        LOGINFO();
+        string audioPort;
+        device::AudioStereoMode soundmode = device::AudioStereoMode::kStereo;
+        mode = UNKNOWN;
+
+        try
+        {
+            /* Return the sound mode of the audio ouput connected to the specified videoDisplay */
+            /* Check if HDMI is connected - Return (default) Stereo Mode if not connected */
+
+            if (device::Host::getInstance().getVideoOutputPort("HDMI0").isDisplayConnected())
+            {
+                audioPort = "HDMI0";
+            }
+            else
+            {
+                /*  * If HDMI is not connected
+                    * Get the SPDIF if it is supported by platform
+                    * If Platform does not have connected ports. Default to HDMI.
+                */
+                audioPort = "HDMI0";
+                device::List<device::VideoOutputPort> vPorts = device::Host::getInstance().getVideoOutputPorts();
+                for (size_t i = 0; i < vPorts.size(); i++)
+                {
+                    device::VideoOutputPort &vPort = vPorts.at(i);
+                    if (vPort.isDisplayConnected())
+                    {
+                        audioPort = "SPDIF0";
+                        break;
+                    }
+                }
+            }
+
+            device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
+
+            if (aPort.isConnected())
+            {
+                soundmode = aPort.getStereoMode();
+                if (soundmode == device::AudioStereoMode::kSurround) mode = SURROUND;
+                else if(soundmode == device::AudioStereoMode::kStereo) mode = STEREO;
+                else if(soundmode == device::AudioStereoMode::kMono) mode = MONO;
+                else if(soundmode == device::AudioStereoMode::kPassThru) mode = PASSTHRU;
+                else mode = UNKNOWN;
+            }
+        }
+        catch (const device::Exception& err)
+        {
+            TRACE(Trace::Error, (_T("Exception during DeviceSetting library call. code = %d message = %s"), err.getCode(), err.what()));
+        }
+
+        return (Core::ERROR_NONE);
+    }
+
+    uint32_t EnableAtmosOutput(const bool& enable /* @in */)
+    {
+        LOGINFO();
+        try
+        {
+            device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort("HDMI0");
+            if (aPort.isConnected()) {
+                aPort.setAudioAtmosOutputMode(enable);
+            }
+            else
+            {
+                TRACE(Trace::Error, (_T("setAudioAtmosOutputMode failure: HDMI0 not connected!\n")));
+            }
+
+        }
+        catch (const device::Exception& err)
+        {
+            TRACE(Trace::Error, (_T("Exception during DeviceSetting library call. code = %d message = %s"), err.getCode(), err.what()));
+        }
+        return (Core::ERROR_NONE);
+    }
+
+    BEGIN_INTERFACE_MAP(PlayerInfoImplementation)
+    INTERFACE_ENTRY(Exchange::IPlayerProperties)
+    INTERFACE_ENTRY(Exchange::Dolby::IOutput)
+    END_INTERFACE_MAP
+
+private:
+
+
+    void UpdateAudioCodecInfo()
+    {
+        AudioCaps audioCaps = {
+            {"audio/mpeg, mpegversion=(int)1", Exchange::IPlayerProperties::AudioCodec::AUDIO_MPEG1},
+            {"audio/mpeg, mpegversion=(int)2", Exchange::IPlayerProperties::AudioCodec::AUDIO_MPEG2},
+            {"audio/mpeg, mpegversion=(int)4", Exchange::IPlayerProperties::AudioCodec::AUDIO_MPEG4},
+            {"audio/mpeg, mpegversion=(int)1, layer=(int)[1, 3]", Exchange::IPlayerProperties::AudioCodec::AUDIO_MPEG3},
+            {"audio/mpeg, mpegversion=(int){2, 4}", Exchange::IPlayerProperties::AudioCodec::AUDIO_AAC},
+            {"audio/x-ac3", Exchange::IPlayerProperties::AUDIO_AC3},
+            {"audio/x-eac3", Exchange::IPlayerProperties::AUDIO_AC3_PLUS},
+            {"audio/x-opus", Exchange::IPlayerProperties::AUDIO_OPUS},
+            {"audio/x-dts", Exchange::IPlayerProperties::AUDIO_DTS},
+            {"audio/x-vorbis", Exchange::IPlayerProperties::AUDIO_VORBIS_OGG},
+            {"audio/x-wav", Exchange::IPlayerProperties::AUDIO_WAV},
+        };
+        if (GstUtils::GstRegistryCheckElementsForMediaTypes(audioCaps, _audioCodecs) != true) {
+            TRACE_L1(_T("There is no Audio Codec support available"));
+        }
+
+    }
+    void UpdateVideoCodecInfo()
+    {
+        VideoCaps videoCaps = {
+            {"video/x-h263", Exchange::IPlayerProperties::VideoCodec::VIDEO_H263},
+            {"video/x-h264, profile=(string)high", Exchange::IPlayerProperties::VideoCodec::VIDEO_H264},
+            {"video/x-h265", Exchange::IPlayerProperties::VideoCodec::VIDEO_H265},
+            {"video/mpeg, mpegversion=(int){1,2}, systemstream=(boolean)false", Exchange::IPlayerProperties::VideoCodec::VIDEO_MPEG},
+            {"video/x-vp8", Exchange::IPlayerProperties::VideoCodec::VIDEO_VP8},
+            {"video/x-vp9", Exchange::IPlayerProperties::VideoCodec::VIDEO_VP9},
+            {"video/x-vp10", Exchange::IPlayerProperties::VideoCodec::VIDEO_VP10}
+        };
+        if (GstUtils::GstRegistryCheckElementsForMediaTypes(videoCaps, _videoCodecs) != true) {
+            TRACE_L1(_T("There is no Video Codec support available"));
+        }
+    }
+
+private:
+    std::list<Exchange::IPlayerProperties::AudioCodec> _audioCodecs;
+    std::list<Exchange::IPlayerProperties::VideoCodec> _videoCodecs;
+
+    std::list<Exchange::Dolby::IOutput::INotification*> _observers;
+    mutable Core::CriticalSection _adminLock;
+public:
+    static PlayerInfoImplementation* _instance;
+};
+    PlayerInfoImplementation* PlayerInfoImplementation::_instance = nullptr;
+    SERVICE_REGISTRATION(PlayerInfoImplementation, 1, 0);
+}
+}

--- a/PlayerInfo/PlayerInfo.cpp
+++ b/PlayerInfo/PlayerInfo.cpp
@@ -16,8 +16,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 #include "PlayerInfo.h"
+
 
 namespace WPEFramework {
 namespace Plugin {
@@ -40,22 +41,41 @@ namespace Plugin {
         _player = service->Root<Exchange::IPlayerProperties>(_connectionId, 2000, _T("PlayerInfoImplementation"));
 
         if (_player != nullptr) {
-
-            _audioCodecs = _player->AudioCodec();
-            if (_audioCodecs != nullptr) {
-
-                _videoCodecs = _player->VideoCodec();
-                if (_videoCodecs == nullptr) {
-
+            Exchange::JPlayerProperties::Register(*this, _player);
+            if ( (_player->AudioCodecs(_audioCodecs) != Core::ERROR_NONE)  || (_audioCodecs == nullptr) ) {
+                if (_audioCodecs != nullptr) {
                     _audioCodecs->Release();
                     _audioCodecs = nullptr;
-
-                    _player->Release();
-                    _player = nullptr;
                 }
-            } else {
                 _player->Release();
                 _player = nullptr;
+            }
+            else if ((_player->VideoCodecs(_videoCodecs) != Core::ERROR_NONE) || (_videoCodecs == nullptr) ) {
+                if (_videoCodecs != nullptr) {
+
+                    _videoCodecs->Release();
+                    _videoCodecs = nullptr;
+                }
+                _audioCodecs->Release();
+                _audioCodecs = nullptr;
+                _player->Release();
+                _player = nullptr;
+            } else {
+
+                // The code execution should proceed regardless of the _dolbyOut
+                // value, as it is not a essential.
+                // The relevant JSONRPC endpoints will return ERROR_UNAVAILABLE,
+                // if it hasn't been initialized.
+                _dolbyOut = _player->QueryInterface<Exchange::Dolby::IOutput>();
+                if(_dolbyOut == nullptr){
+                    SYSLOG(Logging::Startup, (_T("Dolby output switching service is unavailable.")));
+                }
+                else
+                {
+                    _notification.Initialize(_dolbyOut);
+                    Exchange::Dolby::JOutput::Register(*this, _dolbyOut);
+                }
+
             }
         }
 
@@ -69,7 +89,13 @@ namespace Plugin {
     {
         ASSERT(_player != nullptr);
         if (_player != nullptr) {
+            Exchange::JPlayerProperties::Unregister(*this);
             _player->Release();
+        }
+        if (_dolbyOut != nullptr)
+        {
+             _notification.Deinitialize();
+            Exchange::Dolby::JOutput::Unregister(*this);
         }
         _connectionId = 0;
     }
@@ -118,15 +144,17 @@ namespace Plugin {
     void PlayerInfo::Info(JsonData::PlayerInfo::CodecsData& playerInfo) const
     {
         Core::JSON::EnumType<JsonData::PlayerInfo::CodecsData::AudiocodecsType> audioCodec;
-        _audioCodecs->Reset();
-        while(_audioCodecs->Next()) {
-            playerInfo.Audio.Add(audioCodec = static_cast<JsonData::PlayerInfo::CodecsData::AudiocodecsType>(_audioCodecs->Codec()));
+        _audioCodecs->Reset(0);
+        Exchange::IPlayerProperties::AudioCodec audio;
+        while(_audioCodecs->Next(audio)) {
+            playerInfo.Audio.Add(audioCodec = static_cast<JsonData::PlayerInfo::CodecsData::AudiocodecsType>(audio));
         }
 
         Core::JSON::EnumType<JsonData::PlayerInfo::CodecsData::VideocodecsType> videoCodec;
-        _videoCodecs->Reset();
-        while(_videoCodecs->Next()) {
-            playerInfo.Video.Add(videoCodec = static_cast<JsonData::PlayerInfo::CodecsData::VideocodecsType>(_videoCodecs->Codec()));
+        Exchange::IPlayerProperties::VideoCodec video;
+        _videoCodecs->Reset(0);
+        while(_videoCodecs->Next(video)) {
+            playerInfo.Video.Add(videoCodec = static_cast<JsonData::PlayerInfo::CodecsData::VideocodecsType>(video));
         }
     }
 

--- a/PlayerInfo/PlayerInfo.h
+++ b/PlayerInfo/PlayerInfo.h
@@ -16,17 +16,62 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 #pragma once
 
 #include "Module.h"
-#include <interfaces/IPlayerInfo.h>
 #include <interfaces/json/JsonData_PlayerInfo.h>
+#include <interfaces/json/JDolbyOutput.h>
+#include <interfaces/json/JPlayerProperties.h>
 
 namespace WPEFramework {
 namespace Plugin {
 
     class PlayerInfo : public PluginHost::IPlugin, public PluginHost::IWeb, public PluginHost::JSONRPC {
+    private:
+        class Notification : protected Exchange::Dolby::IOutput::INotification {
+        private:
+            Notification() = delete;
+            Notification(const Notification&) = delete;
+            Notification& operator=(const Notification&) = delete;
+        public:
+            explicit Notification(PlayerInfo* parent)
+                : _parent(*parent)
+            {
+                ASSERT(parent != nullptr);
+            }
+            virtual ~Notification()
+            {
+            }
+
+            void Initialize(Exchange::Dolby::IOutput* client)
+            {
+                ASSERT(client != nullptr);
+                _client = client;
+                _client->AddRef();
+                _client->Register(this);
+            }
+            void Deinitialize()
+            {
+                ASSERT(_client != nullptr);
+                if (_client != nullptr) {
+                    _client->Unregister(this);
+                    _client->Release();
+                    _client = nullptr;
+                }
+            }
+            void AudioModeChanged(const Exchange::Dolby::IOutput::SoundModes mode, bool enabled) override
+            {
+                Exchange::Dolby::JOutput::Event::AudioModeChanged(_parent, mode, enabled);
+            }
+            BEGIN_INTERFACE_MAP(Notification)
+            INTERFACE_ENTRY(Exchange::Dolby::IOutput::INotification)
+            END_INTERFACE_MAP
+
+        private:
+            PlayerInfo& _parent;
+            Exchange::Dolby::IOutput* _client;
+        };
     public:
         PlayerInfo(const PlayerInfo&) = delete;
         PlayerInfo& operator=(const PlayerInfo&) = delete;
@@ -37,19 +82,19 @@ namespace Plugin {
             , _player(nullptr)
             , _audioCodecs(nullptr)
             , _videoCodecs(nullptr)
+            , _notification(this)
         {
-            RegisterAll();
         }
 
         virtual ~PlayerInfo()
         {
-            UnregisterAll();
         }
 
         BEGIN_INTERFACE_MAP(PlayerInfo)
         INTERFACE_ENTRY(PluginHost::IPlugin)
         INTERFACE_ENTRY(PluginHost::IWeb)
         INTERFACE_ENTRY(PluginHost::IDispatcher)
+        INTERFACE_AGGREGATE(Exchange::IPlayerProperties, _player)
         END_INTERFACE_MAP
 
     public:
@@ -65,20 +110,22 @@ namespace Plugin {
         virtual Core::ProxyType<Web::Response> Process(const Web::Request& request) override;
 
     private:
-        // JsonRpc
-        void RegisterAll();
-        void UnregisterAll();
-        uint32_t get_playerinfo(JsonData::PlayerInfo::CodecsData&) const;
 
+        uint32_t get_playerinfo(JsonData::PlayerInfo::CodecsData&) const;
         void Info(JsonData::PlayerInfo::CodecsData&) const;
+
+        uint32_t get_dolbymode(Core::JSON::EnumType<JsonData::PlayerInfo::DolbyType>&) const;
+        uint32_t set_dolbymode(const Core::JSON::EnumType<JsonData::PlayerInfo::DolbyType>&);
 
     private:
         uint8_t _skipURL;
         uint32_t _connectionId;
-        Exchange::IPlayerProperties* _player;
 
-        Exchange::IPlayerProperties::IAudioIterator* _audioCodecs;
-        Exchange::IPlayerProperties::IVideoIterator* _videoCodecs;
+        Exchange::IPlayerProperties* _player;
+        Exchange::IPlayerProperties::IAudioCodecIterator* _audioCodecs;
+        Exchange::IPlayerProperties::IVideoCodecIterator* _videoCodecs;
+        Exchange::Dolby::IOutput* _dolbyOut;
+        Core::Sink<Notification> _notification;
     };
 
 } // namespace Plugin

--- a/PlayerInfo/PlayerInfoPlugin.json
+++ b/PlayerInfo/PlayerInfoPlugin.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "plugin.schema.json",
+  "info": {
+    "title": "Player Info Plugin",
+    "callsign": "PlayerInfo",
+    "locator": "libWPEPlayerInfo.so",
+    "status": "beta",
+    "description": "The PlayerInfo plugin helps to get system supported Audio Video codecs",
+    "version": "1.0"
+  },
+  "interface": {
+    "$cppref": "{cppinterfacedir}/IPlayerInfo.h"
+  }
+}

--- a/PlayerInfo/doc/PlayerInfoPlugin.md
+++ b/PlayerInfo/doc/PlayerInfoPlugin.md
@@ -1,0 +1,435 @@
+<!-- Generated automatically, DO NOT EDIT! -->
+<a name="head.Player_Info_Plugin"></a>
+# Player Info Plugin
+
+**Version: 1.0**
+
+**Status: :black_circle::black_circle::white_circle:**
+
+PlayerInfo plugin for Thunder framework.
+
+### Table of Contents
+
+- [Introduction](#head.Introduction)
+- [Description](#head.Description)
+- [Configuration](#head.Configuration)
+- [Methods](#head.Methods)
+- [Properties](#head.Properties)
+
+<a name="head.Introduction"></a>
+# Introduction
+
+<a name="head.Scope"></a>
+## Scope
+
+This document describes purpose and functionality of the PlayerInfo plugin. It includes detailed specification of its configuration, methods and properties provided.
+
+<a name="head.Case_Sensitivity"></a>
+## Case Sensitivity
+
+All identifiers on the interfaces described in this document are case-sensitive. Thus, unless stated otherwise, all keywords, entities, properties, relations and actions should be treated as such.
+
+<a name="head.Acronyms,_Abbreviations_and_Terms"></a>
+## Acronyms, Abbreviations and Terms
+
+The table below provides and overview of acronyms used in this document and their definitions.
+
+| Acronym | Description |
+| :-------- | :-------- |
+| <a name="acronym.API">API</a> | Application Programming Interface |
+| <a name="acronym.HTTP">HTTP</a> | Hypertext Transfer Protocol |
+| <a name="acronym.JSON">JSON</a> | JavaScript Object Notation; a data interchange format |
+| <a name="acronym.JSON-RPC">JSON-RPC</a> | A remote procedure call protocol encoded in JSON |
+
+The table below provides and overview of terms and abbreviations used in this document and their definitions.
+
+| Term | Description |
+| :-------- | :-------- |
+| <a name="term.callsign">callsign</a> | The name given to an instance of a plugin. One plugin can be instantiated multiple times, but each instance the instance name, callsign, must be unique. |
+
+<a name="head.References"></a>
+## References
+
+| Ref ID | Description |
+| :-------- | :-------- |
+| <a name="ref.HTTP">[HTTP](http://www.w3.org/Protocols)</a> | HTTP specification |
+| <a name="ref.JSON-RPC">[JSON-RPC](https://www.jsonrpc.org/specification)</a> | JSON-RPC 2.0 specification |
+| <a name="ref.JSON">[JSON](http://www.json.org/)</a> | JSON specification |
+| <a name="ref.Thunder">[Thunder](https://github.com/WebPlatformForEmbedded/Thunder/blob/master/doc/WPE%20-%20API%20-%20WPEFramework.docx)</a> | Thunder API Reference |
+
+<a name="head.Description"></a>
+# Description
+
+The PlayerInfo plugin helps to get system supported Audio Video codecs
+
+The plugin is designed to be loaded and executed within the Thunder framework. For more information about the framework refer to [[Thunder](#ref.Thunder)].
+
+<a name="head.Configuration"></a>
+# Configuration
+
+The table below lists configuration options of the plugin.
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| callsign | string | Plugin instance name (default: *PlayerInfo*) |
+| classname | string | Class name: *PlayerInfo* |
+| locator | string | Library name: *libWPEPlayerInfo.so* |
+| autostart | boolean | Determines if the plugin is to be started automatically along with the framework |
+
+<a name="head.Methods"></a>
+# Methods
+
+The following methods are provided by the PlayerInfo plugin:
+
+PlayerProperties interface methods:
+
+| Method | Description |
+| :-------- | :-------- |
+| [audiocodecs](#method.audiocodecs) |  |
+| [videocodecs](#method.videocodecs) |  |
+
+<a name="method.audiocodecs"></a>
+## *audiocodecs <sup>method</sup>*
+
+### Parameters
+
+This method takes no parameters.
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | array |  |
+| result[#] | string |  (must be one of the following: *AudioUndefined*, *AudioAac*, *AudioAc3*, *AudioAc3Plus*, *AudioDts*, *AudioMpeg1*, *AudioMpeg2*, *AudioMpeg3*, *AudioMpeg4*, *AudioOpus*, *AudioVorbisOgg*, *AudioWav*) |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "PlayerInfo.1.audiocodecs"
+}
+```
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": [
+        "AudioUndefined"
+    ]
+}
+```
+<a name="method.videocodecs"></a>
+## *videocodecs <sup>method</sup>*
+
+### Parameters
+
+This method takes no parameters.
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | array |  |
+| result[#] | string |  (must be one of the following: *VideoUndefined*, *VideoH263*, *VideoH264*, *VideoH265*, *VideoH26510*, *VideoMpeg*, *VideoVp8*, *VideoVp9*, *VideoVp10*) |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "PlayerInfo.1.videocodecs"
+}
+```
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": [
+        "VideoUndefined"
+    ]
+}
+```
+<a name="head.Properties"></a>
+# Properties
+
+The following properties are provided by the PlayerInfo plugin:
+
+PlayerProperties interface properties:
+
+| Property | Description |
+| :-------- | :-------- |
+| [resolution](#property.resolution) <sup>RO</sup> | Current Video playback resolution |
+| [isaudioequivalenceenabled](#property.isaudioequivalenceenabled) <sup>RO</sup> | Checks Loudness Equivalence in platform |
+
+Dolby Output interface properties:
+
+| Property | Description |
+| :-------- | :-------- |
+| [dolby atmosmetadata](#property.dolby_atmosmetadata) <sup>RO</sup> | Atmos capabilities of Sink |
+| [dolby soundmode](#property.dolby_soundmode) <sup>RO</sup> | Sound Mode - Mono/Stereo/Surround |
+| [dolby enableatmosoutput](#property.dolby_enableatmosoutput) <sup>WO</sup> | Enable Atmos Audio Output |
+| [dolby mode](#property.dolby_mode) | Dolby Mode |
+
+<a name="property.resolution"></a>
+## *resolution <sup>property</sup>*
+
+Provides access to the current Video playback resolution.
+
+> This property is **read-only**.
+
+### Value
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| (property) | string | Current Video playback resolution (must be one of the following: *ResolutionUnknown*, *Resolution480I*, *Resolution480P*, *Resolution576I*, *Resolution576P*, *Resolution720P*, *Resolution1080I*, *Resolution1080P*, *Resolution2160P30*, *Resolution2160P60*) |
+
+### Example
+
+#### Get Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "PlayerInfo.1.resolution"
+}
+```
+#### Get Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": "ResolutionUnknown"
+}
+```
+<a name="property.isaudioequivalenceenabled"></a>
+## *isaudioequivalenceenabled <sup>property</sup>*
+
+Provides access to the checks Loudness Equivalence in platform.
+
+> This property is **read-only**.
+
+### Value
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| (property) | boolean | Checks Loudness Equivalence in platform |
+
+### Example
+
+#### Get Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "PlayerInfo.1.isaudioequivalenceenabled"
+}
+```
+#### Get Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": false
+}
+```
+<a name="property.dolby_atmosmetadata"></a>
+## *dolby_atmosmetadata <sup>property</sup>*
+
+Provides access to the atmos capabilities of Sink.
+
+> This property is **read-only**.
+
+### Value
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| (property) | boolean | Atmos capabilities of Sink |
+
+### Example
+
+#### Get Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "PlayerInfo.1.dolby_atmosmetadata"
+}
+```
+#### Get Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": false
+}
+```
+<a name="property.dolby_soundmode"></a>
+## *dolby_soundmode <sup>property</sup>*
+
+Provides access to the sound Mode - Mono/Stereo/Surround.
+
+> This property is **read-only**.
+
+### Value
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| (property) | string | Sound Mode - Mono/Stereo/Surround (must be one of the following: *Unknown*, *Mono*, *Stereo*, *Surround*, *Passthru*) |
+
+### Example
+
+#### Get Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "PlayerInfo.1.dolby_soundmode"
+}
+```
+#### Get Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": "Unknown"
+}
+```
+<a name="property.dolby_enableatmosoutput"></a>
+## *dolby_enableatmosoutput <sup>property</sup>*
+
+Provides access to the enable Atmos Audio Output.
+
+> This property is **write-only**.
+
+### Value
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| (property) | boolean | Enable Atmos Audio Output |
+
+### Example
+
+#### Set Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "PlayerInfo.1.dolby_enableatmosoutput",
+    "params": false
+}
+```
+#### Set Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": "null"
+}
+```
+<a name="property.dolby_mode"></a>
+## *dolby_mode <sup>property</sup>*
+
+Provides access to the dolby Mode.
+
+### Value
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| (property) | string | Dolby Mode (must be one of the following: *DigitalPcm*, *DigitalPlus*, *DigitalAc3*, *Auto*) |
+
+### Example
+
+#### Get Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "PlayerInfo.1.dolby_mode"
+}
+```
+#### Get Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": "DigitalPcm"
+}
+```
+#### Set Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "PlayerInfo.1.dolby_mode",
+    "params": "DigitalPcm"
+}
+```
+#### Set Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": "null"
+}
+```
+<a name="head.Notifications"></a>
+# Notifications
+
+Notifications are autonomous events, triggered by the internals of the implementation, and broadcasted via JSON-RPC to all registered observers. Refer to [[Thunder](#ref.Thunder)] for information on how to register for a notification.
+
+The following events are provided by the PlayerInfo plugin:
+
+Dolby Output interface events:
+
+| Event | Description |
+| :-------- | :-------- |
+| [dolby audiomodechanged](#event.dolby_audiomodechanged) |  |
+
+<a name="event.dolby_audiomodechanged"></a>
+## *dolby_audiomodechanged <sup>event</sup>*
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.mode | string |  (must be one of the following: *Unknown*, *Mono*, *Stereo*, *Surround*, *Passthru*) |
+| params.enabled | boolean |  |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.1.dolby_audiomodechanged",
+    "params": {
+        "mode": "Unknown",
+        "enabled": false
+    }
+}
+```


### PR DESCRIPTION
Reason for change:
DELIA-46582: Cherrypick infoplugins to rdkcentral/rdkservices 2010 sprint branch
Test Procedure: check compilation against latest Thunder, test using curl commands
Risks: Low
Developer testing: Checked compilation against Thunder revision # 10/09/2020
SRCREV = "c12e5adce13425118b65f66692cfcbc2b21745ba"
Signed-off-by: Vinod Jacob <vinod_jacob@comcast.com>