### PR TITLE
RDK-31910: Add flush to PersistentStore RDK service (pt.4)

### DIFF
--- a/PersistentStore/PersistentStore.cpp
+++ b/PersistentStore/PersistentStore.cpp
@@ -2,6 +2,7 @@
 
 #include <sqlite3.h>
 #include <glib.h>
+#include <unistd.h>
 
 #if defined(USE_PLABELS)
 #include "pbnj_utils.hpp"
@@ -584,6 +585,7 @@ namespace WPEFramework {
                     LOGERR("Error while flushing sqlite database cache: %d", rc);
                 }
             }
+            sync();
             return success;
         }
 


### PR DESCRIPTION
Implements: call to sync() in addition to sqlite3_db_cacheflush()