### PR TITLE
RDKTV-3815: WPEFramework_crashes_in_std_terminate

### DIFF
--- a/HdcpProfile/HdcpProfile.cpp
+++ b/HdcpProfile/HdcpProfile.cpp
@@ -53,7 +53,15 @@ namespace WPEFramework
             HdcpProfile::_instance = this;
 
             InitializeIARM();
-            device::Manager::Initialize();
+            try
+            {
+                device::Manager::Initialize();
+                LOGINFO("device::Manager::Initialize success");
+            }
+            catch (...)
+            {
+                LOGINFO("device::Manager::Initialize failed");
+            }
 
             registerMethod(HDCP_PROFILE_METHOD_GET_HDCP_STATUS, &HdcpProfile::getHDCPStatusWrapper, this);
             registerMethod(HDCP_PROFILE_METHOD_GET_SETTOP_HDCP_SUPPORT, &HdcpProfile::getSettopHDCPSupportWrapper, this);


### PR DESCRIPTION
Reason for change:
device::Manager::Initialize exception handling is
enabled in HdcpProfile.cpp
Test Procedure: None
Risks: Low

Change-Id: Ib811da8b55cbe250c002a5d278f97231f13d999e
Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>