### PR TITLE
DELIA-48778 : Fix JsonArray Usage CS and RAMs Thunder plugins

### DIFF
--- a/ControlService/ControlService.cpp
+++ b/ControlService/ControlService.cpp
@@ -1137,7 +1137,7 @@ namespace WPEFramework {
         // Begin private method implementations
         StatusCode ControlService::getAllRemoteData(JsonObject& response)
         {
-            JObjectArray    infoArray;
+            JsonArray    infoArray;
 
             // The STB data items are directly part of the response - not nested.
             if (!getRf4ceStbData(response))
@@ -1160,7 +1160,7 @@ namespace WPEFramework {
                 {
                     infoArray.Add(m_remoteInfo[i]);
                 }
-                response["remoteData"] = JsonValue(infoArray);
+                response["remoteData"] = infoArray;
             }
 
             return STATUS_OK;

--- a/RemoteActionMapping/RemoteActionMapping.cpp
+++ b/RemoteActionMapping/RemoteActionMapping.cpp
@@ -1092,7 +1092,7 @@ namespace WPEFramework {
             }
 
             mappings = getFullKeyActionMapping(deviceID, keymapType);
-            response["keyMappings"] = JsonValue(mappings);
+            response["keyMappings"] = mappings;
 
             status_code = ((mappings.Length() > 0) ? STATUS_OK : STATUS_FAILURE);
 

--- a/RemoteActionMapping/test/ramTestClient.cpp
+++ b/RemoteActionMapping/test/ramTestClient.cpp
@@ -696,7 +696,7 @@ int main(int argc, char** argv)
                                             tvIRKeyCode.Add(JsonValue(currentTVIRData[i][j]));
                                         }
                                     }
-                                    keyMap["tvIRKeyCode"] = JsonValue(tvIRKeyCode);
+                                    keyMap["tvIRKeyCode"] = tvIRKeyCode;
 
                                     if ((currentAVRIRData != NULL) && (currentAVRIRData[i].size() > 1))
                                     {
@@ -705,11 +705,11 @@ int main(int argc, char** argv)
                                             avrIRKeyCode.Add(JsonValue(currentAVRIRData[i][j]));
                                         }
                                     }
-                                    keyMap["avrIRKeyCode"] = JsonValue(avrIRKeyCode);
+                                    keyMap["avrIRKeyCode"] = avrIRKeyCode;
 
                                     array.Add(keyMap);
                                 }
-                                params["keyActionMapping"] = JsonValue(array);
+                                params["keyActionMapping"] = array;
 
                                 ret = remoteObject->Invoke<JsonObject, JsonObject>(1000,
                                                     _T("setKeyActionMapping"), params, result);


### PR DESCRIPTION
Reason for change: These arrays could cause failures or crashes in CS and RAMS thunder plugins.
Test Procedure: Verify CS getAllRemoteData, RAMs setKeyActionMapping and getFullKeyActionMapping APIs.
Risks: None.
Signed-off-by: jschmidt <Jeff_Schmidt@cable.comcast>