### PR TITLE
DELIA-47123: Split BTMGR_Init and BTRMGR_DeInit

### DIFF
--- a/Bluetooth/Bluetooth.cpp
+++ b/Bluetooth/Bluetooth.cpp
@@ -157,11 +157,12 @@ namespace WPEFramework
             registerMethod(METHOD_GET_DEVICE_INFO, &Bluetooth::getDeviceInfoWrapper, this);
             registerMethod(METHOD_GET_AUDIO_INFO, &Bluetooth::getMediaTrackInfoWrapper, this);
 
-            BTRMGR_Result_t rc = BTRMGR_RESULT_SUCCESS;
-            rc = BTRMGR_Init();
+            Utils::IARM::init();
+
+            BTRMGR_Result_t rc = BTRMGR_RegisterForCallbacks(Utils::IARM::NAME);
             if (BTRMGR_RESULT_SUCCESS != rc)
             {
-                LOGWARN("Failed to init BTRMgr...!");
+                LOGWARN("Failed to Register BTRMgr...!");
             }
             else {
                 BTRMGR_RegisterEventCallback(bluetoothSrv_EventCallback);
@@ -172,6 +173,12 @@ namespace WPEFramework
         {
             LOGINFO();
             Bluetooth::_instance = nullptr;
+
+            BTRMGR_Result_t rc = BTRMGR_UnRegisterFromCallbacks(Utils::IARM::NAME);
+            if (BTRMGR_RESULT_SUCCESS != rc)
+            {
+                LOGWARN("Failed to UnRegister BTRMgr...!");
+            }
 
             if (m_executionThread.joinable())
                 m_executionThread.join();

--- a/Bluetooth/CMakeLists.txt
+++ b/Bluetooth/CMakeLists.txt
@@ -23,6 +23,7 @@ find_package(${NAMESPACE}Plugins REQUIRED)
 add_library(${MODULE_NAME} SHARED
         Bluetooth.cpp
         Module.cpp
+        ../helpers/utils.cpp
 )
 
 set_target_properties(${MODULE_NAME} PROPERTIES
@@ -40,8 +41,9 @@ if(BTMGR_FOUND)
     target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins ${BTMGR_LIBRARIES})
 endif(BTMGR_FOUND)
 
-target_include_directories(${MODULE_NAME} PRIVATE ../helpers)
-target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins)
+find_package(IARMBus)
+target_include_directories(${MODULE_NAME} PRIVATE ../helpers ${IARMBUS_INCLUDE_DIRS})
+target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins ${IARMBUS_LIBRARIES})
 
 install(TARGETS ${MODULE_NAME}
         DESTINATION lib/${STORAGE_DIRECTORY}/plugins)

--- a/helpers/utils.cpp
+++ b/helpers/utils.cpp
@@ -30,9 +30,11 @@
 using namespace WPEFramework;
 using namespace std;
 
+const char* Utils::IARM::NAME = "Thunder_Plugins";
+
 bool Utils::IARM::init()
 {
-    string memberName = "Thunder_Plugins";
+    string memberName = NAME;
     LOGINFO("%s", memberName.c_str());
 
     IARM_Result_t res;

--- a/helpers/utils.h
+++ b/helpers/utils.h
@@ -165,6 +165,8 @@ namespace Utils
         static bool init();
         static bool isConnected() { return m_connected; }
 
+        static const char* NAME;
+
     private:
         static bool m_connected;
     };


### PR DESCRIPTION
Reason for change: Modify rdkservices to reflect BTRMGR changes.
Test Procedure: Activate Bluetooth service, activate System service,
see no IARM errors in log.
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>