### PR TITLE
RDKTV-2024 Honor across standby and reboot

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -2647,6 +2647,9 @@ namespace WPEFramework {
                     if (dsERR_NONE != eRet) {
                         LOGWARN("DisplaySettings::setEnableAudioPort aPort.setEnablePort retuned %04x \n", eRet);
                         success = false;
+                    } else if (aPort.isMuted()) {
+                        LOGWARN("DisplaySettings::setEnableAudioPort aPort.isMuted()\n");
+                        aPort.setMuted(true);
                     }
                 }
                 else {


### PR DESCRIPTION
Reason for change: Mute is not honored across the standby and rebooot
because when ON state change event comes thunder plugin is enabling the
ports and not considering the mute.

Test Procedure: Do mute and put the TV in standby and wakeup and see
audio still muted. Do same test across reboot.

Risks: Low
Signed-off-by: sputhi200 <Sujeesh_Puthiya@comcast.com>