### PR TITLE
Move gst_init() to GStreame thread to reduce startup time

### DIFF
--- a/TextToSpeech/impl/TTSSpeaker.cpp
+++ b/TextToSpeech/impl/TTSSpeaker.cpp
@@ -153,9 +153,9 @@ TTSSpeaker::TTSSpeaker(TTSConfiguration &config) :
     m_source(NULL),
     m_audioSink(NULL),
     m_audioVolume(NULL),
-    main_loop(NULL),
-    main_context(NULL),
-    main_loop_thread(NULL),
+    m_main_loop(NULL),
+    m_main_context(NULL),
+    m_main_loop_thread(NULL),
     m_pipelineError(false),
     m_networkError(false),
     m_runThread(true),
@@ -163,15 +163,17 @@ TTSSpeaker::TTSSpeaker(TTSConfiguration &config) :
     m_flushed(false),
     m_isEOS(false),
     m_ensurePipeline(false),
-    m_gstThread(new std::thread(GStreamerThreadFunc, this)),
     m_busWatch(0),
     m_duration(0),
     m_pipelineConstructionFailures(0),
     m_maxPipelineConstructionFailures(INT_FROM_ENV("MAX_PIPELINE_FAILURE_THRESHOLD", 1)) {
+
         setenv("GST_DEBUG", "2", 0);
-        if (!gst_is_initialized())
-            gst_init(NULL,NULL);
-        this->main_loop_thread = g_thread_new("BusWatch", (void* (*)(void*)) event_loop, this);
+        setenv("GST_REGISTRY_UPDATE", "no", 0);
+        setenv("GST_REGISTRY_FORK", "no", 0);
+
+        m_main_loop_thread = g_thread_new("BusWatch", (void* (*)(void*)) event_loop, this);
+        m_gstThread = new std::thread(GStreamerThreadFunc, this);
 }
 
 TTSSpeaker::~TTSSpeaker() {
@@ -186,9 +188,9 @@ TTSSpeaker::~TTSSpeaker() {
         m_gstThread = NULL;
     }
 
-    if(g_main_loop_is_running(this->main_loop))
-        g_main_loop_quit(this->main_loop);
-    g_thread_join(this->main_loop_thread);
+    if(g_main_loop_is_running(m_main_loop))
+        g_main_loop_quit(m_main_loop);
+    g_thread_join(m_main_loop_thread);
 }
 
 void TTSSpeaker::ensurePipeline(bool flag) {
@@ -715,15 +717,17 @@ void TTSSpeaker::speakText(TTSConfiguration config, SpeechData &data) {
 void TTSSpeaker::event_loop(void *data)
 {
     TTSSpeaker *speaker= (TTSSpeaker*) data;
-    speaker->main_context = g_main_context_new();
-    speaker->main_loop = g_main_loop_new(NULL, false);
-    g_main_loop_run(speaker->main_loop);
+    speaker->m_main_context = g_main_context_new();
+    speaker->m_main_loop = g_main_loop_new(NULL, false);
+    g_main_loop_run(speaker->m_main_loop);
 }
 
 void TTSSpeaker::GStreamerThreadFunc(void *ctx) {
+    TTSLOG_INFO("Starting GStreamerThread");
     TTSSpeaker *speaker = (TTSSpeaker*) ctx;
 
-    TTSLOG_INFO("Starting GStreamerThread");
+    if(!gst_is_initialized())
+        gst_init(NULL,NULL);
 
     while(speaker && speaker->m_runThread) {
         if(speaker->needsPipelineUpdate()) {

--- a/TextToSpeech/impl/TTSSpeaker.h
+++ b/TextToSpeech/impl/TTSSpeaker.h
@@ -150,13 +150,13 @@ private:
     inline void setSpeakingState(bool state, TTSSpeakerClient *client=NULL);
 
     // GStreamer Releated members
-    GstElement *m_pipeline;
-    GstElement *m_source;
-    GstElement *m_audioSink;
-    GstElement *m_audioVolume;
-    GMainLoop  *main_loop;
-    GMainContext *main_context;
-    GThread *main_loop_thread;
+    GstElement  *m_pipeline;
+    GstElement  *m_source;
+    GstElement  *m_audioSink;
+    GstElement  *m_audioVolume;
+    GMainLoop   *m_main_loop;
+    GMainContext *m_main_context;
+    GThread     *m_main_loop_thread;
     bool        m_pipelineError;
     bool        m_networkError;
     bool        m_runThread;


### PR DESCRIPTION
Cherry-picking change 0da11891f3b8c1c7c3d9da51af1dd172ee081d0d from sprint/2101 (https://github.com/rdkcentral/rdkservices/pull/479)