### PR TITLE
RDKTV-297 : return error if IARM init fails

### DIFF
--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -371,6 +371,8 @@ namespace WPEFramework {
             LOGINFO();
 #if defined(USE_IARMBUS) || defined(USE_IARM_BUS)
             InitializeIARM();
+            if (!Utils::IARM::isConnected())
+                return _T("IARM could not be Initialized");
 #endif /* defined(USE_IARMBUS) || defined(USE_IARM_BUS) */
             /* On Success; return empty to indicate no error text. */
             return (string());


### PR DESCRIPTION
Reason for change: IARM init failure should be
indicated by a corresponding error
Test Procedure: activate with IARM failure, see error
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>