### PR TITLE
RDK-31068: HDMI Output HDCP Status Change Notification XiOne

### DIFF
--- a/HdcpProfile/HdcpProfile.h
+++ b/HdcpProfile/HdcpProfile.h
@@ -54,7 +54,11 @@ namespace WPEFramework {
             //Begin methods
             uint32_t getHDCPStatusWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t getSettopHDCPSupportWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t setApiVersionNumberWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t getApiVersionNumberWrapper(const JsonObject& parameters, JsonObject& response);
 
+            virtual unsigned int getApiVersionNumber();
+            void setApiVersionNumber(unsigned int apiVersionNumber);
             //End methods
 
             JsonObject getHDCPStatus();
@@ -70,6 +74,9 @@ namespace WPEFramework {
             void terminate();
 
             static HdcpProfile* _instance;
+        private:
+            uint32_t m_apiVersionNumber;
+
         };
 	} // namespace Plugin
 } // namespace WPEFramework


### PR DESCRIPTION
Reason for change:
HDMI Output HDCP Status Change Notification XiOne
Thunder changes.
Test Procedure: None
Risks: Low

Change-Id: I8a9e23bda040279f6a6de074bad5289a2a5e3585
Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>