### PR TITLE
RDKTV-360: Remove HAS_STATE_OBSERVER

### DIFF
--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -2430,7 +2430,6 @@ namespace WPEFramework {
             string methodType;
 	    if (parameters.HasLabel("param")) {
                 methodType = parameters["param"].String();
-#ifdef HAS_STATE_OBSERVER
                 if (SYSTEM_CHANNEL_MAP == methodType) {
                     LOGERR("methodType : %s\n", methodType.c_str());
                     IARM_Bus_Call(IARM_BUS_SYSMGR_NAME, IARM_BUS_SYSMGR_API_GetSystemStates,
@@ -2520,9 +2519,6 @@ namespace WPEFramework {
                 } else {
                     populateResponseWithError(SysSrv_Unexpected, response);
                 }
-#else /* !HAS_STATE_OBSERVER */
-                populateResponseWithError(SysSrv_SupportNotAvailable, response);
-#endif /* !HAS_STATE_OBSERVER */
 	    } else {
 		    populateResponseWithError(SysSrv_MissingKeyValues, response);
 	    }


### PR DESCRIPTION
Reason for change: Looks like HAS_STATE_OBSERVER
was copied from SM. It's not required for Thunder plugins
Test Procedure: It builds
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>