### PR TITLE
RDKTV-3860: WPEFramework_crashes_setBassEnhancer

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -1872,6 +1872,11 @@ namespace WPEFramework {
                 returnIfParamNotFound(parameters, "bassBoost");
                 string sBassBoost = parameters["bassBoost"].String();
                 int bassBoost = 0;
+                bool isIntiger = Utils::isValidInt ((char*)sBassBoost.c_str());
+                if (false == isIntiger) {
+                    LOGWARN("bassBoost should be an integer");
+                    returnResponse(false);
+                }
                 try {
                         bassBoost = stoi(sBassBoost);
                 }catch (const device::Exception& err) {

--- a/helpers/utils.cpp
+++ b/helpers/utils.cpp
@@ -29,6 +29,7 @@
 #include <securityagent/SecurityTokenUtil.h>
 #include <curl/curl.h>
 #include <utility>
+#include <ctype.h>
 
 #define MAX_STRING_LENGTH 2048
 
@@ -341,4 +342,27 @@ Utils::ThreadRAII::~ThreadRAII()
     }
 }
 
+bool Utils::isValidInt(char* x)
+{
+    bool Checked = true;
+    int i = 0;
+    do
+    {
+        //valid digit?
+        if (isdigit(x[i]))
+        {
+            //to the next character
+            i++;
+            Checked = true;
+        }
+        else
+        {
+            //to the next character
+            i++;
+            Checked = false;
+            break;
+        }
+    } while (x[i] != '\0');
+    return Checked;
+}
 

--- a/helpers/utils.h
+++ b/helpers/utils.h
@@ -349,6 +349,7 @@ namespace Utils
     bool isPluginActivated(const char* callSign);
 
     bool getRFCConfig(char* paramName, RFC_ParamData_t& paramOutput);
+    bool isValidInt(char* x);
 
     //class for std::thread RAII
     class ThreadRAII 


### PR DESCRIPTION
Reason for change:
WPEFramework crashes setBassEnhancer
valid int check added
Test Procedure: None
Risks: Low

Change-Id: I1e61e4a1241e87072963ef4f493dae9c380eade1
Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>
(cherry picked from commit 308b76315f6d51897d7533d4a68b81d40d7e8872)