### PR TITLE
RDKTV-1457-POLL_THREAD_STATE log spew in wpeframework.log

### DIFF
--- a/helpers/utils.h
+++ b/helpers/utils.h
@@ -41,7 +41,7 @@
 #define UNUSED(expr)(void)(expr)
 #define C_STR(x) (x).c_str()
 
-#define LOGINFO(fmt, ...) do { fprintf(stderr, "[%d] INFO [%s:%d] %s: " fmt "\n", (int)syscall(SYS_gettid), Core::FileNameOnly(__FILE__), __LINE__, __FUNCTION__, ##__VA_ARGS__); fflush(stderr); } while (0)
+#define LOGINFO(fmt, ...)
 #define LOGWARN(fmt, ...) do { fprintf(stderr, "[%d] WARN [%s:%d] %s: " fmt "\n", (int)syscall(SYS_gettid), Core::FileNameOnly(__FILE__), __LINE__, __FUNCTION__, ##__VA_ARGS__); fflush(stderr); } while (0)
 #define LOGERR(fmt, ...) do { fprintf(stderr, "[%d] ERROR [%s:%d] %s: " fmt "\n", (int)syscall(SYS_gettid), Core::FileNameOnly(__FILE__), __LINE__, __FUNCTION__, ##__VA_ARGS__); fflush(stderr); Utils::Telemetry::sendError(fmt, ##__VA_ARGS__); } while (0)
 


### PR DESCRIPTION
Reason for change: Disable the LOGINFO from utils.h because wpeframework.log was growing at a rate of 1.5-2MB every hour
Test Procedure: needs to validate in arris xi6