### PR TITLE
AMLOGIC-1623: Add passthru support for spdif

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -1167,6 +1167,16 @@ namespace WPEFramework {
 				}
 			   }
 			}
+                        else if (aPort.getType().getId() == device::AudioOutputPortType::kSPDIF)
+                        {
+			    if(stereoAuto == false) {
+                                aPort.setStereoAuto(false, persist);
+                                aPort.setStereoMode(mode.toString(), persist);
+			    }
+			    else{
+			        aPort.setStereoAuto(true, persist);
+			    }
+                        }
 
                     }
                 }


### PR DESCRIPTION
Reason for change: Add spdif port handling for
setSoundMode thunder API
Test Procedure: Verify setSoundMode thunder
API executes fine
Risks: None

Signed-off-by: Deekshit Devadas <deekshit.devadasy@sky.uk>