### PR TITLE
RDK-32016 : HDMI ARC  eARC - Phase 2

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -61,6 +61,7 @@ using namespace std;
 #define HDMICECSINK_CALLSIGN_VER HDMICECSINK_CALLSIGN".1"
 #define HDMICECSINK_ARC_INITIATION_EVENT "arcInitiationEvent"
 #define HDMICECSINK_ARC_TERMINATION_EVENT "arcTerminationEvent"
+#define HDMICECSINK_SHORT_AUDIO_DESCRIPTOR_EVENT "shortAudiodesciptorEvent"
 #define SERVER_DETAILS  "127.0.0.1:9998"
 #define WARMING_UP_TIME_IN_SECONDS 5
 #define RECONNECTION_TIME_IN_MILLISECONDS 5500
@@ -570,6 +571,26 @@ namespace WPEFramework {
 
                                 if(hdmiin_hotplug_conn) {
                                     aPort.getSupportedARCTypes(&types);
+                                    LOGINFO("dsHdmiEventHandler: Configuring User set Audio mode before starting ARC/eARC Playback...\n");
+                                    if(aPort.getStereoAuto() == true) {
+					if(types & dsAUDIOARCSUPPORT_eARC) {
+					    aPort.setStereoAuto(true,true);
+					}
+					else if (types & dsAUDIOARCSUPPORT_ARC) {
+                                            if (!DisplaySettings::_instance->requestShortAudioDescriptor()) {
+                                                LOGERR("dsHdmiEventHandler (ARC): requestShortAudioDescriptor failed !!!\n");;
+                                            }
+                                            else {
+                                                LOGINFO("dsHdmiEventHandler (ARC): requestShortAudioDescriptor successful\n");
+                                            }
+					}
+                                    }
+                                    else{
+                                        device::AudioStereoMode mode = device::AudioStereoMode::kStereo;  //default to stereo
+                                        mode = aPort.getStereoMode(); //get Last User set stereo mode and set
+                                        aPort.setStereoMode(mode.toString(), true);
+                                    }
+
                                     if(types & dsAUDIOARCSUPPORT_eARC) {
                                         LOGINFO("dsHdmiEventHandler: Enable eARC\n");
                                         aPort.enableARC(dsAUDIOARCSUPPORT_eARC, true);
@@ -1098,6 +1119,15 @@ namespace WPEFramework {
                         else
                             modeString.append(mode.toString());
                     }
+		    else if(aPort.getType().getId() == device::AudioOutputPortType::kARC){
+                        if (aPort.getStereoAuto()) {
+                            LOGINFO("HDMI_ARC0 output mode Auto");
+                            modeString.append("AUTO");
+			}
+			else{
+			    modeString.append(mode.toString());
+			}
+		    }
                     else
                     {
                         if (mode == device::AudioStereoMode::kSurround)
@@ -1207,14 +1237,40 @@ namespace WPEFramework {
                                 else
                                     mode = device::AudioStereoMode::kStereo;
                             }
+                            //TODO: if mode has not changed, we can skip the extra call
+                            aPort.setStereoMode(mode.toString(), persist);
                         }
                         else if (aPort.getType().getId() == device::AudioOutputPortType::kHDMI)
                         {
                             LOGERR("Reset auto on %s for mode = %s!", audioPort.c_str(), soundMode.c_str());
                             aPort.setStereoAuto(false, persist);
+                            //TODO: if mode has not changed, we can skip the extra call
+                            aPort.setStereoMode(mode.toString(), persist);
                         }
-                        //TODO: if mode has not changed, we can skip the extra call
-                        aPort.setStereoMode(mode.toString(), persist);
+			else if (aPort.getType().getId() == device::AudioOutputPortType::kARC) {
+		            if(((mode == device::AudioStereoMode::kSurround) || (mode == device::AudioStereoMode::kPassThru) || (mode == device::AudioStereoMode::kStereo)) && (stereoAuto == false)) {
+				    aPort.setStereoAuto(false, persist);
+				    aPort.setStereoMode(mode.toString(), persist);
+		            }
+			    else { //Auto Mode
+			        int types = dsAUDIOARCSUPPORT_NONE;
+                                aPort.getSupportedARCTypes(&types);
+
+				if(types & dsAUDIOARCSUPPORT_eARC) {
+				    aPort.setStereoAuto(stereoAuto, persist); //setStereoAuto true
+				}
+				else if (types & dsAUDIOARCSUPPORT_ARC) {
+                                    if (!DisplaySettings::_instance->requestShortAudioDescriptor()) {
+                                        success = false;
+                                        LOGERR("setSoundMode Auto: requestShortAudioDescriptor failed !!!\n");;
+                                    }
+                                    else {
+                                        LOGINFO("setSoundMode Auto: requestShortAudioDescriptor successful\n");
+                                    }
+				}
+			   }
+			}
+
                     }
                 }
                 else
@@ -2749,6 +2805,34 @@ namespace WPEFramework {
             return success;
 	}
 
+        bool DisplaySettings::requestShortAudioDescriptor()
+        {
+            bool success = true;
+
+            if (Utils::isPluginActivated(HDMICECSINK_CALLSIGN)) {
+                auto hdmiCecSinkPlugin = getHdmiCecSinkPlugin();
+                if (!hdmiCecSinkPlugin) {
+                    LOGERR("HdmiCecSink plugin not accessible\n");
+                }
+                else {
+                    JsonObject hdmiCecSinkResult;
+                    JsonObject param;
+
+                    LOGINFO("Requesting Short Audio Descriptor \n");
+                    hdmiCecSinkPlugin->Invoke<JsonObject, JsonObject>(2000, "requestShortAudioDescriptor", param, hdmiCecSinkResult);
+                    if (!hdmiCecSinkResult["success"].Boolean()) {
+                        success = false;
+                        LOGERR("HdmiCecSink Plugin returned error\n");
+                    }
+                }
+            }
+            else {
+                success = false;
+                LOGERR("HdmiCecSink plugin not ready\n");
+            }
+
+            return success;
+        }
 
         uint32_t DisplaySettings::setEnableAudioPort (const JsonObject& parameters, JsonObject& response)
         {   //TODO: Handle other audio ports. Currently only supports HDMI ARC/eARC
@@ -2797,6 +2881,28 @@ namespace WPEFramework {
                     device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
 
                     aPort.getSupportedARCTypes(&types);
+                    LOGINFO("DisplaySettings::setEnableAudioPort Configuring User set Audio mode before starting ARC/eARC Playback...\n");
+                    if(aPort.isConnected()) {
+                        if(aPort.getStereoAuto() == true) {
+                            if(types & dsAUDIOARCSUPPORT_eARC) {
+                                aPort.setStereoAuto(true,true);
+                            }
+                            else if (types & dsAUDIOARCSUPPORT_ARC) {
+                                if (!DisplaySettings::_instance->requestShortAudioDescriptor()) {
+                                    LOGERR("DisplaySettings::setEnableAudioPort (ARC): requestShortAudioDescriptor failed !!!\n");;
+                                }
+                                else {
+                                    LOGINFO("DisplaySettings::setEnableAudioPort (ARC): requestShortAudioDescriptor successful\n");
+                                }
+                            }
+                        }
+                        else{
+                            device::AudioStereoMode mode = device::AudioStereoMode::kStereo;  //default to stereo
+                            mode = aPort.getStereoMode(); //get Last User set stereo mode and set
+                            aPort.setStereoMode(mode.toString(), true);
+                        }
+                    }		    
+
                     if(types & dsAUDIOARCSUPPORT_eARC) {
                         if(pEnable) {
                             LOGINFO("DisplaySettings::setEnableAudioPort Enable eARC !!!");
@@ -2942,6 +3048,9 @@ namespace WPEFramework {
                 } else if(strcmp(eventName, HDMICECSINK_ARC_TERMINATION_EVENT) == 0) {
                     err =m_client->Subscribe<JsonObject>(1000, eventName
                             , &DisplaySettings::onARCTerminationEventHandler, this);
+                } else if(strcmp(eventName, HDMICECSINK_SHORT_AUDIO_DESCRIPTOR_EVENT) == 0) {
+                    err =m_client->Subscribe<JsonObject>(1000, eventName
+                            , &DisplaySettings::onShortAudioDescriptorEventHandler, this);
                 }
                 else {
                      err = Core::ERROR_UNAVAILABLE;
@@ -3017,13 +3126,51 @@ namespace WPEFramework {
         }
 
         // 4.
+        void DisplaySettings::onShortAudioDescriptorEventHandler(const JsonObject& parameters) {
+            string message;
+
+            parameters.ToString(message);
+	    JsonArray shortAudioDescriptorList;
+            LOGINFO("[Short Audio Descriptor Event], %s : %s", __FUNCTION__, C_STR(message));
+
+            if (parameters.HasLabel("ShortAudioDescriptor")) {
+                shortAudioDescriptorList = parameters["ShortAudioDescriptor"].Array();
+                    try
+                    {
+                        device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort("HDMI_ARC0");
+			LOGINFO("Total Short Audio Descriptors received from connected ARC device: %d\n",shortAudioDescriptorList.Length());
+			if(shortAudioDescriptorList.Length() <= 0) {
+			    LOGERR("Not setting SAD. No SAD returned by connected ARC device\n");
+			    return;
+			}
+
+			std::vector<int> sad_list;
+			for (int i=0; i<shortAudioDescriptorList.Length(); i++) {
+                            LOGINFO("Short Audio Descriptor[%d]: %ld \n",i, shortAudioDescriptorList[i].Number());
+                            sad_list.push_back(shortAudioDescriptorList[i].Number());
+                        }
+
+		        aPort.setSAD(sad_list);
+			aPort.setStereoAuto(true,true);
+                    }
+                    catch (const device::Exception& err)
+                    {
+                        LOG_DEVICE_EXCEPTION1(string("HDMI_ARC0"));
+                    }
+            } else {
+                LOGERR("Field 'ShortAudioDescriptor' could not be found in the event's payload.");
+            }
+        }
+
+
+        // 5.
         void DisplaySettings::onTimer()
         {
 	    m_callMutex.lock();
             static bool isInitDone = false;
             bool pluginActivated = Utils::isPluginActivated(HDMICECSINK_CALLSIGN);
             if(!m_subscribed) {
-                if (pluginActivated && (subscribeForHdmiCecSinkEvent(HDMICECSINK_ARC_INITIATION_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_ARC_TERMINATION_EVENT) == Core::ERROR_NONE))
+                if (pluginActivated && (subscribeForHdmiCecSinkEvent(HDMICECSINK_ARC_INITIATION_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_ARC_TERMINATION_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_SHORT_AUDIO_DESCRIPTOR_EVENT)== Core::ERROR_NONE))
                 {
                     m_subscribed = true;
                     if (m_timer.isActive()) {

--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -143,6 +143,7 @@ namespace WPEFramework {
             void connectedAudioPortUpdated (int iAudioPortType, bool isPortConnected);
 	    void onARCInitiationEventHandler(const JsonObject& parameters);
             void onARCTerminationEventHandler(const JsonObject& parameters);
+	    void onShortAudioDescriptorEventHandler(const JsonObject& parameters);
             //End events
         public:
             DisplaySettings();
@@ -167,6 +168,7 @@ namespace WPEFramework {
 	    std::shared_ptr<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>> getSystemPlugin();
 	    uint32_t subscribeForHdmiCecSinkEvent(const char* eventName);
 	    bool setUpHdmiCecSinkArcRouting (bool arcEnable);
+	    bool requestShortAudioDescriptor();
 	    void onTimer();
 
 	    TpTimer m_timer;

--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -55,7 +55,7 @@
 #define HDMICECSINK_METHOD_SET_MENU_LANGUAGE  	"setMenuLanguage"
 #define HDMICECSINK_METHOD_REQUEST_ACTIVE_SOURCE "requestActiveSource"
 #define HDMICECSINK_METHOD_SETUP_ARC              "setupARCRouting"
-
+#define HDMICECSINK_METHOD_REQUEST_SHORT_AUDIO_DESCRIPTOR  "requestShortAudioDescriptor"
 
 #define TEST_ADD 0
 #define HDMICECSINK_REQUEST_MAX_RETRY 				3
@@ -68,6 +68,9 @@
 #define HDMISINK_ARCPORT                               1
 #define HDMISINK_ARC_START_STOP_MAX_WAIT_MS           3000
 
+
+#define SAD_FMT_CODE_AC3 2
+#define SAD_FMT_CODE_ENHANCED_AC3 10
 
 enum {
 	DEVICE_POWER_STATE_ON = 0,
@@ -86,6 +89,7 @@ enum {
 	HDMICECSINK_EVENT_INACTIVE_SOURCE,
         HDMICECSINK_EVENT_ARC_INITIATION_EVENT,
 	HDMICECSINK_EVENT_ARC_TERMINATION_EVENT,
+        HDMICECSINK_EVENT_SHORT_AUDIODESCRIPTOR_EVENT,
 };
 
 static char *eventString[] = {
@@ -100,6 +104,7 @@ static char *eventString[] = {
 	"onInActiveSource",
         "arcInitiationEvent",
         "arcTerminationEvent",
+        "shortAudiodesciptorEvent",
 };
 	
 
@@ -117,7 +122,9 @@ static LogicalAddress logicalAddress = 0xF;
 static Language defaultLanguage = "eng";
 static OSDName osdName = "TV Box";
 static int32_t powerState = DEVICE_POWER_STATE_OFF;
-
+static vector<uint8_t> formatid = {0,0};
+static vector<uint8_t> audioFormatCode = { SAD_FMT_CODE_ENHANCED_AC3,SAD_FMT_CODE_AC3 };
+static uint8_t numberofdescriptor = 2;
 
 namespace WPEFramework
 {
@@ -370,7 +377,12 @@ namespace WPEFramework
 				HdmiCecSink::_instance->deviceList[header.from.toInt()].m_featureAborts.push_back(msg);
 			 }
 
-
+                         if(msg.feature.opCode() == REQUEST_SHORT_AUDIO_DESCRIPTOR)
+		         {
+                            JsonArray audiodescriptor;
+                            audiodescriptor.Add(0);
+			    HdmiCecSink::_instance->Send_ShortAudioDescriptor_Event(audiodescriptor);
+                        }
 			
        }
        void HdmiCecSinkProcessor::process (const Abort &msg, const Header &header)
@@ -397,7 +409,13 @@ namespace WPEFramework
            if(!HdmiCecSink::_instance)
 	     return;
            HdmiCecSink::_instance->Process_TerminateArc();
-       }	
+       }
+       void HdmiCecSinkProcessor::process (const ReportShortAudioDescriptor  &msg, const Header &header)
+       {
+             printHeader(header);
+             LOGINFO("Command: ReportShortAudioDescriptor %s : %d \n",GetOpName(msg.opCode()),numberofdescriptor);
+            HdmiCecSink::_instance->Process_ShortAudioDescriptor_msg(msg);
+       }
 //=========================================== HdmiCecSink =========================================
 
        HdmiCecSink::HdmiCecSink()
@@ -432,7 +450,7 @@ namespace WPEFramework
 		  registerMethod(HDMICECSINK_METHOD_REQUEST_ACTIVE_SOURCE, &HdmiCecSink::requestActiveSourceWrapper, this);
                    registerMethod(HDMICECSINK_METHOD_SETUP_ARC, &HdmiCecSink::setArcEnableDisableWrapper, this);
 		   registerMethod(HDMICECSINK_METHOD_SET_MENU_LANGUAGE, &HdmiCecSink::setMenuLanguageWrapper, this);
-
+                   registerMethod(HDMICECSINK_METHOD_REQUEST_SHORT_AUDIO_DESCRIPTOR, &HdmiCecSink::requestShortAudioDescriptorWrapper, this);
            logicalAddressDeviceType = "None";
            logicalAddress = 0xFF;
            
@@ -768,6 +786,40 @@ namespace WPEFramework
            std::lock_guard<std::mutex> lock(_instance->m_arcRoutingStateMutex);
            m_currentArcRoutingState = ARC_STATE_ARC_TERMINATED;
        }
+       void  HdmiCecSink::Send_ShortAudioDescriptor_Event(JsonArray audiodescriptor)
+       {
+           JsonObject params;
+
+	   LOGINFO("Notify the DS ");
+           params["ShortAudioDescriptor"]= JsonValue(audiodescriptor);
+	   sendNotify(eventString[HDMICECSINK_EVENT_SHORT_AUDIODESCRIPTOR_EVENT], params);
+       }
+
+       void HdmiCecSink::Process_ShortAudioDescriptor_msg(const ReportShortAudioDescriptor  &msg)
+       {
+	    uint8_t numberofdescriptor = msg.numberofdescriptor;
+            uint8_t AudioformatCode;
+            uint8_t  atmos;
+	    uint32 descriptor =0;
+	    JsonArray audiodescriptor;
+
+	    if (numberofdescriptor)
+            {
+	     for( uint8_t  i=0; i < numberofdescriptor; i++)
+            {
+               descriptor = msg.shortAudioDescriptor[i].getAudiodescriptor();
+
+	       LOGINFO("descriptor%d 0x%x\n",i,descriptor);
+	       audiodescriptor.Add(descriptor);
+
+	    }
+	    }
+	    else
+	    {
+		    audiodescriptor.Add(descriptor);
+	    }
+	   HdmiCecSink::_instance->Send_ShortAudioDescriptor_Event(audiodescriptor);
+        }
        uint32_t HdmiCecSink::setEnabledWrapper(const JsonObject& parameters, JsonObject& response)
        {
            LOGINFOMETHOD();
@@ -1111,7 +1163,11 @@ namespace WPEFramework
             returnResponse(true);
         }
 
-        
+        uint32_t HdmiCecSink::requestShortAudioDescriptorWrapper(const JsonObject& parameters, JsonObject& response)
+	{
+			requestShortaudioDescriptor();
+			returnResponse(true);
+	}
         bool HdmiCecSink::loadSettings()
         {
             Core::File file;
@@ -1554,7 +1610,20 @@ namespace WPEFramework
 			}
        	}
 
+                void HdmiCecSink::requestShortaudioDescriptor()
+	        {
+			if(!HdmiCecSink::_instance)
+				return;
 
+			if ( _instance->m_logicalAddressAllocated == LogicalAddress::UNREGISTERED ){
+				LOGERR("Logical Address NOT Allocated");
+				return;
+			}
+
+                        LOGINFO(" Send requestShortAudioDescriptor Message ");
+                    _instance->smConnection->sendTo(LogicalAddress::AUDIO_SYSTEM,MessageEncoder().encode(RequestShortAudioDescriptor(formatid,audioFormatCode,numberofdescriptor)), 1100);
+
+		}
 	void HdmiCecSink::pingDevices(std::vector<int> &connected , std::vector<int> &disconnected)
         {
         	int i;

--- a/HdmiCecSink/HdmiCecSink.h
+++ b/HdmiCecSink/HdmiCecSink.h
@@ -83,6 +83,7 @@ namespace WPEFramework {
 	        void process (const Polling &msg, const Header &header);
                 void process (const InitiateArc &msg, const Header &header);
                 void process (const TerminateArc &msg, const Header &header);
+                void process (const ReportShortAudioDescriptor  &msg, const Header &header);
         private:
             Connection conn;
             void printHeader(const Header &header)
@@ -513,6 +514,9 @@ private:
                         void Process_InitiateArc();
                         void Process_TerminateArc();
                         void updateArcState();
+                        void requestShortaudioDescriptor();
+                        void Send_ShortAudioDescriptor_Event(JsonArray audiodescriptor);
+		        void Process_ShortAudioDescriptor_msg(const ReportShortAudioDescriptor  &msg);
 			int m_numberOfDevices; /* Number of connected devices othethan own device */
         private:
             // We do not allow this plugin to be copied !!
@@ -536,7 +540,7 @@ private:
 			uint32_t requestActiveSourceWrapper(const JsonObject& parameters, JsonObject& response);
                         uint32_t setArcEnableDisableWrapper(const JsonObject& parameters, JsonObject& response);
 			uint32_t setMenuLanguageWrapper(const JsonObject& parameters, JsonObject& response);
-
+                        uint32_t requestShortAudioDescriptorWrapper(const JsonObject& parameters, JsonObject& response);
 			
             //End methods
             std::string logicalAddressDeviceType;


### PR DESCRIPTION
RDK-32016 : HDMI ARC  eARC - Phase 2

Added changes for 
1. RDK-32275 : CEC Short Audio Descriptor 
Reason for change: Add support for sending and receiving and

2 RDK-32246: Enable HDMI ARC/eARC Auto and Passthru modes
Reason for change: 1) Added implementation to retrieve
supported Short Audio Descriptor list from connected
ARC device through HdmiCecSink plugin
requestShortAudioDescriptor method
2) update setSoundMode thunder API to handle HDMI ARC/eARC
3) Handle sound mode configuration on ARC/eARC Hotplug
and bootup scenarios
Risks: None

Test Procedure: Verify set/get Sound mode thunder API
for HDMI ARC/eaRC Auto mode



