### PR TITLE
RDKTV-4713 : Update Amlogic chipset name

### DIFF
--- a/DeviceIdentification/Implementation/Amlogic/Amlogic.cpp
+++ b/DeviceIdentification/Implementation/Amlogic/Amlogic.cpp
@@ -12,7 +12,7 @@ namespace Plugin {
 
 
 class DeviceImplementation : public Exchange::IDeviceProperties, public PluginHost::ISubSystem::IIdentifier {
-	static constexpr const TCHAR* ChipsetInofFile= _T("/sys/firmware/devicetree/base/model");
+	static constexpr const TCHAR* ChipsetInfo= _T("T962X3");
 	static constexpr const TCHAR* VERSIONFile= _T("/version.txt");
 
 
@@ -142,25 +142,11 @@ private:
 
     {
 
-        string line;
-
-        std::ifstream file(ChipsetInofFile);
-
-        if (file.is_open()) {
-
-            while(getline(file, line)) {
-
-                if (line.find("Amlogic") != std::string::npos) {
-
-                    chipset.assign(line);
-
-                }
-
-            }
-
-            file.close();
-
-        }
+#ifndef DEVICE_IDENTIFICATION_CHIPSET_INFO
+         chipset.assign(ChipsetInfo);
+#else
+         chipset.assign(DEVICE_IDENTIFICATION_CHIPSET_INFO);
+#endif
 
     }
 


### PR DESCRIPTION
RDKTV-4713 : Update Amlogic chipset name

Reason for change: Remove white space from chip set name

Test Procedure: Test DeviceIdentification plugin
Risks: None
