### PR TITLE
RDK-28186: New APIs and Thunder plugin implementation

### DIFF
--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -57,6 +57,10 @@
 #include "mfrMgr.h"
 #endif
 
+#ifdef ENABLE_DEEP_SLEEP
+#include "deepSleepMgr.h"
+#endif
+
 using namespace std;
 
 #define SYSSRV_MAJOR_VERSION 1
@@ -353,7 +357,9 @@ namespace WPEFramework {
             registerMethod("getPowerStateIsManagedByDevice", &SystemServices::getPowerStateIsManagedByDevice, this);
 
             systemVersion_2.Register<JsonObject, JsonObject>(_T("getTimeZones"), &SystemServices::getTimeZones, this);
-	     systemVersion_2.Register<JsonObject, JsonObject>(_T("getWakeupReason"),&SystemServices::getWakeupReason, this);
+#ifdef ENABLE_DEEP_SLEEP
+	    systemVersion_2.Register<JsonObject, JsonObject>(_T("getWakeupReason"),&SystemServices::getWakeupReason, this);
+#endif
         }
 
         SystemServices::~SystemServices()
@@ -361,7 +367,9 @@ namespace WPEFramework {
             Core::JSONRPC::Handler* systemVersion_2 = JSONRPC::GetHandler(2);
             if (systemVersion_2) {
                 systemVersion_2->Unregister("getTimeZones");
-		 systemVersion_2->Unregister("getWakeupReason");
+#ifdef ENABLE_DEEP_SLEEP
+		systemVersion_2->Unregister("getWakeupReason");
+#endif
 	     }
             else
                 LOGERR("Failed to get handler for version 2");
@@ -1209,7 +1217,7 @@ namespace WPEFramework {
             }
             returnResponse(status);
         }
-
+#ifdef ENABLE_DEEP_SLEEP
         /***
          * @brief Returns the deepsleep wakeup reason.
 	 * Possible values are "WAKEUP_REASON_IR", "WAKEUP_REASON_RCU_BT"
@@ -1282,7 +1290,7 @@ namespace WPEFramework {
 
             returnResponse(status);
         }
-
+#endif
         /***
          * @brief Returns an array of strings containing the supported standby modes.
          * Possible values are "LIGHT_SLEEP" and/or "DEEP_SLEEP".

--- a/SystemServices/SystemServices.h
+++ b/SystemServices/SystemServices.h
@@ -36,7 +36,6 @@
 #include "pwrMgr.h"
 #include "host.hpp"
 #include "sleepMode.hpp"
-#include "deepSleepMgr.h"
 #endif /* USE_IARMBUS || USE_IARM_BUS */
 
 #include "sysMgr.h"
@@ -180,7 +179,9 @@ namespace WPEFramework {
                 uint32_t setPreferredStandbyMode(const JsonObject& parameters, JsonObject& response);
                 uint32_t getPreferredStandbyMode(const JsonObject& parameters, JsonObject& response);
                 uint32_t getAvailableStandbyModes(const JsonObject& parameters, JsonObject& response);
-		  uint32_t getWakeupReason(const JsonObject& parameters, JsonObject& response);
+#ifdef ENABLE_DEEP_SLEEP
+		uint32_t getWakeupReason(const JsonObject& parameters, JsonObject& response);
+#endif
                 uint32_t getXconfParams(const JsonObject& parameters, JsonObject& response);
                 uint32_t getSerialNumber(const JsonObject& parameters, JsonObject& response);
                 bool getSerialNumberTR069(JsonObject& response);


### PR DESCRIPTION
Reason for change: making getWakeupReason available only to 
devices where deepsleep is enabled.
Test Procedure: check for build failures.
Risks: Low
Signed-off-by: Tony Paul <Tony_Paul@comcast.com>