### PR TITLE
RDK-28186: New APIs and Thunder plugin implementation …

### DIFF
--- a/SystemServices/SystemServices.h
+++ b/SystemServices/SystemServices.h
@@ -36,6 +36,7 @@
 #include "pwrMgr.h"
 #include "host.hpp"
 #include "sleepMode.hpp"
+#include "deepSleepMgr.h"
 #endif /* USE_IARMBUS || USE_IARM_BUS */
 
 #include "sysMgr.h"
@@ -179,6 +180,7 @@ namespace WPEFramework {
                 uint32_t setPreferredStandbyMode(const JsonObject& parameters, JsonObject& response);
                 uint32_t getPreferredStandbyMode(const JsonObject& parameters, JsonObject& response);
                 uint32_t getAvailableStandbyModes(const JsonObject& parameters, JsonObject& response);
+		  uint32_t getWakeupReason(const JsonObject& parameters, JsonObject& response);
                 uint32_t getXconfParams(const JsonObject& parameters, JsonObject& response);
                 uint32_t getSerialNumber(const JsonObject& parameters, JsonObject& response);
                 bool getSerialNumberTR069(JsonObject& response);


### PR DESCRIPTION
Reason for change: 1. Added thunder call for deepsleep wakeup reason
2.onSystemPowerStateChanged in thunder plugin returns the actual new power
state instead of on/standby.
Test Procedure: check deepsleep wakeup reason and powerchange change event.
Risks: Low
Signed-off-by: Tony Paul <Tony_Paul@comcast.com>