### PR TITLE
RDK-29867 : uploadLogs build time switch

### DIFF
--- a/SystemServices/README.md
+++ b/SystemServices/README.md
@@ -227,14 +227,14 @@
   _**Response payload:**_ `{"result":{"success":<bool>}}`
   - **setNetworkStandbyMode**
 
-    TBD.  
-  _**Request payload:**_ `{"params":{}}`  
+    Sets the Network standby mode. Network Standby is a feature that allows to let device resume from DEEP SLEEP or Suspend To RAM (STR) to ON power state. This is performed by leaving LAN/WiFi modules active while the rest of the device is in DEEP SLEEP power state.  
+  _**Request payload:**_ `{"params":{"nwStandby":<bool>}}`  
   _**Response payload:**_ `{"result":{"success":<bool>}}`
   - **getNetworkStandbyMode**
 
-    TBD.  
+    Checks for network standby.  
   _**Request payload:**_ `{"params":{}}`  
-  _**Response payload:**_ `{"result":{"success":<bool>}}`
+  _**Response payload:**_ `{"result":{"success":<bool>,"nwStandby":<bool>}}`
   - **getPowerStateIsManagedByDevice**
 
     Returns false if the following environment variable is set and has a value of 1: RDK_NO_ACTION_ON_POWER_KEY=1. Otherwise, this API will return true.  
@@ -348,9 +348,9 @@ Method | Request Payload | Response Payload
 | setTemperatureThresholds | {"jsonrpc":"2.0","id":"40","method":"org.rdk.System.1.setTemperatureThresholds","params":{"thresholds":{"WARN":"50.000000","MAX":"80.000000"}}} | {"jsonrpc":"2.0","id":40,"result":{"success":true}} |  
 | setTimeZoneDST | {"jsonrpc":"2.0","id":"41","method":"org.rdk.System.1.setTimeZoneDST","params":{"timeZone":"UTC-5"}} | {"jsonrpc":"2.0","id":41,"result":{"success":true}} |  
 | updateFirmware | {"jsonrpc":"2.0","id":"42","method":"org.rdk.System.1.updateFirmware","params":{}} | {"jsonrpc":"2.0","id":42,"result":{"success":true}} |  
-| setNetworkStandbyMode | {"jsonrpc":"2.0","id":"46","method":"org.rdk.System.1.setNetworkStandbyMode","params":{}} | TBD |  
-| getNetworkStandbyMode | {"jsonrpc":"2.0","id":"43","method":"org.rdk.System.1.getNetworkStandbyMode","params":{}} | TBD |  
-| getPowerStateIsManagedByDevice | {"jsonrpc":"2.0","id":"44","method":"org.rdk.System.1.getPowerStateIsManagedByDevice","params":{}} | TBD |  
-| getTimeZones | {"jsonrpc":"2.0","id":"45","method":"org.rdk.System.2.getTimeZones","params":{}} | {"jsonrpc":"2.0","id":1,"result":{"zoneinfo":{"America":{"Anchorage":"","Chicago":"","Denver":"","Edmonton":"","Halifax":"","Los_Angeles":"","New_York":"","Phoenix":"","Regina":"","St_Johns":"","Toronto":"","Vancouver":"","Winnipeg":""},"Europe":{"London":"","Moscow":"","Paris":""},"Pacific":{"Honolulu":""},"US":{"Alaska":"","Aleutian":"","Arizona":"","Central":"","East-Indiana":"","Eastern":"","Hawaii":"","Indiana-Starke":"","Michigan":"","Mountain":"","Pacific":"","Samoa":""}}}} |  
+| setNetworkStandbyMode | {"jsonrpc":"2.0","id":"46","method":"org.rdk.System.1.setNetworkStandbyMode","params":{"nwStandby":true}} | {"jsonrpc":"2.0","id":42,"result":{"success":true}} |  
+| getNetworkStandbyMode | {"jsonrpc":"2.0","id":"43","method":"org.rdk.System.1.getNetworkStandbyMode","params":{}} | {"jsonrpc":"2.0","id":43,"result":{"nwStandby":true,"success":true}} |  
+| getPowerStateIsManagedByDevice | {"jsonrpc":"2.0","id":"44","method":"org.rdk.System.1.getPowerStateIsManagedByDevice","params":{}} | {"jsonrpc":"2.0","id":44,"result":{"powerStateManagedByDevice":true,"success":true}} |  
+| getTimeZones | {"jsonrpc":"2.0","id":"45","method":"org.rdk.System.2.getTimeZones","params":{}} | {"jsonrpc":"2.0","id":45,"result":{"zoneinfo":{"Pacific":{"Honolulu":"Tue Dec  8 04:04:12 2020 HST"},"Europe":{"Moscow":"Tue Dec  8 17:04:12 2020 MSK","London":"Tue Dec  8 14:04:12 2020 GMT","Paris":"Tue Dec  8 15:04:12 2020 CET"},"America":{"Halifax":"Tue Dec  8 10:04:12 2020 AST","St_Johns":"Tue Dec  8 10:34:13 2020 NST","Chicago":"Tue Dec  8 08:04:13 2020 CST","Toronto":"Tue Dec  8 09:04:13 2020 EST","Phoenix":"Tue Dec  8 07:04:13 2020 MST","Vancouver":"Tue Dec  8 06:04:13 2020 PST","New_York":"Tue Dec  8 09:04:13 2020 EST","Winnipeg":"Tue Dec  8 08:04:13 2020 CST","Los_Angeles":"Tue Dec  8 06:04:13 2020 PST","Denver":"Tue Dec  8 07:04:13 2020 MST","Anchorage":"Tue Dec  8 05:04:14 2020 AKST","Regina":"Tue Dec  8 08:04:14 2020 CST","Edmonton":"Tue Dec  8 07:04:14 2020 MST"},"US":{"Alaska":"Tue Dec  8 05:04:14 2020 AKST","Michigan":"Tue Dec  8 09:04:14 2020 EST","Central":"Tue Dec  8 08:04:14 2020 CST","Pacific":"Tue Dec  8 06:04:14 2020 PST","Indiana-Starke":"Tue Dec  8 08:04:14 2020 CST","Mountain":"Tue Dec  8 07:04:15 2020 MST","Eastern":"Tue Dec  8 09:04:15 2020 EST","Arizona":"Tue Dec  8 07:04:15 2020 MST","Hawaii":"Tue Dec  8 04:04:15 2020 HST","East-Indiana":"Tue Dec  8 09:04:15 2020 EST","Aleutian":"Tue Dec  8 04:04:15 2020 HST","Samoa":"Tue Dec  8 03:04:15 2020 SST"}}}} |  
 | uploadLogs | {"jsonrpc":"2.0","id":"47","method":"org.rdk.System.2.uploadLogs","params":{"url":"http://192.168.18.102:3000/Logs.tgz"}} | {"jsonrpc":"2.0","id":47,"result":{"success":true}} |  
 </details>

--- a/SystemServices/README.md
+++ b/SystemServices/README.md
@@ -225,6 +225,31 @@
     Initiates a firmware update. This method has no affect if update is not available. The State Observer Method/Event may be used to listen to firmware update events.  
   _**Request payload:**_ `{"params":{}}`  
   _**Response payload:**_ `{"result":{"success":<bool>}}`
+  - **setNetworkStandbyMode**
+
+    TBD.  
+  _**Request payload:**_ `{"params":{}}`  
+  _**Response payload:**_ `{"result":{"success":<bool>}}`
+  - **getNetworkStandbyMode**
+
+    TBD.  
+  _**Request payload:**_ `{"params":{}}`  
+  _**Response payload:**_ `{"result":{"success":<bool>}}`
+  - **getPowerStateIsManagedByDevice**
+
+    Returns false if the following environment variable is set and has a value of 1: RDK_NO_ACTION_ON_POWER_KEY=1. Otherwise, this API will return true.  
+  _**Request payload:**_ `{"params":{}}`  
+  _**Response payload:**_ `{"result":{"success":<bool>,"powerStateManagedByDevice":<bool>}}`
+  - **getTimeZones**
+
+    Reads data available from /usr/share/zoneinfo/ and returns it in a json format.  
+  _**Request payload:**_ `{"params":{}}`  
+  _**Response payload:**_ `{"result":{"zoneinfo":{<Zone>:{<Time Zones>}}}}`
+  - **uploadLogs**
+
+    Uploads the logs to the specified URL or the default url if none were provided. returns success=true for Platco and Llama. Returns success=false, reason=unsupported for other platforms and does not upload logs.  
+  _**Request payload:**_ `"params":{"url":"<URL>"}`  
+  _**Response payload:**_ `{"result":{"success":<bool>}}`
 ## System Thunder Plugin Events
   - **onFirmwareUpdateInfoReceived**
 
@@ -323,4 +348,9 @@ Method | Request Payload | Response Payload
 | setTemperatureThresholds | {"jsonrpc":"2.0","id":"40","method":"org.rdk.System.1.setTemperatureThresholds","params":{"thresholds":{"WARN":"50.000000","MAX":"80.000000"}}} | {"jsonrpc":"2.0","id":40,"result":{"success":true}} |  
 | setTimeZoneDST | {"jsonrpc":"2.0","id":"41","method":"org.rdk.System.1.setTimeZoneDST","params":{"timeZone":"UTC-5"}} | {"jsonrpc":"2.0","id":41,"result":{"success":true}} |  
 | updateFirmware | {"jsonrpc":"2.0","id":"42","method":"org.rdk.System.1.updateFirmware","params":{}} | {"jsonrpc":"2.0","id":42,"result":{"success":true}} |  
+| setNetworkStandbyMode | {"jsonrpc":"2.0","id":"46","method":"org.rdk.System.1.setNetworkStandbyMode","params":{}} | TBD |  
+| getNetworkStandbyMode | {"jsonrpc":"2.0","id":"43","method":"org.rdk.System.1.getNetworkStandbyMode","params":{}} | TBD |  
+| getPowerStateIsManagedByDevice | {"jsonrpc":"2.0","id":"44","method":"org.rdk.System.1.getPowerStateIsManagedByDevice","params":{}} | TBD |  
+| getTimeZones | {"jsonrpc":"2.0","id":"45","method":"org.rdk.System.2.getTimeZones","params":{}} | {"jsonrpc":"2.0","id":1,"result":{"zoneinfo":{"America":{"Anchorage":"","Chicago":"","Denver":"","Edmonton":"","Halifax":"","Los_Angeles":"","New_York":"","Phoenix":"","Regina":"","St_Johns":"","Toronto":"","Vancouver":"","Winnipeg":""},"Europe":{"London":"","Moscow":"","Paris":""},"Pacific":{"Honolulu":""},"US":{"Alaska":"","Aleutian":"","Arizona":"","Central":"","East-Indiana":"","Eastern":"","Hawaii":"","Indiana-Starke":"","Michigan":"","Mountain":"","Pacific":"","Samoa":""}}}} |  
+| uploadLogs | {"jsonrpc":"2.0","id":"47","method":"org.rdk.System.2.uploadLogs","params":{"url":"http://192.168.18.102:3000/Logs.tgz"}} | {"jsonrpc":"2.0","id":47,"result":{"success":true}} |  
 </details>

--- a/SystemServices/TestClient/systemServiceTestClient.cpp
+++ b/SystemServices/TestClient/systemServiceTestClient.cpp
@@ -110,6 +110,11 @@ typedef enum SME_t {
 	SME_setTemperatureThresholds,
 	SME_setTimeZoneDST,
 	SME_updateFirmware,
+	SME_setNetworkStandbyMode,
+	SME_getNetworkStandbyMode,
+	SME_getPowerStateIsManagedByDevice,
+	SME_getTimeZones,
+	SME_uploadLogs,
 	SME_MAX,
 };
 
@@ -159,6 +164,11 @@ std::map<SME_t, std::string> SMName = {
 	{SME_setTemperatureThresholds, "setTemperatureThresholds"},
 	{SME_setTimeZoneDST, "setTimeZoneDST"},
 	{SME_updateFirmware, "updateFirmware"},
+	{SME_setNetworkStandbyMode, "setNetworkStandbyMode"},
+	{SME_getNetworkStandbyMode, "getNetworkStandbyMode"},
+	{SME_getPowerStateIsManagedByDevice, "getPowerStateIsManagedByDevice"},
+	{SME_getTimeZones, "getTimeZones"},
+	{SME_uploadLogs, "uploadLogs"},
 	{SME_MAX, "MAX"},
 };
 
@@ -860,6 +870,82 @@ void updateFirmware(std::string methodName, JSONRPC::LinkType<Core::JSON::IEleme
 	}
 }
 
+void setNetworkStandbyMode(std::string methodName, JSONRPC::LinkType<Core::JSON::IElement> *remoteObject)
+{
+    printf("[%llu] Inside (%s)\n", TimeStamp(), __FUNCTION__);
+
+    JsonObject parameters, response;
+    std::string result;
+    bool nwStandby;
+
+    printf("\nInput 'nwStandby' :");
+    std::cin >> nwStandby;
+
+    parameters["nwStandby"] = nwStandby;
+
+    if (invokeJSONRPC(remoteObject, methodName, parameters, response)) {
+        response.ToString(result);
+        printf("\nResponse: '%s'\n", result.c_str());
+    }
+}
+
+void getNetworkStandbyMode(std::string methodName, JSONRPC::LinkType<Core::JSON::IElement> *remoteObject)
+{
+    printf("[%llu] Inside (%s)\n", TimeStamp(), __FUNCTION__);
+
+    JsonObject parameters, response;
+    std::string result;
+
+    if (invokeJSONRPC(remoteObject, methodName, parameters, response)) {
+        response.ToString(result);
+        printf("\nResponse: '%s'\n", result.c_str());
+    }
+}
+
+void getPowerStateIsManagedByDevice(std::string methodName, JSONRPC::LinkType<Core::JSON::IElement> *remoteObject)
+{
+    printf("[%llu] Inside (%s)\n", TimeStamp(), __FUNCTION__);
+
+    JsonObject parameters, response;
+    std::string result;
+
+    if (invokeJSONRPC(remoteObject, methodName, parameters, response)) {
+        response.ToString(result);
+        printf("\nResponse: '%s'\n", result.c_str());
+    }
+}
+
+void getTimeZones(std::string methodName, JSONRPC::LinkType<Core::JSON::IElement> *remoteObject)
+{
+    printf("[%llu] Inside (%s)\n", TimeStamp(), __FUNCTION__);
+
+    JsonObject parameters, response;
+    std::string result;
+
+    if (invokeJSONRPC(remoteObject, methodName, parameters, response)) {
+        response.ToString(result);
+        printf("\nResponse: '%s'\n", result.c_str());
+    }
+}
+
+void uploadLogs(std::string methodName, JSONRPC::LinkType<Core::JSON::IElement> *remoteObject)
+{
+    printf("[%llu] Inside (%s)\n", TimeStamp(), __FUNCTION__);
+
+    JsonObject parameters, response;
+    std::string result, url;
+
+    printf("\nInput 'url' :");
+    std::cin >> url;
+
+    parameters["url"] = url;
+
+    if (invokeJSONRPC(remoteObject, methodName, parameters, response)) {
+        response.ToString(result);
+        printf("\nResponse: '%s'\n", result.c_str());
+    }
+}
+
 /******************************** End : Handle Selection *******************************/
 
 void showUsage(char *pName)
@@ -959,6 +1045,11 @@ int EvaluateMethods(JSONRPC::LinkType<Core::JSON::IElement>* remoteObject)
 			case SME_setTemperatureThresholds: setTemperatureThresholds(getMethodName((SME_t)retStatus), remoteObject); break;
 			case SME_setTimeZoneDST: setTimeZoneDST(getMethodName((SME_t)retStatus), remoteObject); break;
 			case SME_updateFirmware: updateFirmware(getMethodName((SME_t)retStatus), remoteObject); break;
+			case SME_setNetworkStandbyMode: setNetworkStandbyMode(getMethodName((SME_t)retStatus), remoteObject); break;
+			case SME_getNetworkStandbyMode: getNetworkStandbyMode(getMethodName((SME_t)retStatus), remoteObject); break;
+			case SME_getPowerStateIsManagedByDevice: getPowerStateIsManagedByDevice(getMethodName((SME_t)retStatus), remoteObject); break;
+			case SME_getTimeZones: getTimeZones(getMethodName((SME_t)retStatus), remoteObject); break;
+			case SME_uploadLogs: uploadLogs(getMethodName((SME_t)retStatus), remoteObject); break;
 			case SME_MAX:
 			default:
 				break;

--- a/services.cmake
+++ b/services.cmake
@@ -252,6 +252,11 @@ if(BUILD_ENABLE_CEF)
     add_definitions (-DUSE_CEF)
 endif()
 
+if(BUILD_ENABLE_SYSTEM_UPLOAD_LOGS)
+    message("Building with System Service uploadLogs")
+    add_definitions (-DENABLE_SYSTEM_UPLOAD_LOGS)
+endif()
+
 if(BUILD_BROADCOM)
     include(broadcom.cmake)
 elseif(BUILD_RASPBERRYPI)


### PR DESCRIPTION
Reason for change: Add RFC switch and a build time switch
Test Procedure: Build time switch should be enabled for
Platco and Llama, RFC is disabled by default:
DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.UploadLogsEasterEgg.Enable
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>