### PR TITLE
RDK-30205 : System API: getLastFirmwareFailureReason

### DIFF
--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -383,6 +383,7 @@ namespace WPEFramework {
 	    registerMethod(_T("getWakeupReason"),&SystemServices::getWakeupReason, this, {2});
 #endif
             registerMethod("uploadLogs", &SystemServices::uploadLogs, this, {2});
+            registerMethod("getLastFirmwareFailureReason", &SystemServices::getLastFirmwareFailureReason, this, {2});
         }
 
 
@@ -3398,6 +3399,36 @@ namespace WPEFramework {
 #endif
 
             returnResponse(success);
+        }
+
+        uint32_t SystemServices::getLastFirmwareFailureReason(const JsonObject& parameters, JsonObject& response)
+        {
+            bool retStatus = true;
+            FwFailReason failReason = FwFailReasonNone;
+
+            std::vector<string> lines;
+            if (getFileContent(FWDNLDSTATUS_FILE_NAME, lines)) {
+                std::string str;
+                for (auto i = lines.begin(); i != lines.end(); ++i) {
+                    std::smatch m;
+                    if (std::regex_match(*i, m, std::regex("^FailureReason\\|(.*)$"))) {
+                        str = m.str(1);
+                    }
+                }
+
+                LOGINFO("Lines read:%d. FailureReason|%s", (int) lines.size(), C_STR(str));
+
+                auto it = FwFailReasonFromText.find(str);
+                if (it != FwFailReasonFromText.end())
+                    failReason = it->second;
+                else
+                    LOGWARN("Unrecognised FailureReason!");
+            } else {
+                LOGINFO("Could not read file %s", FWDNLDSTATUS_FILE_NAME);
+            }
+
+            response["failReason"] = FwFailReasonToText.at(failReason);
+            returnResponse(retStatus);
         }
     } /* namespace Plugin */
 } /* namespace WPEFramework */

--- a/SystemServices/SystemServices.h
+++ b/SystemServices/SystemServices.h
@@ -231,6 +231,7 @@ namespace WPEFramework {
                 uint32_t setFirmwareRebootDelay(const JsonObject& parameters, JsonObject& response);
                 uint32_t setFirmwareAutoReboot(const JsonObject& parameters, JsonObject& response);
                 uint32_t uploadLogs(const JsonObject& parameters, JsonObject& response);
+                uint32_t getLastFirmwareFailureReason(const JsonObject& parameters, JsonObject& response);
         }; /* end of system service class */
     } /* end of plugin */
 } /* end of wpeframework */

--- a/helpers/SystemServicesHelper.h
+++ b/helpers/SystemServicesHelper.h
@@ -293,5 +293,47 @@ void removeCharsFromString(string &str, const char* charsToRemove);
  */
 size_t curl_write(void *ptr, size_t size, size_t nmemb, void *stream);
 
+enum FwFailReason
+{
+    FwFailReasonNone = 0,
+    FwFailReasonNetworkFailure,
+    FwFailReasonServerUnreachable,
+    FwFailReasonCorruptDownloadFile,
+    FwFailReasonFailureInFlashWrite,
+    FwFailReasonUpgradeFailedAfterFlashWrite,
+};
+
+static const std::map<FwFailReason, string> FwFailReasonToText =
+        {
+                {FwFailReasonNone, "None"},
+                {FwFailReasonNetworkFailure, "Network failure"},
+                {FwFailReasonServerUnreachable, "Server unreachable"},
+                {FwFailReasonCorruptDownloadFile, "Corrupt download file"},
+                {FwFailReasonFailureInFlashWrite, "Failure in flash write"},
+                {FwFailReasonUpgradeFailedAfterFlashWrite, "Upgrade failed after flash write"},
+        };
+
+static const std::map<string, FwFailReason> FwFailReasonFromText =
+        {
+                {"ESTB Download Failure", FwFailReasonServerUnreachable},
+                {"Image Download Failed - Unable to connect", FwFailReasonNetworkFailure},
+                {"Image Download Failed - Server not Found", FwFailReasonNetworkFailure},
+                {"Image Download Failed - Error response from server", FwFailReasonServerUnreachable},
+                {"Image Download Failed - Unknown", FwFailReasonServerUnreachable},
+                {"Image download failed from server", FwFailReasonServerUnreachable}, // firmwareDwnld.sh only
+                {"RCDL Upgrade Failed", FwFailReasonFailureInFlashWrite},
+                {"ECM trigger failed", FwFailReasonFailureInFlashWrite},
+                {"Failed in flash write", FwFailReasonFailureInFlashWrite},
+                {"Flashing failed", FwFailReasonFailureInFlashWrite}, // userInitiatedFWDnld.sh only
+                {"Versions Match", FwFailReasonNone}, // XConf
+                {"Cloud FW Version is empty", FwFailReasonNone}, // XConf
+                {"Cloud FW Version is invalid", FwFailReasonNone}, // XConf
+                {"Invalid Request", FwFailReasonNone}, // XConf
+                {"Network Communication Error", FwFailReasonNone}, // XConf
+                {"Previous Upgrade In Progress", FwFailReasonNone}, // firmwareDwnld.sh only
+                {"Empty image name from CDL server", FwFailReasonNone}, // firmwareDwnld.sh only
+                {"Upgrade failed after flash write", FwFailReasonUpgradeFailedAfterFlashWrite},
+        };
+
 #endif /* __SYSTEM_SERVICE_HELPER_H__ */
 


### PR DESCRIPTION
Reason for change: Implement new api
Test Procedure: Activate System, call
getLastFirmwareFailureReason
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>