### PR TITLE
RDKTV-71: Fix org.rdk.System.1.getPreviousRebootInfo2 for Platco

### DIFF
--- a/helpers/SystemServicesHelper.h
+++ b/helpers/SystemServicesHelper.h
@@ -33,7 +33,7 @@
 
 /* Status-keeper files */
 
-#if defined (PLATFORM_BROADCOM) || defined (PLATFORM_BROADCOM_REF) || defined (PLATFORM_REALTEK)
+#if defined (PLATFORM_BROADCOM) || defined (PLATFORM_BROADCOM_REF) || defined (PLATFORM_REALTEK) || defined (PLATFORM_AMLOGIC)
 #define SYSTEM_SERVICE_REBOOT_INFO_FILE             "/opt/secure/reboot/reboot.info"
 #define SYSTEM_SERVICE_PREVIOUS_REBOOT_INFO_FILE    "/opt/secure/reboot/previousreboot.info"
 #define SYSTEM_SERVICE_HARD_POWER_INFO_FILE         "/opt/secure/reboot/hardpower.info"


### PR DESCRIPTION
Including PLATFORM_AMLOGIC to get the details for org.rdk.System.1.getPreviousRebootInfo2 from /opt/secure/reboot/