### PR TITLE
DELIA-46829 : getStatusSupport in Bluetooth

### DIFF
--- a/Bluetooth/Bluetooth.cpp
+++ b/Bluetooth/Bluetooth.cpp
@@ -51,11 +51,14 @@ const string WPEFramework::Plugin::Bluetooth::METHOD_DISABLE = "disable";
 const string WPEFramework::Plugin::Bluetooth::METHOD_SET_DISCOVERABLE = "setDiscoverable";
 const string WPEFramework::Plugin::Bluetooth::METHOD_GET_NAME = "getName";
 const string WPEFramework::Plugin::Bluetooth::METHOD_SET_NAME = "setName";
+const string WPEFramework::Plugin::Bluetooth::METHOD_SET_PROPERTIES = "setProperties";
+const string WPEFramework::Plugin::Bluetooth::METHOD_GET_PROPERTIES = "getProperties";
 const string WPEFramework::Plugin::Bluetooth::METHOD_SET_AUDIO_PLAYBACK_COMMAND = "sendAudioPlaybackCommand";
 const string WPEFramework::Plugin::Bluetooth::METHOD_SET_EVENT_RESPONSE = "respondToEvent";
 const string WPEFramework::Plugin::Bluetooth::METHOD_GET_DEVICE_INFO = "getDeviceInfo";
 const string WPEFramework::Plugin::Bluetooth::METHOD_GET_AUDIO_INFO = "getAudioInfo";
 const string WPEFramework::Plugin::Bluetooth::METHOD_GET_API_VERSION_NUMBER = "getApiVersionNumber";
+const string WPEFramework::Plugin::Bluetooth::METHOD_GET_STATUS_SUPPORT = "getStatusSupport";
 
 const string WPEFramework::Plugin::Bluetooth::EVT_STATUS_CHANGED = "onStatusChanged";
 const string WPEFramework::Plugin::Bluetooth::EVT_PAIRING_REQUEST = "onPairingRequest";
@@ -65,6 +68,7 @@ const string WPEFramework::Plugin::Bluetooth::EVT_PLAYBACK_REQUEST = "onPlayback
 
 const string WPEFramework::Plugin::Bluetooth::EVT_PLAYBACK_STARTED = "onPlaybackChange"; // action: started
 const string WPEFramework::Plugin::Bluetooth::EVT_PLAYBACK_PAUSED = "onPlaybackChange";  // action: paused
+const string WPEFramework::Plugin::Bluetooth::EVT_PLAYBACK_RESUMED = "onPlaybackChange"; // action: resumed
 const string WPEFramework::Plugin::Bluetooth::EVT_PLAYBACK_STOPPED = "onPlaybackChange"; // action: stopped
 const string WPEFramework::Plugin::Bluetooth::EVT_PLAYBACK_ENDED = "onPlaybackChange";   // action: paused
 
@@ -133,6 +137,10 @@ namespace WPEFramework
         , m_discoveryRunning(false)
         , m_discoveryTimer(this)
         {
+            LOGINFO();
+
+            Core::JSONRPC::Handler& systemVersion_2 = JSONRPC::CreateHandler({ 2 }, *this);
+
             Bluetooth::_instance = this;
             registerMethod(METHOD_GET_API_VERSION_NUMBER, &Bluetooth::getApiVersionNumber, this);
             registerMethod(METHOD_START_SCAN, &Bluetooth::startScanWrapper, this);
@@ -155,6 +163,10 @@ namespace WPEFramework
             registerMethod(METHOD_SET_EVENT_RESPONSE, &Bluetooth::setEventResponseWrapper, this);
             registerMethod(METHOD_GET_DEVICE_INFO, &Bluetooth::getDeviceInfoWrapper, this);
             registerMethod(METHOD_GET_AUDIO_INFO, &Bluetooth::getMediaTrackInfoWrapper, this);
+            registerMethod(METHOD_GET_STATUS_SUPPORT, &Bluetooth::getStatusSupportWrapper, this);
+
+            systemVersion_2.Register<JsonObject, JsonObject>(METHOD_SET_PROPERTIES, &Bluetooth::setPropertiesWrapper, this);
+            systemVersion_2.Register<JsonObject, JsonObject>(METHOD_GET_PROPERTIES, &Bluetooth::getPropertiesWrapper, this);
 
             BTRMGR_Result_t rc = BTRMGR_RESULT_SUCCESS;
             rc = BTRMGR_Init();
@@ -169,6 +181,16 @@ namespace WPEFramework
 
         Bluetooth::~Bluetooth()
         {
+            LOGINFO();
+
+            Core::JSONRPC::Handler* systemVersion_2 = JSONRPC::GetHandler(2);
+            if (systemVersion_2) {
+                systemVersion_2->Unregister(METHOD_SET_PROPERTIES);
+                systemVersion_2->Unregister(METHOD_GET_PROPERTIES);
+            }
+            else
+                LOGERR("Failed to get handler for version 2");
+
             Bluetooth::_instance = nullptr;
         }
 
@@ -549,44 +571,61 @@ namespace WPEFramework
             return BTRMGR_RESULT_SUCCESS == rc;
         }
 
-        // Sets adapter name. No support for "power" yet
         bool Bluetooth::setBluetoothProperties(const JsonObject& parameters)
         {
-            BTRMGR_Result_t rc = BTRMGR_RESULT_SUCCESS;
+            BTRMGR_Result_t rc = BTRMGR_RESULT_GENERIC_FAILURE;
+
+            if (parameters.HasLabel("power")) {
+                string power;
+                getStringParameter("power", power);
+                LOGWARN ("Power received as %s", C_STR(power));
+                if (power == "OFF") {
+                    rc = BTRMGR_SetAdapterPowerStatus (0, 0 /* FALSE */);
+                }
+                else if (power == "ON") {
+                    rc = BTRMGR_SetAdapterPowerStatus (0, 1 /* TRUE */);
+                }
+            }
+
             if (parameters.HasLabel("name")) {
                 string name;
                 getStringParameter("name", name);
                 LOGWARN ("Name received as %s", C_STR(name));
                 rc = BTRMGR_SetAdapterName (0, C_STR(name));
-                if (BTRMGR_RESULT_SUCCESS != rc)
-                {
-                    LOGERR("Failed to set Name in setBluetoothProperties");
-                }
-                else {
-                    LOGINFO ("Successfully done setBluetoothProperties");
-                }
             }
+
+            if (BTRMGR_RESULT_SUCCESS != rc)
+                LOGERR("Failed to set in setBluetoothProperties");
+            else
+                LOGINFO ("Successfully done setBluetoothProperties");
+
             return BTRMGR_RESULT_SUCCESS == rc;
         }
 
-        // Gets adapter name. No support for "power" yet
-        bool Bluetooth::getBluetoothProperties( JsonObject* rp)
+        bool Bluetooth::getBluetoothProperties(JsonObject* rp, const string& property)
         {
             BTRMGR_Result_t rc = BTRMGR_RESULT_SUCCESS;
             JsonObject response; // responding with a single object
 
-            char adapterName[BTRMGR_NAME_LEN_MAX];
-            rc = BTRMGR_GetAdapterName (0, &adapterName[0]);
-            if (BTRMGR_RESULT_SUCCESS != rc)
-            {
-                LOGERR("Failed to get Name in getBluetoothProperties");
+            if (Utils::String::stringContains(property, "name")) {
+                char pNameOfAdapter[BTRMGR_NAME_LEN_MAX] = {'\0'};
+                rc = BTRMGR_GetAdapterName(0, pNameOfAdapter);
+                if (BTRMGR_RESULT_SUCCESS == rc) {
+                    response["name"] = string(pNameOfAdapter);
+                    LOGWARN ("Name set as %s", pNameOfAdapter);
+                } else
+                    LOGERR("Failed to get device Name");
             }
-            else {
-                LOGINFO ("Successfully done getBluetoothProperties");
+            else if (Utils::String::stringContains(property, "power")) {
+                unsigned char power_status = 0;
+                rc = BTRMGR_GetAdapterPowerStatus(0, &power_status);
+                if (BTRMGR_RESULT_SUCCESS == rc) {
+                    response["power"] = string(power_status ? "ON" : "OFF");
+                    LOGWARN ("Power set as %d", (int)power_status);
+                } else
+                    LOGERR("Failed to get device Power");
             }
 
-            response["name"] = string(adapterName);
-            LOGWARN ("Name set as %s", adapterName);
             if (rp) {
                 *rp = response;
             }
@@ -981,6 +1020,15 @@ namespace WPEFramework
                     break;
 
                 case BTRMGR_EVENT_MEDIA_TRACK_PLAYING:
+                    LOGINFO ("Received %s Event from BTRMgr", C_STR(EVT_PLAYBACK_RESUMED));
+                    params["action"]   = std::string("resumed");
+                    params["deviceID"] = std::to_string(eventMsg.m_mediaInfo.m_deviceHandle);
+                    params["position"] = std::to_string(eventMsg.m_mediaInfo.m_mediaPositionInfo.m_mediaPosition);
+                    params["Duration"] = std::to_string(eventMsg.m_mediaInfo.m_mediaPositionInfo.m_mediaDuration);
+
+                    eventId = EVT_PLAYBACK_RESUMED;
+                    break;
+
                 case BTRMGR_EVENT_MEDIA_TRACK_POSITION:
                     LOGINFO ("Received Playback Position Event from BTRMgr");
                     params["deviceID"] = std::to_string(eventMsg.m_mediaInfo.m_deviceHandle);
@@ -1396,6 +1444,30 @@ namespace WPEFramework
             returnResponse(successFlag);
         }
 
+        uint32_t Bluetooth::getPropertiesWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool successFlag;
+            string property;
+            if (parameters.HasLabel("property")) {
+                getStringParameter("property", property);
+                successFlag = getBluetoothProperties(&response, property);
+            } else {
+                LOGERR("Please specify 'property' parameter");
+                response["error"] = "Please specify 'property' parameter";
+                successFlag = false;
+            }
+            returnResponse(successFlag);
+        }
+
+        uint32_t Bluetooth::setPropertiesWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool successFlag;
+            successFlag = setBluetoothProperties(parameters);
+            returnResponse(successFlag);
+        }
+
         uint32_t Bluetooth::sendAudioPlaybackCommandWrapper(const JsonObject& parameters, JsonObject& response)
         {
             LOGINFOMETHOD();
@@ -1509,6 +1581,15 @@ namespace WPEFramework
                 successFlag = false;
             }
             returnResponse(successFlag);
+        }
+
+        uint32_t Bluetooth::getStatusSupportWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            string status;
+            getStatusSupport(status);
+            response["status"] = status;
+            returnResponse(true);
         }
         //
         /// Registered methods end

--- a/Bluetooth/Bluetooth.h
+++ b/Bluetooth/Bluetooth.h
@@ -92,10 +92,13 @@ namespace WPEFramework {
             uint32_t disableWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t getNameWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t setNameWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t setPropertiesWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t getPropertiesWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t sendAudioPlaybackCommandWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t setEventResponseWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t getDeviceInfoWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t getMediaTrackInfoWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t getStatusSupportWrapper(const JsonObject& parameters, JsonObject& response);
             // Registered methods end
 
         private: /*internal methods*/
@@ -114,7 +117,7 @@ namespace WPEFramework {
             bool setDevicePairing(long long int deviceID, bool pair);
             bool setBluetoothEnabled(const string &enabled);
             bool setBluetoothDiscoverable(bool enabled, int timeout);
-            bool getBluetoothProperties(JsonObject* rp);
+            bool getBluetoothProperties(JsonObject* rp, const string& property = "name");
             bool setBluetoothProperties(const JsonObject& properties);
             bool setAudioControlCommand(long long int  deviceID, const string &audioCtrlCmd);
             bool setEventResponse(long long int  deviceID, const string &eventType, const string &respValue);
@@ -140,11 +143,14 @@ namespace WPEFramework {
             static const string METHOD_SET_DISCOVERABLE;
             static const string METHOD_GET_NAME;
             static const string METHOD_SET_NAME;
+            static const string METHOD_GET_PROPERTIES;
+            static const string METHOD_SET_PROPERTIES;
             static const string METHOD_SET_AUDIO_PLAYBACK_COMMAND;
             static const string METHOD_SET_EVENT_RESPONSE;
             static const string METHOD_GET_DEVICE_INFO;
             static const string METHOD_GET_AUDIO_INFO;
             static const string METHOD_GET_API_VERSION_NUMBER;
+            static const string METHOD_GET_STATUS_SUPPORT;
             static const string EVT_STATUS_CHANGED;
             static const string EVT_PAIRING_REQUEST;
             static const string EVT_REQUEST_FAILED;


### PR DESCRIPTION
Reason for change: Add the missing method
Test Procedure: Call org.rdk.Bluetooth.1.getStatusSupport,
see "status":"AVAILABLE" or similar in response
Risks: None
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>

DELIA-46979: implement getProperties, setProperties

Reason for change: Add getProperties, setProperties
in the same way as in servicemanager.
Test Procedure: Try API getName, setName,
getProperties, setProperties.
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>

move setProperties/getProperties to version 2