### PR TITLE
RDKTV-2681: Move plugin cleanup to Deinitialize

### DIFF
--- a/DeviceIdentification/DeviceIdentification.cpp
+++ b/DeviceIdentification/DeviceIdentification.cpp
@@ -77,7 +77,6 @@ namespace Plugin {
         }
 
         _connectionId = 0;
-         UnregisterAll();
     }
 
     /* virtual */ string DeviceIdentification::Information() const

--- a/DeviceIdentification/DeviceIdentification.h
+++ b/DeviceIdentification/DeviceIdentification.h
@@ -42,6 +42,7 @@ namespace Plugin {
 
         virtual ~DeviceIdentification()
         {
+            UnregisterAll();
         }
 
         BEGIN_INTERFACE_MAP(DeviceIdentification)

--- a/DeviceInfo/DeviceInfo.cpp
+++ b/DeviceInfo/DeviceInfo.cpp
@@ -57,7 +57,6 @@ namespace Plugin {
         }
 
         _service = nullptr;
-         UnregisterAll();
     }
 
     /* virtual */ string DeviceInfo::Information() const

--- a/DeviceInfo/DeviceInfo.h
+++ b/DeviceInfo/DeviceInfo.h
@@ -83,6 +83,7 @@ namespace Plugin {
 
         virtual ~DeviceInfo()
         {
+            UnregisterAll();
         }
 
         BEGIN_INTERFACE_MAP(DeviceInfo)

--- a/LocationSync/LocationSync.cpp
+++ b/LocationSync/LocationSync.cpp
@@ -44,6 +44,7 @@ namespace Plugin {
 
     /* virtual */ LocationSync::~LocationSync()
     {
+        UnregisterAll();
     }
 
     /* virtual */ const string LocationSync::Initialize(PluginHost::IShell* service)
@@ -72,7 +73,6 @@ namespace Plugin {
         ASSERT(_service == service);
 
         _sink.Deinitialize();
-        UnregisterAll();
     }
 
     /* virtual */ string LocationSync::Information() const

--- a/Messenger/Messenger.cpp
+++ b/Messenger/Messenger.cpp
@@ -67,7 +67,6 @@ namespace Plugin {
 
         _service->Release();
         _service = nullptr;
-        UnregisterAll();
     }
 
     // Web request handlers

--- a/Messenger/Messenger.h
+++ b/Messenger/Messenger.h
@@ -49,6 +49,7 @@ namespace Plugin {
 
         ~Messenger()
         {
+            UnregisterAll();
         }
 
         // IPlugin methods

--- a/Monitor/Monitor.cpp
+++ b/Monitor/Monitor.cpp
@@ -53,8 +53,6 @@ namespace Plugin {
         _monitor->Close();
 
         service->Unregister(_monitor);
-        UnregisterAll();
-        _monitor->Release();
     }
 
     /* virtual */ string Monitor::Information() const

--- a/Monitor/Monitor.h
+++ b/Monitor/Monitor.h
@@ -1010,6 +1010,8 @@ namespace Plugin {
 #endif
         virtual ~Monitor()
         {
+            UnregisterAll();
+            _monitor->Release();
         }
 
         BEGIN_INTERFACE_MAP(Monitor)

--- a/OpenCDMi/OCDM.cpp
+++ b/OpenCDMi/OCDM.cpp
@@ -176,7 +176,6 @@ namespace Plugin {
         _memory = nullptr;
         _opencdmi = nullptr;
         _service = nullptr;
-         UnregisterAll();
     }
 
     /* virtual */ string OCDM::Information() const

--- a/OpenCDMi/OCDM.h
+++ b/OpenCDMi/OCDM.h
@@ -156,6 +156,7 @@ namespace Plugin {
         #endif
         virtual ~OCDM()
         {
+            UnregisterAll();
         }
 
     public:

--- a/Packager/Packager.cpp
+++ b/Packager/Packager.cpp
@@ -73,8 +73,6 @@ namespace {
 
         _service = nullptr;
         _implementation = nullptr;
-        Unregister(kInstallMethodName);
-        Unregister(kSynchronizeMethodName);
     }
 
     string Packager::Information() const

--- a/Packager/Packager.h
+++ b/Packager/Packager.h
@@ -71,6 +71,8 @@ namespace {
 
         ~Packager() override
         {
+            Unregister(kInstallMethodName);
+            Unregister(kSynchronizeMethodName);
         }
 
         BEGIN_INTERFACE_MAP(Packager)

--- a/SecurityAgent/SecurityAgent.cpp
+++ b/SecurityAgent/SecurityAgent.cpp
@@ -85,6 +85,7 @@ namespace Plugin {
 
     /* virtual */ SecurityAgent::~SecurityAgent()
     {
+        UnregisterAll();
     }
 
     /* virtual */ const string SecurityAgent::Initialize(PluginHost::IShell* service)
@@ -155,7 +156,6 @@ namespace Plugin {
             subSystem->Release();
         }
         _acl.Clear();
-        UnregisterAll();
     }
 
     /* virtual */ string SecurityAgent::Information() const

--- a/TraceControl/TraceControl.cpp
+++ b/TraceControl/TraceControl.cpp
@@ -102,7 +102,6 @@ namespace Plugin {
 
             _outputs.pop_front();
         }
-        UnregisterAll();
     }
 
     /* virtual */ string TraceControl::Information() const

--- a/TraceControl/TraceControl.h
+++ b/TraceControl/TraceControl.h
@@ -942,6 +942,7 @@ namespace Plugin {
 #endif
         virtual ~TraceControl()
         {
+            UnregisterAll();
         }
 
         BEGIN_INTERFACE_MAP(TraceControl)


### PR DESCRIPTION
Reason for change: Revert unbalanced interface changes
Test Procedure: systemctl stop wpeframework should unload plugins
Risks: None

Signed-off-by: Mark Vandenbriele <mark.vandenbriele@consult.red>