### PR TITLE
Change deinitialize method in out of process plugins.

### DIFF
--- a/OpenCDMi/OCDM.cpp
+++ b/OpenCDMi/OCDM.cpp
@@ -145,17 +145,13 @@ namespace Plugin {
 
         _opencdmi->Deinitialize(service);
 
-        if (_opencdmi->Release() != Core::ERROR_DESTRUCTION_SUCCEEDED) {
+        _opencdmi->Release();
 
-            ASSERT(_connectionId != 0);
-
-            TRACE_L1("OCDM Plugin is not properly destructed. %d", _connectionId);
-
+        if(_connectionId != 0){
             RPC::IRemoteConnection* connection(_service->RemoteConnection(_connectionId));
 
             // The process can disappear in the meantime...
             if (connection != nullptr) {
-
                 // But if it did not dissapear in the meantime, forcefully terminate it. Shoot to kill :-)
                 connection->Terminate();
                 connection->Release();

--- a/Packager/Packager.cpp
+++ b/Packager/Packager.cpp
@@ -56,15 +56,13 @@ namespace {
 
         _service->Unregister(&_notification);
 
-        if (_implementation->Release() != Core::ERROR_DESTRUCTION_SUCCEEDED) {
-
-            ASSERT(_connectionId != 0);
-
+        _implementation->Release();
+        
+        if(_connectionId != 0){
             RPC::IRemoteConnection* connection(_service->RemoteConnection(_connectionId));
 
             // The process can disappear in the meantime...
             if (connection != nullptr) {
-
                 // But if it did not dissapear in the meantime, forcefully terminate it. Shoot to kill :-)
                 connection->Terminate();
                 connection->Release();


### PR DESCRIPTION
Make sure all plugins capable to run out of process are properly deactivated regardless for the respose of the Release method.