### PR TITLE
FETCHTV-13: org.rdk.DisplaySettings.1.setScartParameter curl command …

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -2314,7 +2314,7 @@ namespace WPEFramework {
             returnIfParamNotFound(parameters, "scartParameterData");
 
             string sScartParameter = parameters["scartParameter"].String();
-            string sScartParameterData = parameters["cartParameterData"].String();
+            string sScartParameterData = parameters["scartParameterData"].String();
 
             bool success = true;
             try


### PR DESCRIPTION
Executing the "org.rdk.DisplaySettings.1.setScartParameter" gives the following error Destined invoke failed. scartParameterData parameter not found.