### PR TITLE
RDK-32246: Enable HDMI ARC/eARC Auto and Passthru modes

### DIFF
--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -135,6 +135,7 @@ namespace WPEFramework {
             void connectedAudioPortUpdated (int iAudioPortType, bool isPortConnected);
 	    void onARCInitiationEventHandler(const JsonObject& parameters);
             void onARCTerminationEventHandler(const JsonObject& parameters);
+	    void onShortAudioDescriptorEventHandler(const JsonObject& parameters);
             //End events
         public:
             DisplaySettings();
@@ -159,6 +160,7 @@ namespace WPEFramework {
 	    std::shared_ptr<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>> getSystemPlugin();
 	    uint32_t subscribeForHdmiCecSinkEvent(const char* eventName);
 	    bool setUpHdmiCecSinkArcRouting (bool arcEnable);
+	    bool requestShortAudioDescriptor();
 	    void onTimer();
 
 	    TpTimer m_timer;


### PR DESCRIPTION
Reason for change: 1) Added implementation to retrieve
supported Short Audio Descriptor list from connected
ARC device through HdmiCecSink plugin
requestShortAudioDescriptor method
2) update setSoundMode thunder API to handle HDMI ARC/eARC
3) Handle sound mode configuration on ARC/eARC Hotplug
and bootup scenarios
Risks: None

Test Procedure: Verify set/get Sound mode thunder API
for HDMI ARC/eaRC Auto mode

Signed-off-by: Deekshit Devadas <deekshit.devadasy@sky.uk>