### PR TITLE
RDK-32240: tts-mode for TTS audio (#1108)

### DIFF
--- a/TextToSpeech/impl/TTSSpeaker.cpp
+++ b/TextToSpeech/impl/TTSSpeaker.cpp
@@ -524,7 +524,7 @@ void TTSSpeaker::createPipeline() {
         if(m_pcmAudioEnabled) {
             //Raw PCM audio does not work with souphhtpsrc on Amlogic alsaasink
             m_source = gst_element_factory_make("httpsrc", NULL);
-            g_object_set(G_OBJECT(m_audioSink), "direct-mode", FALSE, NULL);
+            g_object_set(G_OBJECT(m_audioSink), "tts-mode", TRUE, NULL);
         }
         else {
             m_source = gst_element_factory_make("souphttpsrc", NULL);


### PR DESCRIPTION
Reason for change: tts-mode true, will have app audio for Amlogic
Test Procedure:
           3 audio( app, system, primary ) can be mixed. User can hear 3 mixed audio
    Risk: Low
    Signed-off-by: Manoj Bhatta <manoj_bhatta@comcast.com>

Co-authored-by: Manoj Bhatta <manoj_bhatta@comcast.com>