### PR TITLE
Revert "RDK-30533: Enable tv zoom settings"

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -151,7 +151,7 @@ namespace WPEFramework {
             registerMethod("getSupportedAudioPorts", &DisplaySettings::getSupportedAudioPorts, this);
             registerMethod("getSupportedAudioModes", &DisplaySettings::getSupportedAudioModes, this);
             registerMethod("getZoomSetting", &DisplaySettings::getZoomSetting, this);
-            registerMethod("setZoomSetting", &DisplaySettings::setZoomSettingWrapper, this);
+            registerMethod("setZoomSetting", &DisplaySettings::setZoomSetting, this);
             registerMethod("getCurrentResolution", &DisplaySettings::getCurrentResolution, this);
             registerMethod("setCurrentResolution", &DisplaySettings::setCurrentResolution, this);
             registerMethod("getSoundMode", &DisplaySettings::getSoundMode, this);
@@ -212,15 +212,6 @@ namespace WPEFramework {
 
 	    m_subscribed = false; //HdmiCecSink event subscription
 	    m_timer.connect(std::bind(&DisplaySettings::onTimer, this));
-
-#ifdef ENABLE_TV_ZOOM_SETTINGS
-            tvZoomSettings.push_back("TV AUTO");
-            tvZoomSettings.push_back("TV DIRECT");
-            tvZoomSettings.push_back("TV NORMAL");
-            tvZoomSettings.push_back("TV 16X9 STRETCH");
-            tvZoomSettings.push_back("TV LETTERBOX");
-            tvZoomSettings.push_back("TV ZOOM");
-#endif
         }
 
         DisplaySettings::~DisplaySettings()
@@ -315,10 +306,6 @@ namespace WPEFramework {
                 LOGWARN("Current power state %d", m_powerState);
             }
 
-            if (!setZoomSetting(getZoomSettingConfig()))
-            {
-                LOGERR("Couldn't restore zoom settings");
-            }
             // On success return empty, to indicate there is no error text.
             return (string());
         }
@@ -868,9 +855,6 @@ namespace WPEFramework {
         uint32_t DisplaySettings::getZoomSetting(const JsonObject& parameters, JsonObject& response)
         {   //sample servicemanager response:
             LOGINFOMETHOD();
-#ifdef ENABLE_TV_ZOOM_SETTINGS
-            string zoomSetting = getZoomSettingConfig();
-#else
             string zoomSetting = "unknown";
             try
             {
@@ -885,66 +869,18 @@ namespace WPEFramework {
 #ifdef USE_IARM
             zoomSetting = iarm2svc(zoomSetting);
 #endif
-#endif
             response["zoomSetting"] = zoomSetting;
             returnResponse(true);
         }
 
-        std::string DisplaySettings::getZoomSettingConfig()
-        {
-#ifdef ENABLE_TV_ZOOM_SETTINGS
-            string zoomSetting = "TV AUTO";
-#else
-            string zoomSetting = "FULL";
-#endif
-            Core::File settingsFile;
-            settingsFile = ZOOM_SETTINGS_FILE;
-            if (settingsFile.Open())
-            {
-                JsonObject settingsJson;
-                if (settingsJson.IElement::FromFile(settingsFile))
-                {
-                    zoomSetting = settingsJson["zoomSetting"].String();
-                }
-                else
-                {
-                    LOGERR("Couldn't read zoom settings file %s", ZOOM_SETTINGS_FILE);
-                }
-                settingsFile.Close();
-            }
-            else
-            {
-                LOGWARN("Couldn't open zoom settings file %s", ZOOM_SETTINGS_FILE);
-            }
-
-            return zoomSetting;
-        }
-
-
-        uint32_t DisplaySettings::setZoomSettingWrapper(const JsonObject& parameters, JsonObject& response)
+        uint32_t DisplaySettings::setZoomSetting(const JsonObject& parameters, JsonObject& response)
         {   //sample servicemanager response:
             LOGINFOMETHOD();
 
             returnIfParamNotFound(parameters, "zoomSetting");
             string zoomSetting = parameters["zoomSetting"].String();
 
-            returnResponse(setZoomSetting(zoomSetting));
-        }
-
-        bool DisplaySettings::setZoomSetting(std::string zoomSetting)
-        {
             bool success = true;
-#ifdef ENABLE_TV_ZOOM_SETTINGS
-            if (std::find(tvZoomSettings.begin(), tvZoomSettings.end(), zoomSetting) != tvZoomSettings.end())
-            {
-                success = setZoomSettingConfig(zoomSetting);
-            }
-            else
-            {
-                LOGERR("Unsupported tv zoom settings value %s", zoomSetting.c_str());
-                success = false;
-            }
-#else
             try
             {
 #ifdef USE_IARM
@@ -953,52 +889,13 @@ namespace WPEFramework {
                 // TODO: why is this always the first one in the list?
                 device::VideoDevice &decoder = device::Host::getInstance().getVideoDevices().at(0);
                 decoder.setDFC(zoomSetting);
-                success = setZoomSettingConfig(zoomSetting);
             }
             catch(const device::Exception& err)
             {
                 LOG_DEVICE_EXCEPTION1(zoomSetting);
                 success = false;
             }
-#endif
-            return success;
-        }
-
-        bool DisplaySettings::setZoomSettingConfig(std::string zoomSetting)
-        {
-            bool success = true;
-            Core::File settingsFile;
-            settingsFile = ZOOM_SETTINGS_FILE;
-            if (!settingsFile.Open(false))
-            {
-                LOGWARN("Couldn't open zoom settings file %s", ZOOM_SETTINGS_FILE);
-
-                Core::Directory settingsDirectory(ZOOM_SETTINGS_DIRECTORY);
-                if (!settingsDirectory.CreatePath())
-                {
-                    LOGERR("Couldn't create zoom settings file path %s", ZOOM_SETTINGS_DIRECTORY);
-                    success = false;
-                }
-                else if (!settingsFile.Create())
-                {
-                    LOGERR("Couldn't create zoom settings file %s", ZOOM_SETTINGS_FILE);
-                    success = false;
-                }
-            }
-
-            if (settingsFile.IsOpen())
-            {
-                JsonObject settingsJson;
-                settingsJson["zoomSetting"] = zoomSetting;
-                if (!settingsJson.IElement::ToFile(settingsFile))
-                {
-                    LOGERR("Couldn't save zoom settings file %s", ZOOM_SETTINGS_FILE);
-                    success = false;
-                }
-                settingsFile.Close();
-            }
-
-            return success;
+            returnResponse(success);
         }
 
         uint32_t DisplaySettings::getCurrentResolution(const JsonObject& parameters, JsonObject& response)

--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -51,13 +51,6 @@ namespace WPEFramework {
             typedef Core::JSON::ArrayType<JString> JStringArray;
             typedef Core::JSON::Boolean JBool;
 
-#ifdef ENABLE_TV_ZOOM_SETTINGS
-            std::vector<std::string> tvZoomSettings;
-#endif
-            std::string getZoomSettingConfig();
-            bool setZoomSettingConfig(std::string zoomSetting);
-            bool setZoomSetting(std::string zoomSetting);
-
             // We do not allow this plugin to be copied !!
             DisplaySettings(const DisplaySettings&) = delete;
             DisplaySettings& operator=(const DisplaySettings&) = delete;
@@ -73,7 +66,7 @@ namespace WPEFramework {
             uint32_t getSupportedAudioPorts(const JsonObject& parameters, JsonObject& response);
             uint32_t getSupportedAudioModes(const JsonObject& parameters, JsonObject& response);
             uint32_t getZoomSetting(const JsonObject& parameters, JsonObject& response);
-            uint32_t setZoomSettingWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t setZoomSetting(const JsonObject& parameters, JsonObject& response);
             uint32_t getCurrentResolution(const JsonObject& parameters, JsonObject& response);
             uint32_t setCurrentResolution(const JsonObject& parameters, JsonObject& response);
             uint32_t getSoundMode(const JsonObject& parameters, JsonObject& response);

--- a/amlogic.cmake
+++ b/amlogic.cmake
@@ -82,11 +82,6 @@ if (BUILD_ENABLE_DEVICE_MANUFACTURER_INFO)
     add_definitions (-DENABLE_DEVICE_MANUFACTURER_INFO)
 endif()
 
-if (BUILD_ENABLE_TV_ZOOM_SETTINGS)
-    message("Building with tv zoom settings")
-    add_definitions (-DENABLE_TV_ZOOM_SETTINGS)
-endif()
-
 if (AMLOGIC_E2)
     add_definitions (-DAMLOGIC_E2)
 endif()


### PR DESCRIPTION
This reverts commit 76de06f34842f396e9cc0dede6f0e802009ae5bc.

Revert "RDK-30533: Enable tv zoom settings"

This reverts commit 837ae4a389e935a3b02891c90aa1eca89520c70c.

Revert "RDK-30533: Enable tv zoom settings"

This reverts commit c5954001ac2539a55faa7724de0cd9be86acb85c.

Revert "RDK-30533: Enable tv zoom settings"

This reverts commit 52ceb3187e0337797cefcf079fb3df4c6ed0b634.