### PR TITLE
RDKPI-424: WPEframework crashes when DisplayInfo plugin is enabled

### DIFF
--- a/DisplayInfo/CMakeLists.txt
+++ b/DisplayInfo/CMakeLists.txt
@@ -88,6 +88,12 @@ if (BUILD_BROADCOM)
         PRIVATE
             DeviceSettings/Broadcom/SoC_abstraction.cpp
     )
+elseif (BUILD_RASPBERRYPI)
+    target_sources(${MODULE_NAME}
+        PRIVATE
+	    #Dummy inclusion to prevent controller UI crash. This MUST be replaced with the proper implementation.
+            DeviceSettings/Broadcom/SoC_abstraction.cpp
+    )
 elseif (BUILD_REALTEK)
     target_sources(${MODULE_NAME}
         PRIVATE


### PR DESCRIPTION
Reason for change: Add dummy implementation to prevent WPEframework
from crashing when Controller UI is enabled and tries to get GPU RAM
statistics.
Test Procedure: Launch Controller UI. WPEFramework should not crash
Risks: Low

Signed-off-by: Simi Mathew <simim@tataelxsi.co.in>