### PR TITLE
RDK-30181-Implement Thunder APIs

### DIFF
--- a/Network/Network.h
+++ b/Network/Network.h
@@ -74,6 +74,8 @@ namespace WPEFramework {
             uint32_t setIPSettings(const JsonObject& parameters, JsonObject& response);
             uint32_t getIPSettings(const JsonObject& parameters, JsonObject& response);
             uint32_t getSTBIPFamily(const JsonObject& parameters, JsonObject& response);
+            uint32_t isConnectedToInternet(const JsonObject& parameters, JsonObject& response);
+            uint32_t setConnectivityTestEndpoints(const JsonObject& parameters, JsonObject& response);
 
             void onInterfaceEnabledStatusChanged(std::string interface, bool enabled);
             void onInterfaceConnectionStatusChanged(std::string interface, bool connected);


### PR DESCRIPTION
Reason for change:Implemeted api's - isConnectedToInternet() and setConnectivityTestEndpoints() for validate internet connectivity(RDK-29443)
Test Procedure: validated with thunder api curl request & results attached into ticket