### PR TITLE
RDKTV-2681: Move plugin cleanup to Deinitialize

### DIFF
--- a/AVInput/AVInput.cpp
+++ b/AVInput/AVInput.cpp
@@ -66,8 +66,7 @@ namespace WPEFramework {
 
         AVInput::~AVInput()
         {
-            LOGINFO("dtor");
-            AVInput::_instance = nullptr;
+            //LOGINFO("dtor");
         }
 
         const string AVInput::Initialize(PluginHost::IShell* /* service */)
@@ -84,6 +83,7 @@ namespace WPEFramework {
 
         void AVInput::Deinitialize(PluginHost::IShell* /* service */)
         {
+            AVInput::_instance = nullptr;
         }
 
         string AVInput::Information() const

--- a/ActivityMonitor/ActivityMonitor.cpp
+++ b/ActivityMonitor/ActivityMonitor.cpp
@@ -123,6 +123,10 @@ namespace WPEFramework
 
         ActivityMonitor::~ActivityMonitor()
         {
+        }
+
+        void ActivityMonitor::Deinitialize(PluginHost::IShell* /* service */)
+        {
             ActivityMonitor::_instance = nullptr;
 
             if (m_monitor.joinable())

--- a/ActivityMonitor/ActivityMonitor.h
+++ b/ActivityMonitor/ActivityMonitor.h
@@ -67,6 +67,7 @@ namespace WPEFramework {
         public:
             ActivityMonitor();
             virtual ~ActivityMonitor();
+            virtual void Deinitialize(PluginHost::IShell* service) override;
 
         public:
             static ActivityMonitor* _instance;

--- a/Bluetooth/Bluetooth.cpp
+++ b/Bluetooth/Bluetooth.cpp
@@ -169,10 +169,11 @@ namespace WPEFramework
 
         Bluetooth::~Bluetooth()
         {
-            Bluetooth::_instance = nullptr;
+        }
 
-            if (m_executionThread.joinable())
-                m_executionThread.join();
+        void Bluetooth::Deinitialize(PluginHost::IShell* /* service */)
+        {
+            Bluetooth::_instance = nullptr;
         }
 
         string Bluetooth::Information() const

--- a/Bluetooth/Bluetooth.h
+++ b/Bluetooth/Bluetooth.h
@@ -165,6 +165,7 @@ namespace WPEFramework {
 
             Bluetooth();
             virtual ~Bluetooth();
+            virtual void Deinitialize(PluginHost::IShell* service) override;
             virtual string Information() const override;
 
         public:
@@ -208,7 +209,7 @@ namespace WPEFramework {
             uint32_t m_apiVersionNumber;
             // Assuming that there will be only one threaded call at a time (which is the case for Bluetooth)
             // Otherwise we might need a thread for each async command for better performance
-            std::thread m_executionThread;
+            Utils::ThreadRAII m_executionThread;
             bool m_discoveryRunning;
             DiscoveryTimer m_discoveryTimer;
             friend class DiscoveryTimer;

--- a/CompositeInput/CompositeInput.cpp
+++ b/CompositeInput/CompositeInput.cpp
@@ -59,6 +59,10 @@ namespace WPEFramework
 
         CompositeInput::~CompositeInput()
         {
+        }
+
+        void CompositeInput::Deinitialize(PluginHost::IShell* /* service */)
+        {
             CompositeInput::_instance = nullptr;
 
             DeinitializeIARM();

--- a/CompositeInput/CompositeInput.h
+++ b/CompositeInput/CompositeInput.h
@@ -69,6 +69,7 @@ namespace WPEFramework {
         public:
             CompositeInput();
             virtual ~CompositeInput();
+            virtual void Deinitialize(PluginHost::IShell* service) override;
 
             void terminate();
 

--- a/ContinueWatching/ContinueWatching.cpp
+++ b/ContinueWatching/ContinueWatching.cpp
@@ -80,6 +80,10 @@ namespace WPEFramework {
 
 		ContinueWatching::~ContinueWatching()
 		{
+		}
+
+		void ContinueWatching::Deinitialize(PluginHost::IShell* /* service */)
+		{
 			ContinueWatching::_instance = nullptr;
 		}
 

--- a/ContinueWatching/ContinueWatching.h
+++ b/ContinueWatching/ContinueWatching.h
@@ -88,6 +88,7 @@ namespace WPEFramework {
         	public:
 			ContinueWatching();
 			virtual ~ContinueWatching();
+                        virtual void Deinitialize(PluginHost::IShell* service) override;
         	private:
 			uint32_t getApiVersionNumber();
 			void setApiVersionNumber(uint32_t apiVersionNumber);

--- a/ControlService/ControlService.cpp
+++ b/ControlService/ControlService.cpp
@@ -95,8 +95,7 @@ namespace WPEFramework {
 
         ControlService::~ControlService()
         {
-            LOGINFO("dtor");
-            ControlService::_instance = nullptr;
+            //LOGINFO("dtor");
 
         }
 
@@ -110,6 +109,7 @@ namespace WPEFramework {
         void ControlService::Deinitialize(PluginHost::IShell* /* service */)
         {
             DeinitializeIARM();
+            ControlService::_instance = nullptr;
         }
 
         void ControlService::InitializeIARM()

--- a/DTV/DTV.cpp
+++ b/DTV/DTV.cpp
@@ -249,6 +249,7 @@ namespace WPEFramework
          _dtv = nullptr;
 
          _service = nullptr;
+         UnregisterAll();
 
          SYSLOG(Logging::Shutdown, (string(_T("DTV de-initialised"))));
       }

--- a/DTV/DTV.h
+++ b/DTV/DTV.h
@@ -144,7 +144,6 @@ namespace WPEFramework
 
             virtual ~DTV()
             {
-               UnregisterAll();
             }
 
             static DTV* instance(DTV *dtv = nullptr)

--- a/DataCapture/DataCapture.cpp
+++ b/DataCapture/DataCapture.cpp
@@ -87,9 +87,7 @@ namespace WPEFramework {
 
         DataCapture::~DataCapture()
         {
-            LOGINFO("dtor");
-            delete _sock_adaptor;
-            DataCapture::_instance = nullptr;
+            //LOGINFO("dtor");
         }
 
         const string DataCapture::Initialize(PluginHost::IShell* /* service */)
@@ -101,6 +99,8 @@ namespace WPEFramework {
         void DataCapture::Deinitialize(PluginHost::IShell* /* service */)
         {
             DeinitializeIARM();
+            delete _sock_adaptor;
+            DataCapture::_instance = nullptr;
         }
 
         string DataCapture::Information() const

--- a/DeviceDiagnostics/DeviceDiagnostics.cpp
+++ b/DeviceDiagnostics/DeviceDiagnostics.cpp
@@ -53,6 +53,10 @@ namespace WPEFramework
 
         DeviceDiagnostics::~DeviceDiagnostics()
         {
+        }
+
+        void DeviceDiagnostics::Deinitialize(PluginHost::IShell* /* service */)
+        {
             DeviceDiagnostics::_instance = nullptr;
         }
 

--- a/DeviceDiagnostics/DeviceDiagnostics.h
+++ b/DeviceDiagnostics/DeviceDiagnostics.h
@@ -56,6 +56,7 @@ namespace WPEFramework {
         public:
             DeviceDiagnostics();
             virtual ~DeviceDiagnostics();
+            virtual void Deinitialize(PluginHost::IShell* service) override;
 
         public:
             static DeviceDiagnostics* _instance;

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -223,8 +223,7 @@ namespace WPEFramework {
 
         DisplaySettings::~DisplaySettings()
         {
-            LOGINFO("dtor");
-            DisplaySettings::_instance = nullptr;
+            //LOGINFO("dtor");
         }
 
         void DisplaySettings::InitAudioPorts() 
@@ -323,6 +322,7 @@ namespace WPEFramework {
         void DisplaySettings::Deinitialize(PluginHost::IShell* /* service */)
         {
             DeinitializeIARM();
+            DisplaySettings::_instance = nullptr;
         }
 
         void DisplaySettings::InitializeIARM()

--- a/FrameRate/FrameRate.cpp
+++ b/FrameRate/FrameRate.cpp
@@ -62,6 +62,10 @@ namespace WPEFramework
 
         FrameRate::~FrameRate()
         {
+        }
+
+        void FrameRate::Deinitialize(PluginHost::IShell* /* service */)
+        {
             FrameRate::_instance = nullptr;
         }
 

--- a/FrameRate/FrameRate.h
+++ b/FrameRate/FrameRate.h
@@ -74,6 +74,7 @@ namespace WPEFramework {
         public:
             FrameRate();
             virtual ~FrameRate();
+            virtual void Deinitialize(PluginHost::IShell* service) override;
 
         public:
             static FrameRate* _instance;

--- a/FrontPanel/FrontPanel.cpp
+++ b/FrontPanel/FrontPanel.cpp
@@ -185,6 +185,10 @@ namespace WPEFramework
 
         FrontPanel::~FrontPanel()
         {
+        }
+
+        void FrontPanel::Deinitialize(PluginHost::IShell* /* service */)
+        {
             FrontPanel::_instance = nullptr;
 
             {

--- a/FrontPanel/FrontPanel.h
+++ b/FrontPanel/FrontPanel.h
@@ -125,6 +125,7 @@ namespace WPEFramework {
         public:
             FrontPanel();
             virtual ~FrontPanel();
+            virtual void Deinitialize(PluginHost::IShell* service) override;
 
             void updateLedTextPattern();
 

--- a/HdcpProfile/HdcpProfile.cpp
+++ b/HdcpProfile/HdcpProfile.cpp
@@ -61,6 +61,10 @@ namespace WPEFramework
 
         HdcpProfile::~HdcpProfile()
         {
+        }
+
+        void HdcpProfile::Deinitialize(PluginHost::IShell* /* service */)
+        {
             HdcpProfile::_instance = nullptr;
             device::Manager::DeInitialize();
             DeinitializeIARM();

--- a/HdcpProfile/HdcpProfile.h
+++ b/HdcpProfile/HdcpProfile.h
@@ -66,6 +66,7 @@ namespace WPEFramework {
         public:
             HdcpProfile();
             virtual ~HdcpProfile();
+            virtual void Deinitialize(PluginHost::IShell* service) override;
 
             void terminate();
 

--- a/HdmiCec/HdmiCec.cpp
+++ b/HdmiCec/HdmiCec.cpp
@@ -103,6 +103,10 @@ namespace WPEFramework
 
         HdmiCec::~HdmiCec()
         {
+        }
+
+        void HdmiCec::Deinitialize(PluginHost::IShell* /* service */)
+        {
             HdmiCec::_instance = nullptr;
 
             DeinitializeIARM();

--- a/HdmiCec/HdmiCec.h
+++ b/HdmiCec/HdmiCec.h
@@ -65,6 +65,7 @@ namespace WPEFramework {
         public:
             HdmiCec();
             virtual ~HdmiCec();
+            virtual void Deinitialize(PluginHost::IShell* service) override;
 
         public:
             static HdmiCec* _instance;

--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -502,7 +502,10 @@ namespace WPEFramework
 
        HdmiCecSink::~HdmiCecSink()
        {
-	  
+       }
+
+       void HdmiCecSink::Deinitialize(PluginHost::IShell* /* service */)
+       {
 	    CECDisable();
 	    m_currentArcRoutingState = ARC_STATE_ARC_EXIT;
 
@@ -524,7 +527,7 @@ namespace WPEFramework
 
             HdmiCecSink::_instance = nullptr;
             DeinitializeIARM();
-	    LOGWARN(" ~HdmiCecSink() Done");
+	    LOGWARN(" HdmiCecSink Deinitialize() Done");
        }
 
        const void HdmiCecSink::InitializeIARM()

--- a/HdmiCecSink/HdmiCecSink.h
+++ b/HdmiCecSink/HdmiCecSink.h
@@ -484,6 +484,7 @@ private:
         public:
             HdmiCecSink();
             virtual ~HdmiCecSink();
+            virtual void Deinitialize(PluginHost::IShell* service) override;
             static HdmiCecSink* _instance;
 			CECDeviceParams deviceList[16];
 			std::vector<HdmiPortMap> hdmiInputs;

--- a/HdmiCec_2/HdmiCec_2.cpp
+++ b/HdmiCec_2/HdmiCec_2.cpp
@@ -382,6 +382,10 @@ namespace WPEFramework
 
        HdmiCec_2::~HdmiCec_2()
        {
+       }
+
+       void HdmiCec_2::Deinitialize(PluginHost::IShell* /* service */)
+       {
            HdmiCec_2::_instance = nullptr;
            DeinitializeIARM();
        }

--- a/HdmiCec_2/HdmiCec_2.h
+++ b/HdmiCec_2/HdmiCec_2.h
@@ -102,6 +102,7 @@ namespace WPEFramework {
         public:
             HdmiCec_2();
             virtual ~HdmiCec_2();
+            virtual void Deinitialize(PluginHost::IShell* service) override;
             static HdmiCec_2* _instance;
         private:
             // We do not allow this plugin to be copied !!

--- a/HdmiInput/HdmiInput.cpp
+++ b/HdmiInput/HdmiInput.cpp
@@ -65,6 +65,10 @@ namespace WPEFramework
 
         HdmiInput::~HdmiInput()
         {
+        }
+
+        void HdmiInput::Deinitialize(PluginHost::IShell* /* service */)
+        {
             HdmiInput::_instance = nullptr;
 
             DeinitializeIARM();

--- a/HdmiInput/HdmiInput.h
+++ b/HdmiInput/HdmiInput.h
@@ -79,6 +79,7 @@ namespace WPEFramework {
         public:
             HdmiInput();
             virtual ~HdmiInput();
+            virtual void Deinitialize(PluginHost::IShell* service) override;
 
             void terminate();
 

--- a/LoggingPreferences/LoggingPreferences.cpp
+++ b/LoggingPreferences/LoggingPreferences.cpp
@@ -41,8 +41,7 @@ namespace WPEFramework {
 
         LoggingPreferences::~LoggingPreferences()
         {
-            LOGINFO("dtor");
-            LoggingPreferences::_instance = nullptr;
+            //LOGINFO("dtor");
         }
 
         const string LoggingPreferences::Initialize(PluginHost::IShell* /* service */)
@@ -54,6 +53,7 @@ namespace WPEFramework {
         void LoggingPreferences::Deinitialize(PluginHost::IShell* /* service */)
         {
             DeinitializeIARM();
+            LoggingPreferences::_instance = nullptr;
         }
 
         void LoggingPreferences::InitializeIARM()

--- a/MotionDetection/MotionDetection.cpp
+++ b/MotionDetection/MotionDetection.cpp
@@ -73,19 +73,6 @@ namespace WPEFramework {
 
         MotionDetection::~MotionDetection()
         {
-            LOGINFO("MotionDetection dtor");
-            MotionDetection::_instance = nullptr;
-            Unregister("getMotionDetectors");
-            Unregister("arm");
-            Unregister("disarm");
-            Unregister("isarmed");
-            Unregister("setNoMotionPeriod");
-            Unregister("getNoMotionPeriod");
-            Unregister("setSensitivity");
-            Unregister("getSensitivity");
-            Unregister("getLastMotionEventElapsedTime");
-            Unregister("setMotionEventsActivePeriod");
-            Unregister("getMotionEventsActivePeriod");
         }
 
         void setResponseArray(JsonObject& response, const char* key, const vector<string>& items)
@@ -114,7 +101,20 @@ namespace WPEFramework {
 
         void MotionDetection::Deinitialize(PluginHost::IShell* /* service */)
         {
+            LOGINFO("MotionDetection Deinitialize");
 	    MOTION_DETECTION_Platform_Term();
+            MotionDetection::_instance = nullptr;
+            Unregister("getMotionDetectors");
+            Unregister("arm");
+            Unregister("disarm");
+            Unregister("isarmed");
+            Unregister("setNoMotionPeriod");
+            Unregister("getNoMotionPeriod");
+            Unregister("setSensitivity");
+            Unregister("getSensitivity");
+            Unregister("getLastMotionEventElapsedTime");
+            Unregister("setMotionEventsActivePeriod");
+            Unregister("getMotionEventsActivePeriod");
         }
 
         //Begin methods

--- a/Network/Network.cpp
+++ b/Network/Network.cpp
@@ -168,26 +168,6 @@ namespace WPEFramework
 
         Network::~Network()
         {
-            Unregister("getQuirks");
-            Unregister("getInterfaces");
-            Unregister("isInterfaceEnabled");
-            Unregister("setInterfaceEnabled");
-            Unregister("getDefaultInterface");
-            Unregister("setDefaultInterface");
-            Unregister("getStbIp");
-            Unregister("setApiVersionNumber");
-            Unregister("getApiVersionNumber");
-            Unregister("trace");
-            Unregister("traceNamedEndpoint");
-            Unregister("getNamedEndpoints");
-            Unregister("ping");
-            Unregister("pingNamedEndpoint");
-            Unregister("setIPSettings");
-            Unregister("getIPSettings");
-            Unregister("isConnectedToInternet");
-            Unregister("setConnectivityTestEndpoints");
-
-            Network::_instance = nullptr;
         }
 
         const string Network::Initialize(PluginHost::IShell* /* service */)
@@ -214,6 +194,26 @@ namespace WPEFramework
                 IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_NETWORK_MANAGER_EVENT_INTERFACE_IPADDRESS) );
                 IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_NETWORK_MANAGER_EVENT_DEFAULT_INTERFACE) );
             }
+            Unregister("getQuirks");
+            Unregister("getInterfaces");
+            Unregister("isInterfaceEnabled");
+            Unregister("setInterfaceEnabled");
+            Unregister("getDefaultInterface");
+            Unregister("setDefaultInterface");
+            Unregister("getStbIp");
+            Unregister("setApiVersionNumber");
+            Unregister("getApiVersionNumber");
+            Unregister("trace");
+            Unregister("traceNamedEndpoint");
+            Unregister("getNamedEndpoints");
+            Unregister("ping");
+            Unregister("pingNamedEndpoint");
+            Unregister("setIPSettings");
+            Unregister("getIPSettings");
+            Unregister("isConnectedToInternet");
+            Unregister("setConnectivityTestEndpoints");
+
+            Network::_instance = nullptr;
         }
 
         string Network::Information() const

--- a/OCIContainer/OCIContainer.cpp
+++ b/OCIContainer/OCIContainer.cpp
@@ -31,15 +31,6 @@ OCIContainer::OCIContainer()
 
 OCIContainer::~OCIContainer()
 {
-    Unregister("listContainers");
-    Unregister("getContainerState");
-    Unregister("getContainerInfo");
-    Unregister("startContainer");
-    Unregister("startContainerFromDobbySpec");
-    Unregister("stopContainer");
-    Unregister("pauseContainer");
-    Unregister("resumeContainer");
-    Unregister("executeCommand");
 }
 
 const string OCIContainer::Initialize(PluginHost::IShell *service)
@@ -70,6 +61,15 @@ const string OCIContainer::Initialize(PluginHost::IShell *service)
 void OCIContainer::Deinitialize(PluginHost::IShell *service)
 {
     mDobbyProxy->unregisterListener(mEventListenerId);
+    Unregister("listContainers");
+    Unregister("getContainerState");
+    Unregister("getContainerInfo");
+    Unregister("startContainer");
+    Unregister("startContainerFromDobbySpec");
+    Unregister("stopContainer");
+    Unregister("pauseContainer");
+    Unregister("resumeContainer");
+    Unregister("executeCommand");
 }
 
 string OCIContainer::Information() const

--- a/PersistentStore/PersistentStore.cpp
+++ b/PersistentStore/PersistentStore.cpp
@@ -87,10 +87,7 @@ namespace WPEFramework {
 
         PersistentStore::~PersistentStore()
         {
-            LOGINFO("dtor");
-            PersistentStore::_instance = nullptr;
-
-            term();
+            //LOGINFO("dtor");
         }
 
         const string PersistentStore::Initialize(PluginHost::IShell* /* service */)
@@ -109,6 +106,7 @@ namespace WPEFramework {
         void PersistentStore::Deinitialize(PluginHost::IShell* /* service */)
         {
             term();
+            PersistentStore::_instance = nullptr;
         }
 
         string PersistentStore::Information() const

--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -351,14 +351,7 @@ namespace WPEFramework {
 
         RDKShell::~RDKShell()
         {
-            LOGINFO("dtor");
-            mClientsMonitor->Release();
-            RDKShell::_instance = nullptr;
-            mRemoteShell = false;
-            CompositorController::setEventListener(nullptr);
-            mEventListener = nullptr;
-            mEnableUserInactivityNotification = false;
-            gActivePluginsData.clear();
+            //LOGINFO("dtor");
         }
 
         const string RDKShell::Initialize(PluginHost::IShell* service )
@@ -599,8 +592,16 @@ namespace WPEFramework {
 
         void RDKShell::Deinitialize(PluginHost::IShell* service)
         {
+            LOGINFO("Deinitialize");
             mCurrentService = nullptr;
             service->Unregister(mClientsMonitor);
+            mClientsMonitor->Release();
+            RDKShell::_instance = nullptr;
+            mRemoteShell = false;
+            CompositorController::setEventListener(nullptr);
+            mEventListener = nullptr;
+            mEnableUserInactivityNotification = false;
+            gActivePluginsData.clear();
         }
 
         string RDKShell::Information() const

--- a/RemoteActionMapping/RemoteActionMapping.cpp
+++ b/RemoteActionMapping/RemoteActionMapping.cpp
@@ -118,9 +118,7 @@ namespace WPEFramework {
 
         RemoteActionMapping::~RemoteActionMapping()
         {
-            LOGINFO("dtor");
-            RemoteActionMapping::_instance = nullptr;
-
+            //LOGINFO("dtor");
         }
 
         const string RemoteActionMapping::Initialize(PluginHost::IShell* /* service */)
@@ -133,6 +131,7 @@ namespace WPEFramework {
         void RemoteActionMapping::Deinitialize(PluginHost::IShell* /* service */)
         {
             DeinitializeIARM();
+            RemoteActionMapping::_instance = nullptr;
         }
 
         void RemoteActionMapping::InitializeIARM()

--- a/ScreenCapture/ScreenCapture.cpp
+++ b/ScreenCapture/ScreenCapture.cpp
@@ -66,6 +66,10 @@ namespace WPEFramework
 
         ScreenCapture::~ScreenCapture()
         {
+        }
+
+        void ScreenCapture::Deinitialize(PluginHost::IShell* /* service */)
+        {
             ScreenCapture::_instance = nullptr;
 
             delete screenShotDispatcher;

--- a/ScreenCapture/ScreenCapture.h
+++ b/ScreenCapture/ScreenCapture.h
@@ -104,6 +104,7 @@ namespace WPEFramework {
         public:
             ScreenCapture();
             virtual ~ScreenCapture();
+            virtual void Deinitialize(PluginHost::IShell* service) override;
 
         public:
             static ScreenCapture* _instance;

--- a/StateObserver/StateObserver.cpp
+++ b/StateObserver/StateObserver.cpp
@@ -78,8 +78,6 @@ namespace WPEFramework {
 
 		StateObserver::~StateObserver()
 		{
-			StateObserver::_instance = nullptr;
-			//Unregister all the APIs
 		}
 
 		const string StateObserver::Initialize(PluginHost::IShell* /* service */)
@@ -93,6 +91,8 @@ namespace WPEFramework {
 		void StateObserver::Deinitialize(PluginHost::IShell* /* service */)
 		{
 			DeinitializeIARM();
+			StateObserver::_instance = nullptr;
+			//Unregister all the APIs
 		}
 
 		void StateObserver::InitializeIARM()

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -370,7 +370,6 @@ namespace WPEFramework {
 
         SystemServices::~SystemServices()
         {       
-            SystemServices::_instance = nullptr;
         }
 
         const string SystemServices::Initialize(PluginHost::IShell*)
@@ -387,6 +386,7 @@ namespace WPEFramework {
 #if defined(USE_IARMBUS) || defined(USE_IARM_BUS)
             DeinitializeIARM();
 #endif /* defined(USE_IARMBUS) || defined(USE_IARM_BUS) */
+            SystemServices::_instance = nullptr;
         }
 
 #if defined(USE_IARMBUS) || defined(USE_IARM_BUS)

--- a/Timer/Timer.cpp
+++ b/Timer/Timer.cpp
@@ -82,6 +82,10 @@ namespace WPEFramework
 
         Timer::~Timer()
         {
+        }
+
+        void Timer::Deinitialize(PluginHost::IShell* /* service */)
+        {
             Timer::_instance = nullptr;
         }
 

--- a/Timer/Timer.h
+++ b/Timer/Timer.h
@@ -102,6 +102,7 @@ namespace WPEFramework {
         public:
             Timer();
             virtual ~Timer();
+            virtual void Deinitialize(PluginHost::IShell* service) override;
 
         public:
             static Timer* _instance;

--- a/UsbAccess/UsbAccess.cpp
+++ b/UsbAccess/UsbAccess.cpp
@@ -36,7 +36,6 @@ namespace WPEFramework {
 
         UsbAccess::~UsbAccess()
         {
-            UsbAccess::_instance = nullptr;
         }
 
         const string UsbAccess::Initialize(PluginHost::IShell* /* service */)
@@ -46,6 +45,20 @@ namespace WPEFramework {
 
         void UsbAccess::Deinitialize(PluginHost::IShell* /* service */)
         {
+#if defined(USE_IARMBUS) || defined(USE_IARM_BUS)
+            DeinitializeIARM();
+#endif /* defined(USE_IARMBUS) || defined(USE_IARM_BUS) */
+            UsbAccess::_instance = nullptr;
+        }
+
+#if defined(USE_IARMBUS) || defined(USE_IARM_BUS)
+        void UsbAccess::InitializeIARM()
+        {
+            if (Utils::IARM::init())
+            {
+                IARM_Result_t res;
+                IARM_CHECK(IARM_Bus_RegisterEventHandler(IARM_BUS_SYSMGR_NAME, IARM_BUS_SYSMGR_EVENT_USB_FW_UPDATE, _usbFirmwareUpdateStateChanged));
+            }
         }
 
         string UsbAccess::Information() const

--- a/UserPreferences/UserPreferences.cpp
+++ b/UserPreferences/UserPreferences.cpp
@@ -48,7 +48,12 @@ namespace WPEFramework {
 
         UserPreferences::~UserPreferences()
         {
-            LOGINFO("dtor");
+            //LOGINFO("dtor");
+        }
+
+        void UserPreferences::Deinitialize(PluginHost::IShell* /* service */)
+        {
+            LOGINFO("Deinitialize");
             UserPreferences::_instance = nullptr;
         }
 

--- a/UserPreferences/UserPreferences.h
+++ b/UserPreferences/UserPreferences.h
@@ -43,6 +43,7 @@ namespace WPEFramework {
         public:
             UserPreferences();
             virtual ~UserPreferences();
+            virtual void Deinitialize(PluginHost::IShell* service) override;
 
 
         public:

--- a/Warehouse/Warehouse.cpp
+++ b/Warehouse/Warehouse.cpp
@@ -97,10 +97,6 @@ namespace WPEFramework
 
         Warehouse::~Warehouse()
         {
-            Warehouse::_instance = nullptr;
-
-            if (m_resetThread.joinable())
-                m_resetThread.join();
         }
 
         const string Warehouse::Initialize(PluginHost::IShell* /* service */)
@@ -113,6 +109,7 @@ namespace WPEFramework
         void Warehouse::Deinitialize(PluginHost::IShell* /* service */)
         {
             DeinitializeIARM();
+            Warehouse::_instance = nullptr;
         }
 
         void Warehouse::InitializeIARM()
@@ -265,18 +262,33 @@ namespace WPEFramework
 
         void Warehouse::resetDevice(bool suppressReboot, const string& resetType)
         {
+            JsonObject params;
 #if defined(USE_IARMBUS) || defined(USE_IARM_BUS)
 
             LOGWARN("Received request to reset device");
 
-            if (m_resetThread.joinable())
-                m_resetThread.join();
+            try
+            {
+                if (m_resetThread.get().joinable())
+                    m_resetThread.get().join();
 
-            m_resetThread = std::thread(WareHouseResetIARM, this, suppressReboot, resetType);
+                m_resetThread = Utils::ThreadRAII(std::thread(WareHouseResetIARM, this, suppressReboot, resetType));
+            }
+            catch(const std::system_error& e)
+            {
+                LOGERR("system_error exception in thread join %s", e.what());
+                params[PARAM_SUCCESS] = false;
+                params[PARAM_ERROR] = "exception in submitting request";
+                sendNotify(WAREHOUSE_EVT_RESET_DONE, params);
+            }
+            catch(const std::exception& e)
+            {
+                LOGERR("exception in thread join %s", e.what());
+                params[PARAM_SUCCESS] = false;
+                params[PARAM_ERROR] = "exception in submitting request";
+                sendNotify(WAREHOUSE_EVT_RESET_DONE, params);
+            }
 #else
-
-            JsonObject params;
-
             bool ok = false;
             params[PARAM_SUCCESS] = ok;
 

--- a/Warehouse/Warehouse.h
+++ b/Warehouse/Warehouse.h
@@ -114,7 +114,7 @@ namespace WPEFramework {
 
             void getDeviceInfo(JsonObject &params);
 
-            std::thread m_resetThread;
+            Utils::ThreadRAII m_resetThread;
 
 #ifdef HAS_FRONT_PANEL
             Core::TimerType<LedInfo> m_ledTimer;

--- a/WifiManager/WifiManager.cpp
+++ b/WifiManager/WifiManager.cpp
@@ -80,7 +80,6 @@ namespace WPEFramework
 
         WifiManager::~WifiManager()
         {
-            WifiManager::instance=nullptr;
         }
 
         const string WifiManager::Initialize(PluginHost::IShell* service)

--- a/XCast/XCast.cpp
+++ b/XCast/XCast.cpp
@@ -91,20 +91,6 @@ XCast::XCast() : AbstractPlugin()
 
 XCast::~XCast()
 {
-    Unregister(METHOD_GET_API_VERSION_NUMBER);
-    Unregister(METHOD_ON_APPLICATION_STATE_CHANGED);
-    Unregister(METHOD_SET_ENABLED);
-    Unregister(METHOD_GET_ENABLED);
-    Unregister(METHOD_GET_STANDBY_BEHAVIOR);
-    Unregister(METHOD_SET_STANDBY_BEHAVIOR);
-    Unregister(METHOD_GET_FRIENDLYNAME);
-    Unregister(METHOD_SET_FRIENDLYNAME);
-
-    DeinitializeIARM();
-    if ( m_locateCastTimer.isActive())
-    {
-        m_locateCastTimer.stop();
-    }
 }
 const void XCast::InitializeIARM()
 {
@@ -128,6 +114,20 @@ void XCast::DeinitializeIARM()
      {
          IARM_Result_t res;
          IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_PWRMGR_NAME,IARM_BUS_PWRMGR_EVENT_MODECHANGED) );
+     }
+     Unregister(METHOD_GET_API_VERSION_NUMBER);
+     Unregister(METHOD_ON_APPLICATION_STATE_CHANGED);
+     Unregister(METHOD_SET_ENABLED);
+     Unregister(METHOD_GET_ENABLED);
+     Unregister(METHOD_GET_STANDBY_BEHAVIOR);
+     Unregister(METHOD_SET_STANDBY_BEHAVIOR);
+     Unregister(METHOD_GET_FRIENDLYNAME);
+     Unregister(METHOD_SET_FRIENDLYNAME);
+
+     DeinitializeIARM();
+     if ( m_locateCastTimer.isActive())
+     {
+         m_locateCastTimer.stop();
      }
 }
 void XCast::powerModeChange(const char *owner, IARM_EventId_t eventId, void *data, size_t len)


### PR DESCRIPTION
(cherry picked from commit fa825bd2c08ee66a9dd624e787cb4dd82f75f1c3)
(cherry picked from commit 4a5d9c7970a8a17ad58c7271aa6fe63247795062)

RDKTV-2681: Move plugin cleanup to Deinitialize

Reason for change: Plugin is unloaded after Deinitialize & then should not be used
Test Procedure: systemctl stop wpeframework should unload plugins
Risks: None

Signed-off-by: Mark Vandenbriele <mark.vandenbriele@consult.red>
(cherry picked from commit c9e7f7cb17981ef9cf37736f320fa30452423cc1)

RDKTV-2681: Move plugin cleanup to Deinitialize

Reason for change: Revert unbalanced interface changes
Test Procedure: systemctl stop wpeframework should unload plugins
Risks: None

Signed-off-by: Mark Vandenbriele <mark.vandenbriele@consult.red>
(cherry picked from commit 9d02a5006449b795394623ba023d98c10a60bcf2)