### PR TITLE
    REFPLTV-860 VIP7802-290 :  Controller UI is not giving output for…

### DIFF
--- a/Network/PingNotifier.cpp
+++ b/Network/PingNotifier.cpp
@@ -167,7 +167,7 @@ namespace WPEFramework
                         if (index >= 0)
                         {
                             fullpath = fullpath.substr(index + 1, fullpath.length());
-                            prefix = fullpath.substr(0, fullpath.find("/"));
+                            prefix = fullpath.substr(0, fullpath.find(" "));
                             pingResult["tripMax"] = prefix.c_str();
                         }
 


### PR DESCRIPTION
… Ping an Endpoint

    Reason for change : Json response of ping from network plugin in controller UI was not valid
    Risks : None
    Test Procedure : load network plugin from controller UI and verify the ping response

Signed-off-by: vijith-tv <vijith.tv@ltts.com>