### PR TITLE
RDK-29867 : uploadLogs method

### DIFF
--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -357,12 +357,12 @@ namespace WPEFramework {
             registerMethod("setNetworkStandbyMode", &SystemServices::setNetworkStandbyMode, this);
             registerMethod("getNetworkStandbyMode", &SystemServices::getNetworkStandbyMode, this);
             registerMethod("getPowerStateIsManagedByDevice", &SystemServices::getPowerStateIsManagedByDevice, this);
-            registerMethod("uploadLogs", &SystemServices::uploadLogs, this);
 
             systemVersion_2.Register<JsonObject, JsonObject>(_T("getTimeZones"), &SystemServices::getTimeZones, this);
 #ifdef ENABLE_DEEP_SLEEP
 	    systemVersion_2.Register<JsonObject, JsonObject>(_T("getWakeupReason"),&SystemServices::getWakeupReason, this);
 #endif
+            systemVersion_2.Register<JsonObject, JsonObject>("uploadLogs", &SystemServices::uploadLogs, this);
         }
 
         SystemServices::~SystemServices()
@@ -373,6 +373,7 @@ namespace WPEFramework {
 #ifdef ENABLE_DEEP_SLEEP
 		systemVersion_2->Unregister("getWakeupReason");
 #endif
+                systemVersion_2->Unregister("uploadLogs");
 	     }
             else
                 LOGERR("Failed to get handler for version 2");

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -68,6 +68,8 @@ using namespace std;
 
 #define ZONEINFO_DIR "/usr/share/zoneinfo"
 
+#define DEFAULT_STB_LOGS_UPLOAD_URL "https://stbrtl.stb.r53.xcal.tv"
+
 /**
  * @struct firmwareUpdate
  * @brief This structure contains information of firmware update.
@@ -355,6 +357,7 @@ namespace WPEFramework {
             registerMethod("setNetworkStandbyMode", &SystemServices::setNetworkStandbyMode, this);
             registerMethod("getNetworkStandbyMode", &SystemServices::getNetworkStandbyMode, this);
             registerMethod("getPowerStateIsManagedByDevice", &SystemServices::getPowerStateIsManagedByDevice, this);
+            registerMethod("uploadLogs", &SystemServices::uploadLogs, this);
 
             systemVersion_2.Register<JsonObject, JsonObject>(_T("getTimeZones"), &SystemServices::getTimeZones, this);
 #ifdef ENABLE_DEEP_SLEEP
@@ -3082,6 +3085,105 @@ namespace WPEFramework {
             params["rebootReason"] = reason;
             LOGINFO("Notifying onRebootRequest\n");
             sendNotify(EVT_ONREBOOTREQUEST, params);
+        }
+
+        static size_t uploadLogs_CURL_readCallback(void *ptr, size_t size, size_t nmemb, void *stream)
+        {
+            FILE *fd = (FILE *)stream;
+            size_t retcode = fread(ptr, size, nmemb, fd);
+            // curl_off_t nread = (curl_off_t)retcode;
+            // LOGINFO("Read %" CURL_FORMAT_CURL_OFF_T " bytes from file", nread);
+            return retcode;
+        }
+
+        /***
+         * @brief : upload STB logs to the specified URL.
+         * @param1[in] : url::String
+         */
+        uint32_t SystemServices::uploadLogs(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+
+            bool success = false;
+
+#ifdef ENABLE_SYSTEM_UPLOAD_LOGS
+            string url;
+            getStringParameter("url", url);
+            if (url.empty())
+                url = DEFAULT_STB_LOGS_UPLOAD_URL;
+            if (url.find('\'') != string::npos)
+                response["error"] = "bad url";
+            else
+            {
+                string mac = collectDeviceInfo("eth_mac");
+                removeCharsFromString(mac, "\n\r:");
+                if (mac.empty())
+                    response["error"] = "get mac fail";
+                else
+                {
+                    string dt = currentDateTimeUtc("+%m-%d-%y-%I-%M%p");
+
+                    string logFile = "/tmp/" + convertCase(mac) + "_Logs_" + dt + ".tgz";
+                    LOGINFO("filename %s", logFile.c_str());
+
+                    string cmd = "nice -n 19 tar -C /opt/logs -zcvf " + logFile + " ./";
+                    Utils::cRunScript(cmd.c_str());
+
+                    if (!Utils::fileExists(logFile.c_str()))
+                        response["error"] = "prepare log fail";
+                    else
+                    {
+                        CURL *curl;
+                        CURLcode res;
+                        FILE *fd;
+                        struct stat file_info;
+                        long http_code = 0;
+
+                        stat(logFile.c_str(), &file_info);
+                        fd = fopen(logFile.c_str(), "rb");
+                        curl = curl_easy_init();
+                        if (curl)
+                        {
+                            curl_easy_setopt(curl, CURLOPT_READFUNCTION, uploadLogs_CURL_readCallback);
+                            curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);
+                            curl_easy_setopt(curl, CURLOPT_PUT, 1L);
+                            curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+                            curl_easy_setopt(curl, CURLOPT_READDATA, fd);
+                            curl_easy_setopt(curl, CURLOPT_INFILESIZE_LARGE, (curl_off_t)file_info.st_size);
+                            curl_easy_setopt(curl, CURLOPT_TIMEOUT, 120L);
+                            curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 60L);
+
+                            res = curl_easy_perform(curl);
+                            if (res != CURLE_OK)
+                                LOGERR("curl_easy_perform() failed: %s", curl_easy_strerror(res));
+
+                            curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+                            LOGINFO("curl response code %ld", http_code);
+
+                            curl_easy_cleanup(curl);
+                        }
+                        fclose(fd);
+
+                        int removeStatus = remove(logFile.c_str());
+                        LOGERR("remove %s exit code %d", logFile.c_str(), removeStatus);
+
+                        if (res != CURLE_OK || http_code != 200)
+                            response["error"] = "upload fail";
+                        else
+                        {
+                            if (removeStatus != 0)
+                                response["error"] = "cleanup fail";
+                            else
+                                success = true;
+                        }
+                    }
+                }
+            }
+#else
+            response["error"] = "unsupported";
+#endif
+
+            returnResponse(success);
         }
     } /* namespace Plugin */
 } /* namespace WPEFramework */

--- a/SystemServices/SystemServices.h
+++ b/SystemServices/SystemServices.h
@@ -211,6 +211,7 @@ namespace WPEFramework {
                 uint32_t setNetworkStandbyMode (const JsonObject& parameters, JsonObject& response);
                 uint32_t getNetworkStandbyMode (const JsonObject& parameters, JsonObject& response);
                 uint32_t getPowerStateIsManagedByDevice(const JsonObject& parameters, JsonObject& response);
+                uint32_t uploadLogs(const JsonObject& parameters, JsonObject& response);
         }; /* end of system service class */
     } /* end of plugin */
 } /* end of wpeframework */


### PR DESCRIPTION
Reason for change: Add a new method to the System
RDK Service: uploadLogs.
Test Procedure: Call uploadLogs with or without "url".
Risks: None
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>