### PR TITLE
RDK-32015: Implement the new AC

### DIFF
--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -3451,7 +3451,7 @@ namespace WPEFramework {
                 auto it = FwFailReasonFromText.find(str);
                 if (it != FwFailReasonFromText.end())
                     failReason = it->second;
-                else
+                else if (!str.empty())
                     LOGWARN("Unrecognised FailureReason!");
             } else {
                 LOGINFO("Could not read file %s", FWDNLDSTATUS_FILE_NAME);

--- a/helpers/SystemServicesHelper.h
+++ b/helpers/SystemServicesHelper.h
@@ -306,6 +306,7 @@ enum FwFailReason
 static const std::map<FwFailReason, string> FwFailReasonToText =
         {
                 {FwFailReasonNone, "None"},
+                {FwFailReasonNotFound, "Not found"},
                 {FwFailReasonNetworkFailure, "Network failure"},
                 {FwFailReasonServerUnreachable, "Server unreachable"},
                 {FwFailReasonCorruptDownloadFile, "Corrupt download file"},
@@ -317,7 +318,7 @@ static const std::map<string, FwFailReason> FwFailReasonFromText =
         {
                 {"ESTB Download Failure", FwFailReasonServerUnreachable},
                 {"Image Download Failed - Unable to connect", FwFailReasonNetworkFailure},
-                {"Image Download Failed - Server not Found", FwFailReasonNetworkFailure},
+                {"Image Download Failed - Server not Found", FwFailReasonNotFound},
                 {"Image Download Failed - Error response from server", FwFailReasonServerUnreachable},
                 {"Image Download Failed - Unknown", FwFailReasonServerUnreachable},
                 {"Image download failed from server", FwFailReasonServerUnreachable}, // firmwareDwnld.sh only


### PR DESCRIPTION
Reason for change: new AC - "Not found" FailureReason.
Test Procedure: when image download returns 404,
FailureReason shall be "Not found".
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>