### PR TITLE
RDK-31844: Aspect ratio for tv settings should be in tvsetting instead of device settings.

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -210,15 +210,6 @@ namespace WPEFramework {
 
 	    m_subscribed = false; //HdmiCecSink event subscription
 	    m_timer.connect(std::bind(&DisplaySettings::onTimer, this));
-
-#ifdef ENABLE_TV_ZOOM_SETTINGS
-        tvZoomSettings.push_back("TV AUTO");
-        tvZoomSettings.push_back("TV DIRECT");
-        tvZoomSettings.push_back("TV NORMAL");
-        tvZoomSettings.push_back("TV 16X9 STRETCH");
-        tvZoomSettings.push_back("TV LETTERBOX");
-        tvZoomSettings.push_back("TV ZOOM");
-#endif
         }
 
         DisplaySettings::~DisplaySettings()
@@ -839,36 +830,6 @@ namespace WPEFramework {
         uint32_t DisplaySettings::getZoomSetting(const JsonObject& parameters, JsonObject& response)
         {   //sample servicemanager response:
             LOGINFOMETHOD();
-#ifdef ENABLE_TV_ZOOM_SETTINGS
-            string zoomSetting = "TV AUTO";
-            Core::File settingsFile;
-            settingsFile = TV_ZOOM_SETTINGS_FILE;
-            if (settingsFile.Open())
-            {
-                JsonObject settingsJson;
-                if (settingsJson.IElement::FromFile(settingsFile))
-                {
-                    std::string settingsValue = settingsJson["zoomSetting"].String();
-                    if (std::find(tvZoomSettings.begin(), tvZoomSettings.end(), settingsValue) != tvZoomSettings.end())
-                    {
-                        zoomSetting = settingsValue;
-                    }
-                    else
-                    {
-                        LOGERR("Couldn't parse tv zoom settings file %s", TV_ZOOM_SETTINGS_FILE);
-                    }
-                }
-                else
-                {
-                    LOGERR("Couldn't read tv zoom settings file %s", TV_ZOOM_SETTINGS_FILE);
-                }
-                settingsFile.Close();
-            }
-            else
-            {
-                LOGWARN("Couldn't open tv zoom settings file %s", TV_ZOOM_SETTINGS_FILE);
-            }
-#else
             string zoomSetting = "unknown";
             try
             {
@@ -883,7 +844,6 @@ namespace WPEFramework {
 #ifdef USE_IARM
             zoomSetting = iarm2svc(zoomSetting);
 #endif
-#endif
             response["zoomSetting"] = zoomSetting;
             returnResponse(true);
         }
@@ -896,43 +856,6 @@ namespace WPEFramework {
             string zoomSetting = parameters["zoomSetting"].String();
 
             bool success = true;
-#ifdef ENABLE_TV_ZOOM_SETTINGS
-            if (std::find(tvZoomSettings.begin(), tvZoomSettings.end(), zoomSetting) != tvZoomSettings.end())
-            {
-                LOGWARN("Couldn't open zoom settings file %s", ZOOM_SETTINGS_FILE);
-
-                Core::Directory settingsDirectory(ZOOM_SETTINGS_DIRECTORY);
-                if (!settingsDirectory.CreatePath())
-                {
-                    LOGERR("Couldn't create zoom settings file path %s", ZOOM_SETTINGS_DIRECTORY);
-                    success = false;
-                }
-                else if (!settingsFile.Create())
-                {
-                    LOGWARN("Couldn't open tv zoom settings file %s", TV_ZOOM_SETTINGS_FILE);
-                    if (!settingsFile.Create())
-                    {
-                        LOGERR("Couldn't create tv zoom settings file %s", TV_ZOOM_SETTINGS_FILE);
-                        success = false;
-                    }
-                }
-
-                if (settingsFile.IsOpen())
-                {
-                    if (!parameters.IElement::ToFile(settingsFile))
-                    {
-                        LOGERR("Couldn't save tv zoom settings file %s", TV_ZOOM_SETTINGS_FILE);
-                        success = false;
-                    }
-                    settingsFile.Close();
-                }
-            }
-            else
-            {
-                LOGERR("Unsupported tv zoom settings value %s", zoomSetting.c_str());
-                success = false;
-            }
-#else
             try
             {
 #ifdef USE_IARM
@@ -947,7 +870,6 @@ namespace WPEFramework {
                 LOG_DEVICE_EXCEPTION1(zoomSetting);
                 success = false;
             }
-#endif
             returnResponse(success);
         }
 

--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -52,8 +52,6 @@ namespace WPEFramework {
             typedef Core::JSON::Boolean JBool;
 
 #ifdef ENABLE_TV_ZOOM_SETTINGS
-            std::string getTVZoomSetting();
-            bool setTVZoomSetting(std::string zoomSetting);
             std::vector<std::string> tvZoomSettings;
 #endif
 

--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -51,10 +51,6 @@ namespace WPEFramework {
             typedef Core::JSON::ArrayType<JString> JStringArray;
             typedef Core::JSON::Boolean JBool;
 
-#ifdef ENABLE_TV_ZOOM_SETTINGS
-            std::vector<std::string> tvZoomSettings;
-#endif
-
             // We do not allow this plugin to be copied !!
             DisplaySettings(const DisplaySettings&) = delete;
             DisplaySettings& operator=(const DisplaySettings&) = delete;

--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -52,11 +52,10 @@ namespace WPEFramework {
             typedef Core::JSON::Boolean JBool;
 
 #ifdef ENABLE_TV_ZOOM_SETTINGS
+            std::string getTVZoomSetting();
+            bool setTVZoomSetting(std::string zoomSetting);
             std::vector<std::string> tvZoomSettings;
 #endif
-            std::string getZoomSettingConfig();
-            bool setZoomSettingConfig(std::string zoomSetting);
-            bool setZoomSetting(std::string zoomSetting);
 
             // We do not allow this plugin to be copied !!
             DisplaySettings(const DisplaySettings&) = delete;
@@ -73,7 +72,7 @@ namespace WPEFramework {
             uint32_t getSupportedAudioPorts(const JsonObject& parameters, JsonObject& response);
             uint32_t getSupportedAudioModes(const JsonObject& parameters, JsonObject& response);
             uint32_t getZoomSetting(const JsonObject& parameters, JsonObject& response);
-            uint32_t setZoomSettingWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t setZoomSetting(const JsonObject& parameters, JsonObject& response);
             uint32_t getCurrentResolution(const JsonObject& parameters, JsonObject& response);
             uint32_t setCurrentResolution(const JsonObject& parameters, JsonObject& response);
             uint32_t getSoundMode(const JsonObject& parameters, JsonObject& response);

--- a/amlogic.cmake
+++ b/amlogic.cmake
@@ -82,11 +82,6 @@ if (BUILD_ENABLE_DEVICE_MANUFACTURER_INFO)
     add_definitions (-DENABLE_DEVICE_MANUFACTURER_INFO)
 endif()
 
-if (BUILD_ENABLE_TV_ZOOM_SETTINGS)
-    message("Building with tv zoom settings")
-    add_definitions (-DENABLE_TV_ZOOM_SETTINGS)
-endif()
-
 if (AMLOGIC_E2)
     add_definitions (-DAMLOGIC_E2)
 endif()


### PR DESCRIPTION
Removing tv zoom settings from displaysettings. 