### PR TITLE
RDK-32035 : Modify USB Access Plugin

### DIFF
--- a/UsbAccess/UsbAccess.cpp
+++ b/UsbAccess/UsbAccess.cpp
@@ -5,6 +5,7 @@
 #include <dirent.h>
 #include <unistd.h>
 #include <mntent.h>
+#include <regex>
 
 const short WPEFramework::Plugin::UsbAccess::API_VERSION_NUMBER_MAJOR = 1;
 const short WPEFramework::Plugin::UsbAccess::API_VERSION_NUMBER_MINOR = 0;
@@ -198,7 +199,17 @@ namespace WPEFramework {
                 struct dirent * dp;
                 while ((dp = readdir(dirp)) != nullptr)
                 {
-                    files.emplace_back(dp->d_name, dp->d_type == DT_DIR ? "d" : "f");
+                    if (dp->d_type == DT_DIR)
+                        files.emplace_back(dp->d_name, "d");
+                    else
+                    {
+                        if (std::regex_match(dp->d_name, std::regex(
+                                "([\\w-]*)\\.(png|jpg|jpeg|tiff|tif|bmp|mp4|mov|avi|mp3|wav|m4a|flac|mp4|aac|wma)",
+                                std::regex_constants::icase)) == true)
+                            files.emplace_back(dp->d_name, "f");
+                        else
+                            LOGWARN("unsupported file name: '%s'", dp->d_name);
+                    }
                 }
                 closedir(dirp);
 

--- a/UsbAccess/UsbAccess.cpp
+++ b/UsbAccess/UsbAccess.cpp
@@ -204,7 +204,7 @@ namespace WPEFramework {
                     else
                     {
                         if (std::regex_match(dp->d_name, std::regex(
-                                "([\\w-]*)\\.(png|jpg|jpeg|tiff|tif|bmp|mp4|mov|avi|mp3|wav|m4a|flac|mp4|aac|wma|txt)",
+                                "([\\w-]*)\\.(png|jpg|jpeg|tiff|tif|bmp|mp4|mov|avi|mp3|wav|m4a|flac|mp4|aac|wma|txt|bin|enc)",
                                 std::regex_constants::icase)) == true)
                             files.emplace_back(dp->d_name, "f");
                         else

--- a/UsbAccess/UsbAccess.cpp
+++ b/UsbAccess/UsbAccess.cpp
@@ -204,7 +204,7 @@ namespace WPEFramework {
                     else
                     {
                         if (std::regex_match(dp->d_name, std::regex(
-                                "([\\w-]*)\\.(png|jpg|jpeg|tiff|tif|bmp|mp4|mov|avi|mp3|wav|m4a|flac|mp4|aac|wma)",
+                                "([\\w-]*)\\.(png|jpg|jpeg|tiff|tif|bmp|mp4|mov|avi|mp3|wav|m4a|flac|mp4|aac|wma|txt)",
                                 std::regex_constants::icase)) == true)
                             files.emplace_back(dp->d_name, "f");
                         else


### PR DESCRIPTION
Reason for change: getFileList should return
folders, and files that have media extensions.
Test Procedure: See parent ticket
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>