### PR TITLE
Fix RDKShell build: missing IARMBus package find

### DIFF
--- a/RDKShell/CMakeLists.txt
+++ b/RDKShell/CMakeLists.txt
@@ -21,6 +21,7 @@ set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
 set(PLUGIN_RDKSHELL_AUTOSTART true CACHE STRING "Automatically start RDKShell plugin")
 
 find_package(${NAMESPACE}Plugins REQUIRED)
+find_package(IARMBus)
 
 add_library(${MODULE_NAME} SHARED
         RDKShell.cpp


### PR DESCRIPTION
* CMakeLists.txt adds IARMBUS_INCLUDE_DIRS and IARMBUS_LIBRARIES
  so it should also try to find the IARMBus package first
* this build error does not occur with all builds configs.
  It probably depends on which other pluginx are also enabled.
  I noticed this on RPI reference image build.
* needed because ../helpers/utils.cpp always pulls in IARMBus