### PR TITLE
RDKTV-3712 : USBAccess.getFileList must also return .txt files

### DIFF
--- a/UsbAccess/UsbAccess.cpp
+++ b/UsbAccess/UsbAccess.cpp
@@ -5,6 +5,7 @@
 #include <dirent.h>
 #include <unistd.h>
 #include <mntent.h>
+#include <regex>
 
 const short WPEFramework::Plugin::UsbAccess::API_VERSION_NUMBER_MAJOR = 1;
 const short WPEFramework::Plugin::UsbAccess::API_VERSION_NUMBER_MINOR = 0;
@@ -198,7 +199,17 @@ namespace WPEFramework {
                 struct dirent * dp;
                 while ((dp = readdir(dirp)) != nullptr)
                 {
-                    files.emplace_back(dp->d_name, dp->d_type == DT_DIR ? "d" : "f");
+                    if (dp->d_type == DT_DIR)
+                        files.emplace_back(dp->d_name, "d");
+                    else
+                    {
+                        if (std::regex_match(dp->d_name, std::regex(
+                                "([\\w-]*)\\.(png|jpg|jpeg|tiff|tif|bmp|mp4|mov|avi|mp3|wav|m4a|flac|mp4|aac|wma|txt|bin|enc)",
+                                std::regex_constants::icase)) == true)
+                            files.emplace_back(dp->d_name, "f");
+                        else
+                            LOGWARN("unsupported file name: '%s'", dp->d_name);
+                    }
                 }
                 closedir(dirp);
 


### PR DESCRIPTION
Reason for change: Include .txt extension
in a list of allowed extensions.
Test Procedure: getFileList returns .txt files
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>

RDKTV-3712 Add .enc and .bin to files returned from getFileList (#1005)