### PR TITLE
RDKTV-4785 : Event property "phsicalAddress"

### DIFF
--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -1549,7 +1549,7 @@ namespace WPEFramework
 				}
 
 				params["logicalAddress"] = JsonValue(logical_address);
-				params["phsicalAddress"] = _instance->deviceList[logical_address].m_physicalAddr.toString().c_str(); 
+				params["physicalAddress"] = _instance->deviceList[logical_address].m_physicalAddr.toString().c_str(); 
 				sendNotify(eventString[HDMICECSINK_EVENT_ACTIVE_SOURCE_CHANGE], params);
 			}
        	}


### PR DESCRIPTION
Reason for change: onActiveSourceChange: Event property "phsicalAddress"
Test Procedure: none
Risks: low

Signed-off-by: Bijas Babu <bijas.babu@sky.uk>