### PR TITLE
RDKTV-4097 : getSinkDeviceAtmosCapability return false fix

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -2667,14 +2667,21 @@ namespace WPEFramework {
 			dsATMOSCapability_t atmosCapability;
             try
             {
-                device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort("HDMI0");
-                if (aPort.isConnected()) {
-                    aPort.getSinkDeviceAtmosCapability (atmosCapability);
-                    response["atmos_capability"] = (int)atmosCapability;
+                if (isSettopbox())
+                {
+                    device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort("HDMI0");
+                    if (aPort.isConnected()) {
+                        aPort.getSinkDeviceAtmosCapability (atmosCapability);
+                        response["atmos_capability"] = (int)atmosCapability;
+                    }
+                    else {
+                        LOGERR("getSinkAtmosCapability failure: HDMI0 not connected!\n");
+                        success = false;
+                    }
                 }
                 else {
-					LOGERR("getSinkAtmosCapability failure: HDMI0 not connected!\n");
-                    success = false;
+                    device::Host::getInstance().getSinkDeviceAtmosCapability (atmosCapability);
+                    response["atmos_capability"] = (int)atmosCapability;
                 }
             }
             catch(const device::Exception& err)
@@ -2696,15 +2703,20 @@ namespace WPEFramework {
             bool success = true;
             try
             {
-                device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort("HDMI0");
-                if (aPort.isConnected()) {
-                    aPort.setAudioAtmosOutputMode (enable);
+                if (isSettopbox())
+                {
+                    device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort("HDMI0");
+                    if (aPort.isConnected()) {
+                        aPort.setAudioAtmosOutputMode (enable);
+                    }
+                    else {
+					    LOGERR("setAudioAtmosOutputMode failure: HDMI0 not connected!\n");
+                        success = false;
+                    }
                 }
                 else {
-					LOGERR("setAudioAtmosOutputMode failure: HDMI0 not connected!\n");
-                    success = false;
+                    device::Host::getInstance().setAudioAtmosOutputMode (enable);
                 }
-
             }
             catch (const device::Exception& err)
             {
@@ -2864,6 +2876,29 @@ namespace WPEFramework {
             returnResponse(success);
         }
 
+        bool DisplaySettings::isSettopbox ()
+        {
+            bool isSTB = false;
+            try
+            {
+                device::List<device::AudioOutputPort> aPorts = device::Host::getInstance().getAudioOutputPorts();
+                for (size_t i = 0; i < aPorts.size(); i++)
+                {
+                    device::AudioOutputPort &vPort = aPorts.at(i);
+                    string portName  = vPort.getName();
+                    //If HDMI0 audio port it is STB
+                    if (strcmp(portName.c_str(), "HDMI0") == 0) {
+                        isSTB = true;
+                        break;
+                    }
+                }
+            }
+            catch(const device::Exception& err)
+            {
+                LOG_DEVICE_EXCEPTION0();
+            }
+            return isSTB;
+        }
 
         // Thunder plugins communication
         std::shared_ptr<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>> DisplaySettings::getHdmiCecSinkPlugin()

--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -167,6 +167,7 @@ namespace WPEFramework {
 	    uint32_t subscribeForHdmiCecSinkEvent(const char* eventName);
 	    bool setUpHdmiCecSinkArcRouting (bool arcEnable);
 	    void onTimer();
+	    bool isSettopbox ();
 
 	    TpTimer m_timer;
             bool m_subscribed;


### PR DESCRIPTION
Reason for change:
getSinkDeviceAtmosCapability return false fix
Test Procedure: None
Risks: Low

Change-Id: If485e0385b126a022fe547c17d9aae3f3962d6d6
Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>