### PR TITLE
RDK-32240: tts-mode for TTS audio

### DIFF
--- a/TextToSpeech/impl/TTSSpeaker.cpp
+++ b/TextToSpeech/impl/TTSSpeaker.cpp
@@ -522,7 +522,7 @@ void TTSSpeaker::createPipeline() {
 
 #if defined(PLATFORM_AMLOGIC)
         if(m_pcmAudioEnabled) {
-            g_object_set(G_OBJECT(m_audioSink), "direct-mode", FALSE, NULL);
+            g_object_set(G_OBJECT(m_audioSink), "tts-mode", TRUE, NULL);
         }
 #endif
 


### PR DESCRIPTION
Reason for change: tts-mode true, will have app audio for Amlogic
Test Procedure:
           3 audio( app, system, primary ) can be mixed. User can hear 3 mixed audio
    Risk: Low
    Signed-off-by: Manoj Bhatta <manoj_bhatta@comcast.com>