### PR TITLE
 RDK-28506 : Changes for the HDMI-CEC Audio Return Channel (ARC) Control

### DIFF
--- a/HdmiCecSink/CMakeLists.txt
+++ b/HdmiCecSink/CMakeLists.txt
@@ -22,6 +22,7 @@ find_package(${NAMESPACE}Plugins REQUIRED)
 add_library(${MODULE_NAME} SHARED
         HdmiCecSink.cpp
         Module.cpp
+        ../helpers/tptimer.cpp
         ../helpers/utils.cpp)
 
 set_target_properties(${MODULE_NAME} PROPERTIES

--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -54,8 +54,7 @@
 #define HDMICECSINK_METHOD_GET_ACTIVE_ROUTE   	"getActiveRoute"
 #define HDMICECSINK_METHOD_SET_MENU_LANGUAGE  	"setMenuLanguage"
 #define HDMICECSINK_METHOD_REQUEST_ACTIVE_SOURCE "requestActiveSource"
-#define HDMICECSINK_METHOD_SET_ARC               "setARCRouting"
-
+#define HDMICECSINK_METHOD_SETUP_ARC              "setupARCRouting"
 
 
 #define TEST_ADD 0
@@ -423,7 +422,7 @@ namespace WPEFramework
 	       registerMethod(HDMICECSINK_METHOD_GET_ACTIVE_ROUTE, &HdmiCecSink::getActiveRouteWrapper, this);
 		   registerMethod(HDMICECSINK_METHOD_REQUEST_ACTIVE_SOURCE, &HdmiCecSink::requestActiveSourceWrapper, this);
 		   registerMethod(HDMICECSINK_METHOD_SET_MENU_LANGUAGE, &HdmiCecSink::setMenuLanguageWrapper, this);
-                   registerMethod(HDMICECSINK_METHOD_SET_ARC, &HdmiCecSink::setArcEnableDisableWrapper, this);
+                   registerMethod(HDMICECSINK_METHOD_SETUP_ARC, &HdmiCecSink::setArcEnableDisableWrapper, this);
            logicalAddressDeviceType = "None";
            logicalAddress = 0xFF;
            

--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -19,13 +19,11 @@
 
 #include "HdmiCecSink.h"
 
-
 #include "ccec/Connection.hpp"
 #include "ccec/CECFrame.hpp"
 #include "ccec/MessageEncoder.hpp"
 #include "host.hpp"
 #include "ccec/host/RDK.hpp"
-
 
 #include "ccec/drivers/iarmbus/CecIARMBusMgr.h"
 
@@ -56,7 +54,7 @@
 #define HDMICECSINK_METHOD_GET_ACTIVE_ROUTE   	"getActiveRoute"
 #define HDMICECSINK_METHOD_SET_MENU_LANGUAGE  	"setMenuLanguage"
 #define HDMICECSINK_METHOD_REQUEST_ACTIVE_SOURCE "requestActiveSource"
-
+#define HDMICECSINK_METHOD_SET_ARC               "setARCRouting"
 
 
 
@@ -68,8 +66,8 @@
 #define HDMICECSINK_REQUEST_INTERVAL_TIME_MS 		200
 #define HDMICECSINK_NUMBER_TV_ADDR 					2
 #define HDMICECSINK_UPDATE_POWER_STATUS_INTERVA_MS    (60 * 1000)
-
-
+#define HDMISINK_ARCPORT                               1
+#define HDMISINK_ARC_START_STOP_MAX_WAIT_MS           3000
 
 
 enum {
@@ -81,6 +79,8 @@ enum {
 	HDMICECSINK_EVENT_DEVICE_REMOVED,
 	HDMICECSINK_EVENT_DEVICE_INFO_UPDATED,
 	HDMICECSINK_EVENT_INACTIVE_SOURCE,
+        HDMICECSINK_EVENT_ARC_INITIATION_EVENT,
+	HDMICECSINK_EVENT_ARC_TERMINATION_EVENT,
 };
 
 static char *eventString[] = {
@@ -93,6 +93,8 @@ static char *eventString[] = {
 	"onDeviceRemoved",
 	"onDeviceInfoUpdated",
 	"onInActiveSource",
+        "arcInitiationEvent",
+        "arcTerminationEvent",
 };
 	
 
@@ -374,7 +376,21 @@ namespace WPEFramework
              LOGINFO("Command: Polling\n");
        }
 
-
+       void HdmiCecSinkProcessor::process (const InitiateArc &msg, const Header &header)
+       {
+            printHeader(header);
+            LOGINFO("Command: INITIATE_ARC \n");
+            if(!HdmiCecSink::_instance)
+	    return;
+            HdmiCecSink::_instance->Process_InitiateArc();	
+       }  
+       void HdmiCecSinkProcessor::process (const TerminateArc &msg, const Header &header)
+       {
+           printHeader(header);
+           if(!HdmiCecSink::_instance)
+	     return;
+           HdmiCecSink::_instance->Process_TerminateArc();
+       }	
 //=========================================== HdmiCecSink =========================================
 
        HdmiCecSink::HdmiCecSink()
@@ -407,10 +423,17 @@ namespace WPEFramework
 	       registerMethod(HDMICECSINK_METHOD_GET_ACTIVE_ROUTE, &HdmiCecSink::getActiveRouteWrapper, this);
 		   registerMethod(HDMICECSINK_METHOD_REQUEST_ACTIVE_SOURCE, &HdmiCecSink::requestActiveSourceWrapper, this);
 		   registerMethod(HDMICECSINK_METHOD_SET_MENU_LANGUAGE, &HdmiCecSink::setMenuLanguageWrapper, this);
-
+                   registerMethod(HDMICECSINK_METHOD_SET_ARC, &HdmiCecSink::setArcEnableDisableWrapper, this);
            logicalAddressDeviceType = "None";
            logicalAddress = 0xFF;
+           
+           m_currentArcRoutingState = ARC_STATE_ARC_TERMINATED;
+           m_semSignaltoArcRoutingThread.acquire();
+           m_arcRoutingThread = std::thread(threadArcRouting);
 
+
+           m_arcStartStopTimer.connect( std::bind( &HdmiCecSink::arcStartStopTimerFunction, this ) );
+           m_arcStartStopTimer.setSingleShot(true);
            // load persistence setting
            loadSettings();
 
@@ -482,6 +505,13 @@ namespace WPEFramework
        HdmiCecSink::~HdmiCecSink()
        {
            LOGINFO();
+		   
+		    m_currentArcRoutingState = ARC_STATE_ARC_EXIT;
+
+            m_semSignaltoArcRoutingThread.release();
+            LOGINFO(" ~HdmiCecSink() waiting for thread join %d",m_arcRoutingThread.joinable());
+            if (m_arcRoutingThread.joinable())
+            m_arcRoutingThread.join();
            HdmiCecSink::_instance = nullptr;
            DeinitializeIARM();
        }
@@ -642,9 +672,48 @@ namespace WPEFramework
 					m_pollNextState = POLL_THREAD_STATE_PING;
 				}
 			}
-            return;
+          updateArcState();  
+          return;
        }
+       void HdmiCecSink::updateArcState()
+       {
+           if ( m_currentArcRoutingState != ARC_STATE_ARC_TERMINATED )
+           {
+        	if (!(hdmiInputs[HDMISINK_ARCPORT].m_isConnected))
+		{
+                   std::lock_guard<std::mutex> lock(_instance->m_arcRoutingStateMutex);
+		   m_currentArcRoutingState = ARC_STATE_ARC_TERMINATED;
+		}
+                else
+                {
+                   LOGINFO("updateArcState :not updating ARC state current arc state %d ",m_currentArcRoutingState);
+                }
+           } 
+      }
+      void HdmiCecSink::arcStartStopTimerFunction()
+      {
+           JsonObject params;
 
+	   if (m_arcstarting)
+	   {
+               LOGINFO("arcStartStopTimerFunction ARC start timer expired");
+	       LOGINFO("notify_device setting that Initiate ARC failed to get the ARC_STATE_ARC_INITIATED state\n");
+               params["status"] = string("failure");
+               sendNotify(eventString[HDMICECSINK_EVENT_ARC_INITIATION_EVENT], params); 
+	   }
+	   else
+	   {
+	      LOGINFO("arcStartStopTimerFunction ARC stop timer expired");
+	      LOGINFO("notify_device setting that Terminate  ARC failed to get the ARC_STATE_ARC_TERMINATED state\n");
+              params["status"] = string("failure");
+              sendNotify(eventString[HDMICECSINK_EVENT_ARC_TERMINATION_EVENT], params);
+ 
+		       
+	   }
+             /* bring the state machine to the clean state for a new start */ 
+           std::lock_guard<std::mutex> lock(_instance->m_arcRoutingStateMutex);
+           m_currentArcRoutingState = ARC_STATE_ARC_TERMINATED;
+       }
        uint32_t HdmiCecSink::setEnabledWrapper(const JsonObject& parameters, JsonObject& response)
        {
             LOGINFO();
@@ -939,7 +1008,31 @@ namespace WPEFramework
             }
             returnResponse(true);
         }
+        uint32_t HdmiCecSink::setArcEnableDisableWrapper(const JsonObject& parameters, JsonObject& response)
+       {
+           
+            bool enabled = false;
 
+            if (parameters.HasLabel("enabled"))
+            {
+                getBoolParameter("enabled", enabled);
+            }
+            else
+            {
+                returnResponse(false);
+            }
+            if(enabled)
+	    {
+	         startArc();
+	    }
+	    else
+	    {
+		 stopArc();
+			
+	    }
+            
+            returnResponse(true);
+       }
         uint32_t HdmiCecSink::getVendorIdWrapper(const JsonObject& parameters, JsonObject& response)
         {
             LOGINFO("getVendorIdWrapper  appVendorId : %s  \n",appVendorId.toString().c_str());
@@ -2065,20 +2158,29 @@ namespace WPEFramework
 
 				m_pollThread = std::thread(threadRun);
             }
-
-			
+ 
             return;
         }
 
         void HdmiCecSink::CECDisable(void)
         {
             LOGINFO("Entered CECDisable ");
-
             if(!cecEnableStatus)
             {
                 LOGWARN("CEC Already Disabled ");
                 return;
             }
+            
+            if(m_currentArcRoutingState != ARC_STATE_ARC_TERMINATED)
+            {
+                stopArc();
+	      while(m_currentArcRoutingState != ARC_STATE_ARC_TERMINATED)	
+              {
+                     usleep(500000);
+               }
+            }
+
+             LOGINFO(" CECDisable ARC stopped ");
 
             if (smConnection != NULL)
             {
@@ -2087,7 +2189,7 @@ namespace WPEFramework
                 smConnection = NULL;
             }
             cecEnableStatus = false;
-
+            m_currentArcRoutingState = ARC_STATE_ARC_TERMINATED;
             if(1 == libcecInitStatus)
             {
                 try
@@ -2101,7 +2203,7 @@ namespace WPEFramework
             }
 
             libcecInitStatus--;
-
+             
             return;
         }
 
@@ -2126,11 +2228,240 @@ namespace WPEFramework
 
         bool HdmiCecSink::getEnabled()
         {
+
+            
+            LOGINFO("getEnabled :%d ",cecEnableStatus);
             if(true == cecEnableStatus)
                 return true;
             else
                 return false;
-            LOGINFO("getEnabled :%d ",cecEnableStatus);
         }
+        //Arc Routing related  functions
+        void HdmiCecSink::startArc()
+        {
+           if ( cecEnableStatus != true  )
+           {
+              LOGINFO("Initiate_Arc Cec is disabled-> EnableCEC first");
+	      return;
+           }
+           if(!HdmiCecSink::_instance)
+            return;
+
+            if(m_currentArcRoutingState == ARC_STATE_REQUEST_ARC_INITIATION || m_currentArcRoutingState == ARC_STATE_ARC_INITIATED)
+            {
+               LOGINFO("ARC is either initiation in progress or already initiated");
+               return;
+            }				
+           _instance->requestArcInitiation();
+ 
+          // start initiate ARC timer 3 sec
+            if (m_arcStartStopTimer.isActive())
+            {
+                m_arcStartStopTimer.stop();
+            }
+            m_arcstarting = true;
+            m_arcStartStopTimer.start((HDMISINK_ARC_START_STOP_MAX_WAIT_MS)); 
+
+        }
+        void  HdmiCecSink::requestArcInitiation()
+        {
+
+           std::lock_guard<std::mutex> lock(m_arcRoutingStateMutex);
+           m_currentArcRoutingState = ARC_STATE_REQUEST_ARC_INITIATION;
+          LOGINFO("requestArcInitiation release sem");
+          _instance->m_semSignaltoArcRoutingThread.release();
+
+        }
+        void HdmiCecSink::stopArc()
+        {
+            if ( cecEnableStatus != true  )
+            {
+              LOGINFO("Initiate_Arc Cec is disabled-> EnableCEC first");
+	      return;
+            }
+            if(!HdmiCecSink::_instance)
+                return;
+	    if(m_currentArcRoutingState == ARC_STATE_REQUEST_ARC_TERMINATION || m_currentArcRoutingState == ARC_STATE_ARC_TERMINATED)
+            {
+               LOGINFO("ARC is either Termination  in progress or already Terminated");
+               return;
+            }
+		
+           _instance->requestArcTermination();
+           /* start a timer for 3 sec to get the desired ARC_STATE_ARC_TERMINATED */
+           if (m_arcStartStopTimer.isActive())
+            {
+                m_arcStartStopTimer.stop();
+            }
+            /* m_arcstarting = true means starting the ARC start timer ,false means ARC stopping timer*/
+            m_arcstarting = false; 
+            m_arcStartStopTimer.start((HDMISINK_ARC_START_STOP_MAX_WAIT_MS));
+
+  				
+        }
+        void HdmiCecSink::requestArcTermination()
+        {  
+
+           std::lock_guard<std::mutex> lock(m_arcRoutingStateMutex);
+           m_currentArcRoutingState = ARC_STATE_REQUEST_ARC_TERMINATION;
+           LOGINFO("requestArcTermination release sem");
+           _instance->m_semSignaltoArcRoutingThread.release();
+
+       }  	
+       
+	void  HdmiCecSink::Process_InitiateArc()
+        {
+            JsonObject params;
+             
+            LOGINFO("Command: INITIATE_ARC \n");
+              
+            if(!HdmiCecSink::_instance)
+	    return;
+
+	    LOGINFO("Got : INITIATE_ARC  and current Arcstate is %d",_instance->m_currentArcRoutingState);
+            std::lock_guard<std::mutex> lock(_instance->m_arcRoutingStateMutex);
+	
+            if( _instance->m_currentArcRoutingState == ARC_STATE_REQUEST_ARC_INITIATION )
+            {   
+	           if (m_arcStartStopTimer.isActive())
+                   {
+                      m_arcStartStopTimer.stop();
+                   }
+                    
+	           _instance->m_currentArcRoutingState = ARC_STATE_ARC_INITIATED;
+	
+                  _instance->m_semSignaltoArcRoutingThread.release();
+                  LOGINFO("Got : ARC_INITIATED  and notify Device setting");
+                  params["status"] = string("success");
+                  sendNotify(eventString[HDMICECSINK_EVENT_ARC_INITIATION_EVENT], params); 
+           }
+	  
+
+       }
+       void HdmiCecSink::Process_TerminateArc()
+       {
+            JsonObject params;
+            std::lock_guard<std::mutex> lock(m_arcRoutingStateMutex);
+	
+            LOGINFO("Command: TERMINATE_ARC current arc state %d\n",HdmiCecSink::_instance->m_currentArcRoutingState);
+            if( (HdmiCecSink::_instance->m_currentArcRoutingState == ARC_STATE_REQUEST_ARC_TERMINATION) || 
+                                 (HdmiCecSink::_instance->m_currentArcRoutingState == ARC_STATE_ARC_INITIATED) )
+            {
+                if (m_arcStartStopTimer.isActive())
+                {
+                      m_arcStartStopTimer.stop();
+                }
+                HdmiCecSink::_instance->m_currentArcRoutingState = ARC_STATE_ARC_TERMINATED;
+                _instance->m_semSignaltoArcRoutingThread.release();
+            	  
+                // trigger callback to Device setting informing to TERMINATE_ARC
+                LOGINFO("Got : ARC_TERMINATED  and notify Device setting");
+                params["status"] = string("success");
+                sendNotify(eventString[HDMICECSINK_EVENT_ARC_TERMINATION_EVENT], params);
+            }
+
+        }
+        void HdmiCecSink::threadArcRouting()
+        {
+        	int i;
+		bool isExit = false;
+		uint32_t currentArcRoutingState;
+
+		if(!HdmiCecSink::_instance)
+                return;
+
+		LOGINFO("Running threadArcRouting");
+
+
+        	while(1)
+        	{
+			
+		    _instance->m_semSignaltoArcRoutingThread.acquire();
+			   
+			   
+		   
+			  
+                   LOGINFO(" threadArcRouting Got semaphore"); 
+ 		   std::lock_guard<std::mutex> lock(_instance->m_arcRoutingStateMutex);
+			   
+		   currentArcRoutingState = _instance->m_currentArcRoutingState;
+	   
+		   LOGINFO(" threadArcRouting  Got Sem arc state %d",currentArcRoutingState);
+			   
+			   
+		  switch (currentArcRoutingState) 
+		  {   
+
+			     case ARC_STATE_REQUEST_ARC_INITIATION :
+                             { 
+				 
+				 _instance->Send_Request_Arc_Initiation_Message();
+				   
+			     }
+			          break;
+			    case ARC_STATE_ARC_INITIATED :
+			    {
+			       _instance->Send_Report_Arc_Initiated_Message();
+		     	    }
+				 break;
+			    case ARC_STATE_REQUEST_ARC_TERMINATION :
+			    {
+				    
+			       _instance->Send_Request_Arc_Termination_Message();
+				 
+			    }
+			       break;
+			    case ARC_STATE_ARC_TERMINATED :
+			    {
+				  _instance->Send_Report_Arc_Terminated_Message();
+			    }
+			       break;
+			    case ARC_STATE_ARC_EXIT :
+			    {
+				isExit = true;
+			    }
+			    break;
+	         }
+			 
+	         if (isExit == true)
+	         {  
+		     LOGINFO(" threadArcRouting EXITing"); 
+	             break;
+	          }
+            }//while(1)
+        }//threadArcRouting
+  
+        void HdmiCecSink::Send_Request_Arc_Initiation_Message()
+	{
+           if(!HdmiCecSink::_instance)
+	     return;
+          LOGINFO(" Send_Request_Arc_Initiation_Message ");
+           _instance->smConnection->sendTo(LogicalAddress::AUDIO_SYSTEM,MessageEncoder().encode(RequestArcInitiation()), 1100);
+
+        }
+        void HdmiCecSink::Send_Report_Arc_Initiated_Message()
+        {   
+            if(!HdmiCecSink::_instance)
+	    return;
+            _instance->smConnection->sendTo(LogicalAddress::AUDIO_SYSTEM,MessageEncoder().encode(ReportArcInitiation()), 1000);
+
+        }
+        void HdmiCecSink::Send_Request_Arc_Termination_Message()
+        {
+
+            if(!HdmiCecSink::_instance)
+	     return;
+            _instance->smConnection->sendTo(LogicalAddress::AUDIO_SYSTEM,MessageEncoder().encode(RequestArcTermination()), 1100);
+        }
+
+       void HdmiCecSink::Send_Report_Arc_Terminated_Message()
+       {
+            if(!HdmiCecSink::_instance)
+		return;
+           _instance->smConnection->sendTo(LogicalAddress::AUDIO_SYSTEM,MessageEncoder().encode(ReportArcTermination()), 1000);
+
+       }
+
+
     } // namespace Plugin
-} // namespace WPEFramework
+} // namespace WPEFrameworklk

--- a/HdmiCecSink/HdmiCecSink.h
+++ b/HdmiCecSink/HdmiCecSink.h
@@ -34,10 +34,10 @@
 #include "Module.h"
 #include "utils.h"
 #include "AbstractPlugin.h"
-
+#include "tptimer.h"
 #include <thread>
 #include <mutex>
-
+#include <condition_variable>
 
 namespace WPEFramework {
 
@@ -75,12 +75,14 @@ namespace WPEFramework {
 	        void process (const SetStreamPath &msg, const Header &header);
 	        void process (const GetMenuLanguage &msg, const Header &header);
 	        void process (const ReportPhysicalAddress &msg, const Header &header);
-            void process (const DeviceVendorID &msg, const Header &header);
+                void process (const DeviceVendorID &msg, const Header &header);
 	        void process (const GiveDevicePowerStatus &msg, const Header &header);
 	        void process (const ReportPowerStatus &msg, const Header &header);
 	        void process (const FeatureAbort &msg, const Header &header);
 	        void process (const Abort &msg, const Header &header);
 	        void process (const Polling &msg, const Header &header);
+                void process (const InitiateArc &msg, const Header &header);
+                void process (const TerminateArc &msg, const Header &header);
         private:
             Connection conn;
             void printHeader(const Header &header)
@@ -361,7 +363,92 @@ namespace WPEFramework {
 				}
 			}
 		};
-		
+
+       class binary_semaphore {
+
+     public:
+
+    explicit binary_semaphore(int init_count = count_max)
+
+      : count_(init_count) {}
+
+
+
+    // P-operation / acquire
+
+    void wait()
+
+    {
+
+        std::unique_lock<std::mutex> lk(m_);
+
+        cv_.wait(lk, [=]{ return 0 < count_; });
+
+        --count_;
+
+    }
+
+    bool try_wait()
+
+    {
+
+        std::lock_guard<std::mutex> lk(m_);
+
+        if (0 < count_) {
+
+            --count_;
+
+            return true;
+
+        } else {
+
+            return false;
+
+        }
+
+    }
+
+    // V-operation / release
+
+    void signal()
+
+    {
+
+        std::lock_guard<std::mutex> lk(m_);
+
+        if (count_ < count_max) {
+
+            ++count_;
+
+            cv_.notify_one();
+
+        }
+
+    }
+
+
+
+    // Lockable requirements
+
+    void acquire() { wait(); }
+
+    bool try_lock() { return try_wait(); }
+
+    void release() { signal(); }
+
+
+
+private:
+
+    static const int count_max = 1;
+
+    int count_;
+
+    std::mutex m_;
+
+    std::condition_variable cv_;
+
+};
 		// This is a server for a JSONRPC communication channel. 
 		// For a plugin to be capable to handle JSONRPC, inherit from PluginHost::JSONRPC.
 		// By inheriting from this class, the plugin realizes the interface PluginHost::IDispatcher.
@@ -387,6 +474,13 @@ namespace WPEFramework {
 			POLL_THREAD_STATE_UPDATE,
 			POLL_THREAD_STATE_EXIT,
 		};
+                enum {
+                        ARC_STATE_REQUEST_ARC_INITIATION,
+		        ARC_STATE_ARC_INITIATED,
+		        ARC_STATE_REQUEST_ARC_TERMINATION,
+		        ARC_STATE_ARC_TERMINATED,
+			ARC_STATE_ARC_EXIT
+		     };
         public:
             HdmiCecSink();
             virtual ~HdmiCecSink();
@@ -409,6 +503,11 @@ namespace WPEFramework {
 			void sendMenuLanguage();
 			void setActiveSource(bool isResponse);
 			void requestActiveSource();
+                        void startArc();
+                        void stopArc();
+                        void Process_InitiateArc();
+                        void Process_TerminateArc();
+                        void updateArcState();
 			int m_numberOfDevices; /* Number of connected devices othethan own device */
         private:
             // We do not allow this plugin to be copied !!
@@ -422,16 +521,16 @@ namespace WPEFramework {
             uint32_t getOSDNameWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t setVendorIdWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t getVendorIdWrapper(const JsonObject& parameters, JsonObject& response);
-			uint32_t printDeviceListWrapper(const JsonObject& parameters, JsonObject& response);
-			uint32_t setActivePathWrapper(const JsonObject& parameters, JsonObject& response);
-			uint32_t setRoutingChangeWrapper(const JsonObject& parameters, JsonObject& response);
-			uint32_t getDeviceListWrapper(const JsonObject& parameters, JsonObject& response);
-			uint32_t getActiveSourceWrapper(const JsonObject& parameters, JsonObject& response);
-			uint32_t setActiveSourceWrapper(const JsonObject& parameters, JsonObject& response);
-			uint32_t getActiveRouteWrapper(const JsonObject& parameters, JsonObject& response);
-			uint32_t requestActiveSourceWrapper(const JsonObject& parameters, JsonObject& response);
-			uint32_t setMenuLanguageWrapper(const JsonObject& parameters, JsonObject& response);
-
+	    uint32_t printDeviceListWrapper(const JsonObject& parameters, JsonObject& response);
+	    uint32_t setActivePathWrapper(const JsonObject& parameters, JsonObject& response);
+	    uint32_t setRoutingChangeWrapper(const JsonObject& parameters, JsonObject& response);
+	    uint32_t getDeviceListWrapper(const JsonObject& parameters, JsonObject& response);
+	    uint32_t getActiveSourceWrapper(const JsonObject& parameters, JsonObject& response);
+	    uint32_t setActiveSourceWrapper(const JsonObject& parameters, JsonObject& response);
+	    uint32_t getActiveRouteWrapper(const JsonObject& parameters, JsonObject& response);
+	    uint32_t requestActiveSourceWrapper(const JsonObject& parameters, JsonObject& response);
+	    uint32_t setMenuLanguageWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t setArcEnableDisableWrapper(const JsonObject& parameters, JsonObject& response);
 			
             //End methods
             std::string logicalAddressDeviceType;
@@ -447,6 +546,14 @@ namespace WPEFramework {
 			uint32_t m_pollNextState;
 			uint32_t m_sleepTime;
             std::mutex m_pollMutex;
+            /* ARC related */
+            std::thread m_arcRoutingThread;
+	    uint32_t m_currentArcRoutingState;
+	    std::mutex m_arcRoutingStateMutex;
+	    binary_semaphore m_semSignaltoArcRoutingThread;
+            bool m_arcstarting;
+            TpTimer m_arcStartStopTimer;
+
             Connection *smConnection;
 			std::vector<uint8_t> m_connectedDevices;
             HdmiCecSinkProcessor *msgProcessor;
@@ -482,6 +589,17 @@ namespace WPEFramework {
             void getPhysicalAddress();
             void getLogicalAddress();
             void cecAddressesChanged(int changeStatus);
+            
+            // Arc functions
+    
+            static void  threadArcRouting();
+            void requestArcInitiation();
+            void requestArcTermination();
+            void Send_Request_Arc_Initiation_Message();
+            void Send_Report_Arc_Initiated_Message();
+            void Send_Request_Arc_Termination_Message();
+            void Send_Report_Arc_Terminated_Message();
+            void arcStartStopTimerFunction();
         };
 	} // namespace Plugin
 } // namespace WPEFramework


### PR DESCRIPTION
Reason for change: For ARC Audio Routing the cec handshake needs to be done to bring the AVR/Sound Bar to receive the audio through ARC.
Test Procedure: Tested using Curl Commands to start and stop ARC to  see the CEC messages
Risks: None

Signed-off-by: Bijas Babu <bijas.babu@sky.uk>