### PR TITLE
RDKTV-231: System setCachedValue and removeCacheKey fix

### DIFF
--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -1690,13 +1690,20 @@ namespace WPEFramework {
                 JsonObject& response)
         {
             bool retStat = false;
-            JsonObject param;
-            param.FromString(parameters["param"].String());
-            std::string key = param["cacheKey"].String();
-            if (m_cacheService.contains(key)) {
-                retStat = true;
+            if (parameters.HasLabel("key")) {
+                std::string key = parameters["key"].String();
+                if (key.length()) {
+                    if (m_cacheService.contains(key)) {
+                        retStat = true;
+                    } else {
+                        LOGERR("Accessing m_cacheService.contains; no matching key '%s'\n.", key.c_str());
+                        populateResponseWithError(SysSrv_KeyNotFound, response);
+                    }
+                } else {
+                    populateResponseWithError(SysSrv_UnSupportedFormat, response);
+                }
             } else {
-                LOGERR("Accessing m_cacheService.contains failed\n.");
+                populateResponseWithError(SysSrv_MissingKeyValues, response);
             }
             returnResponse(retStat);
         }

--- a/helpers/SystemServicesHelper.cpp
+++ b/helpers/SystemServicesHelper.cpp
@@ -41,7 +41,8 @@ std::map<int, std::string> ErrCodeMap = {
     {SysSrv_SupportNotAvailable, "Support not available/enabled"},
     {SysSrv_LibcurlError, "LIbCurl service error"},
     {SysSrv_DynamicMemoryAllocationFailed, "Dynamic Memory Allocation Failed"},
-    {SysSrv_ManufacturerDataReadFailed, "Manufacturer Data Read Failed"}
+    {SysSrv_ManufacturerDataReadFailed, "Manufacturer Data Read Failed"},
+    {SysSrv_KeyNotFound, "Key not found"}
 };
 
 std::string getErrorDescription(int errCode)

--- a/helpers/SystemServicesHelper.h
+++ b/helpers/SystemServicesHelper.h
@@ -90,7 +90,8 @@ enum SysSrv_ErrorCode {
     SysSrv_SupportNotAvailable,
     SysSrv_LibcurlError,
     SysSrv_DynamicMemoryAllocationFailed,
-    SysSrv_ManufacturerDataReadFailed
+    SysSrv_ManufacturerDataReadFailed,
+    SysSrv_KeyNotFound
 };
 
 enum FirmwareUpdateState {

--- a/helpers/cSettings.cpp
+++ b/helpers/cSettings.cpp
@@ -30,7 +30,17 @@
 cSettings::cSettings(std::string file)
 {
     filename = file;
-    readFromFile();
+    if (!readFromFile()) {
+        /* File not present; create a new one assuming a fresh partition. */
+        std::fstream fs;
+        fs.open(filename.c_str(), std::fstream::in|std::fstream::out|std::fstream::app);
+        if (!fs.is_open()) {
+            std::cout << "Error:[ctor cSettings] unable to open configuration file." << std::endl;
+        } else {
+            fs << flush;
+            fs.close();
+        }
+    }
 }
 
 /***


### PR DESCRIPTION
Reason for change: Fix ctor for creating a file if not existing.
Test Procedure: Test and verify cache related System plugin APIs.
Risks: Low
Signed-off-by: Arun Madhavan <Arun_Madhavan@comcast.com>