### PR TITLE
ActivityMonitor: remove delay when stopping monitor

### DIFF
--- a/ActivityMonitor/ActivityMonitor.cpp
+++ b/ActivityMonitor/ActivityMonitor.cpp
@@ -204,17 +204,7 @@ namespace WPEFramework
         {
             LOGINFO();
 
-            {
-                std::lock_guard<std::mutex> lock(m_monitoringMutex);
-                m_stopMonitoring = true;
-            }
-
-            if (m_monitor.joinable())
-            {
-                LOGWARN("Terminating monitor thread");
-                m_monitor.join();
-            }
-
+            threadStop();
             JsonArray configArray = parameters["config"].Array();
 
             if (0 == configArray.Length())
@@ -290,14 +280,7 @@ namespace WPEFramework
         {
             LOGINFO();
 
-            {
-                std::lock_guard<std::mutex> lock(m_monitoringMutex);
-                m_stopMonitoring = true;
-            }
-
-            if (m_monitor.joinable())
-                m_monitor.join();
-            else
+            if (threadStop() == -1);
                 LOGWARN("Monitoring is already disabled");
 
             delete m_monitorParams;
@@ -732,6 +715,19 @@ namespace WPEFramework
             am->monitoring();
         }
 
+        int ActivityMonitor::threadStop()
+        {
+            if (!m_monitor.joinable())
+                return -1;
+
+            std::unique_lock<std::mutex> lock(m_monitoringMutex);
+            m_stopMonitoring = true;
+            m_cond.notify_one();
+            lock.unlock();
+            m_monitor.join();
+            return 0;
+        }
+
         void ActivityMonitor::monitoring()
         {
             if (0 == m_monitorParams->config.size())
@@ -742,13 +738,6 @@ namespace WPEFramework
 
             while (1)
             {
-                {
-                    std::lock_guard<std::mutex> lock(m_monitoringMutex);
-
-                    if (m_stopMonitoring)
-                        break;
-                }
-
                 std::chrono::duration<double> elapsed = std::chrono::system_clock::now() - m_monitorParams->lastMemCheck;
                 bool memCheck = m_monitorParams->memoryIntervalSeconds > 0 && elapsed.count() > m_monitorParams->memoryIntervalSeconds - 0.01;
 
@@ -959,7 +948,10 @@ namespace WPEFramework
                     sleepTime = 0.01;
                 }
 
-                usleep(int(sleepTime * 1000000));
+                auto sleepfor = std::chrono::milliseconds((long)(sleepTime * 1000));
+                std::unique_lock<std::mutex> lock(m_monitoringMutex);
+                if (m_cond.wait_for(lock, sleepfor, [this] { return this->m_stopMonitoring; }))
+                    break;
             }
         }
 

--- a/ActivityMonitor/ActivityMonitor.h
+++ b/ActivityMonitor/ActivityMonitor.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <condition_variable>
 #include <thread>
 #include <mutex>
 
@@ -73,10 +74,12 @@ namespace WPEFramework {
         private:
 
             static void threadRun(ActivityMonitor *am);
+            int threadStop();
             void monitoring();
 
             std::thread m_monitor;
             std::mutex m_monitoringMutex;
+            std::condition_variable m_cond;
 
             MonitorParams *m_monitorParams;
             bool m_stopMonitoring;


### PR DESCRIPTION
Activity monitor has unconditional sleep in its thread at the very
end of while(1) loop. When activity monitor is started, caller
passes inverval in seconds, which defines how often monitoring loop
shall be triggered.

When monitor is being stopped, code will set flag to notify loop to
stop, but this flag will be read only after inverval (or what is
left of it) seconds of time passed, which can lead to high delay
when inverval is high enough.

This patch implements stopping on conditional variables. Monitor
will sleep in conditional variable wait_for() instead of usleep(),
and stop function will notify monitoring thread, thus forcing it to
stop immediately without waiting for whole inverval.

Signed-off-by: Michał Łyszczek <michal.lyszczek@consult.red>