### PR TITLE
RDKTV-1785:[Platco]Audio ports getting enabled even in boot to Standb…

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -284,7 +284,6 @@ namespace WPEFramework {
             LOGINFO("Starting the timer");
             m_timer.start(RECONNECTION_TIME_IN_MILLISECONDS);
 
-            InitAudioPorts();
 
             // On success return empty, to indicate there is no error text.
             return (string());
@@ -312,6 +311,7 @@ namespace WPEFramework {
                 IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_HOTPLUG, dsHdmiEventHandler) );
 		IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_IN_HOTPLUG, dsHdmiEventHandler) );
                 IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_AUDIO_OUT_HOTPLUG, dsHdmiEventHandler) );
+		IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_PWRMGR_NAME, IARM_BUS_PWRMGR_EVENT_MODECHANGED, powerEventHandler) );
             }
 
             try
@@ -340,6 +340,7 @@ namespace WPEFramework {
                 IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_HOTPLUG) );
 		IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_IN_HOTPLUG) );
                 IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_AUDIO_OUT_HOTPLUG) );
+		IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_PWRMGR_NAME, IARM_BUS_PWRMGR_EVENT_MODECHANGED) );
             }
 
 
@@ -573,6 +574,30 @@ namespace WPEFramework {
             default:
                 //do nothing
                 break;
+            }
+        }
+
+	void DisplaySettings::powerEventHandler(const char *owner, IARM_EventId_t eventId,
+                void *data, size_t len)
+        {
+
+            if(!DisplaySettings::_instance)
+                return;
+
+            switch (eventId) {
+                case  IARM_BUS_PWRMGR_EVENT_MODECHANGED:
+                    {
+                        IARM_Bus_PWRMgr_EventData_t *eventData = (IARM_Bus_PWRMgr_EventData_t *)data;
+			LOGINFO("Event IARM_BUS_PWRMGR_EVENT_MODECHANGED: State Changed %d -- > %d\r",
+                            eventData->data.state.curState, eventData->data.state.newState);
+
+                        if(eventData->data.state.newState == IARM_BUS_PWRMGR_POWERSTATE_ON) {
+                                DisplaySettings::_instance->InitAudioPorts();
+                        }
+                    }
+                    break;
+
+                default: break;
             }
         }
 

--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -142,6 +142,7 @@ namespace WPEFramework {
             static void ResolutionPostChange(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
             static void DisplResolutionHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
             static void dsHdmiEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
+	     static void powerEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
             void getConnectedVideoDisplaysHelper(std::vector<string>& connectedDisplays);
             bool checkPortName(std::string& name) const;
 


### PR DESCRIPTION
RDKTV-1785:[Platco]Audio ports getting enabled even in boot to Standby mode

Reason for change: Even though pwrMgr disables the audio port during boot to standby,
Audio ports were getting enabled from DisplaySetting thunder plugin activation.
Audioports will not get enabled from DisplaySetting plugin activation but from power state
transition to ON.
Test Procedure: Verify all audio ports work after powerstate transition to ON.
Risks: Low
Signed-off-by: Tony Paul <Tony_Paul@comcast.com>