### PR TITLE
DELIA-47483: Fix JSON parse error with getAvailableSSIDs

### DIFF
--- a/WifiManager/impl/WifiManagerScan.cpp
+++ b/WifiManager/impl/WifiManagerScan.cpp
@@ -253,7 +253,7 @@ void WifiManagerScan::iarmEventHandler(char const* owner, IARM_EventId_t eventId
         LOGINFO("Event IARM_BUS_WIFI_MGR_EVENT_onAvailableSSIDs[Incr] received. '%s'", eventData->data.wifiSSIDList.ssid_list);
 
         // The returned SSIDs are in a JSON document
-        std::string const serialized(eventData->data.wifiSSIDList.ssid_list, MAX_SSIDLIST_BUF);
+        std::string const serialized(eventData->data.wifiSSIDList.ssid_list);
         JsonObject eventDocument;
         WPEC::OptionalType<WPEJ::Error> error;
         if (!WPEJ::IElement::FromString(serialized, eventDocument, error)) {


### PR DESCRIPTION
Fix copying of char buffer with getAvailableSSIDs into std::string to only copy the required chars upto null terminating char and not the entire buffer (MAX_SSIDLIST_BUF).