### PR TITLE
CPC-2640: FrameRate thunder proxy

### DIFF
--- a/FrameRate/FrameRate.cpp
+++ b/FrameRate/FrameRate.cpp
@@ -46,6 +46,9 @@ namespace WPEFramework
 
         FrameRate::FrameRate()
         : AbstractPlugin()
+          , m_fpsCollectionFrequencyInMs(DEFAULT_FPS_COLLECTION_TIME_IN_MILLISECONDS)
+          , m_minFpsValue(DEFAULT_MIN_FPS_VALUE), m_maxFpsValue(DEFAULT_MAX_FPS_VALUE)
+          , m_totalFpsValues(0), m_numberOfFpsUpdates(0), m_fpsCollectionInProgress(false), m_lastFpsValue(-1)
         {
             LOGINFO();
             FrameRate::_instance = this;


### PR DESCRIPTION
Reason for change: Initialize FrameRate plugin class members

Test Procedure: Refer to ticket

Risks: Low

Signed-off-by: Mariusz Strozynski <mariusz.strozynski@consult.red>