### PR TITLE
RDK-30268: Provide Required HDMI Source Properties to Netflix App

### DIFF
--- a/DisplayInfo/DeviceSettings/Broadcom/SoC_abstraction.cpp
+++ b/DisplayInfo/DeviceSettings/Broadcom/SoC_abstraction.cpp
@@ -46,7 +46,7 @@ using namespace WPEFramework;
  */
 void sanitizeLine(string& line)
 {
-    for(int i = 0; i < line.size(); i++)
+    for(unsigned int i = 0; i < line.size(); i++)
     {
         while(line[i] == ' ' && line[i+1] == ' ')
         {
@@ -161,7 +161,7 @@ uint64_t SoC_GetTotalGpuRam()
     }
     catch(...)
     {
-        LOGERR("Unable to process Total Gpu ram", value.c_str());
+        LOGERR("Unable to process Total Gpu ram");
     }
     return ret;
 }
@@ -180,7 +180,7 @@ uint64_t SoC_GetFreeGpuRam()
     }
     catch(...)
     {
-        LOGERR("Unable to process Free Gpu ram", value.c_str());
+        LOGERR("Unable to process Free Gpu ram");
     }
 
     ret = (100 - usedPercentage) * 0.01 * SoC_GetTotalGpuRam();

--- a/DisplayInfo/DisplayInfo.cpp
+++ b/DisplayInfo/DisplayInfo.cpp
@@ -58,6 +58,19 @@ namespace Plugin {
                     Exchange::JGraphicsProperties::Register(*this, _graphicsProperties);
                     Exchange::JConnectionProperties::Register(*this, _connectionProperties);
                     Exchange::JHDRProperties::Register(*this, _hdrProperties);
+
+                    // The code execution should proceed regardless of the _displayProperties
+                    // value, as it is not a essential.
+                    // The relevant JSONRPC endpoints will return ERROR_UNAVAILABLE,
+                    // if it hasn't been initialized.
+                    _displayProperties = _connectionProperties->QueryInterface<Exchange::IDisplayProperties>();
+                    if (_displayProperties == nullptr) {
+                        SYSLOG(Logging::Startup, (_T("Display Properties service is unavailable.")));
+                    }
+                    else
+                    {
+                        Exchange::JDisplayProperties::Register(*this, _displayProperties);
+                    }
                 }
             }
         }
@@ -73,6 +86,7 @@ namespace Plugin {
     {
         ASSERT(_connectionProperties != nullptr);
 
+        Exchange::JGraphicsProperties::Unregister(*this);
         Exchange::JHDRProperties::Unregister(*this);
         Exchange::JConnectionProperties::Unregister(*this);
 
@@ -94,6 +108,14 @@ namespace Plugin {
             _hdrProperties->Release();
             _hdrProperties = nullptr;
         }
+
+        if (_displayProperties != nullptr)
+        {
+            _displayProperties->Release();
+            Exchange::JDisplayProperties::Unregister(*this);
+            _displayProperties = nullptr;
+        }
+
         _connectionId = 0;
     }
 

--- a/DisplayInfo/DisplayInfo.h
+++ b/DisplayInfo/DisplayInfo.h
@@ -24,6 +24,7 @@
 #include <interfaces/json/JGraphicsProperties.h>
 #include <interfaces/json/JConnectionProperties.h>
 #include <interfaces/json/JHDRProperties.h>
+#include <interfaces/json/JDisplayProperties.h>
 
 namespace WPEFramework {
 namespace Plugin {
@@ -85,6 +86,7 @@ namespace Plugin {
             , _graphicsProperties(nullptr)
             , _connectionProperties(nullptr)
             , _hdrProperties(nullptr)
+            , _displayProperties(nullptr)
             , _notification(this)
         {
         }
@@ -99,6 +101,7 @@ namespace Plugin {
         INTERFACE_AGGREGATE(Exchange::IGraphicsProperties, _graphicsProperties)
         INTERFACE_AGGREGATE(Exchange::IConnectionProperties, _connectionProperties)
         INTERFACE_AGGREGATE(Exchange::IHDRProperties, _hdrProperties)
+        INTERFACE_AGGREGATE(Exchange::IDisplayProperties, _displayProperties)
         INTERFACE_ENTRY(PluginHost::IDispatcher)
         END_INTERFACE_MAP
 
@@ -124,6 +127,7 @@ namespace Plugin {
         Exchange::IGraphicsProperties* _graphicsProperties;
         Exchange::IConnectionProperties* _connectionProperties;
         Exchange::IHDRProperties* _hdrProperties;
+        Exchange::IDisplayProperties* _displayProperties;
         Core::Sink<Notification> _notification;
     };
 


### PR DESCRIPTION
Reason for change: Adding HDMI source
properties to IConnectionProperties interface
Added properties
1. Colour space
2. Frame Rate
3. Colour depth
4. Quantization Range
5. Colorimetry
6. EOTF
Test Procedure: Check compilation of rdkservices
Risks: Low
Signed-off-by: Vinod Jacob <vinod_jacob@comcast.com>