### PR TITLE
RDKTV-2681: Move plugin cleanup to Deinitialize

### DIFF
--- a/AVInput/AVInput.cpp
+++ b/AVInput/AVInput.cpp
@@ -66,8 +66,7 @@ namespace WPEFramework {
 
         AVInput::~AVInput()
         {
-            LOGINFO("dtor");
-            AVInput::_instance = nullptr;
+            //LOGINFO("dtor");
         }
 
         const string AVInput::Initialize(PluginHost::IShell* /* service */)
@@ -84,6 +83,7 @@ namespace WPEFramework {
 
         void AVInput::Deinitialize(PluginHost::IShell* /* service */)
         {
+            AVInput::_instance = nullptr;
         }
 
         string AVInput::Information() const

--- a/ActivityMonitor/ActivityMonitor.cpp
+++ b/ActivityMonitor/ActivityMonitor.cpp
@@ -123,6 +123,10 @@ namespace WPEFramework
 
         ActivityMonitor::~ActivityMonitor()
         {
+        }
+
+        void ActivityMonitor::Deinitialize(PluginHost::IShell* /* service */)
+        {
             ActivityMonitor::_instance = nullptr;
 
             if (m_monitor.joinable())

--- a/ActivityMonitor/ActivityMonitor.h
+++ b/ActivityMonitor/ActivityMonitor.h
@@ -68,6 +68,7 @@ namespace WPEFramework {
         public:
             ActivityMonitor();
             virtual ~ActivityMonitor();
+            virtual void Deinitialize(PluginHost::IShell* service) override;
 
         public:
             static ActivityMonitor* _instance;

--- a/Bluetooth/Bluetooth.cpp
+++ b/Bluetooth/Bluetooth.cpp
@@ -179,6 +179,10 @@ namespace WPEFramework
 
         Bluetooth::~Bluetooth()
         {
+        }
+
+        void Bluetooth::Deinitialize(PluginHost::IShell* /* service */)
+        {
             Bluetooth::_instance = nullptr;
 
             BTRMGR_Result_t rc = BTRMGR_UnRegisterFromCallbacks(Utils::IARM::NAME);

--- a/Bluetooth/Bluetooth.h
+++ b/Bluetooth/Bluetooth.h
@@ -171,6 +171,7 @@ namespace WPEFramework {
 
             Bluetooth();
             virtual ~Bluetooth();
+            virtual void Deinitialize(PluginHost::IShell* service) override;
             virtual string Information() const override;
 
         public:

--- a/CompositeInput/CompositeInput.cpp
+++ b/CompositeInput/CompositeInput.cpp
@@ -59,6 +59,10 @@ namespace WPEFramework
 
         CompositeInput::~CompositeInput()
         {
+        }
+
+        void CompositeInput::Deinitialize(PluginHost::IShell* /* service */)
+        {
             CompositeInput::_instance = nullptr;
 
             DeinitializeIARM();

--- a/CompositeInput/CompositeInput.h
+++ b/CompositeInput/CompositeInput.h
@@ -69,6 +69,7 @@ namespace WPEFramework {
         public:
             CompositeInput();
             virtual ~CompositeInput();
+            virtual void Deinitialize(PluginHost::IShell* service) override;
 
             void terminate();
 

--- a/ContinueWatching/ContinueWatching.cpp
+++ b/ContinueWatching/ContinueWatching.cpp
@@ -80,6 +80,10 @@ namespace WPEFramework {
 
 		ContinueWatching::~ContinueWatching()
 		{
+		}
+
+		void ContinueWatching::Deinitialize(PluginHost::IShell* /* service */)
+		{
 			ContinueWatching::_instance = nullptr;
 		}
 

--- a/ContinueWatching/ContinueWatching.h
+++ b/ContinueWatching/ContinueWatching.h
@@ -88,6 +88,7 @@ namespace WPEFramework {
         	public:
 			ContinueWatching();
 			virtual ~ContinueWatching();
+                        virtual void Deinitialize(PluginHost::IShell* service) override;
         	private:
 			uint32_t getApiVersionNumber();
 			void setApiVersionNumber(uint32_t apiVersionNumber);

--- a/ControlService/ControlService.cpp
+++ b/ControlService/ControlService.cpp
@@ -95,8 +95,7 @@ namespace WPEFramework {
 
         ControlService::~ControlService()
         {
-            LOGINFO("dtor");
-            ControlService::_instance = nullptr;
+            //LOGINFO("dtor");
 
         }
 
@@ -110,6 +109,7 @@ namespace WPEFramework {
         void ControlService::Deinitialize(PluginHost::IShell* /* service */)
         {
             DeinitializeIARM();
+            ControlService::_instance = nullptr;
         }
 
         void ControlService::InitializeIARM()

--- a/DTV/DTV.cpp
+++ b/DTV/DTV.cpp
@@ -249,6 +249,7 @@ namespace WPEFramework
          _dtv = nullptr;
 
          _service = nullptr;
+         UnregisterAll();
 
          SYSLOG(Logging::Shutdown, (string(_T("DTV de-initialised"))));
       }

--- a/DTV/DTV.h
+++ b/DTV/DTV.h
@@ -144,7 +144,6 @@ namespace WPEFramework
 
             virtual ~DTV()
             {
-               UnregisterAll();
             }
 
             static DTV* instance(DTV *dtv = nullptr)

--- a/DataCapture/DataCapture.cpp
+++ b/DataCapture/DataCapture.cpp
@@ -87,9 +87,7 @@ namespace WPEFramework {
 
         DataCapture::~DataCapture()
         {
-            LOGINFO("dtor");
-            delete _sock_adaptor;
-            DataCapture::_instance = nullptr;
+            //LOGINFO("dtor");
         }
 
         const string DataCapture::Initialize(PluginHost::IShell* /* service */)
@@ -101,6 +99,8 @@ namespace WPEFramework {
         void DataCapture::Deinitialize(PluginHost::IShell* /* service */)
         {
             DeinitializeIARM();
+            delete _sock_adaptor;
+            DataCapture::_instance = nullptr;
         }
 
         string DataCapture::Information() const

--- a/DeviceDiagnostics/DeviceDiagnostics.cpp
+++ b/DeviceDiagnostics/DeviceDiagnostics.cpp
@@ -53,6 +53,10 @@ namespace WPEFramework
 
         DeviceDiagnostics::~DeviceDiagnostics()
         {
+        }
+
+        void DeviceDiagnostics::Deinitialize(PluginHost::IShell* /* service */)
+        {
             DeviceDiagnostics::_instance = nullptr;
         }
 

--- a/DeviceDiagnostics/DeviceDiagnostics.h
+++ b/DeviceDiagnostics/DeviceDiagnostics.h
@@ -56,6 +56,7 @@ namespace WPEFramework {
         public:
             DeviceDiagnostics();
             virtual ~DeviceDiagnostics();
+            virtual void Deinitialize(PluginHost::IShell* service) override;
 
         public:
             static DeviceDiagnostics* _instance;

--- a/DeviceIdentification/DeviceIdentification.cpp
+++ b/DeviceIdentification/DeviceIdentification.cpp
@@ -77,6 +77,7 @@ namespace Plugin {
         }
 
         _connectionId = 0;
+         UnregisterAll();
     }
 
     /* virtual */ string DeviceIdentification::Information() const

--- a/DeviceIdentification/DeviceIdentification.h
+++ b/DeviceIdentification/DeviceIdentification.h
@@ -42,7 +42,6 @@ namespace Plugin {
 
         virtual ~DeviceIdentification()
         {
-            UnregisterAll();
         }
 
         BEGIN_INTERFACE_MAP(DeviceIdentification)

--- a/DeviceInfo/DeviceInfo.cpp
+++ b/DeviceInfo/DeviceInfo.cpp
@@ -57,6 +57,7 @@ namespace Plugin {
         }
 
         _service = nullptr;
+         UnregisterAll();
     }
 
     /* virtual */ string DeviceInfo::Information() const

--- a/DeviceInfo/DeviceInfo.h
+++ b/DeviceInfo/DeviceInfo.h
@@ -83,7 +83,6 @@ namespace Plugin {
 
         virtual ~DeviceInfo()
         {
-            UnregisterAll();
         }
 
         BEGIN_INTERFACE_MAP(DeviceInfo)

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -213,8 +213,7 @@ namespace WPEFramework {
 
         DisplaySettings::~DisplaySettings()
         {
-            LOGINFO("dtor");
-            DisplaySettings::_instance = nullptr;
+            //LOGINFO("dtor");
         }
 
         void DisplaySettings::InitAudioPorts() 
@@ -310,6 +309,7 @@ namespace WPEFramework {
         void DisplaySettings::Deinitialize(PluginHost::IShell* /* service */)
         {
             DeinitializeIARM();
+            DisplaySettings::_instance = nullptr;
         }
 
         void DisplaySettings::InitializeIARM()

--- a/FrameRate/FrameRate.cpp
+++ b/FrameRate/FrameRate.cpp
@@ -62,6 +62,10 @@ namespace WPEFramework
 
         FrameRate::~FrameRate()
         {
+        }
+
+        void FrameRate::Deinitialize(PluginHost::IShell* /* service */)
+        {
             FrameRate::_instance = nullptr;
         }
 

--- a/FrameRate/FrameRate.h
+++ b/FrameRate/FrameRate.h
@@ -74,6 +74,7 @@ namespace WPEFramework {
         public:
             FrameRate();
             virtual ~FrameRate();
+            virtual void Deinitialize(PluginHost::IShell* service) override;
 
         public:
             static FrameRate* _instance;

--- a/FrontPanel/FrontPanel.cpp
+++ b/FrontPanel/FrontPanel.cpp
@@ -185,6 +185,10 @@ namespace WPEFramework
 
         FrontPanel::~FrontPanel()
         {
+        }
+
+        void FrontPanel::Deinitialize(PluginHost::IShell* /* service */)
+        {
             FrontPanel::_instance = nullptr;
 
             {

--- a/FrontPanel/FrontPanel.h
+++ b/FrontPanel/FrontPanel.h
@@ -125,6 +125,7 @@ namespace WPEFramework {
         public:
             FrontPanel();
             virtual ~FrontPanel();
+            virtual void Deinitialize(PluginHost::IShell* service) override;
 
             void updateLedTextPattern();
 

--- a/HdcpProfile/HdcpProfile.cpp
+++ b/HdcpProfile/HdcpProfile.cpp
@@ -61,6 +61,10 @@ namespace WPEFramework
 
         HdcpProfile::~HdcpProfile()
         {
+        }
+
+        void HdcpProfile::Deinitialize(PluginHost::IShell* /* service */)
+        {
             HdcpProfile::_instance = nullptr;
             device::Manager::DeInitialize();
             DeinitializeIARM();

--- a/HdcpProfile/HdcpProfile.h
+++ b/HdcpProfile/HdcpProfile.h
@@ -66,6 +66,7 @@ namespace WPEFramework {
         public:
             HdcpProfile();
             virtual ~HdcpProfile();
+            virtual void Deinitialize(PluginHost::IShell* service) override;
 
             void terminate();
 

--- a/HdmiCec/HdmiCec.cpp
+++ b/HdmiCec/HdmiCec.cpp
@@ -103,6 +103,10 @@ namespace WPEFramework
 
         HdmiCec::~HdmiCec()
         {
+        }
+
+        void HdmiCec::Deinitialize(PluginHost::IShell* /* service */)
+        {
             HdmiCec::_instance = nullptr;
 
             DeinitializeIARM();

--- a/HdmiCec/HdmiCec.h
+++ b/HdmiCec/HdmiCec.h
@@ -65,6 +65,7 @@ namespace WPEFramework {
         public:
             HdmiCec();
             virtual ~HdmiCec();
+            virtual void Deinitialize(PluginHost::IShell* service) override;
 
         public:
             static HdmiCec* _instance;

--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -502,7 +502,10 @@ namespace WPEFramework
 
        HdmiCecSink::~HdmiCecSink()
        {
-	  
+       }
+
+       void HdmiCecSink::Deinitialize(PluginHost::IShell* /* service */)
+       {
 	    CECDisable();
 	    m_currentArcRoutingState = ARC_STATE_ARC_EXIT;
 
@@ -524,7 +527,7 @@ namespace WPEFramework
 
             HdmiCecSink::_instance = nullptr;
             DeinitializeIARM();
-	    LOGWARN(" ~HdmiCecSink() Done");
+	    LOGWARN(" HdmiCecSink Deinitialize() Done");
        }
 
        const void HdmiCecSink::InitializeIARM()

--- a/HdmiCecSink/HdmiCecSink.h
+++ b/HdmiCecSink/HdmiCecSink.h
@@ -484,6 +484,7 @@ private:
         public:
             HdmiCecSink();
             virtual ~HdmiCecSink();
+            virtual void Deinitialize(PluginHost::IShell* service) override;
             static HdmiCecSink* _instance;
 			CECDeviceParams deviceList[16];
 			std::vector<HdmiPortMap> hdmiInputs;

--- a/HdmiCec_2/HdmiCec_2.cpp
+++ b/HdmiCec_2/HdmiCec_2.cpp
@@ -382,6 +382,10 @@ namespace WPEFramework
 
        HdmiCec_2::~HdmiCec_2()
        {
+       }
+
+       void HdmiCec_2::Deinitialize(PluginHost::IShell* /* service */)
+       {
            HdmiCec_2::_instance = nullptr;
            DeinitializeIARM();
        }

--- a/HdmiCec_2/HdmiCec_2.h
+++ b/HdmiCec_2/HdmiCec_2.h
@@ -102,6 +102,7 @@ namespace WPEFramework {
         public:
             HdmiCec_2();
             virtual ~HdmiCec_2();
+            virtual void Deinitialize(PluginHost::IShell* service) override;
             static HdmiCec_2* _instance;
         private:
             // We do not allow this plugin to be copied !!

--- a/HdmiInput/HdmiInput.cpp
+++ b/HdmiInput/HdmiInput.cpp
@@ -70,6 +70,10 @@ namespace WPEFramework
 
         HdmiInput::~HdmiInput()
         {
+        }
+
+        void HdmiInput::Deinitialize(PluginHost::IShell* /* service */)
+        {
             HdmiInput::_instance = nullptr;
 
             DeinitializeIARM();

--- a/HdmiInput/HdmiInput.h
+++ b/HdmiInput/HdmiInput.h
@@ -79,6 +79,7 @@ namespace WPEFramework {
         public:
             HdmiInput();
             virtual ~HdmiInput();
+            virtual void Deinitialize(PluginHost::IShell* service) override;
 
             void terminate();
 

--- a/LocationSync/LocationSync.cpp
+++ b/LocationSync/LocationSync.cpp
@@ -44,7 +44,6 @@ namespace Plugin {
 
     /* virtual */ LocationSync::~LocationSync()
     {
-        UnregisterAll();
     }
 
     /* virtual */ const string LocationSync::Initialize(PluginHost::IShell* service)
@@ -73,6 +72,7 @@ namespace Plugin {
         ASSERT(_service == service);
 
         _sink.Deinitialize();
+        UnregisterAll();
     }
 
     /* virtual */ string LocationSync::Information() const

--- a/LoggingPreferences/LoggingPreferences.cpp
+++ b/LoggingPreferences/LoggingPreferences.cpp
@@ -41,8 +41,7 @@ namespace WPEFramework {
 
         LoggingPreferences::~LoggingPreferences()
         {
-            LOGINFO("dtor");
-            LoggingPreferences::_instance = nullptr;
+            //LOGINFO("dtor");
         }
 
         const string LoggingPreferences::Initialize(PluginHost::IShell* /* service */)
@@ -54,6 +53,7 @@ namespace WPEFramework {
         void LoggingPreferences::Deinitialize(PluginHost::IShell* /* service */)
         {
             DeinitializeIARM();
+            LoggingPreferences::_instance = nullptr;
         }
 
         void LoggingPreferences::InitializeIARM()

--- a/Messenger/Messenger.cpp
+++ b/Messenger/Messenger.cpp
@@ -67,6 +67,7 @@ namespace Plugin {
 
         _service->Release();
         _service = nullptr;
+        UnregisterAll();
     }
 
     // Web request handlers

--- a/Messenger/Messenger.h
+++ b/Messenger/Messenger.h
@@ -49,7 +49,6 @@ namespace Plugin {
 
         ~Messenger()
         {
-            UnregisterAll();
         }
 
         // IPlugin methods

--- a/Monitor/Monitor.cpp
+++ b/Monitor/Monitor.cpp
@@ -53,6 +53,8 @@ namespace Plugin {
         _monitor->Close();
 
         service->Unregister(_monitor);
+        UnregisterAll();
+        _monitor->Release();
     }
 
     /* virtual */ string Monitor::Information() const

--- a/Monitor/Monitor.h
+++ b/Monitor/Monitor.h
@@ -1010,8 +1010,6 @@ namespace Plugin {
 #endif
         virtual ~Monitor()
         {
-            UnregisterAll();
-            _monitor->Release();
         }
 
         BEGIN_INTERFACE_MAP(Monitor)

--- a/MotionDetection/MotionDetection.cpp
+++ b/MotionDetection/MotionDetection.cpp
@@ -73,19 +73,6 @@ namespace WPEFramework {
 
         MotionDetection::~MotionDetection()
         {
-            LOGINFO("MotionDetection dtor");
-            MotionDetection::_instance = nullptr;
-            Unregister("getMotionDetectors");
-            Unregister("arm");
-            Unregister("disarm");
-            Unregister("isarmed");
-            Unregister("setNoMotionPeriod");
-            Unregister("getNoMotionPeriod");
-            Unregister("setSensitivity");
-            Unregister("getSensitivity");
-            Unregister("getLastMotionEventElapsedTime");
-            Unregister("setMotionEventsActivePeriod");
-            Unregister("getMotionEventsActivePeriod");
         }
 
         void setResponseArray(JsonObject& response, const char* key, const vector<string>& items)
@@ -114,7 +101,20 @@ namespace WPEFramework {
 
         void MotionDetection::Deinitialize(PluginHost::IShell* /* service */)
         {
+            LOGINFO("MotionDetection Deinitialize");
 	    MOTION_DETECTION_Platform_Term();
+            MotionDetection::_instance = nullptr;
+            Unregister("getMotionDetectors");
+            Unregister("arm");
+            Unregister("disarm");
+            Unregister("isarmed");
+            Unregister("setNoMotionPeriod");
+            Unregister("getNoMotionPeriod");
+            Unregister("setSensitivity");
+            Unregister("getSensitivity");
+            Unregister("getLastMotionEventElapsedTime");
+            Unregister("setMotionEventsActivePeriod");
+            Unregister("getMotionEventsActivePeriod");
         }
 
         //Begin methods

--- a/Network/Network.cpp
+++ b/Network/Network.cpp
@@ -168,26 +168,6 @@ namespace WPEFramework
 
         Network::~Network()
         {
-            Unregister("getQuirks");
-            Unregister("getInterfaces");
-            Unregister("isInterfaceEnabled");
-            Unregister("setInterfaceEnabled");
-            Unregister("getDefaultInterface");
-            Unregister("setDefaultInterface");
-            Unregister("getStbIp");
-            Unregister("setApiVersionNumber");
-            Unregister("getApiVersionNumber");
-            Unregister("trace");
-            Unregister("traceNamedEndpoint");
-            Unregister("getNamedEndpoints");
-            Unregister("ping");
-            Unregister("pingNamedEndpoint");
-            Unregister("setIPSettings");
-            Unregister("getIPSettings");
-            Unregister("isConnectedToInternet");
-            Unregister("setConnectivityTestEndpoints");
-
-            Network::_instance = nullptr;
         }
 
         const string Network::Initialize(PluginHost::IShell* /* service */)
@@ -214,6 +194,26 @@ namespace WPEFramework
                 IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_NETWORK_MANAGER_EVENT_INTERFACE_IPADDRESS) );
                 IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_NETWORK_MANAGER_EVENT_DEFAULT_INTERFACE) );
             }
+            Unregister("getQuirks");
+            Unregister("getInterfaces");
+            Unregister("isInterfaceEnabled");
+            Unregister("setInterfaceEnabled");
+            Unregister("getDefaultInterface");
+            Unregister("setDefaultInterface");
+            Unregister("getStbIp");
+            Unregister("setApiVersionNumber");
+            Unregister("getApiVersionNumber");
+            Unregister("trace");
+            Unregister("traceNamedEndpoint");
+            Unregister("getNamedEndpoints");
+            Unregister("ping");
+            Unregister("pingNamedEndpoint");
+            Unregister("setIPSettings");
+            Unregister("getIPSettings");
+            Unregister("isConnectedToInternet");
+            Unregister("setConnectivityTestEndpoints");
+
+            Network::_instance = nullptr;
         }
 
         string Network::Information() const

--- a/OCIContainer/OCIContainer.cpp
+++ b/OCIContainer/OCIContainer.cpp
@@ -49,15 +49,6 @@ OCIContainer::OCIContainer()
 
 OCIContainer::~OCIContainer()
 {
-    Unregister("listContainers");
-    Unregister("getContainerState");
-    Unregister("getContainerInfo");
-    Unregister("startContainer");
-    Unregister("startContainerFromDobbySpec");
-    Unregister("stopContainer");
-    Unregister("pauseContainer");
-    Unregister("resumeContainer");
-    Unregister("executeCommand");
 }
 
 const string OCIContainer::Initialize(PluginHost::IShell *service)
@@ -97,6 +88,15 @@ const string OCIContainer::Initialize(PluginHost::IShell *service)
 void OCIContainer::Deinitialize(PluginHost::IShell *service)
 {
     mDobbyProxy->unregisterListener(mEventListenerId);
+    Unregister("listContainers");
+    Unregister("getContainerState");
+    Unregister("getContainerInfo");
+    Unregister("startContainer");
+    Unregister("startContainerFromDobbySpec");
+    Unregister("stopContainer");
+    Unregister("pauseContainer");
+    Unregister("resumeContainer");
+    Unregister("executeCommand");
 }
 
 string OCIContainer::Information() const

--- a/OpenCDMi/OCDM.cpp
+++ b/OpenCDMi/OCDM.cpp
@@ -176,6 +176,7 @@ namespace Plugin {
         _memory = nullptr;
         _opencdmi = nullptr;
         _service = nullptr;
+         UnregisterAll();
     }
 
     /* virtual */ string OCDM::Information() const

--- a/OpenCDMi/OCDM.h
+++ b/OpenCDMi/OCDM.h
@@ -156,7 +156,6 @@ namespace Plugin {
         #endif
         virtual ~OCDM()
         {
-            UnregisterAll();
         }
 
     public:

--- a/Packager/Packager.cpp
+++ b/Packager/Packager.cpp
@@ -73,6 +73,8 @@ namespace {
 
         _service = nullptr;
         _implementation = nullptr;
+        Unregister(kInstallMethodName);
+        Unregister(kSynchronizeMethodName);
     }
 
     string Packager::Information() const

--- a/Packager/Packager.h
+++ b/Packager/Packager.h
@@ -71,8 +71,6 @@ namespace {
 
         ~Packager() override
         {
-            Unregister(kInstallMethodName);
-            Unregister(kSynchronizeMethodName);
         }
 
         BEGIN_INTERFACE_MAP(Packager)

--- a/PersistentStore/PersistentStore.cpp
+++ b/PersistentStore/PersistentStore.cpp
@@ -87,10 +87,7 @@ namespace WPEFramework {
 
         PersistentStore::~PersistentStore()
         {
-            LOGINFO("dtor");
-            PersistentStore::_instance = nullptr;
-
-            term();
+            //LOGINFO("dtor");
         }
 
         const string PersistentStore::Initialize(PluginHost::IShell* /* service */)
@@ -109,6 +106,7 @@ namespace WPEFramework {
         void PersistentStore::Deinitialize(PluginHost::IShell* /* service */)
         {
             term();
+            PersistentStore::_instance = nullptr;
         }
 
         string PersistentStore::Information() const

--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -389,14 +389,7 @@ namespace WPEFramework {
 
         RDKShell::~RDKShell()
         {
-            LOGINFO("dtor");
-            mClientsMonitor->Release();
-            RDKShell::_instance = nullptr;
-            mRemoteShell = false;
-            CompositorController::setEventListener(nullptr);
-            mEventListener = nullptr;
-            mEnableUserInactivityNotification = false;
-            gActivePluginsData.clear();
+            //LOGINFO("dtor");
         }
 
         const string RDKShell::Initialize(PluginHost::IShell* service )
@@ -660,8 +653,16 @@ namespace WPEFramework {
 
         void RDKShell::Deinitialize(PluginHost::IShell* service)
         {
+            LOGINFO("Deinitialize");
             mCurrentService = nullptr;
             service->Unregister(mClientsMonitor);
+            mClientsMonitor->Release();
+            RDKShell::_instance = nullptr;
+            mRemoteShell = false;
+            CompositorController::setEventListener(nullptr);
+            mEventListener = nullptr;
+            mEnableUserInactivityNotification = false;
+            gActivePluginsData.clear();
         }
 
         string RDKShell::Information() const

--- a/RemoteActionMapping/RemoteActionMapping.cpp
+++ b/RemoteActionMapping/RemoteActionMapping.cpp
@@ -118,9 +118,7 @@ namespace WPEFramework {
 
         RemoteActionMapping::~RemoteActionMapping()
         {
-            LOGINFO("dtor");
-            RemoteActionMapping::_instance = nullptr;
-
+            //LOGINFO("dtor");
         }
 
         const string RemoteActionMapping::Initialize(PluginHost::IShell* /* service */)
@@ -133,6 +131,7 @@ namespace WPEFramework {
         void RemoteActionMapping::Deinitialize(PluginHost::IShell* /* service */)
         {
             DeinitializeIARM();
+            RemoteActionMapping::_instance = nullptr;
         }
 
         void RemoteActionMapping::InitializeIARM()

--- a/ScreenCapture/ScreenCapture.cpp
+++ b/ScreenCapture/ScreenCapture.cpp
@@ -59,6 +59,10 @@ namespace WPEFramework
 
         ScreenCapture::~ScreenCapture()
         {
+        }
+
+        void ScreenCapture::Deinitialize(PluginHost::IShell* /* service */)
+        {
             ScreenCapture::_instance = nullptr;
 
             delete screenShotDispatcher;

--- a/ScreenCapture/ScreenCapture.h
+++ b/ScreenCapture/ScreenCapture.h
@@ -100,6 +100,7 @@ namespace WPEFramework {
         public:
             ScreenCapture();
             virtual ~ScreenCapture();
+            virtual void Deinitialize(PluginHost::IShell* service) override;
 
         public:
             static ScreenCapture* _instance;

--- a/SecurityAgent/SecurityAgent.cpp
+++ b/SecurityAgent/SecurityAgent.cpp
@@ -85,7 +85,6 @@ namespace Plugin {
 
     /* virtual */ SecurityAgent::~SecurityAgent()
     {
-        UnregisterAll();
     }
 
     /* virtual */ const string SecurityAgent::Initialize(PluginHost::IShell* service)
@@ -156,6 +155,7 @@ namespace Plugin {
             subSystem->Release();
         }
         _acl.Clear();
+        UnregisterAll();
     }
 
     /* virtual */ string SecurityAgent::Information() const

--- a/StateObserver/StateObserver.cpp
+++ b/StateObserver/StateObserver.cpp
@@ -78,8 +78,6 @@ namespace WPEFramework {
 
 		StateObserver::~StateObserver()
 		{
-			StateObserver::_instance = nullptr;
-			//Unregister all the APIs
 		}
 
 		const string StateObserver::Initialize(PluginHost::IShell* /* service */)
@@ -93,6 +91,8 @@ namespace WPEFramework {
 		void StateObserver::Deinitialize(PluginHost::IShell* /* service */)
 		{
 			DeinitializeIARM();
+			StateObserver::_instance = nullptr;
+			//Unregister all the APIs
 		}
 
 		void StateObserver::InitializeIARM()

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -379,7 +379,6 @@ namespace WPEFramework {
 
         SystemServices::~SystemServices()
         {       
-            SystemServices::_instance = nullptr;
         }
 
         const string SystemServices::Initialize(PluginHost::IShell*)
@@ -396,6 +395,7 @@ namespace WPEFramework {
 #if defined(USE_IARMBUS) || defined(USE_IARM_BUS)
             DeinitializeIARM();
 #endif /* defined(USE_IARMBUS) || defined(USE_IARM_BUS) */
+            SystemServices::_instance = nullptr;
         }
 
 #if defined(USE_IARMBUS) || defined(USE_IARM_BUS)

--- a/Timer/Timer.cpp
+++ b/Timer/Timer.cpp
@@ -82,6 +82,10 @@ namespace WPEFramework
 
         Timer::~Timer()
         {
+        }
+
+        void Timer::Deinitialize(PluginHost::IShell* /* service */)
+        {
             Timer::_instance = nullptr;
         }
 

--- a/Timer/Timer.h
+++ b/Timer/Timer.h
@@ -102,6 +102,7 @@ namespace WPEFramework {
         public:
             Timer();
             virtual ~Timer();
+            virtual void Deinitialize(PluginHost::IShell* service) override;
 
         public:
             static Timer* _instance;

--- a/TraceControl/TraceControl.cpp
+++ b/TraceControl/TraceControl.cpp
@@ -102,6 +102,7 @@ namespace Plugin {
 
             _outputs.pop_front();
         }
+        UnregisterAll();
     }
 
     /* virtual */ string TraceControl::Information() const

--- a/TraceControl/TraceControl.h
+++ b/TraceControl/TraceControl.h
@@ -942,7 +942,6 @@ namespace Plugin {
 #endif
         virtual ~TraceControl()
         {
-            UnregisterAll();
         }
 
         BEGIN_INTERFACE_MAP(TraceControl)

--- a/UsbAccess/UsbAccess.cpp
+++ b/UsbAccess/UsbAccess.cpp
@@ -61,7 +61,6 @@ namespace WPEFramework {
 
         UsbAccess::~UsbAccess()
         {
-            UsbAccess::_instance = nullptr;
         }
 
         const string UsbAccess::Initialize(PluginHost::IShell* /* service */)
@@ -77,6 +76,7 @@ namespace WPEFramework {
 #if defined(USE_IARMBUS) || defined(USE_IARM_BUS)
             DeinitializeIARM();
 #endif /* defined(USE_IARMBUS) || defined(USE_IARM_BUS) */
+            UsbAccess::_instance = nullptr;
         }
 
 #if defined(USE_IARMBUS) || defined(USE_IARM_BUS)

--- a/UserPreferences/UserPreferences.cpp
+++ b/UserPreferences/UserPreferences.cpp
@@ -48,7 +48,12 @@ namespace WPEFramework {
 
         UserPreferences::~UserPreferences()
         {
-            LOGINFO("dtor");
+            //LOGINFO("dtor");
+        }
+
+        void UserPreferences::Deinitialize(PluginHost::IShell* /* service */)
+        {
+            LOGINFO("Deinitialize");
             UserPreferences::_instance = nullptr;
         }
 

--- a/UserPreferences/UserPreferences.h
+++ b/UserPreferences/UserPreferences.h
@@ -43,6 +43,7 @@ namespace WPEFramework {
         public:
             UserPreferences();
             virtual ~UserPreferences();
+            virtual void Deinitialize(PluginHost::IShell* service) override;
 
 
         public:

--- a/Warehouse/Warehouse.cpp
+++ b/Warehouse/Warehouse.cpp
@@ -97,7 +97,6 @@ namespace WPEFramework
 
         Warehouse::~Warehouse()
         {
-            Warehouse::_instance = nullptr;
         }
 
         const string Warehouse::Initialize(PluginHost::IShell* /* service */)
@@ -110,6 +109,7 @@ namespace WPEFramework
         void Warehouse::Deinitialize(PluginHost::IShell* /* service */)
         {
             DeinitializeIARM();
+            Warehouse::_instance = nullptr;
         }
 
         void Warehouse::InitializeIARM()

--- a/WifiManager/WifiManager.cpp
+++ b/WifiManager/WifiManager.cpp
@@ -80,7 +80,6 @@ namespace WPEFramework
 
         WifiManager::~WifiManager()
         {
-            WifiManager::instance=nullptr;
         }
 
         const string WifiManager::Initialize(PluginHost::IShell* service)

--- a/XCast/XCast.cpp
+++ b/XCast/XCast.cpp
@@ -91,20 +91,6 @@ XCast::XCast() : AbstractPlugin()
 
 XCast::~XCast()
 {
-    Unregister(METHOD_GET_API_VERSION_NUMBER);
-    Unregister(METHOD_ON_APPLICATION_STATE_CHANGED);
-    Unregister(METHOD_SET_ENABLED);
-    Unregister(METHOD_GET_ENABLED);
-    Unregister(METHOD_GET_STANDBY_BEHAVIOR);
-    Unregister(METHOD_SET_STANDBY_BEHAVIOR);
-    Unregister(METHOD_GET_FRIENDLYNAME);
-    Unregister(METHOD_SET_FRIENDLYNAME);
-
-    DeinitializeIARM();
-    if ( m_locateCastTimer.isActive())
-    {
-        m_locateCastTimer.stop();
-    }
 }
 const void XCast::InitializeIARM()
 {
@@ -128,6 +114,20 @@ void XCast::DeinitializeIARM()
      {
          IARM_Result_t res;
          IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_PWRMGR_NAME,IARM_BUS_PWRMGR_EVENT_MODECHANGED) );
+     }
+     Unregister(METHOD_GET_API_VERSION_NUMBER);
+     Unregister(METHOD_ON_APPLICATION_STATE_CHANGED);
+     Unregister(METHOD_SET_ENABLED);
+     Unregister(METHOD_GET_ENABLED);
+     Unregister(METHOD_GET_STANDBY_BEHAVIOR);
+     Unregister(METHOD_SET_STANDBY_BEHAVIOR);
+     Unregister(METHOD_GET_FRIENDLYNAME);
+     Unregister(METHOD_SET_FRIENDLYNAME);
+
+     DeinitializeIARM();
+     if ( m_locateCastTimer.isActive())
+     {
+         m_locateCastTimer.stop();
      }
 }
 void XCast::powerModeChange(const char *owner, IARM_EventId_t eventId, void *data, size_t len)


### PR DESCRIPTION
Reason for change: Plugin is unloaded after Deinitialize & then should not be used
Test Procedure: systemctl stop wpeframework should unload plugins
Risks: None

Signed-off-by: Mark Vandenbriele <mark.vandenbriele@consult.red>