### PR TITLE
RDK-31910: Add flush to PersistentStore RDK service

### DIFF
--- a/PersistentStore/PersistentStore.cpp
+++ b/PersistentStore/PersistentStore.cpp
@@ -2,6 +2,7 @@
 
 #include <sqlite3.h>
 #include <glib.h>
+#include <unistd.h>
 
 #if defined(USE_PLABELS)
 #include "pbnj_utils.hpp"
@@ -23,6 +24,7 @@ const string WPEFramework::Plugin::PersistentStore::METHOD_DELETE_NAMESPACE = "d
 const string WPEFramework::Plugin::PersistentStore::METHOD_GET_KEYS = "getKeys";
 const string WPEFramework::Plugin::PersistentStore::METHOD_GET_NAMESPACES = "getNamespaces";
 const string WPEFramework::Plugin::PersistentStore::METHOD_GET_STORAGE_SIZE = "getStorageSize";
+const string WPEFramework::Plugin::PersistentStore::METHOD_FLUSH_CACHE = "flushCache";
 const string WPEFramework::Plugin::PersistentStore::EVT_ON_STORAGE_EXCEEDED = "onStorageExceeded";
 const char* WPEFramework::Plugin::PersistentStore::STORE_NAME = "rdkservicestore";
 const char* WPEFramework::Plugin::PersistentStore::STORE_KEY = "xyzzy123";
@@ -80,6 +82,7 @@ namespace WPEFramework {
             registerMethod(METHOD_GET_KEYS, &PersistentStore::getKeysWrapper, this);
             registerMethod(METHOD_GET_NAMESPACES, &PersistentStore::getNamespacesWrapper, this);
             registerMethod(METHOD_GET_STORAGE_SIZE, &PersistentStore::getStorageSizeWrapper, this);
+            registerMethod(METHOD_FLUSH_CACHE, &PersistentStore::flushCacheWrapper, this);
         }
 
         PersistentStore::~PersistentStore()
@@ -277,6 +280,15 @@ namespace WPEFramework {
                     jsonNamespaceSizes[it->first.c_str()] = it->second;
                 response["namespaceSizes"] = jsonNamespaceSizes;
             }
+
+            returnResponse(success);
+        }
+
+        uint32_t PersistentStore::flushCacheWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+
+            bool success = flushCache();
 
             returnResponse(success);
         }
@@ -559,13 +571,37 @@ namespace WPEFramework {
             return success;
         }
 
+        bool PersistentStore::flushCache()
+        {
+            sqlite3* &db = SQLITE;
+            bool success = false;
+
+            if (db)
+            {
+                int rc = sqlite3_db_cacheflush(db);
+                success = (rc == SQLITE_OK);
+                if (rc != SQLITE_OK)
+                {
+                    LOGERR("Error while flushing sqlite database cache: %d", rc);
+                }
+            }
+            sync();
+            return success;
+        }
+
         void PersistentStore::term()
         {
             sqlite3* &db = SQLITE;
 
             if (db)
+            {
+                int rc = sqlite3_db_cacheflush(db);
+                if (rc != SQLITE_OK)
+                {
+                    LOGERR("Error while flushing sqlite database cache: %d", rc);
+                }
                 sqlite3_close(db);
-
+            }
             db = NULL;
         }
 

--- a/PersistentStore/PersistentStore.h
+++ b/PersistentStore/PersistentStore.h
@@ -34,6 +34,7 @@ namespace WPEFramework {
             static const string METHOD_GET_KEYS;
             static const string METHOD_GET_NAMESPACES;
             static const string METHOD_GET_STORAGE_SIZE;
+            static const string METHOD_FLUSH_CACHE;
             //events
             static const string EVT_ON_STORAGE_EXCEEDED;
             //other
@@ -52,6 +53,7 @@ namespace WPEFramework {
             uint32_t getKeysWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t getNamespacesWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t getStorageSizeWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t flushCacheWrapper(const JsonObject& parameters, JsonObject& response);
 
         private/*internal methods*/:
             PersistentStore(const PersistentStore&) = delete;
@@ -64,6 +66,7 @@ namespace WPEFramework {
             bool getKeys(const string& ns, std::vector<string>& keys);
             bool getNamespaces(std::vector<string>& namespaces);
             bool getStorageSize(std::map<string, uint64_t>& namespaceSizes);
+            bool flushCache();
 
             void term();
             void vacuum();

--- a/PersistentStore/README.md
+++ b/PersistentStore/README.md
@@ -13,6 +13,7 @@ curl -d '{"jsonrpc":"2.0","id":"3","method":"org.rdk.PersistentStore.1.deleteNam
 curl -d '{"jsonrpc":"2.0","id":"3","method":"org.rdk.PersistentStore.1.getKeys","params":{"namespace":"foo"}}' http://127.0.0.1:9998/jsonrpc
 curl -d '{"jsonrpc":"2.0","id":"3","method":"org.rdk.PersistentStore.1.getNamespaces","params":{}}' http://127.0.0.1:9998/jsonrpc
 curl -d '{"jsonrpc":"2.0","id":"3","method":"org.rdk.PersistentStore.1.getStorageSize","params":{}}' http://127.0.0.1:9998/jsonrpc
+curl -d '{"jsonrpc":"2.0","id":"3","method":"org.rdk.PersistentStore.1.flushCache"}' http://127.0.0.1:9998/jsonrpc
 ```
 
 ## Responses


### PR DESCRIPTION
(cherry picked from commit 2f885801f63c8787eba635fe8307ef4e2b8cef33)
(cherry picked from commit 6ff7fe109256de9367749e3b25a2e05141334eb2)

RDK-31910: Add flush to PersistentStore RDK service (pt.2)

(cherry picked from commit c8f19ac7ed66c3ea15d555634e776fa2cf4c5c52)

RDK-31910: Add flush to PersistentStore RDK service (pt.3)

(cherry picked from commit 88db2465b2d2b38f47567a99039f9f4a50191a10)

RDK-31910: Add flush to PersistentStore RDK service (pt.4)

Implements: call to sync() in addition to sqlite3_db_cacheflush()
(cherry picked from commit 5ed725f573dd0d3a323d7e2a0369665b8108f0a0)