### PR TITLE
RDK-31101: Thunder changes to get SPD info

### DIFF
--- a/HdmiInput/HdmiInput.cpp
+++ b/HdmiInput/HdmiInput.cpp
@@ -56,7 +56,7 @@ namespace WPEFramework
         HdmiInput* HdmiInput::_instance = nullptr;
 
         HdmiInput::HdmiInput()
-        : AbstractPlugin()
+        : AbstractPlugin(2)
         {
             HdmiInput::_instance = this;
 
@@ -65,8 +65,10 @@ namespace WPEFramework
             registerMethod(HDMIINPUT_METHOD_GET_HDMI_INPUT_DEVICES, &HdmiInput::getHDMIInputDevicesWrapper, this);
             registerMethod(HDMIINPUT_METHOD_WRITE_EDID, &HdmiInput::writeEDIDWrapper, this);
             registerMethod(HDMIINPUT_METHOD_READ_EDID, &HdmiInput::readEDIDWrapper, this);
-            registerMethod(HDMIINPUT_METHOD_READ_RAWHDMISPD, &HdmiInput::getRawHDMISPDWrapper, this);
-            registerMethod(HDMIINPUT_METHOD_READ_HDMISPD, &HdmiInput::getHDMISPDWrapper, this);
+	    //version2 api start
+            registerMethod(HDMIINPUT_METHOD_READ_RAWHDMISPD, &HdmiInput::getRawHDMISPDWrapper, this, {2});
+            registerMethod(HDMIINPUT_METHOD_READ_HDMISPD, &HdmiInput::getHDMISPDWrapper, this, {2});
+	    //version2 api end
             registerMethod(HDMIINPUT_METHOD_START_HDMI_INPUT, &HdmiInput::startHdmiInput, this);
             registerMethod(HDMIINPUT_METHOD_STOP_HDMI_INPUT, &HdmiInput::stopHdmiInput, this);
             registerMethod(HDMIINPUT_METHOD_SCALE_HDMI_INPUT, &HdmiInput::setVideoRectangleWrapper, this);

--- a/HdmiInput/HdmiInput.h
+++ b/HdmiInput/HdmiInput.h
@@ -55,6 +55,8 @@ namespace WPEFramework {
             uint32_t getHDMIInputDevicesWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t writeEDIDWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t readEDIDWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t getRawHDMISPDWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t getHDMISPDWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t startHdmiInput(const JsonObject& parameters, JsonObject& response);
             uint32_t stopHdmiInput(const JsonObject& parameters, JsonObject& response);
 
@@ -64,6 +66,9 @@ namespace WPEFramework {
             JsonArray getHDMIInputDevices();
             void writeEDID(int deviceId, std::string message);
             std::string readEDID(int iPort);
+            std::string getRawHDMISPD(int iPort);
+            std::string getHDMISPD(int iPort);
+
 
             bool setVideoRectangle(int x, int y, int width, int height);
 


### PR DESCRIPTION
Reason for change: get HDMISPD data
Test Procedure: curl command to get HDMISPD data
Risks: None

Signed-off-by: thanushree.rajaselvam@sky.uk