### PR TITLE
RDKTV-3712 : USBAccess.getFileList must also return .txt files

### DIFF
--- a/UsbAccess/UsbAccess.cpp
+++ b/UsbAccess/UsbAccess.cpp
@@ -262,7 +262,7 @@ namespace WPEFramework {
                     else
                     {
                         if (std::regex_match(dp->d_name, std::regex(
-                                "([\\w-]*)\\.(png|jpg|jpeg|tiff|tif|bmp|mp4|mov|avi|mp3|wav|m4a|flac|mp4|aac|wma)",
+                                "([\\w-]*)\\.(png|jpg|jpeg|tiff|tif|bmp|mp4|mov|avi|mp3|wav|m4a|flac|mp4|aac|wma|txt)",
                                 std::regex_constants::icase)) == true)
                             files.emplace_back(dp->d_name, "f");
                         else


### PR DESCRIPTION
Reason for change: Include .txt extension
in a list of allowed extensions.
Test Procedure: getFileList returns .txt files
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>