### PR TITLE
DELIA-49650 : xcast mem leak

### DIFF
--- a/XCast/RtXcastConnector.cpp
+++ b/XCast/RtXcastConnector.cpp
@@ -234,7 +234,11 @@ int RtXcastConnector::connectToRemoteService()
 RtXcastConnector::~RtXcastConnector()
 {
     LOGINFO("Dtr");
-    _instance = nullptr;
+    if(_instance != nullptr)
+    {
+        delete _instance;
+        _instance = nullptr;
+    }
     m_observer = nullptr;
 }
 
@@ -264,6 +268,11 @@ void RtXcastConnector::shutdown()
         m_eventMtrThread.join();    
 
     rtRemoteShutdown(rtEnvironmentGetGlobal());
+    if(RtXcastConnector::_instance != nullptr)
+    {
+        delete RtXcastConnector::_instance;
+        RtXcastConnector::_instance = nullptr;
+    }
 }
 
 int RtXcastConnector::applicationStateChanged( string app, string state, string id, string error)


### PR DESCRIPTION
Reason for change: Free dynamically allocated memory in RtXcastConnector::getInstance() .
Test Procedure: Refer Jira
Risks: Low
Signed-off-by:Anaswara KookkalAnaswara_Kookkal@comcast.com