### PR TITLE
DELIA-49301: Enable close-on-exec flag in getGraphicSize() API

### DIFF
--- a/DisplayInfo/DeviceSettings/Amlogic/SoC_abstraction.cpp
+++ b/DisplayInfo/DeviceSettings/Amlogic/SoC_abstraction.cpp
@@ -24,6 +24,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <unistd.h>
 #include "kms.h"
 
 #define MEM_PROCFS "/proc/meminfo"
@@ -108,7 +109,7 @@ static void getGraphicSize(uint32_t &w, uint32_t &h)
 
     do {
         /* Setup buffer information */
-        drm_fd = open( DEFAULT_DEVICE, O_RDWR);
+        drm_fd = open( DEFAULT_DEVICE, O_RDWR | O_CLOEXEC);
 
         /* Setup KMS */
         kms = kms_setup(drm_fd);
@@ -152,6 +153,7 @@ static void getGraphicSize(uint32_t &w, uint32_t &h)
 
     cout << "[getGraphicSize] width : " << w << endl;
     cout << "[getGraphicSize] height : " << h << endl;
+    close(drm_fd);
 }
 
 


### PR DESCRIPTION
Reason for change: Adding O_CLOEXEC flag in getGraphicSize() API
Test Procedure: Build and Verify.
Risks: Low
Signed-off-by: bp-snadig771 <suraj.nadiger@sky.uk>