### PR TITLE
RDKTV-404 Save tts setting values(enabletts,rate,volume,voice,languag…

### DIFF
--- a/TextToSpeech/impl/TTSManager.h
+++ b/TextToSpeech/impl/TTSManager.h
@@ -96,7 +96,6 @@ private:
     TTSConfiguration m_defaultConfiguration;
     TTSEventCallback *m_callback;
     TTSSpeaker *m_speaker;
-    bool m_ttsEnabled;
 };
 
 } // namespace TTS

--- a/TextToSpeech/impl/TTSSpeaker.h
+++ b/TextToSpeech/impl/TTSSpeaker.h
@@ -52,12 +52,13 @@ public:
     TTSConfiguration();
     ~TTSConfiguration();
 
-    void setEndPoint(const std::string endpoint);
-    void setSecureEndPoint(const std::string endpoint);
-    void setLanguage(const std::string language);
-    void setVoice(const std::string voice);
-    void setVolume(const double volume);
-    void setRate(const uint8_t rate);
+    bool setEndPoint(const std::string endpoint);
+    bool setSecureEndPoint(const std::string endpoint);
+    bool setLanguage(const std::string language);
+    bool setVoice(const std::string voice);
+    bool setEnabled(const bool dnabled);
+    bool setVolume(const double volume);
+    bool setRate(const uint8_t rate);
     void setPreemptiveSpeak(const bool preemptive);
 
     const std::string &endPoint() { return m_ttsEndPoint; }
@@ -65,10 +66,13 @@ public:
     const std::string &language() { return m_language; }
     const double &volume() { return m_volume; }
     const uint8_t &rate() { return m_rate; }
+    const bool enabled() { return m_enabled; }
     bool isPreemptive() { return m_preemptiveSpeaking; }
+    bool loadFromConfigStore();
+    bool updateConfigStore();
     const std::string voice();
 
-    void updateWith(TTSConfiguration &config);
+    bool updateWith(TTSConfiguration &config);
     bool isValid();
 
     static std::map<std::string, std::string> m_others;
@@ -81,6 +85,7 @@ private:
     double m_volume;
     uint8_t m_rate;
     bool m_preemptiveSpeaking;
+    bool m_enabled;
 };
 
 class TTSSpeakerClient {


### PR DESCRIPTION
…e) into persistent

Reason for change: To Save TTS settings value to Persistent
Test Procedure: User can enable/disable VG,rate,volume and on next bootup tts should speak with same settings
Risks: Low

Signed-off-by: Vishnu_Dinakaran@comcast.com