### PR TITLE
HP40A-898: empty network interface fix

### DIFF
--- a/amlogic.cmake
+++ b/amlogic.cmake
@@ -128,6 +128,10 @@ if (BUILD_LLAMA)
     add_definitions (-DPLUGIN_STATEOBSERVER)
 endif()
 
+if (BUILD_AML_STB)
+    add_definitions(-DNET_DEFINED_INTERFACES_ONLY)
+endif()
+
 if(SCREEN_CAPTURE)
     if(NOT DISABLE_SCREEN_CAPTURE)
 	    message("Yocto AMLOGIC build: Building Amlogic specific screen capturing")


### PR DESCRIPTION
Reason for change: We have two wifi interfaces and second interface details are coming as empty. Fix logic is enable the build flag to filter out unsupported interfaces.
Test Procedure: Please see ticket for details.
Risks: Low
Signed-off-by: Arun Madhavan <Arun_Madhavan@comcast.com>