### PR TITLE
RDK-31068: HDMI Output HDCP Status Change Notification XiOne

### DIFF
--- a/HdcpProfile/HdcpProfile.cpp
+++ b/HdcpProfile/HdcpProfile.cpp
@@ -229,7 +229,7 @@ namespace WPEFramework
             LOGWARN("[%s]-HDCPStatus::supportedHDCPVersion: %s", trigger, status["supportedHDCPVersion"].String().c_str());
             LOGWARN("[%s]-HDCPStatus::receiverHDCPVersion: %s", trigger, status["receiverHDCPVersion"].String().c_str());
             LOGWARN("[%s]-HDCPStatus::currentHDCPVersion %s", trigger, status["currentHDCPVersion"].String().c_str());
-            LOGWARN("[%s]-HDCPStatus::hdcpReason %s", trigger, getHdcpReasonStr(atoi(status["hdcpReason"].String().c_str())));
+            LOGWARN("[%s]-HDCPStatus::hdcpReason %s", trigger, status["hdcpReason"].String().c_str());
         }
 
         void HdcpProfile::onHdmiOutputHDCPStatusEvent(int hdcpStatus)


### PR DESCRIPTION
Reason for change:
HDMI Output HDCP Status Change Notification XiOne
Thunder changes.
Test Procedure: None
Risks: Low

Change-Id: Ib2f8b28b534bdea4a6ad8e614e7b22bfed2e7f83
Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>