### PR TITLE
RDK-30728: Thunder support for Hdmi Input events

### DIFF
--- a/HdmiInput/HdmiInput.h
+++ b/HdmiInput/HdmiInput.h
@@ -70,6 +70,12 @@ namespace WPEFramework {
             void hdmiInputHotplug( int input , int connect);
             static void dsHdmiEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
 
+	    void hdmiInputSignalChange( int port , int signalStatus);
+            static void dsHdmiSignalStatusEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
+
+            void hdmiInputStatusChange( int port , bool isPresented);
+	    static void dsHdmiStatusEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
+
         public:
             HdmiInput();
             virtual ~HdmiInput();


### PR DESCRIPTION
Reason for change: Added support for HDMI Input
status and signal status events in HdmiInput thunder
plugin
Test Procedure: Verify HDMI In events via thunder
Risks: None

Signed-off-by: Deekshit Devadas <deekshit.devadasy@sky.uk>