### PR TITLE
RDKTV-1785 and RDKTV-1999 Disable audio ports on bootup

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -38,8 +38,10 @@
 #include "dsError.h"
 #include "list.hpp"
 #include "libIBus.h"
+#include "libIBusDaemon.h"
 #include "dsDisplay.h"
 #include "rdk/iarmmgrs-hal/pwrMgr.h"
+#include "pwrMgr.h"
 
 #include "tr181api.h"
 
@@ -127,6 +129,7 @@ namespace WPEFramework {
         SERVICE_REGISTRATION(DisplaySettings, 1, 0);
 
         DisplaySettings* DisplaySettings::_instance = nullptr;
+        IARM_Bus_PWRMgr_PowerState_t DisplaySettings::m_powerState = IARM_BUS_PWRMGR_POWERSTATE_STANDBY;
 
         DisplaySettings::DisplaySettings()
             : AbstractPlugin()
@@ -289,7 +292,14 @@ namespace WPEFramework {
             LOGINFO("Starting the timer");
             m_timer.start(RECONNECTION_TIME_IN_MILLISECONDS);
 
-            InitAudioPorts();
+            if (IARM_BUS_PWRMGR_POWERSTATE_ON == getSystemPowerState())
+            {
+                InitAudioPorts();
+            }
+            else
+            {
+                LOGWARN("Current power state %d", m_powerState);
+            }
 
             // On success return empty, to indicate there is no error text.
             return (string());
@@ -308,6 +318,8 @@ namespace WPEFramework {
             if (Utils::IARM::init())
             {
                 IARM_Result_t res;
+                IARM_Bus_PWRMgr_GetPowerState_Param_t param;
+
                 IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_RX_SENSE, DisplResolutionHandler) );
                 IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_ZOOM_SETTINGS, DisplResolutionHandler) );
                 //TODO(MROLLINS) localinput.cpp has PreChange guarded with #if !defined(DISABLE_PRE_RES_CHANGE_EVENTS)
@@ -317,6 +329,14 @@ namespace WPEFramework {
                 IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_HOTPLUG, dsHdmiEventHandler) );
 		IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_IN_HOTPLUG, dsHdmiEventHandler) );
                 IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_AUDIO_OUT_HOTPLUG, dsHdmiEventHandler) );
+                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_PWRMGR_NAME, IARM_BUS_PWRMGR_EVENT_MODECHANGED, powerEventHandler) );
+
+                res = IARM_Bus_Call(IARM_BUS_PWRMGR_NAME, IARM_BUS_PWRMGR_API_GetPowerState, (void *)&param, sizeof(param));
+                if (res == IARM_RESULT_SUCCESS)
+                {
+                    m_powerState = param.curState;
+                    LOGINFO("DisplaySettings::m_powerState:%d", m_powerState);
+                }
             }
 
             try
@@ -338,6 +358,7 @@ namespace WPEFramework {
             if (Utils::IARM::isConnected())
             {
                 IARM_Result_t res;
+
                 IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_RX_SENSE) );
                 IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_ZOOM_SETTINGS) );
                 IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_RES_PRECHANGE) );
@@ -345,8 +366,8 @@ namespace WPEFramework {
                 IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_HOTPLUG) );
 		IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_IN_HOTPLUG) );
                 IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_AUDIO_OUT_HOTPLUG) );
+                IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_PWRMGR_NAME, IARM_BUS_PWRMGR_EVENT_MODECHANGED) );
             }
-
 
             try
             {
@@ -1870,6 +1891,12 @@ namespace WPEFramework {
                         LOG_DEVICE_EXCEPTION1(sMuted);
                         returnResponse(false);
                 }
+
+                if (false == muted && IARM_BUS_PWRMGR_POWERSTATE_STANDBY == getSystemPowerState()) {
+                        LOGWARN("Ignoring the setMuted(false) request based on the power state");
+                        returnResponse(false);
+                }
+
                 bool success = true;
                 string audioPort = parameters.HasLabel("audioPort") ? parameters["audioPort"].String() : "HDMI0";
                 LOGWARN("DisplaySettings::setMuted called Audio Port :%s muted:%d\n", audioPort.c_str(), muted);
@@ -1898,6 +1925,13 @@ namespace WPEFramework {
                         LOG_DEVICE_EXCEPTION1(sLevel);
                         returnResponse(false);
                 }
+
+                if (IARM_BUS_PWRMGR_POWERSTATE_STANDBY == getSystemPowerState()) {
+                        LOGWARN("Ignoring the setVolumeLevel(%s) request based on the power state", sLevel.c_str());
+                        returnResponse(false);
+                }
+
+
                 bool success = true;
                 string audioPort = parameters.HasLabel("audioPort") ? parameters["audioPort"].String() : "HDMI0";
                 try
@@ -2627,6 +2661,11 @@ namespace WPEFramework {
                     returnResponse(false);
             }
 
+            if (true == pEnable && IARM_BUS_PWRMGR_POWERSTATE_STANDBY == getSystemPowerState()) {
+                LOGWARN("Ignoring the setEnableAudioPort(true) request based on the power state");
+                returnResponse(false);
+            }
+
             try
             {
                 device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
@@ -2720,6 +2759,55 @@ namespace WPEFramework {
         {
             Core::SystemInfo::SetEnvironment(_T("THUNDER_ACCESS"), (_T("127.0.0.1:9998")));
             return make_shared<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>>("org.rdk.HdmiCecSink.1", "");
+        }
+
+        std::shared_ptr<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>> DisplaySettings::getSystemPlugin()
+        {
+            Core::SystemInfo::SetEnvironment(_T("THUNDER_ACCESS"), (_T("127.0.0.1:9998")));
+            return make_shared<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>>("org.rdk.System.1", "");
+        }
+
+        IARM_Bus_PWRMgr_PowerState_t DisplaySettings::getSystemPowerState()
+        {
+            IARM_Result_t res;
+            IARM_Bus_PWRMgr_GetPowerState_Param_t param;
+
+            res = IARM_Bus_Call(IARM_BUS_PWRMGR_NAME, IARM_BUS_PWRMGR_API_GetPowerState, (void *)&param, sizeof(param));
+            if (res == IARM_RESULT_SUCCESS)
+            {
+                m_powerState = param.curState;
+                LOGWARN("DisplaySettings::m_powerState: %d", m_powerState);
+            }
+            else
+            {
+                LOGWARN("GetPowerState failed");
+            }
+
+            return m_powerState;
+        }
+
+        void DisplaySettings::powerEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
+        {
+            if(!DisplaySettings::_instance)
+                 return;
+            if (strcmp(owner, IARM_BUS_PWRMGR_NAME) != 0)
+                 return;
+
+            switch (eventId) {
+            case  IARM_BUS_PWRMGR_EVENT_MODECHANGED:
+            {
+                IARM_Bus_PWRMgr_EventData_t *eventData = (IARM_Bus_PWRMgr_EventData_t *)data;
+                LOGWARN("Event IARM_BUS_PWRMGR_EVENT_MODECHANGED: State Changed %d --> %d\r",
+                             eventData->data.state.curState, eventData->data.state.newState);
+                m_powerState = eventData->data.state.newState;
+                if (eventData->data.state.newState == IARM_BUS_PWRMGR_POWERSTATE_ON) {
+                    DisplaySettings::_instance->InitAudioPorts();
+                }
+            }
+            break;
+
+            default: break;
+            }
         }
 
         // Event management

--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -25,7 +25,9 @@
 #include "tptimer.h"
 #include "AbstractPlugin.h"
 #include "libIBus.h"
+#include "libIBusDaemon.h"
 #include "irMgr.h"
+#include "pwrMgr.h"
 
 namespace WPEFramework {
 
@@ -147,11 +149,14 @@ namespace WPEFramework {
             static void ResolutionPostChange(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
             static void DisplResolutionHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
             static void dsHdmiEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
+            static void powerEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
             void getConnectedVideoDisplaysHelper(std::vector<string>& connectedDisplays);
             bool checkPortName(std::string& name) const;
+            IARM_Bus_PWRMgr_PowerState_t getSystemPowerState();
 
 	    std::shared_ptr<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>> getHdmiCecSinkPlugin();
 	    std::shared_ptr<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement> > m_client;
+	    std::shared_ptr<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>> getSystemPlugin();
 	    uint32_t subscribeForHdmiCecSinkEvent(const char* eventName);
 	    bool setUpHdmiCecSinkArcRouting (bool arcEnable);
 	    void onTimer();
@@ -161,6 +166,7 @@ namespace WPEFramework {
             std::mutex m_callMutex;
 	    JsonObject m_audioOutputPortConfig;
             JsonObject getAudioOutputPortConfig() { return m_audioOutputPortConfig; }
+            static IARM_Bus_PWRMgr_PowerState_t m_powerState;
 
         public:
             static DisplaySettings* _instance;


### PR DESCRIPTION
Reason for change: Enable audio port based on the power state and
controlling audio ports/volume/mutes based on the power state

Test Procedure: On bootup tv boots to lightsleep no audio should
not be heard. If application is trying to enable the audio ports
on standby RDK should ignore the request.

Risks: Medium
Signed-off-by: sputhi200 <Sujeesh_Puthiya@comcast.com>