### PR TITLE
RDKTV-1440: Fix crash while destructing std::thread objects in System…

### DIFF
--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -386,6 +386,12 @@ namespace WPEFramework {
 
         SystemServices::~SystemServices()
         {
+            if (thread_getMacAddresses.joinable())
+                thread_getMacAddresses.join();
+
+            if( m_getFirmwareInfoThread.joinable())
+                m_getFirmwareInfoThread.join();
+                
             SystemServices::_instance = nullptr;
         }
 


### PR DESCRIPTION
… Plugin.

Wait for all the std::thread objects to join before destructing System Plugin to avoid std::terminate.