### PR TITLE
XIONE-3215: getFirmwareDownloadPercent sometimes returns 100 early

### DIFF
--- a/helpers/SystemServicesHelper.h
+++ b/helpers/SystemServicesHelper.h
@@ -74,7 +74,7 @@
 #define MODE_EAS        "EAS"
 #define MODE_WAREHOUSE  "WAREHOUSE"
 
-#define CAT_DWNLDPROGRESSFILE_AND_GET_INFO "cat /opt/curl_progress | tr -s '\r' '\n' | tail -n 1 | sed 's/^ *//g' | tr -s ' ' | cut -d ' ' -f3"
+#define CAT_DWNLDPROGRESSFILE_AND_GET_INFO "cat /opt/curl_progress | tr -s '\r' '\n' | tail -n 1 | sed 's/^ *//g' | sed '/^[^M/G]*$/d' | tr -s ' ' | cut -d ' ' -f3"
 
 enum eRetval { E_NOK = -1,
     E_OK };


### PR DESCRIPTION
Reason for change: Updates the percentage only for firmware and not to redirect response codes before.
Risks:Low
Test Procedure: Check API working.

Signed-off-by: Rohith Damodaran <Rohith_Damodaran@comcast.com>