### PR TITLE
RDKB-27781: fix gcc 4.8.4 compile error when building for xb7

### DIFF
--- a/Messenger/RoomMaintainer.cpp
+++ b/Messenger/RoomMaintainer.cpp
@@ -192,7 +192,7 @@ namespace Plugin {
 
         _adminLock.Lock();
 
-        auto const it(std::find(_observers.cbegin(), _observers.cend(), sink));
+        auto it(std::find(_observers.begin(), _observers.end(), sink));
 
         // Make sure it was really registered.
         ASSERT(it != _observers.cend());


### PR DESCRIPTION
Reason for change: While porting thunder to xb7, got compile errors
which needed addressing.  xb7 is currently using gcc 4.8.4.
Got errors passing const iterators to list::erase.
Test Procedure: verify build succeeds.  Ran a few basic tests with messenger on xb7 which worked.
Risks: Low
Signed-off-by: mrollins <mark_rollins@cable.comcast.com>