### PR TITLE
RDK-30554: Thunder API for Set System Time

### DIFF
--- a/SystemServices/README.md
+++ b/SystemServices/README.md
@@ -321,6 +321,7 @@ Method | Request Payload | Response Payload
 | setPowerState | {"jsonrpc":"2.0","id":"38","method":"org.rdk.System.1.setPowerState","params":{"powerState":"ON", "standbyReason":"APIUnitTest"}} | {"jsonrpc":"2.0","id":38,"result":{"success":true}} |  
 | setPreferredStandbyMode | {"jsonrpc":"2.0","id":"39","method":"org.rdk.System.1.setPreferredStandbyMode","params":{"standbyMode":"DEEP_SLEEP"}} | {"jsonrpc":"2.0","id":39,"result":{"success":true}} |  
 | setTemperatureThresholds | {"jsonrpc":"2.0","id":"40","method":"org.rdk.System.1.setTemperatureThresholds","params":{"thresholds":{"WARN":"50.000000","MAX":"80.000000"}}} | {"jsonrpc":"2.0","id":40,"result":{"success":true}} |  
-| setTimeZoneDST | {"jsonrpc":"2.0","id":"41","method":"org.rdk.System.1.setTimeZoneDST","params":{"timeZone":"UTC-5"}} | {"jsonrpc":"2.0","id":41,"result":{"success":true}} |  
-| updateFirmware | {"jsonrpc":"2.0","id":"42","method":"org.rdk.System.1.updateFirmware","params":{}} | {"jsonrpc":"2.0","id":42,"result":{"success":true}} |  
+| setTimeZoneDST | {"jsonrpc":"2.0","id":"41","method":"org.rdk.System.1.setTimeZoneDST","params":{"timeZone":"UTC-5"}} | {"jsonrpc":"2.0","id":41,"result":{"success":true}} |
+| updateFirmware | {"jsonrpc":"2.0","id":"42","method":"org.rdk.System.1.updateFirmware","params":{}} | {"jsonrpc":"2.0","id":42,"result":{"success":true}} |
+| setTimeFromUser| {"jsonrpc":"2.0","id":"43","method":"org.rdk.System.1.setTimeFromUser","params":{"timestamp": "1994-11-06T08:49:37"}} |{"jsonrpc":"2.0","id":43,"result":{"success":true}} |
 </details>

--- a/SystemServices/SystemServices.h
+++ b/SystemServices/SystemServices.h
@@ -196,6 +196,7 @@ namespace WPEFramework {
                 uint32_t getMacAddresses(const JsonObject& parameters, JsonObject& response);
                 uint32_t setTimeZoneDST(const JsonObject& parameters, JsonObject& response);
                 uint32_t getTimeZoneDST(const JsonObject& parameters, JsonObject& response);
+                uint32_t setTimeFromUser(const JsonObject& parameters, JsonObject& response);
                 bool getZoneInfoZDump(std::string file, std::string &zoneInfo);
                 bool processTimeZones(std::string dir, JsonObject& out);
                 uint32_t getTimeZones(const JsonObject& parameters, JsonObject& response);


### PR DESCRIPTION
Reason for change: the need to set the time by the user
Implements: 	new method: setTimeFromUser, parameter: timestamp: string
Test Procedure: see the docs
Signed-off-by: Sergiy Gladkyy <sgladkyy@productengine.com>
Risks: None