### PR TITLE
RDK-30083: USB Firmware Update event

### DIFF
--- a/UsbAccess/CMakeLists.txt
+++ b/UsbAccess/CMakeLists.txt
@@ -8,15 +8,18 @@ find_package(PkgConfig)
 add_library(${MODULE_NAME} SHARED
         UsbAccess.cpp
         Module.cpp
+        ../helpers/utils.cpp
 )
 
 set_target_properties(${MODULE_NAME} PROPERTIES
         CXX_STANDARD 11
         CXX_STANDARD_REQUIRED YES)
 
-target_include_directories(${MODULE_NAME} PRIVATE ../helpers)
+find_package(IARMBus REQUIRED)
 
-target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins)
+target_include_directories(${MODULE_NAME} PRIVATE ../helpers ${IARMBUS_INCLUDE_DIRS})
+
+target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins ${IARMBUS_LIBRARIES})
 
 install(TARGETS ${MODULE_NAME}
         DESTINATION lib/${STORAGE_DIRECTORY}/plugins)

--- a/UsbAccess/UsbAccess.h
+++ b/UsbAccess/UsbAccess.h
@@ -16,6 +16,10 @@ namespace WPEFramework {
             virtual void Deinitialize(PluginHost::IShell* service) override;
             virtual string Information() const override;
 
+            void InitializeIARM();
+            void DeinitializeIARM();
+            void onUSBFirmwareUpdate(const char *status);
+
         public/*members*/:
             static UsbAccess* _instance;
 
@@ -28,6 +32,7 @@ namespace WPEFramework {
             static const string METHOD_CREATE_LINK;
             static const string METHOD_CLEAR_LINK;
             //events
+            static const string EVT_ON_USB_FIRMWARE_UPDATE;
             //other
             static const string LINK_URL_HTTP;
             static const string LINK_PATH;


### PR DESCRIPTION
Reason for change: Fire event about update progress
Test Procedure: Thunder UsbAccess API,
event onUSBFirmwareUpdate
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>