### PR TITLE
XRE-16865: Correct the  implementation of Graphics related properties

### DIFF
--- a/DisplayInfo/CMakeLists.txt
+++ b/DisplayInfo/CMakeLists.txt
@@ -64,6 +64,34 @@ if (USE_DEVICESETTINGS)
         PRIVATE
             DeviceSettings/PlatformImplementation.cpp
             ../helpers/utils.cpp)
+
+    if (GRAPHICS_APIS_IMPLEMENTED_IN_DS_HAL)
+        add_definitions("-DGRAPHICS_APIS_IMPLEMENTED_IN_DS_HAL=1")
+    elseif(BUILD_BROADCOM)
+        target_sources(${MODULE_NAME}
+            PRIVATE
+                DeviceSettings/Broadcom/SoC_abstraction.cpp
+        )
+    elseif (BUILD_RASPBERRYPI)
+        target_sources(${MODULE_NAME}
+            PRIVATE
+            #Dummy inclusion to prevent controller UI crash. This MUST be replaced with the proper implementation.
+                DeviceSettings/Broadcom/SoC_abstraction.cpp
+        )
+    elseif (BUILD_REALTEK)
+        target_sources(${MODULE_NAME}
+            PRIVATE
+                DeviceSettings/Realtek/SoC_abstraction.cpp
+                DeviceSettings/Realtek/kms.c
+        )
+    elseif (BUILD_AMLOGIC)
+        target_sources(${MODULE_NAME}
+            PRIVATE
+                DeviceSettings/Amlogic/SoC_abstraction.cpp
+                DeviceSettings/Amlogic/kms.c
+        )
+    endif ()
+
 elseif (NXCLIENT_FOUND AND NEXUS_FOUND)
     target_sources(${MODULE_NAME}
         PRIVATE
@@ -81,31 +109,6 @@ elseif (BCM_HOST_FOUND)
             BCM_HOST::BCM_HOST)
 else ()
     message(FATAL_ERROR "There is no graphic backend for display info plugin")
-endif ()
-
-if (BUILD_BROADCOM)
-    target_sources(${MODULE_NAME}
-        PRIVATE
-            DeviceSettings/Broadcom/SoC_abstraction.cpp
-    )
-elseif (BUILD_RASPBERRYPI)
-    target_sources(${MODULE_NAME}
-        PRIVATE
-	    #Dummy inclusion to prevent controller UI crash. This MUST be replaced with the proper implementation.
-            DeviceSettings/Broadcom/SoC_abstraction.cpp
-    )
-elseif (BUILD_REALTEK)
-    target_sources(${MODULE_NAME}
-        PRIVATE
-            DeviceSettings/Realtek/SoC_abstraction.cpp
-            DeviceSettings/Realtek/kms.c
-    )
-elseif (BUILD_AMLOGIC)
-    target_sources(${MODULE_NAME}
-        PRIVATE
-            DeviceSettings/Amlogic/SoC_abstraction.cpp
-            DeviceSettings/Amlogic/kms.c
-    )
 endif ()
 
 install(TARGETS ${MODULE_NAME}

--- a/DisplayInfo/DeviceSettings/PlatformImplementation.cpp
+++ b/DisplayInfo/DeviceSettings/PlatformImplementation.cpp
@@ -18,7 +18,10 @@
  */
 #include "../Module.h"
 #include "../DisplayInfoTracing.h"
+
+#ifndef GRAPHICS_APIS_IMPLEMENTED_IN_DS_HAL
 #include "SoC_abstraction.h"
+#endif
 
 #include <interfaces/IDisplayInfo.h>
 
@@ -90,14 +93,40 @@ public:
     uint32_t TotalGpuRam(uint64_t& total) const override
     {
         LOGINFO();
-        total = SoC_GetTotalGpuRam(); // TODO: Implement using DeviceSettings
-        return (Core::ERROR_NONE);
+        uint32_t ret = Core::ERROR_NONE;
+#ifdef GRAPHICS_APIS_IMPLEMENTED_IN_DS_HAL
+        try
+        {
+            total = device::Host::getInstance().getTotalSystemGraphicsMemory();
+        }
+        catch (const device::Exception& err)
+        {
+            TRACE(Trace::Error, (_T("Exception during DeviceSetting library call. code = %d message = %s"), err.getCode(), err.what()));
+            ret = Core::ERROR_GENERAL;
+        }
+#else
+        total = SoC_GetTotalGpuRam();
+#endif
+        return (ret);
     }
     uint32_t FreeGpuRam(uint64_t& free ) const override
     {
         LOGINFO();
-        free = SoC_GetFreeGpuRam(); // TODO: Implement using DeviceSettings
-        return (Core::ERROR_NONE);
+        uint32_t ret = Core::ERROR_NONE;
+#ifdef GRAPHICS_APIS_IMPLEMENTED_IN_DS_HAL
+        try
+        {
+            free = device::Host::getInstance().getFreeSystemGraphicsMemory();
+        }
+        catch (const device::Exception& err)
+        {
+            TRACE(Trace::Error, (_T("Exception during DeviceSetting library call. code = %d message = %s"), err.getCode(), err.what()));
+            ret = Core::ERROR_GENERAL;
+        }
+#else
+        free = SoC_GetFreeGpuRam();
+#endif
+        return (ret);
     }
 
     // Connection Properties interface
@@ -213,13 +242,43 @@ public:
     uint32_t Width(uint32_t& value) const override
     {
         LOGINFO();
+        uint32_t ret = Core::ERROR_NONE;
+#ifdef GRAPHICS_APIS_IMPLEMENTED_IN_DS_HAL
+        uint32_t height, width;
+        try
+        {
+            device::Host::getInstance().getSystemGraphicsResolution(height, width);
+            value = width;
+        }
+        catch (const device::Exception& err)
+        {
+            TRACE(Trace::Error, (_T("Exception during DeviceSetting library call. code = %d message = %s"), err.getCode(), err.what()));
+            ret = Core::ERROR_GENERAL;
+        }
+#else
         value = SoC_GetGraphicsWidth();
-        return (Core::ERROR_NONE);
+#endif
+        return (ret);
     }
     uint32_t Height(uint32_t& value) const override
     {
         LOGINFO();
+        uint32_t ret = Core::ERROR_NONE;
+#ifdef GRAPHICS_APIS_IMPLEMENTED_IN_DS_HAL
+        uint32_t height, width;
+        try
+        {
+            device::Host::getInstance().getSystemGraphicsResolution(height, width);
+            value = height;
+        }
+        catch (const device::Exception& err)
+        {
+            TRACE(Trace::Error, (_T("Exception during DeviceSetting library call. code = %d message = %s"), err.getCode(), err.what()));
+            ret = Core::ERROR_GENERAL;
+        }
+#else
         value = SoC_GetGraphicsHeight();
+#endif
         return (Core::ERROR_NONE);
     }
     uint32_t VerticalFreq(uint32_t& value) const override


### PR DESCRIPTION
Reason for change: We must make use of DS lib API
to fetch values from Platform in all cases where
functioning DS Lib API is existing.
The DS HAL implementation for Braodcom for
Graphics related properties have been implemented
as part of XRE-16610 & XRE-16627. Therefore make arrisXi6
rely on these for the implementation of
1. totalgpuram
2. freegpuram
3. height
4. width
Test Procedure: use curl commands
Risks: None
Signed-off-by: Vinod Jacob <vinod_jacob@comcast.com>