### PR TITLE
RDKTV-1625: Don't pass invalid response string from xconf

### DIFF
--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -1079,6 +1079,11 @@ namespace WPEFramework {
                     LOGWARN("fwVersion: '%s'\n", _fwUpdate.firmwareUpdateVersion.c_str());
                     _fwUpdate.success = true;
                 }
+                else
+                {
+                    LOGERR("Response String is not valid json and/or doesn't contain firmwareVersion. '%s'\n", response.c_str());
+                    response = "";
+                }
             }
             if (_instance) {
                 _instance->reportFirmwareUpdateInfoReceived(_fwUpdate.firmwareUpdateVersion,


### PR DESCRIPTION
(cherry picked from commit cbac19928288624181f6eb57c2b5d95379e95518)

RDKTV-1625: Don't pass invalid response string from xconf

(cherry picked from commit 93d9ff1ea12969bfed9305385768976240fa41d1)