### PR TITLE
DELIA-48264: getSupportedAudioModes returns empty

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -743,7 +743,7 @@ namespace WPEFramework {
         uint32_t DisplaySettings::getSupportedAudioModes(const JsonObject& parameters, JsonObject& response)
         {   //sample response: {"success":true,"supportedAudioModes":["STEREO","PASSTHRU","AUTO (Dolby Digital 5.1)"]}
             LOGINFOMETHOD();
-            string audioPort = parameters["audioPort"].String();
+            string audioPort = parameters.HasLabel("audioPort") ? parameters["audioPort"].String() : "";
             vector<string> supportedAudioModes;
             try
             {


### PR DESCRIPTION
Reason for change:
getSupportedAudioModes_returns_empty
fix
Test Procedure: None
Risks: Low

Change-Id: Ib5fe3d6d69a7dede60344b845d3ebd27bb238389
Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>