### PR TITLE
RDK-32057: make the check case insensitive

### DIFF
--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -3340,7 +3340,10 @@ namespace WPEFramework {
 
                 LOGINFO("Lines read:%d. FailureReason|%s", (int) lines.size(), C_STR(str));
 
-                auto it = FwFailReasonFromText.find(str);
+                auto it = find_if(FwFailReasonFromText.begin(), FwFailReasonFromText.end(),
+                                  [&str](const pair<string, FwFailReason> & t) {
+                                      return strcasecmp(C_STR(t.first), C_STR(str)) == 0;
+                                  });
                 if (it != FwFailReasonFromText.end())
                     failReason = it->second;
                 else if (!str.empty())


### PR DESCRIPTION
Reason for change: Scripts return various
versions of the same lines.
Test Procedure: Use org.rdk.System.2.getLastFirmwareFailureReason,
verify that the failure reasons from /opt/fwdnldstatus.txt
are handled and no "Unrecognised FailureReason!" is
printed in logs.
Risks: Medium
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>