### PR TITLE
 XIONE-3259, XIONE-3273, XIONE-3215: getFirmwareUpdateState returns invalid state and invalid percentage

### DIFF
--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -1622,6 +1622,8 @@ namespace WPEFramework {
                             fwUpdateState = FirmwareUpdateStatePreparingReboot;
                         } else if (!strcmp(line.c_str(), "No upgrade needed")) {
                             fwUpdateState = FirmwareUpdateStateNoUpgradeNeeded;
+                        } else if (!strcmp(line.c_str(), "Uninitialized")){
+                            fwUpdateState = FirmwareUpdateStateUninitialized;
                         }
                     }
                 }

--- a/helpers/SystemServicesHelper.h
+++ b/helpers/SystemServicesHelper.h
@@ -74,7 +74,7 @@
 #define MODE_EAS        "EAS"
 #define MODE_WAREHOUSE  "WAREHOUSE"
 
-#define CAT_DWNLDPROGRESSFILE_AND_GET_INFO "cat /opt/curl_progress | tr -s '\r' '\n' | tail -n 1 | sed 's/^ *//g' | tr -s ' ' | cut -d ' ' -f3"
+#define CAT_DWNLDPROGRESSFILE_AND_GET_INFO "cat /opt/curl_progress | tr -s '\r' '\n' | tail -n 1 | sed 's/^ *//g' | sed '/^[^M/G]*$/d' | tr -s ' ' | cut -d ' ' -f3"
 
 enum eRetval { E_NOK = -1,
     E_OK };


### PR DESCRIPTION
Risks: Low
Reason for change: Adding uninitialized. Adding proper firmware percentage check.
Test Procedure: AS Jail UI starts working.