### PR TITLE
HISENSE-198 : Fix UsbAccess flaws

### DIFF
--- a/UsbAccess/UsbAccess.h
+++ b/UsbAccess/UsbAccess.h
@@ -29,9 +29,8 @@ namespace WPEFramework {
             static const string METHOD_CLEAR_LINK;
             //events
             //other
-            static const string USB_MOUNT_PATH;
             static const string LINK_URL_HTTP;
-            static const string LIGHTTPD_CONF_PATH;
+            static const string LINK_PATH;
 
         private/*registered methods (wrappers)*/:
 
@@ -44,7 +43,12 @@ namespace WPEFramework {
             UsbAccess(const UsbAccess&) = delete;
             UsbAccess& operator=(const UsbAccess&) = delete;
 
-            string getLinkPath() const;
+            typedef string FileType;
+            typedef std::pair<string,FileType> PathInfo;
+            typedef std::list<PathInfo> FileList;
+
+            bool getFileList(const string& dir, FileList& files) const;
+            bool getMountPath(string& dir) const;
         };
     } // namespace Plugin
 } // namespace WPEFramework


### PR DESCRIPTION
Reason for change: Do not rely on lighttpd document-root,
and don't parse lighttpd config which is unreliable.
Instead, create and use a specific lighttpd alias.
Return error "file exists" for createLink if link exists.
Do not hardcode mount path but find it using system files.
Test Procedure: Test UsbAccess as usually
but with multiple USB drives having single or
multiple partitions.
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>