### PR TITLE
RDKTV-2384: Make DisplayInfo & PlayerInfo Out-of-Process

### DIFF
--- a/DisplayInfo/DisplayInfo.config
+++ b/DisplayInfo/DisplayInfo.config
@@ -4,7 +4,7 @@ set(preconditions Platform)
 map()
     key(root)
     map()
-      kv(mode "Off")
+      kv(outofprocess ${PLUGIN_DISPLAYINFO_OOP})
     end()
 end()
 

--- a/PlayerInfo/PlayerInfo.config
+++ b/PlayerInfo/PlayerInfo.config
@@ -3,7 +3,7 @@ set(autostart true)
 map()
     key(root)
     map()
-      kv(mode "Off")
+      kv(outofprocess ${PLUGIN_PLAYERINFO_OOP})
     end()
 end()
 


### PR DESCRIPTION
Reason for change: edit config file to
make Displayinfo and PlayerInfo pick up
Out-of-process parameter from recipe file
Test Procedure:Displayinfo and PlayerInfo should be
running with as a separate process (check systemctl status wpeframework)
Risks: None
Signed-off-by: Vinod Jacob <vinod_jacob@comcast.com>