### PR TITLE
FETCHTV-13: org.rdk.DisplaySettings.1.setScartParameter curl command …

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -2314,7 +2314,7 @@ namespace WPEFramework {
             returnIfParamNotFound(parameters, "scartParameterData");
 
             string sScartParameter = parameters["scartParameter"].String();
-            string sScartParameterData = parameters["cartParameterData"].String();
+            string sScartParameterData = parameters["scartParameterData"].String();
 
             bool success = true;
             try


### PR DESCRIPTION
…error Destined invoke failed.

Reason for change:  Unable to execute the org.rdk.DisplaySettings.1.setScartParameter curl command.
Test Procedure: Execute org.rdk.DisplaySettings.1.setScartParameter curl command.
Risks: None