### PR TITLE
XIONE-1313 : Add DeviceIdentification/DisplayInfo implementation for …

### DIFF
--- a/DeviceIdentification/CMakeLists.txt
+++ b/DeviceIdentification/CMakeLists.txt
@@ -59,6 +59,10 @@ elseif (BUILD_AMLOGIC)
     target_sources(${MODULE_NAME}
         PRIVATE
             Implementation/Amlogic/Amlogic.cpp)
+elseif (BUILD_REALTEK)
+	target_sources(${MODULE_NAME}
+        PRIVATE
+            Implementation/Realtek/Realtek.cpp)
 else ()
     message(FATAL_ERROR "There is no platform backend for device identifier plugin")
 endif()

--- a/DeviceIdentification/Implementation/Realtek/Realtek.cpp
+++ b/DeviceIdentification/Implementation/Realtek/Realtek.cpp
@@ -1,0 +1,135 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2020 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "../../Module.h"
+#include <interfaces/IDeviceIdentification.h>
+#include <fstream>
+
+namespace WPEFramework {
+namespace Plugin {
+
+class DeviceImplementation : public Exchange::IDeviceProperties, public PluginHost::ISubSystem::IIdentifier {
+	static constexpr const TCHAR* CPUInfoFile= _T("/proc/cpuinfo");
+	static constexpr const TCHAR* VERSIONFile= _T("/version.txt");
+
+public:
+    DeviceImplementation()
+    {
+        UpdateChipset(_chipset);
+        UpdateFirmwareVersion(_firmwareVersion);
+        UpdateIdentifier();
+    }
+
+    DeviceImplementation(const DeviceImplementation&) = delete;
+    DeviceImplementation& operator= (const DeviceImplementation&) = delete;
+    virtual ~DeviceImplementation()
+    {
+         /* Nothing to do here. */
+    }
+
+public:
+    // Device Propertirs interface
+    const string Chipset() const override
+    {
+        return _chipset;
+    }
+    const string FirmwareVersion() const override
+    {
+        return _firmwareVersion;
+    }
+
+    // Identifier interface
+    uint8_t Identifier(const uint8_t length, uint8_t buffer[]) const override
+    {
+        uint8_t result = 0;
+        if ((_identity.length())) {
+            result = (_identity.length() > length ? length : _identity.length());
+            ::memcpy(buffer, _identity.c_str(), result);
+        } else {
+            SYSLOG(Logging::Notification, (_T("Cannot determine system identity")));
+        }
+        return result;
+    }
+
+    BEGIN_INTERFACE_MAP(DeviceImplementation)
+        INTERFACE_ENTRY(Exchange::IDeviceProperties)
+        INTERFACE_ENTRY(PluginHost::ISubSystem::IIdentifier)
+    END_INTERFACE_MAP
+
+private:
+    inline void UpdateFirmwareVersion(string& firmwareVersion) const
+    {
+        string line;
+        std::ifstream file(VERSIONFile);
+        if (file.is_open()) {
+            while (getline(file, line)) {
+                if (line.find("SDK_VERSION") != std::string::npos) {
+                    std::size_t position = line.find('=');
+                    if (position != std::string::npos) {
+                        firmwareVersion.assign(line.substr(position + 1, string::npos));
+                        break;
+                    }
+                }
+            }
+            file.close();
+        }
+    }
+
+    inline void UpdateChipset(string& chipset) const
+    {
+        string line;
+        std::ifstream file(CPUInfoFile);
+        if (file.is_open()) {
+            while (getline(file, line)) {
+                if (line.find("Hardware") != std::string::npos) {
+                    std::size_t position = line.find(": ");
+                    if (position != std::string::npos) {
+                        chipset.assign(line.substr(position + 2, string::npos));
+                    }
+                }
+            }
+            file.close();
+        }
+    }
+
+    inline void UpdateIdentifier()
+    {
+        string line;
+        std::ifstream file(CPUInfoFile);
+        if (file.is_open()) {
+            while (getline(file, line)) {
+                if (line.find("Serial") != std::string::npos) {
+                    std::size_t position = line.find(": ");
+                    if (position != std::string::npos) {
+                        _identity.assign(line.substr(position + 2, string::npos));
+                    }
+                }
+            }
+            file.close();
+        }
+    }
+
+private:
+    string _chipset;
+    string _firmwareVersion;
+    string _identity;
+};
+
+    SERVICE_REGISTRATION(DeviceImplementation, 1, 0);
+}
+}

--- a/DisplayInfo/CMakeLists.txt
+++ b/DisplayInfo/CMakeLists.txt
@@ -90,6 +90,14 @@ else ()
     message(FATAL_ERROR "There is no graphic backend for display info plugin")
 endif ()
 
+if (BUILD_REALTEK)
+    target_sources(${MODULE_NAME}
+        PRIVATE
+            DeviceSettings/Realtek/kms.c
+    )
+    add_definitions("-DUSE_DISPLAYINFO_REALTEK=1")
+endif ()
+
 install(TARGETS ${MODULE_NAME}
     DESTINATION lib/${STORAGE_DIRECTORY}/plugins)
 

--- a/DisplayInfo/DeviceSettings/Realtek/kms.c
+++ b/DisplayInfo/DeviceSettings/Realtek/kms.c
@@ -1,0 +1,211 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2020 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <assert.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+#include "kms.h"
+
+void kms_setup_encoder( int fd, kms_ctx *kms )
+{
+    int crtcId = 0;
+
+    for( int i = 0; i < kms->res->count_encoders; i++ ) {
+
+        kms->encoder = drmModeGetEncoder(fd,kms->res->encoders[i]);
+
+        if ( kms->encoder && ( kms->encoder->encoder_id == kms->connector->encoder_id ) ) {
+
+            kms->encoder_id = kms->encoder->encoder_id;
+            return;
+        }
+
+
+        for( int j = 0; j < kms->res->count_crtcs; j++ ) {
+
+            if( kms->encoder->possible_crtcs & ( 1 << j ) ) {
+
+                drmModeFreeEncoder( kms->encoder );
+                kms->encoder = drmModeGetEncoder(fd, kms->res->encoders[j]);
+
+                crtcId = kms->res->crtcs[j];
+                kms->encoder->crtc_id = kms->crtc_id = j;
+                goto exit;
+            }
+        }
+    }
+
+exit:
+    return;
+}
+
+
+
+
+void kms_setup_connector( int fd, kms_ctx *kms )
+{
+    int i = 0, j = 0;
+    drmModeConnector *connector;
+
+    for( i = 0; i < kms->res->count_connectors; i++ ) {
+
+        connector = drmModeGetConnector(fd, kms->res->connectors[i]);
+        if( connector ) {
+
+            if( connector->count_modes && ( connector->connection == DRM_MODE_CONNECTED ) ) {
+                break;
+            }
+        }
+    }
+
+    if ( connector ) {
+
+        kms->connector = connector;
+        kms->connector_id = connector->connector_id;
+    }
+
+    return;
+}
+
+
+void kms_setup_crtc( int fd, kms_ctx *kms )
+{
+    if( kms->encoder ) {
+
+        kms->crtc = drmModeGetCrtc(fd, kms->encoder->crtc_id);
+
+        if( kms->crtc && kms->crtc->mode_valid ) {
+
+            kms->current_info = kms->crtc->mode;
+            kms->crtc_id = kms->encoder->crtc_id;
+        }
+    }
+
+    return;
+}
+
+
+kms_ctx* kms_setup( int fd )
+{
+    kms_ctx *kms = NULL;
+    kms = (kms_ctx*)calloc(1,sizeof(*kms));
+    if( !kms )
+        assert(0);
+
+    kms->res = drmModeGetResources(fd);
+
+    kms_setup_connector(fd, kms);
+    kms_setup_encoder(fd, kms);
+    kms_setup_crtc(fd, kms);
+    return kms;
+}
+
+
+void kms_cleanup_context( kms_ctx *kms )
+{
+    if( kms->connector )
+        drmModeFreeConnector(kms->connector);
+
+    if( kms->encoder )
+        drmModeFreeEncoder(kms->encoder);
+
+    if( kms->crtc )
+        drmModeFreeCrtc(kms->crtc);
+
+    if( kms->res )
+        drmModeFreeResources(kms->res);
+}
+
+
+uint32_t kms_get_properties(int fd, drmModeObjectProperties *props, const char *name)
+{
+    drmModePropertyPtr property;
+    uint32_t i, id = 0;
+
+    for (i = 0; i < props->count_props; i++) {
+
+        property = drmModeGetProperty(fd, props->props[i]);
+        if (!strcmp(property->name, name))
+            id = property->prop_id;
+
+        drmModeFreeProperty(property);
+
+        if ( id )
+            return id;
+    }
+}
+
+
+
+void kms_get_plane( int fd, kms_ctx *kms )
+{
+    int len = 0, n = 0, j = 0, plane_index = -1;
+
+    drmModePlane *plane = NULL;
+    drmModePlaneRes *planeRes = NULL;
+    drmModePropertyRes *prop = NULL;
+    drmModeObjectProperties *props = NULL;
+
+    drmSetClientCap(fd, DRM_CLIENT_CAP_UNIVERSAL_PLANES, 1);
+
+    kms->primary_plane_id = kms->overlay_plane_id = -1;
+
+    planeRes = drmModeGetPlaneResources( fd );
+    if ( planeRes ) {
+
+        for( n= 0; n < planeRes->count_planes; ++n ) {
+
+            plane = drmModeGetPlane( fd, planeRes->planes[n] );
+
+            if ( plane ) {
+
+                props = drmModeObjectGetProperties( fd, planeRes->planes[n], DRM_MODE_OBJECT_PLANE );
+                if ( props ) {
+
+                    for( j= 0; j < props->count_props; ++j ) {
+
+                        prop = drmModeGetProperty( fd, props->props[j] );
+                        if ( prop ) {
+
+                            len = strlen(prop->name);
+                            if ( !strcmp( prop->name, "type") ) {
+
+                                if ( ( props->prop_values[j] == DRM_PLANE_TYPE_PRIMARY ) && ( kms->primary_plane_id == -1 ) )
+                                    kms->primary_plane_id = planeRes->planes[n];
+
+                                else if ( ( props->prop_values[j] == DRM_PLANE_TYPE_OVERLAY ) && ( kms->overlay_plane_id == -1 ) )
+                                    kms->overlay_plane_id = planeRes->planes[n];
+                            }
+                        }
+
+                        drmModeFreeProperty( prop );
+                    }
+                }
+
+                drmModeFreeObjectProperties( props );
+            }
+
+            drmModeFreePlane( plane );
+        }
+
+    }
+
+    drmModeFreePlaneResources( planeRes );
+}

--- a/DisplayInfo/DeviceSettings/Realtek/kms.h
+++ b/DisplayInfo/DeviceSettings/Realtek/kms.h
@@ -1,0 +1,139 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2020 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __DRM_KMS_H__
+#define __DRM_KMS_H__
+
+#include <xf86drm.h>
+#include <xf86drmMode.h>
+#include <drm_mode.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct _kms_ctx {
+
+    drmModeRes *res;
+    drmModeConnector *connector;
+    drmModeEncoder *encoder;
+    drmModeCrtc *crtc;
+
+    drmModeCrtc *previous_crtc;
+    drmModeModeInfo current_info;
+
+    uint32_t connector_id;      /**< Connector id which will be use in program  */
+    uint32_t crtc_id;
+    uint32_t encoder_id;
+    uint32_t primary_plane_id;
+    uint32_t overlay_plane_id;
+
+    /* atomic properties */
+    uint32_t active_property;
+    uint32_t mode_id_property;
+    uint32_t crtc_id_property;
+    uint32_t blob_id;
+
+    uint32_t fb_id_property;
+    uint32_t crtc_x_property;
+    uint32_t crtc_y_property;
+    uint32_t crtc_h_property;
+    uint32_t crtc_w_property;
+    uint32_t src_x_property;
+    uint32_t src_y_property;
+    uint32_t src_w_property;
+    uint32_t src_h_property;
+
+    drmModeAtomicReq *req;
+
+} kms_ctx;
+
+/**
+ * @brief Create kms context 
+ *
+ * @param[in] fd    drm file descriptor
+ *
+ *
+ * @retval kms context
+ */
+kms_ctx* kms_setup(int fd);
+
+
+
+/**
+ * @brief Cleanup kms context 
+ *
+ * @param[in] kms    kms context
+ *
+ */
+void kms_cleanup_context(kms_ctx *kms);
+
+/**
+ * @brief Set and get possible encoder id
+ *
+ * @param[in] fd    drm file descriptor
+ * @param[in] kms   kms context
+ *
+ */
+void kms_setup_encoder(int fd, kms_ctx *kms);
+
+
+/**
+ * @brief Set and get possible connector id
+ *
+ * @param[in] fd    drm file descriptor
+ * @para,[in] kms   kms context
+ *  
+ */
+void kms_setup_connector(int fd, kms_ctx *kms);
+
+/**
+ * @brief Set and get possible crtc id 
+ *
+ * @param[in] fd    drm file descriptor
+ * @param[in] kms   kms context
+ *
+ */
+void kms_setup_crtc(int fd, kms_ctx *kms);
+
+/**
+ * @brief Get the specific object properties
+ *
+ * @param[in] fd     drm file descriptor
+ * @param[in] props  all object properties
+ * @param[in] name   the property name which want to be queried
+ *
+ */
+uint32_t kms_get_properties(int fd, drmModeObjectProperties *props, const char *name);
+
+
+/**
+ * @brief Get primary and overlay plane. 
+ *        The plane id will set to -1 if cannot get.
+ *
+ * @param[in] fd    drm file descriptor
+ * @param[in] kms   kms context
+ *
+ */
+void kms_get_plane( int fd, kms_ctx *kms);
+
+#ifdef __cplusplus
+}
+#endif
+#endif


### PR DESCRIPTION
…Realtek

Reason for change:
* Add DeviceIdentification/DisplayInfo implementation for Realtek SOC
* Implement Width()/Height() using libdrm
* Implement TotalGpuRam()/FreeGpuRam() using MemTotal: and MemFree: field
  from /proc/meminfo because Realtek platform Mali GPU has MMU and use the
  system memory
* Implement VerticalFreq(), IsAudioPassthrough() using ds
* Use USE_DISPLAYINFO_REALTEK compiler option for Realtek related code

Test Procedure:
* Add DeviceIdentification, DisplayInfo in PACKAGECONFIG in rdkservices_git.bbappend for Realtek SOC layer
  and build RDKServices, DeviceIdentification, DisplayInfo plug-in should be build and works.
Risks: Low

Change-Id: I3c5942a8deabcc0b263eb43734eeb0b06825c09b
Signed-off-by: Mark Yang <mark.yang@realtek.com>