### PR TITLE
RDKTV-1440: Fix std::thread crash in SystemServices & HDMICecSink

### DIFF
--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -517,8 +517,20 @@ namespace WPEFramework
 
             m_semSignaltoArcRoutingThread.release();
             LOGINFO(" ~HdmiCecSink() waiting for thread join %d",m_arcRoutingThread.joinable());
-            if (m_arcRoutingThread.joinable())
-            m_arcRoutingThread.join();
+
+			try
+			{
+				if (m_arcRoutingThread.joinable())
+            		m_arcRoutingThread.join();
+			}
+			catch(const std::system_error& e)
+			{
+				LOGERR("system_error exception in thread join %s", e.what());
+			}
+			catch(const std::exception& e)
+			{
+				LOGERR("exception in thread join %s", e.what());
+			}
            HdmiCecSink::_instance = nullptr;
            DeinitializeIARM();
        }
@@ -2343,11 +2355,21 @@ namespace WPEFramework
 		LOGWARN("Stop Thread %p", smConnection );
 		m_pollThreadState = POLL_THREAD_STATE_EXIT;
 
-
-		if (m_pollThread.joinable())
+		try
 		{
-			LOGWARN("Join Thread %p", smConnection );
-			m_pollThread.join();
+			if (m_pollThread.joinable())
+			{
+				LOGWARN("Join Thread %p", smConnection );
+				m_pollThread.join();
+			}
+		}
+		catch(const std::system_error& e)
+		{
+			LOGERR("system_error exception in thread join %s", e.what());
+		}
+		catch(const std::exception& e)
+		{
+			LOGERR("exception in thread join %s", e.what());
 		}
 
 		LOGWARN("Deleted Thread %p", smConnection );

--- a/SystemServices/SystemServices.h
+++ b/SystemServices/SystemServices.h
@@ -90,7 +90,7 @@ namespace WPEFramework {
 #if defined(USE_IARMBUS) || defined(USE_IARM_BUS)
                 static IARM_Bus_SYSMgr_GetSystemStates_Param_t paramGetSysState;
 #endif /* defined(USE_IARMBUS) || defined(USE_IARM_BUS) */
-                std::thread thread_getMacAddresses;
+                Utils::ThreadRAII thread_getMacAddresses;
                 SystemServices* m_systemService;
                 /* TODO: Need to decide whether needed or not since setProperty
                    and getProperty functionalities are XRE/RTRemote dependent. */
@@ -106,7 +106,7 @@ namespace WPEFramework {
                 static std::string m_currentMode;
                 static cTimer m_operatingModeTimer;
                 static int m_remainingDuration;
-                std::thread m_getFirmwareInfoThread;
+                Utils::ThreadRAII m_getFirmwareInfoThread;
 
                 static void startModeTimer(int duration);
                 static void stopModeTimer();

--- a/helpers/utils.cpp
+++ b/helpers/utils.cpp
@@ -28,6 +28,7 @@
 #include "libIBus.h"
 #include <securityagent/SecurityTokenUtil.h>
 #include <curl/curl.h>
+#include <utility>
 
 #define MAX_STRING_LENGTH 2048
 
@@ -312,4 +313,28 @@ bool Utils::getRFCConfig(char* paramName, RFC_ParamData_t& paramOutput)
 
 std::string Utils::SecurityToken::m_sToken = "";
 bool Utils::SecurityToken::m_sThunderSecurityChecked = false;
+
+
+//Thread RAII
+Utils::ThreadRAII::ThreadRAII(std::thread&& t): t(std::move(t)) {}
+
+Utils::ThreadRAII::~ThreadRAII()
+{
+    try
+    {
+        if (t.joinable()) 
+        {
+            t.join();
+        }
+    }
+    catch(const std::system_error& e)
+    {
+        LOGERR("system_error exception in thread join %s", e.what());
+    }
+    catch(const std::exception& e)
+    {
+        LOGERR("exception in thread join %s", e.what());
+    }
+}
+
 

--- a/helpers/utils.h
+++ b/helpers/utils.h
@@ -32,6 +32,7 @@
 
 // std
 #include <string>
+#include <thread>
 
 #define UNUSED(expr)(void)(expr)
 #define C_STR(x) (x).c_str()
@@ -343,4 +344,23 @@ namespace Utils
     bool isPluginActivated(const char* callSign);
 
     bool getRFCConfig(char* paramName, RFC_ParamData_t& paramOutput);
-}
+
+    //class for std::thread RAII
+    class ThreadRAII 
+    {
+        public:
+            ThreadRAII() {}
+            ThreadRAII(std::thread&& t);
+            ~ThreadRAII(); 
+            
+            //support moving
+            ThreadRAII(ThreadRAII&&) = default;
+            ThreadRAII& operator=(ThreadRAII&&) = default;
+
+            std::thread& get() { return t; }
+
+        private:
+            std::thread t;
+    };
+
+} // namespace Utils


### PR DESCRIPTION
(cherry picked from commit c99eb06053539455868226b0b9078b9ff97fe8ef)
(cherry picked from commit 416aafc5805d6ad2b884fdb3974b874b65b7181c)

RDKTV-1440: Fix std::thread crash in SystemServices

(cherry picked from commit 36f884543dc40fb97f8cf2c630596a15ce43aa8a)
(cherry picked from commit 2059b31cd23ce640b25d63377fdf5f1e5996286e)

RDKTV-1440: Fix std::thread crash in HDMICecSink

(cherry picked from commit 2dd75c6eace62ccb98291450c7d012bead47d5a1)
(cherry picked from commit d5ca767bb7b05ab56f75118c84e22eff2b86a8e8)

RDKTV-1440: Fix std::thread crash in SystemServices

(cherry picked from commit 17ddb112954ffe876ae5b97d33f6a8a11481a550)