### PR TITLE
RDKTV-1056: Handle additional FW upgrade exclusion scenarios in onFir…

### DIFF
--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -72,6 +72,8 @@ using namespace std;
 
 #define ZONEINFO_DIR "/usr/share/zoneinfo"
 
+#define STATUS_CODE_NO_SWUPDATE_CONF 460 
+
 /**
  * @struct firmwareUpdate
  * @brief This structure contains information of firmware update.
@@ -1034,22 +1036,49 @@ namespace WPEFramework {
             JsonObject params;
             params["status"] = httpStatus;
             params["responseString"] = responseString.c_str();
+            params["rebootImmediately"] = false;
 
-            int updateAvailableEnum = 0;
-            if (firmwareUpdateVersion.length() > 0) {
-                params["firmwareUpdateVersion"] = firmwareUpdateVersion.c_str();
-                if (firmwareUpdateVersion.compare(firmwareVersion)) {
-                    updateAvailableEnum = 0;
-                } else {
-                    updateAvailableEnum = 1;
-                }
-            } else {
-                params["firmwareUpdateVersion"] = "";
-                updateAvailableEnum = 2;
+            JsonObject xconfResponse;
+            if(!responseString.empty() && xconfResponse.FromString(responseString))
+            {
+                params["rebootImmediately"] = xconfResponse["rebootImmediately"];
             }
-            params["updateAvailable"] = !updateAvailableEnum ;
-            params["updateAvailableEnum"] = updateAvailableEnum;
-            params["success"] = success;
+
+            if(httpStatus == STATUS_CODE_NO_SWUPDATE_CONF)
+            {
+                // Empty /opt/swupdate.conf
+                params["status"] = 0;
+                params["updateAvailable"] = false;
+                params["updateAvailableEnum"] = static_cast<int>(FWUpdateAvailableEnum::EMPTY_SW_UPDATE_CONF);
+                params["success"] = true;
+            }
+            else if(httpStatus == 404)
+            {
+                // if XCONF server returns 404 there is no FW available to download
+                params["updateAvailable"] = false;
+                params["updateAvailableEnum"] = static_cast<int>(FWUpdateAvailableEnum::FW_MATCH_CURRENT_VER);
+                params["success"] = true;
+            }
+            else
+            {
+                FWUpdateAvailableEnum updateAvailableEnum = FWUpdateAvailableEnum::NO_FW_VERSION;
+                bool bUpdateAvailable = false;
+                if (firmwareUpdateVersion.length() > 0) {
+                    params["firmwareUpdateVersion"] = firmwareUpdateVersion.c_str();
+                    if (firmwareUpdateVersion.compare(firmwareVersion)) {
+                        updateAvailableEnum = FWUpdateAvailableEnum::FW_UPDATE_AVAILABLE;
+                        bUpdateAvailable = true;
+                    } else {
+                        updateAvailableEnum = FWUpdateAvailableEnum::FW_MATCH_CURRENT_VER;
+                    }
+                } else {
+                    params["firmwareUpdateVersion"] = "";
+                    updateAvailableEnum = FWUpdateAvailableEnum::NO_FW_VERSION;
+                }
+                params["updateAvailable"] = bUpdateAvailable ;
+                params["updateAvailableEnum"] = static_cast<int>(updateAvailableEnum);
+                params["success"] = success;
+            }
 
             string jsonLog;
             params.ToString(jsonLog);
@@ -1103,7 +1132,22 @@ namespace WPEFramework {
             string match = "http://";
             std::vector<std::pair<std::string, std::string>> fields;
 
-            string xconfOverride = getXconfOverrideUrl();
+            bool bFileExists = false;
+            string xconfOverride; 
+            if(env != "PROD")
+            {
+                xconfOverride = getXconfOverrideUrl(bFileExists);
+                if(bFileExists && xconfOverride.empty())
+                {
+                    // empty /opt/swupdate.conf. Don't initiate FW download
+                    LOGWARN("Empty /opt/swupdate.conf. Skipping FW upgrade check with xconf");
+                    if (_instance) {
+                        _instance->reportFirmwareUpdateInfoReceived("",
+                        STATUS_CODE_NO_SWUPDATE_CONF, true, "", response);
+                    }
+                    return;
+                }
+            }
             string fullCommand = (xconfOverride.empty()? URL_XCONF : xconfOverride);
             size_t start_pos = fullCommand.find(match);
             if (std::string::npos != start_pos) {

--- a/SystemServices/SystemServices.h
+++ b/SystemServices/SystemServices.h
@@ -99,6 +99,7 @@ namespace WPEFramework {
                 static const string MODEL_NAME;
                 static const string HARDWARE_ID;
 
+                enum class FWUpdateAvailableEnum { FW_UPDATE_AVAILABLE, FW_MATCH_CURRENT_VER, NO_FW_VERSION, EMPTY_SW_UPDATE_CONF };
                 // We do not allow this plugin to be copied !!
                 SystemServices(const SystemServices&) = delete;
                 SystemServices& operator=(const SystemServices&) = delete;

--- a/helpers/SystemServicesHelper.cpp
+++ b/helpers/SystemServicesHelper.cpp
@@ -383,22 +383,26 @@ bool findCaseInsensitive(std::string data, std::string toSearch, size_t pos)
 
 /***
  * @brief	: To retrieve Xconf version of URL to override
+ * @param1[out]	: bFileExists - Returns true if /opt/swupdate.conf is present
  * @return	: string
  */
-string getXconfOverrideUrl(void)
+string getXconfOverrideUrl(bool& bFileExists)
 {
     string xconfUrl = "";
     vector<string> lines;
+    bFileExists = false;
 
     if (!Utils::fileExists(XCONF_OVERRIDE_FILE)) {
         return xconfUrl;
     }
 
+    bFileExists = true;
+
     if (getFileContent(XCONF_OVERRIDE_FILE, lines)) {
         if (lines.size()) {
             for (int i = 0; i < (int)lines.size(); ++i) {
                 string line = lines.at(i);
-                if (!line.rfind("#", 0)) {
+                if (!line.empty() && (line[0] != '#')) {
                     xconfUrl = line;
                 }
             }

--- a/helpers/SystemServicesHelper.h
+++ b/helpers/SystemServicesHelper.h
@@ -223,9 +223,10 @@ bool findCaseInsensitive(std::string data, std::string toSearch, size_t pos = 0)
 
 /***
  * @brief	: To retrieve Xconf version of URL to override
+ * @param1[out]	: bFileExists - Returns true if /opt/swupdate.conf is present
  * @return	: string
  */
-string getXconfOverrideUrl(void);
+string getXconfOverrideUrl(bool& bFileExists);
 
 /***
  * @brief	: To retrieve TimeZone


### PR DESCRIPTION
…mwareUpdateInfoReceived

RDKTV-1056 : Handle additional FW upgrade exclusion scenarios

Handle additional FW upgrade exclusion scenarios in onFirmwareUpdateInfoReceived
a) if empty /opt/swupdate.conf is present, then ignore FW upgrade and don't reach out to xconf. Set updateAvailableEnum as 3 and updateAvailable as false in the response.
b) If Xconf returns 404 which can occur if device is in exclusion list, then set updateAvailableEnum as 1 and updateAvailable as false in the response.
c) Set rebootImmediately in the onFirmwareUpdateInfoReceived response.
d) These exclusions are not applicable for PROD builds.