### PR TITLE
XIONE-3259, XIONE-3273: getFirmwareUpdateState returns invalid state

### DIFF
--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -1778,6 +1778,8 @@ namespace WPEFramework {
                             fwUpdateState = FirmwareUpdateStatePreparingReboot;
                         } else if (!strcmp(line.c_str(), "No upgrade needed")) {
                             fwUpdateState = FirmwareUpdateStateNoUpgradeNeeded;
+                        } else if (!strcmp(line.c_str(), "Uninitialized")){
+                            fwUpdateState = FirmwareUpdateStateUninitialized;
                         }
                     }
                 }


### PR DESCRIPTION
Risks: Low
Test Procedure: getFirmwareUpdateState returns more precise value.
Reason for change: getFirmwareUpdateState needs to returns uninitialised case also

Signed-off-by: Rohith Damodaran <Rohith_Damodaran@comcast.com>