### PR TITLE
RDKTV-71: Fix org.rdk.System.1.getPreviousRebootInfo2 for Platco

### DIFF
--- a/helpers/SystemServicesHelper.h
+++ b/helpers/SystemServicesHelper.h
@@ -32,7 +32,7 @@
 #include "utils.h"
 
 /* Status-keeper files */
-#if defined (PLATFORM_BROADCOM) || defined (PLATFORM_BROADCOM_REF) || defined (PLATFORM_REALTEK)
+#if defined (PLATFORM_BROADCOM) || defined (PLATFORM_BROADCOM_REF) || defined (PLATFORM_REALTEK) || defined (PLATFORM_AMLOGIC)
 #define SYSTEM_SERVICE_REBOOT_INFO_FILE             "/opt/secure/reboot/reboot.info"
 #define SYSTEM_SERVICE_PREVIOUS_REBOOT_INFO_FILE    "/opt/secure/reboot/previousreboot.info"
 #define SYSTEM_SERVICE_HARD_POWER_INFO_FILE         "/opt/secure/reboot/hardpower.info"


### PR DESCRIPTION
(cherry picked from commit 110957fd0ffe18a4bf6436acd9722c30236af373)