### PR TITLE
RDK-30784 : Provide Required HDMI Source Properties

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -1549,13 +1549,14 @@ namespace WPEFramework {
                 device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort("HDMI0");
                 if (vPort.isDisplayConnected())
                 {
-                    int videoEOTF, matrixCoefficients, colorSpace, colorDepth;
-                    vPort.getCurrentOutputSettings(videoEOTF, matrixCoefficients, colorSpace, colorDepth);
+                    int videoEOTF, matrixCoefficients, colorSpace, colorDepth, quantizationRange;
+                    vPort.getCurrentOutputSettings(videoEOTF, matrixCoefficients, colorSpace, colorDepth, quantizationRange);
 
                     response["colorSpace"] = colorSpace;
                     response["colorDepth"] = colorDepth;
                     response["matrixCoefficients"] = matrixCoefficients;
                     response["videoEOTF"] = videoEOTF;
+                    response["quantizationRange"] = quantizationRange;
                 }
                 else
                 {


### PR DESCRIPTION
Reason for change: Provide Api to get quantization range.
Test Procedure: Refer Jira
Risks: Low
Signed-off-by:Anaswara Kookkal<Anaswara_Kookkal@comcast.com>