### PR TITLE
RDKTV-3762: Reopen if db removed

### DIFF
--- a/PersistentStore/PersistentStore.h
+++ b/PersistentStore/PersistentStore.h
@@ -6,6 +6,8 @@
 
 #include <vector>
 #include <map>
+#include <mutex>
+#include <atomic>
 
 namespace WPEFramework {
 
@@ -68,11 +70,14 @@ namespace WPEFramework {
             bool getStorageSize(std::map<string, uint64_t>& namespaceSizes);
             bool flushCache();
 
+            bool open();
             void term();
             void vacuum();
             bool init(const char* filename, const char* key = nullptr);
 
             void* mData;
+            std::mutex mLock;
+            std::atomic<int> mReading;
         };
     } // namespace Plugin
 } // namespace WPEFramework


### PR DESCRIPTION
Reason for change: If db file is removed while
connection is open, read operations work,
write operations fail with SQLITE_READONLY.
If such errors occur, check whether db file exists
and reopen if needed.
Test Procedure: See ticket.
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>
(cherry picked from commit ad43ec6f3a9304828a6e21e24d9bc4ea0599abc9)

allow concurrent reads

(cherry picked from commit 7dccc06b615c1a1b2657e7f9a85134314e916685)

fix macro

(cherry picked from commit 39eb952bcc8adf32218f003019dd75aa3072852e)