### PR TITLE
DELIA-46582: Cherry-pick DeviceInfo to 2010

### DIFF
--- a/DeviceInfo/DeviceInfo.cpp
+++ b/DeviceInfo/DeviceInfo.cpp
@@ -139,7 +139,7 @@ namespace Plugin {
             JsonData::DeviceInfo::AddressesData& element(addressInfo.Add(newElement));
 
             // get an interface with a public IP address, then we will have a proper MAC address..
-            Core::IPV4AddressIterator selectedNode(interfaces.Index());
+            Core::IPV4AddressIterator selectedNode(interfaces.IPV4Addresses());
 
             while (selectedNode.Next() == true) {
                 Core::JSON::String nodeName;


### PR DESCRIPTION
Cherry-picking one-line change brought in by Metro in 2009

Reason for change: "DeviceInfo: update to get ip address based on latest network info changes"

Test procedure: 
1. check compilation against Thunder (compiled against c12e5adce13425118b65f66692cfcbc2b21745ba)
2. use curl commands to verify the working of DeviceInfo plugin

