### PR TITLE
RDK-29647 : HDMI-CEC Abort Command

### DIFF
--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -389,10 +389,17 @@ namespace WPEFramework
        {
               printHeader(header);
              LOGINFO("Command: Abort\n");
-             AbortReason reason = AbortReason::UNRECOGNIZED_OPCODE;
-             LogicalAddress logicaladdress =header.from.toInt();
-             OpCode feature = msg.opCode();
-             HdmiCecSink::_instance->sendFeatureAbort(logicaladdress, feature,reason);
+	      if (!(header.to == LogicalAddress(LogicalAddress::BROADCAST)))
+             {
+                AbortReason reason = AbortReason::UNRECOGNIZED_OPCODE;
+                LogicalAddress logicaladdress =header.from.toInt();
+                OpCode feature = msg.opCode();
+                HdmiCecSink::_instance->sendFeatureAbort(logicaladdress, feature,reason);
+	     }
+	     else
+	     {
+		LOGINFO("Command: Abort broadcast msg so ignore\n");
+	     }
        }
        void HdmiCecSinkProcessor::process (const Polling &msg, const Header &header)                                 {
              printHeader(header);
@@ -1633,7 +1640,7 @@ namespace WPEFramework
 
                        if(!HdmiCecSink::_instance)
                                return;
-		       LOGINFO(" Sending sendFeatureAbort to %s for opcode %s with reason %s ",logicalAddress.toString().c_str(),feature.toString().c_str(),reason.toString().c_str());
+		       LOGINFO(" Sending FeatureAbort to %s for opcode %s with reason %s ",logicalAddress.toString().c_str(),feature.toString().c_str(),reason.toString().c_str());
                        _instance->smConnection->sendTo(logicalAddress, MessageEncoder().encode(FeatureAbort(feature,reason)), 1000);
                  }
 	void HdmiCecSink::pingDevices(std::vector<int> &connected , std::vector<int> &disconnected)

--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -387,8 +387,12 @@ namespace WPEFramework
        }
        void HdmiCecSinkProcessor::process (const Abort &msg, const Header &header)
        {
-             printHeader(header);
+              printHeader(header);
              LOGINFO("Command: Abort\n");
+             AbortReason reason = AbortReason::UNRECOGNIZED_OPCODE;
+             LogicalAddress logicaladdress =header.from.toInt();
+             OpCode feature = msg.opCode();
+             HdmiCecSink::_instance->sendFeatureAbort(logicaladdress, feature,reason);
        }
        void HdmiCecSinkProcessor::process (const Polling &msg, const Header &header)                                 {
              printHeader(header);
@@ -1624,6 +1628,14 @@ namespace WPEFramework
                     _instance->smConnection->sendTo(LogicalAddress::AUDIO_SYSTEM,MessageEncoder().encode(RequestShortAudioDescriptor(formatid,audioFormatCode,numberofdescriptor)), 1100);
 
 		}
+		void HdmiCecSink::sendFeatureAbort(const LogicalAddress logicalAddress, const OpCode feature, const AbortReason reason)
+	        {
+
+                       if(!HdmiCecSink::_instance)
+                               return;
+		       LOGINFO(" Sending sendFeatureAbort to %s for opcode %s with reason %s ",logicalAddress.toString().c_str(),feature.toString().c_str(),reason.toString().c_str());
+                       _instance->smConnection->sendTo(logicalAddress, MessageEncoder().encode(FeatureAbort(feature,reason)), 1000);
+                 }
 	void HdmiCecSink::pingDevices(std::vector<int> &connected , std::vector<int> &disconnected)
         {
         	int i;

--- a/HdmiCecSink/HdmiCecSink.h
+++ b/HdmiCecSink/HdmiCecSink.h
@@ -517,6 +517,7 @@ private:
                         void requestShortaudioDescriptor();
                         void Send_ShortAudioDescriptor_Event(JsonArray audiodescriptor);
 		        void Process_ShortAudioDescriptor_msg(const ReportShortAudioDescriptor  &msg);
+			void sendFeatureAbort(const LogicalAddress logicalAddress, const OpCode feature, const AbortReason reason);
 			int m_numberOfDevices; /* Number of connected devices othethan own device */
         private:
             // We do not allow this plugin to be copied !!


### PR DESCRIPTION
Reason for change: Support for HDMI-CEC Abort Command
Test Procedure: none
Risks: low

Signed-off-by: Bijas Babu bijas.babu@sky.uk