### PR TITLE
DELIA-48811: Suppress POLL_THREAD_STATE verbose logs in wpeframework.log

### DIFF
--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -2049,7 +2049,7 @@ namespace WPEFramework
 
 				case POLL_THREAD_STATE_POLL :
 				{
-					LOGINFO("POLL_THREAD_STATE_POLL");
+					//LOGINFO("POLL_THREAD_STATE_POLL");
 					_instance->allocateLogicalAddress(DeviceType::TV);
 					if ( _instance->m_logicalAddressAllocated != LogicalAddress::UNREGISTERED)
 					{
@@ -2092,7 +2092,7 @@ namespace WPEFramework
 				
 				case POLL_THREAD_STATE_PING :
 				{
-					LOGINFO("POLL_THREAD_STATE_PING");
+					//LOGINFO("POLL_THREAD_STATE_PING");
 					_instance->m_pollThreadState = POLL_THREAD_STATE_INFO;
 					connected.clear();
 					disconnected.clear();
@@ -2127,7 +2127,7 @@ namespace WPEFramework
 
 				case POLL_THREAD_STATE_INFO :
 				{
-					LOGINFO("POLL_THREAD_STATE_INFO");
+					//LOGINFO("POLL_THREAD_STATE_INFO");
 
 					if ( logicalAddressRequested == LogicalAddress::UNREGISTERED + TEST_ADD )
 					{
@@ -2137,7 +2137,7 @@ namespace WPEFramework
 								_instance->deviceList[i].m_isDevicePresent &&
 								!_instance->deviceList[i].isAllUpdated() )
 							{
-								LOGINFO("POLL_THREAD_STATE_INFO -> request for %d", i);
+								//LOGINFO("POLL_THREAD_STATE_INFO -> request for %d", i);
 								logicalAddressRequested = i;
 								_instance->request(logicalAddressRequested);
 								_instance->m_sleepTime = HDMICECSINK_REQUEST_INTERVAL_TIME_MS;
@@ -2171,7 +2171,7 @@ namespace WPEFramework
 				/* updating the power status and if required we can add other information later*/
 				case POLL_THREAD_STATE_UPDATE :
 				{
-					LOGINFO("POLL_THREAD_STATE_UPDATE");
+					//LOGINFO("POLL_THREAD_STATE_UPDATE");
 
 					for(i=0;i<LogicalAddress::UNREGISTERED + TEST_ADD;i++)
 					{
@@ -2197,7 +2197,7 @@ namespace WPEFramework
 
 				case POLL_THREAD_STATE_IDLE :
 				{
-					LOGINFO("POLL_THREAD_STATE_IDLE");
+					//LOGINFO("POLL_THREAD_STATE_IDLE");
 					_instance->m_sleepTime = HDMICECSINK_PING_INTERVAL_MS;
 					_instance->m_pollThreadState = POLL_THREAD_STATE_PING;
 				}
@@ -2206,7 +2206,7 @@ namespace WPEFramework
 				case POLL_THREAD_STATE_WAIT :
 				{
 					/* Wait for Hdmi is connected, in case it disconnected */
-					LOGINFO("19Aug2020-[01] -> POLL_THREAD_STATE_WAIT");
+					//LOGINFO("19Aug2020-[01] -> POLL_THREAD_STATE_WAIT");
 					_instance->m_sleepTime = HDMICECSINK_WAIT_FOR_HDMI_IN_MS;
 
 					if ( _instance->m_isHdmiInConnected == true )


### PR DESCRIPTION
This is to suppress POLL_THREAD_STATE logs to prevent rolling over of wpeframework.log as originally reported in https://ccp.sys.comcast.net/browse/RDKTV-1457