### PR TITLE
DELIA-42792 SystemServices: use strings in firmwareUpdateState

### DIFF
--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -1629,7 +1629,7 @@ namespace WPEFramework {
                         }
                     }
                 }
-                response["firmwareUpdateState"] = (int)fwUpdateState;
+                response["firmwareUpdateState"] = FIRMWARE_UPDATE_STATE_STR[fwUpdateState];
                 retStatus = true;
             } else {
                 LOGERR("Could not read file %s\n", FWDNLDSTATUS_FILE_NAME);
@@ -1644,15 +1644,18 @@ namespace WPEFramework {
          * @param1[in]  : newstate
          * @param2[out] : {"jsonrpc": "2.0","method":
          *			"org.rdk.SystemServices.events.1.onFirmwareUpdateStateChange",
-         *			"param":{"firmwareUpdateState":<enum:0-6>}}
+         *			"param":{"firmwareUpdateState":<string>}}
          */
         void SystemServices::onFirmwareUpdateStateChange(int newState)
         {
             JsonObject params;
 
-            const FirmwareUpdateState firmwareUpdateState = (FirmwareUpdateState)newState;
-            params["firmwareUpdateStateChange"] = (int)firmwareUpdateState;
-            LOGINFO("New firmwareUpdateState = %d\n", (int)firmwareUpdateState);
+            if (newState >= FirmwareUpdateStateMax) {
+                LOGERR("Invalid firmware update state: %d", newState);
+                return;
+            }
+            params["firmwareUpdateStateChange"] = FIRMWARE_UPDATE_STATE_STR[newState];
+            LOGINFO("New firmwareUpdateState = %s\n", FIRMWARE_UPDATE_STATE_STR[newState]);
             sendNotify(EVT_ONFIRMWAREUPDATESTATECHANGED, params);
         }
 

--- a/helpers/SystemServicesHelper.cpp
+++ b/helpers/SystemServicesHelper.cpp
@@ -47,6 +47,19 @@ std::map<int, std::string> ErrCodeMap = {
     {SysSrv_KeyNotFound, "Key not found"}
 };
 
+const char *FIRMWARE_UPDATE_STATE_STR[] = {
+    "UNINITIALIZED",
+    "REQUESTING",
+    "DOWNLOADING",
+    "FAILED",
+    "DOWNLOAD_COMPLETE",
+    "VALIDATION_COMPLETE",
+    "PREPARING_TO_REBOOT",
+    "NO_UPGRADE_NEEDED",
+    NULL
+};
+
+
 std::string getErrorDescription(int errCode)
 {
     std::string errMsg = "Unexpected Error";

--- a/helpers/SystemServicesHelper.h
+++ b/helpers/SystemServicesHelper.h
@@ -103,9 +103,11 @@ enum FirmwareUpdateState {
     FirmwareUpdateStateDownloadComplete,
     FirmwareUpdateStateValidationComplete,
     FirmwareUpdateStatePreparingReboot,
-    FirmwareUpdateStateNoUpgradeNeeded
+    FirmwareUpdateStateNoUpgradeNeeded,
+    FirmwareUpdateStateMax
 };
 
+extern const char *FIRMWARE_UPDATE_STATE_STR[];
 const string GZ_STATUS = "/opt/gzenabled";
 
 /* Used as CURL Data buffer */


### PR DESCRIPTION
Right now firmwareUpdateState returns update state as int (ranging
from 0 to 6), this patch changes it so it returns state as string
like "DOWNLOADING_COMPLETE" or "PREPARING_TO_REBOOT".

Signed-off-by: Michał Łyszczek <michal.lyszczek@consult.red>