### PR TITLE
Network/PingNotifier.cpp: remove newline from tripMax

### DIFF
--- a/Network/PingNotifier.cpp
+++ b/Network/PingNotifier.cpp
@@ -109,6 +109,8 @@ namespace WPEFramework
                 char linearray[1000]={0x0};
                 while(fgets(linearray, sizeof(linearray), fp) != NULL)
                 {
+                    // remove newline from linearray
+                    linearray[strcspn(linearray, "\n")] = '\0';
                     string line(linearray);
                     LOGINFO("ping result: %s", line.c_str());
 


### PR DESCRIPTION
From fgets(3) we can read:
  fgets() (...) If a newline is read, it is stored into the buffer.

This causes line, and thus fullpath and later prefix variables
to contain new line character. All fields are substr()ed before
newline, but last field is substr()ed until the end of buffer,
which also contains new line character. This new line character
is later seen in jsonrpc response.

strcspn(3) function returns number of bytes before '\n' or
length of linebuffer if '\n' does not exist. So if '\n' does
not exist or linebuffer is empty, this will effectively make
'\0' to be overwritten with '\0'.

Signed-off-by: Michał Łyszczek <michal.lyszczek@consult.red>