### PR TITLE
StateObserver: fix memory leaks

### DIFF
--- a/StateObserver/StateObserver.cpp
+++ b/StateObserver/StateObserver.cpp
@@ -244,6 +244,7 @@ namespace WPEFramework {
 			if( items == NULL)
 			{
 				LOGWARN("not able to fetch property names from request \n");
+				cJSON_Delete(root);
 				returnResponse(ret);
 			}
 			int arrsize=cJSON_GetArraySize(items);
@@ -263,6 +264,7 @@ namespace WPEFramework {
 				getVal(pname,response);
 			}
 			LOGTRACEMETHODFIN();
+			cJSON_Delete(root);
 			returnResponse(ret);
 		}
 
@@ -619,6 +621,7 @@ namespace WPEFramework {
 			if( items == NULL)
 			{
 				LOGWARN("not able to fetch property names from request \n");
+				cJSON_Delete(root);
 				returnResponse(ret);
 			}
 			int arrsize=cJSON_GetArraySize(items);
@@ -646,6 +649,7 @@ namespace WPEFramework {
 				getVal(pname,response);
 			}
 			LOGTRACEMETHODFIN();
+			cJSON_Delete(root);
 			returnResponse(ret);
 		}
 
@@ -679,6 +683,7 @@ namespace WPEFramework {
 			if( items == NULL)
 			{
 				LOGWARN("not able to fetch property names from request \n");
+				cJSON_Delete(root);
 				returnResponse(ret);
 			}
 			int arrsize=cJSON_GetArraySize(items);
@@ -706,6 +711,7 @@ namespace WPEFramework {
 				}
 			}
 			LOGTRACEMETHODFIN();
+			cJSON_Delete(root);
 			returnResponse(ret);
 		}
 


### PR DESCRIPTION
Every cJSON_Parse() should have matching cJSON_Delete().

Signed-off-by: Michał Łyszczek <michal.lyszczek@consult.red>