### PR TITLE
RDK-28658: Add getSupportedSecurityModes() to Wifi (#909)

### DIFF
--- a/WifiManager/WifiManager.cpp
+++ b/WifiManager/WifiManager.cpp
@@ -25,6 +25,9 @@
 
 #include "libIBus.h"
 
+const short WPEFramework::Plugin::WifiManager::API_VERSION_NUMBER_MAJOR = 2;
+const short WPEFramework::Plugin::WifiManager::API_VERSION_NUMBER_MINOR = 0;
+
 namespace {
     using WPEFramework::Plugin::WifiManager;
     using WifiManagerConstMethod = uint32_t (WifiManager::*)(const JsonObject &parameters, JsonObject &response) const;
@@ -58,27 +61,26 @@ namespace WPEFramework
 {
     namespace Plugin
     {
-        SERVICE_REGISTRATION(WifiManager, 1, 0);
+        SERVICE_REGISTRATION(WifiManager, WifiManager::API_VERSION_NUMBER_MAJOR, WifiManager::API_VERSION_NUMBER_MINOR);
 
         WifiManager::WifiManager()
-        : PluginHost::JSONRPC(),
-          apiVersionNumber(1),
+        : AbstractPlugin(WifiManager::API_VERSION_NUMBER_MAJOR),
+          apiVersionNumber(API_VERSION_NUMBER_MAJOR),
           wifiSignalThreshold(*this)
         {
             for(const auto &mapping: constMethods)
-                Register(mapping.first, mapping.second, this);
+                registerMethod(mapping.first, mapping.second, this);
 
             for(const auto &mapping: mutableMethods)
-                Register(mapping.first, mapping.second, this);
+                registerMethod(mapping.first, mapping.second, this);
+
+            /* Version 2 API */
+            registerMethod("getSupportedSecurityModes", &WifiManager::getSupportedSecurityModes, this, {2});
         }
 
         WifiManager::~WifiManager()
         {
-            for(const auto &mapping: constMethods)
-                Unregister(mapping.first);
-
-            for(const auto &mapping: mutableMethods)
-                Unregister(mapping.first);
+            WifiManager::instance=nullptr;
         }
 
         const string WifiManager::Initialize(PluginHost::IShell* service)
@@ -294,6 +296,16 @@ namespace WPEFramework
             LOGINFOMETHOD();
 
             uint32_t result = wifiSignalThreshold.isSignalThresholdChangeEnabled(parameters, response);
+
+            LOGTRACEMETHODFIN();
+            return result;
+        }
+
+        uint32_t WifiManager::getSupportedSecurityModes(const JsonObject &parameters, JsonObject &response)
+        {
+            LOGINFOMETHOD();
+
+            uint32_t result = wifiState.getSupportedSecurityModes(parameters, response);
 
             LOGTRACEMETHODFIN();
             return result;

--- a/WifiManager/WifiManager.h
+++ b/WifiManager/WifiManager.h
@@ -28,6 +28,8 @@
 #include "impl/WifiManagerSignalThreshold.h"
 #include "impl/WifiManagerScan.h"
 #include "impl/WifiManagerEvents.h"
+#include "utils.h"
+#include "AbstractPlugin.h"
 
 namespace WPEFramework {
 
@@ -44,12 +46,15 @@ namespace WPEFramework {
         // As the registration/unregistration of notifications is realized by the class PluginHost::JSONRPC,
         // this class exposes a public method called, Notify(), using this methods, all subscribed clients
         // will receive a JSONRPC message as a notification, in case this method is called.
-        class WifiManager : public WifiManagerInterface, public PluginHost::IPlugin, public PluginHost::JSONRPC {
+        class WifiManager : public WifiManagerInterface, public AbstractPlugin {
         public:
             WifiManager();
             virtual ~WifiManager();
             WifiManager(const WifiManager&) = delete;
             WifiManager& operator=(const WifiManager&) = delete;
+
+            static const short API_VERSION_NUMBER_MAJOR;
+            static const short API_VERSION_NUMBER_MINOR;
 
             //Begin methods
             virtual uint32_t getQuirks(const JsonObject& parameters, JsonObject& response) const override;
@@ -69,6 +74,7 @@ namespace WPEFramework {
             virtual uint32_t isPaired(const JsonObject& parameters, JsonObject& response) const override;
             virtual uint32_t setSignalThresholdChangeEnabled(const JsonObject& parameters, JsonObject& response) override;
             virtual uint32_t isSignalThresholdChangeEnabled(const JsonObject& parameters, JsonObject& response) const;
+            virtual uint32_t getSupportedSecurityModes(const JsonObject& parameters, JsonObject& response) override;
             //End methods
 
             //Begin events

--- a/WifiManager/WifiManagerInterface.h
+++ b/WifiManager/WifiManagerInterface.h
@@ -46,6 +46,7 @@ namespace WPEFramework {
             virtual uint32_t isPaired(const JsonObject& parameters, JsonObject& response) const = 0;
             virtual uint32_t setSignalThresholdChangeEnabled(const JsonObject& parameters, JsonObject& response) = 0;
             virtual uint32_t isSignalThresholdChangeEnabled(const JsonObject& parameters, JsonObject& response) const = 0;
+            virtual uint32_t getSupportedSecurityModes(const JsonObject& parameters, JsonObject& response) = 0;
             //End methods
 
             //Begin events

--- a/WifiManager/impl/WifiManagerState.cpp
+++ b/WifiManager/impl/WifiManagerState.cpp
@@ -104,3 +104,28 @@ uint32_t WifiManagerState::setEnabled(const JsonObject &parameters, JsonObject &
 
     returnResponse(retVal == IARM_RESULT_SUCCESS);
 }
+
+uint32_t WifiManagerState::getSupportedSecurityModes(const JsonObject &parameters, JsonObject &response)
+{
+    LOGINFOMETHOD();
+
+    JsonObject security_modes;
+
+    //from the SsidSecurity enum in wifiSrvMgrIarmIf.h
+    security_modes["NET_WIFI_SECURITY_NONE"]                 = (int)NET_WIFI_SECURITY_NONE;
+    security_modes["NET_WIFI_SECURITY_WEP_64"]               = (int)NET_WIFI_SECURITY_WEP_64;
+    security_modes["NET_WIFI_SECURITY_WEP_128"]              = (int)NET_WIFI_SECURITY_WEP_128;
+    security_modes["NET_WIFI_SECURITY_WPA_PSK_TKIP"]         = (int)NET_WIFI_SECURITY_WPA_PSK_TKIP;
+    security_modes["NET_WIFI_SECURITY_WPA_PSK_AES"]          = (int)NET_WIFI_SECURITY_WPA_PSK_AES;
+    security_modes["NET_WIFI_SECURITY_WPA2_PSK_TKIP"]        = (int)NET_WIFI_SECURITY_WPA2_PSK_TKIP;
+    security_modes["NET_WIFI_SECURITY_WPA2_PSK_AES"]         = (int)NET_WIFI_SECURITY_WPA2_PSK_AES;
+    security_modes["NET_WIFI_SECURITY_WPA_ENTERPRISE_TKIP"]  = (int)NET_WIFI_SECURITY_WPA_ENTERPRISE_TKIP;
+    security_modes["NET_WIFI_SECURITY_WPA_ENTERPRISE_AES"]   = (int)NET_WIFI_SECURITY_WPA_ENTERPRISE_AES;
+    security_modes["NET_WIFI_SECURITY_WPA2_ENTERPRISE_TKIP"] = (int)NET_WIFI_SECURITY_WPA2_ENTERPRISE_TKIP;
+    security_modes["NET_WIFI_SECURITY_WPA2_ENTERPRISE_AES"]  = (int)NET_WIFI_SECURITY_WPA2_ENTERPRISE_AES;
+    security_modes["NET_WIFI_SECURITY_WPA3_SAE"]             = (int)NET_WIFI_SECURITY_WPA3_SAE;
+
+    response["security_modes"] = security_modes;
+
+    returnResponse(true);
+}

--- a/WifiManager/impl/WifiManagerState.h
+++ b/WifiManager/impl/WifiManagerState.h
@@ -34,6 +34,7 @@ namespace WPEFramework {
             uint32_t getCurrentState(const JsonObject& parameters, JsonObject& response) const;
             uint32_t getConnectedSSID(const JsonObject& parameters, JsonObject& response) const;
             uint32_t setEnabled(const JsonObject& parameters, JsonObject& response);
+            uint32_t getSupportedSecurityModes(const JsonObject& parameters, JsonObject& response);
         };
     }
 }


### PR DESCRIPTION
Reason for change:Added new api getSupportedSecurityModes() to
thunder framework.Added Version 2 API logic.
Test Procedure: Refer Ticket

(cherry picked from commit 6071ce4064e81e0b42b587c9aafee7e45285d8bc)
(cherry picked from commit 182f3124a56bdc81749193f4491a8be2f11fe933)