### PR TITLE
    RDKTV-2067 : WPEFramework crash at signature std::terminate in Hd…

### DIFF
--- a/HdmiCecSink/HdmiCecSink.h
+++ b/HdmiCecSink/HdmiCecSink.h
@@ -549,6 +549,7 @@ private:
 			std::thread m_pollThread;
 			uint32_t m_pollThreadState;
 			uint32_t m_pollNextState;
+			bool m_pollThreadExit;
 			uint32_t m_sleepTime;
             std::mutex m_pollMutex;
             /* ARC related */


### PR DESCRIPTION
…miCecSink

    Reason for change: Fix for HdmiCecSink crash .
    Test Procedure: Tested using Curl Commands
    Risks: Low

    Signed-off-by: Bijas Babu <bijas.babu@sky.uk>

    RDKTV-2067 : WPEFramework crash at signature std::terminate in HdmiCecSink

    Reason for change: Fix for HdmiCecSink crash .
    Test Procedure: Tested using Curl Commands
    Risks: Low

    Signed-off-by: Bijas Babu <bijas.babu@sky.uk>