### PR TITLE
RDKTV-1805 Check driver is initialized before sending the message

### DIFF
--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -609,7 +609,7 @@ namespace WPEFramework
                 return;
 
             if (strcmp(owner, IARM_BUS_PWRMGR_NAME)  == 0) {
-                if (eventId == IARM_BUS_PWRMGR_EVENT_MODECHANGED && 1 == libcecInitStatus) {
+                if (eventId == IARM_BUS_PWRMGR_EVENT_MODECHANGED && libcecInitStatus >= 1) {
                     IARM_Bus_PWRMgr_EventData_t *param = (IARM_Bus_PWRMgr_EventData_t *)data;
                     LOGINFO("Event IARM_BUS_PWRMGR_EVENT_MODECHANGED: State Changed %d -- > %d\r",
                             param->data.state.curState, param->data.state.newState);


### PR DESCRIPTION
Reason for change: Without driver initialization trying to send the cec message causes the crash
Test Procedure: Wake up the TV and see if it take long time and any WPEframework crash observed
Risks: Low

Signed-off-by: sputhi200 <Sujeesh_Puthiya@comcast.com>