### PR TITLE
Delia 49650 2103

### DIFF
--- a/XCast/RtXcastConnector.cpp
+++ b/XCast/RtXcastConnector.cpp
@@ -264,6 +264,8 @@ void RtXcastConnector::shutdown()
         m_eventMtrThread.join();    
 
     rtRemoteShutdown(rtEnvironmentGetGlobal());
+    if(RtXcastConnector::_instance != nullptr)
+        delete RtXcastConnector::_instance;
 }
 
 int RtXcastConnector::applicationStateChanged( string app, string state, string id, string error)


### PR DESCRIPTION
DELIA-49650 : xcast mem leak

Reason for change: Free dynamically allocated memory in RtXcastConnector::getInstance() .
Test Procedure: Refer Jira
Risks: Low
Signed-off-by:Anaswara KookkalAnaswara_Kookkal@comcast.com