### PR TITLE
RDKTV-297 RDKTV-422 - Do IARM Init before calling BTMgrInit

### DIFF
--- a/Bluetooth/Bluetooth.cpp
+++ b/Bluetooth/Bluetooth.cpp
@@ -159,6 +159,9 @@ namespace WPEFramework
             registerMethod(METHOD_GET_AUDIO_INFO, &Bluetooth::getMediaTrackInfoWrapper, this);
             registerMethod(METHOD_GET_STATUS_SUPPORT, &Bluetooth::getStatusSupportWrapper, this);
 
+            Utils::IARM::init();
+
+            
             BTRMGR_Result_t rc = BTRMGR_RESULT_SUCCESS;
             rc = BTRMGR_Init();
             if (BTRMGR_RESULT_SUCCESS != rc)

--- a/Bluetooth/CMakeLists.txt
+++ b/Bluetooth/CMakeLists.txt
@@ -41,8 +41,9 @@ if(BTMGR_FOUND)
     target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins ${BTMGR_LIBRARIES})
 endif(BTMGR_FOUND)
 
-target_include_directories(${MODULE_NAME} PRIVATE ../helpers)
-target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins)
+find_package(IARMBus)
+target_include_directories(${MODULE_NAME} PRIVATE ../helpers ${IARMBUS_INCLUDE_DIRS})
+target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins ${IARMBUS_LIBRARIES})
 
 install(TARGETS ${MODULE_NAME}
         DESTINATION lib/${STORAGE_DIRECTORY}/plugins)

--- a/Bluetooth/CMakeLists.txt
+++ b/Bluetooth/CMakeLists.txt
@@ -23,6 +23,7 @@ find_package(${NAMESPACE}Plugins REQUIRED)
 add_library(${MODULE_NAME} SHARED
         Bluetooth.cpp
         Module.cpp
+        ../helpers/utils.cpp
 )
 
 set_target_properties(${MODULE_NAME} PROPERTIES

--- a/WifiManager/impl/WifiManagerScan.cpp
+++ b/WifiManager/impl/WifiManagerScan.cpp
@@ -253,7 +253,7 @@ void WifiManagerScan::iarmEventHandler(char const* owner, IARM_EventId_t eventId
         LOGINFO("Event IARM_BUS_WIFI_MGR_EVENT_onAvailableSSIDs[Incr] received. '%s'", eventData->data.wifiSSIDList.ssid_list);
 
         // The returned SSIDs are in a JSON document
-        std::string const serialized(eventData->data.wifiSSIDList.ssid_list, MAX_SSIDLIST_BUF);
+        std::string const serialized(eventData->data.wifiSSIDList.ssid_list);
         JsonObject eventDocument;
         WPEC::OptionalType<WPEJ::Error> error;
         if (!WPEJ::IElement::FromString(serialized, eventDocument, error)) {


### PR DESCRIPTION
Reason for change:
Do IARM Init within Bluetooth thunder plugin before calling BTMgrInit. This will avoid
IARM Init within BTMgr
Test Procedure:
Refer to ticket for details
Risks: Low