### PR TITLE
OCIContainer: Add environment variables at container startup

### DIFF
--- a/OCIContainer/CMakeLists.txt
+++ b/OCIContainer/CMakeLists.txt
@@ -1,3 +1,21 @@
+# If not stated otherwise in this file or this component's license file the
+# following copyright and licenses apply:
+#
+# Copyright 2021 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 set(PLUGIN_NAME OCIContainer)
 set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
 
@@ -7,6 +25,18 @@ find_package(Dobby REQUIRED CONFIG)
 
 # Temporary fix to get defines in Dobby. Will be removed later.
 add_definitions( -DRDK )
+
+# Set default Dobby dbus service to org.rdk.dobby and add defines
+set( DOBBY_SERVICE "org.rdk.dobby" CACHE STRING "Dobby dbus service name")
+if(NOT DOBBY_SERVICE STREQUAL "org.rdk.dobby")
+    add_definitions( -DDOBBY_SERVICE_OVERRIDE="${DOBBY_SERVICE}")
+endif()
+
+# Set default Dobby dbus object path to /org/rdk/dobby and add defines
+set( DOBBY_OBJECT "/org/rdk/dobby" CACHE STRING "Dobby dbus object path")
+if(NOT DOBBY_OBJECT STREQUAL "/org/rdk/dobby")
+    add_definitions( -DDOBBY_OBJECT_OVERRIDE="${DOBBY_OBJECT}")
+endif()
 
 add_library(${MODULE_NAME} SHARED
         OCIContainer.cpp

--- a/OCIContainer/Module.cpp
+++ b/OCIContainer/Module.cpp
@@ -1,3 +1,22 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2020 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
 #include "Module.h"
 
 MODULE_NAME_DECLARATION(BUILD_REFERENCE)

--- a/OCIContainer/Module.h
+++ b/OCIContainer/Module.h
@@ -1,3 +1,22 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2020 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
 #pragma once
 #ifndef MODULE_NAME
 #define MODULE_NAME OCIContainer

--- a/OCIContainer/OCIContainer.cpp
+++ b/OCIContainer/OCIContainer.cpp
@@ -1,8 +1,26 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2021 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
 #include "OCIContainer.h"
 
 #include <Dobby/DobbyProxy.h>
 #include <Dobby/IpcService/IpcFactory.h>
-
 
 namespace WPEFramework
 {
@@ -65,6 +83,15 @@ const string OCIContainer::Initialize(PluginHost::IShell *service)
     // Create a DobbyProxy remote service that wraps up the dbus API
     // calls to the Dobby daemon
     mDobbyProxy = std::make_shared<DobbyProxy>(mIpcService, DOBBY_SERVICE, DOBBY_OBJECT);
+
+    if (mDobbyProxy->isAlive())
+    {
+        LOGINFO("Dobby Daemon is alive and connected (%s, %s)", DOBBY_SERVICE, DOBBY_OBJECT);
+    }
+    else
+    {
+        LOGWARN("Dobby daemon is not currently available");
+    }
 
     // Register a state change event listener
     mEventListenerId = mDobbyProxy->registerListener(stateListener, static_cast<const void*>(this));
@@ -241,6 +268,7 @@ uint32_t OCIContainer::startContainer(const JsonObject &parameters, JsonObject &
     std::string bundlePath = parameters["bundlePath"].String();
     std::string command = parameters["command"].String();
     std::string westerosSocket = parameters["westerosSocket"].String();
+    JsonArray envVars = parameters["envvar"].Array();
 
     // Can be used to pass file descriptors to container construction.
     // Currently unsupported, see DobbyProxy::startContainerFromBundle().
@@ -248,7 +276,7 @@ uint32_t OCIContainer::startContainer(const JsonObject &parameters, JsonObject &
 
     int descriptor;
     // If no additional arguments, start the container
-    if ((command == "null" || command.empty()) && (westerosSocket == "null" || westerosSocket.empty()))
+    if ((command == "null" || command.empty()) && (westerosSocket == "null" || westerosSocket.empty()) && envVars.Length() == 0)
     {
         descriptor = mDobbyProxy->startContainerFromBundle(id, bundlePath, emptyList);
     }
@@ -263,7 +291,29 @@ uint32_t OCIContainer::startContainer(const JsonObject &parameters, JsonObject &
         {
             westerosSocket = "";
         }
-        descriptor = mDobbyProxy->startContainerFromBundle(id, bundlePath, emptyList, command, westerosSocket);
+
+        // Convert the JsonArray to a vector of strings Dobby can work with
+        std::vector<std::string> envVarVector = std::vector<std::string>();
+
+        // If no envvars, just give Dobby the empty vector
+        if (envVars.Length() > 0)
+        {
+            JsonArray::Iterator index(envVars.Elements());
+            while (index.Next())
+            {
+                if (Core::JSON::Variant::type::STRING == index.Current().Content())
+                {
+                    //JSON::String s = index.Current().String();
+                    envVarVector.push_back(index.Current().String());
+                }
+                else
+                {
+                    LOGWARN("Unexpected variant type");
+                }
+            }
+        }
+
+        descriptor = mDobbyProxy->startContainerFromBundle(id, bundlePath, emptyList, command, westerosSocket, envVarVector);
     }
 
     // startContainer returns -1 on failure
@@ -298,6 +348,7 @@ uint32_t OCIContainer::startContainerFromDobbySpec(const JsonObject &parameters,
     JsonObject dobbySpec = parameters["dobbySpec"].Object();
     std::string command = parameters["command"].String();
     std::string westerosSocket = parameters["westerosSocket"].String();
+    JsonArray envVars = parameters["envvar"].Array();
 
     std::string specString;
     if (!WPEFramework::Core::JSON::IElement::ToString(dobbySpec, specString))
@@ -312,7 +363,7 @@ uint32_t OCIContainer::startContainerFromDobbySpec(const JsonObject &parameters,
 
     int descriptor;
     // If no additional arguments, start the container
-    if ((command == "null" || command.empty()) && (westerosSocket == "null" || westerosSocket.empty()))
+    if ((command == "null" || command.empty()) && (westerosSocket == "null" || westerosSocket.empty()) && envVars.Length() == 0)
     {
         descriptor = mDobbyProxy->startContainerFromSpec(id, specString, emptyList);
     }
@@ -327,7 +378,29 @@ uint32_t OCIContainer::startContainerFromDobbySpec(const JsonObject &parameters,
         {
             westerosSocket = "";
         }
-        descriptor = mDobbyProxy->startContainerFromSpec(id, specString, emptyList, command, westerosSocket);
+
+        // Convert the JsonArray to a vector of strings Dobby can work with
+        std::vector<std::string> envVarVector = std::vector<std::string>();
+
+        // If no envvars, just give Dobby the empty vector
+        if (envVars.Length() > 0)
+        {
+            JsonArray::Iterator index(envVars.Elements());
+            while (index.Next())
+            {
+                if (Core::JSON::Variant::type::STRING == index.Current().Content())
+                {
+                    //JSON::String s = index.Current().String();
+                    envVarVector.push_back(index.Current().String());
+                }
+                else
+                {
+                    LOGWARN("Unexpected variant type");
+                }
+            }
+        }
+
+        descriptor = mDobbyProxy->startContainerFromSpec(id, specString, emptyList, command, westerosSocket, envVarVector);
     }
 
     // startContainer returns -1 on failure

--- a/OCIContainer/OCIContainer.h
+++ b/OCIContainer/OCIContainer.h
@@ -1,3 +1,22 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2021 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
 #pragma once
 
 #include "Module.h"

--- a/OCIContainer/README.md
+++ b/OCIContainer/README.md
@@ -112,6 +112,7 @@ Starts a new container from an existing OCI bundle.
 | bundlePath     | string | Path to the OCI bundle containing the rootfs and config to use to create the container     |
 | command        | string | Custom command to run inside the container, overriding the command in the container config |
 | westerosSocket | string | Path to a westeros socket to mount inside the container                                    |
+| envvar         | array  | Array of environment variables (`["FOO=BAR"`]) to add to the container                      |
 ---
 
 ### Response


### PR DESCRIPTION
* Allow adding environment variables into container dynamically at container startup
* Check daemon is alive when starting plugin
* Allow changing dbus service/object from default to use different values for Sky builds

Requires accompanying PR in Dobby to be merged