### PR TITLE
RDKTV-3290 log reduction

### DIFF
--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -1582,7 +1582,6 @@ namespace WPEFramework
 						LOGINFO("Ping caught %s \r\n",e.what());
 					  }
 					  
-					  LOGINFO("PING got Device ACK 0x%x \r\n",i);
 					  /* If we get ACK, then the device is present in the network*/
 					  if ( !_instance->deviceList[i].m_isDevicePresent )
 					  {


### PR DESCRIPTION
Reason for change: Removed recurring logs from wpeframework

Test Procedure: load the build and see log mentioned in the ticket
is reduced.

Risks: Low
Signed-off-by: sputhi200 <Sujeesh_Puthiya@comcast.com>