### PR TITLE
XIONE-3594: Build breaks at VNC_FRAMEBUFFER_LIBRARIES

### DIFF
--- a/ScreenCapture/CMakeLists.txt
+++ b/ScreenCapture/CMakeLists.txt
@@ -35,8 +35,8 @@ if (NOT ${FRAMEBUFFER_API_HEADER} STREQUAL "FRAMEBUFFER_API_HEADER-NOTFOUND")
 add_definitions (-DHAS_FRAMEBUFFER_API_HEADER)
 find_library(VNC_FRAMEBUFFER_LIBRARIES NAMES vncframebuffer)
 target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins -lpng -lcurl ${VNC_FRAMEBUFFER_LIBRARIES})
-else
-target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins -lpng -lcurl
+else()
+target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins -lpng -lcurl)
 endif()
 
 target_include_directories(${MODULE_NAME} PRIVATE ../helpers)

--- a/ScreenCapture/CMakeLists.txt
+++ b/ScreenCapture/CMakeLists.txt
@@ -34,11 +34,12 @@ if (NOT ${FRAMEBUFFER_API_HEADER} STREQUAL "FRAMEBUFFER_API_HEADER-NOTFOUND")
     message("Found framebuffer-api.h")
 add_definitions (-DHAS_FRAMEBUFFER_API_HEADER)
 find_library(VNC_FRAMEBUFFER_LIBRARIES NAMES vncframebuffer)
+target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins -lpng -lcurl ${VNC_FRAMEBUFFER_LIBRARIES})
+else
+target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins -lpng -lcurl
 endif()
 
 target_include_directories(${MODULE_NAME} PRIVATE ../helpers)
-
-target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins -lpng -lcurl ${VNC_FRAMEBUFFER_LIBRARIES})
 
 install(TARGETS ${MODULE_NAME}
         DESTINATION lib/${STORAGE_DIRECTORY}/plugins)

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -1626,6 +1626,8 @@ namespace WPEFramework {
                             fwUpdateState = FirmwareUpdateStatePreparingReboot;
                         } else if (!strcmp(line.c_str(), "No upgrade needed")) {
                             fwUpdateState = FirmwareUpdateStateNoUpgradeNeeded;
+                        } else if (!strcmp(line.c_str(), "Uninitialized")){
+                            fwUpdateState = FirmwareUpdateStateUninitialized;
                         }
                     }
                 }

--- a/helpers/SystemServicesHelper.h
+++ b/helpers/SystemServicesHelper.h
@@ -74,7 +74,7 @@
 #define MODE_EAS        "EAS"
 #define MODE_WAREHOUSE  "WAREHOUSE"
 
-#define CAT_DWNLDPROGRESSFILE_AND_GET_INFO "cat /opt/curl_progress | tr -s '\r' '\n' | tail -n 1 | sed 's/^ *//g' | tr -s ' ' | cut -d ' ' -f3"
+#define CAT_DWNLDPROGRESSFILE_AND_GET_INFO "cat /opt/curl_progress | tr -s '\r' '\n' | tail -n 1 | sed 's/^ *//g' | sed '/^[^M/G]*$/d' | tr -s ' ' | cut -d ' ' -f3"
 
 enum eRetval { E_NOK = -1,
     E_OK };


### PR DESCRIPTION
Risks: Low
Reason for change: Builds fail if it didnt find VNC_FRAMEBUFFER_LIBRARIES
Test Procedure: Builds are okay.

Signed-off-by: Rohith Damodaran <Rohith_Damodaran@comcast.com>