### PR TITLE
RDK-29647 : HDMI-CEC Abort Command

### DIFF
--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -415,8 +415,19 @@ namespace WPEFramework
        }
        void HdmiCecSinkProcessor::process (const Abort &msg, const Header &header)
        {
-             printHeader(header);
+              printHeader(header);
              LOGINFO("Command: Abort\n");
+	      if (!(header.to == LogicalAddress(LogicalAddress::BROADCAST)))
+             {
+                AbortReason reason = AbortReason::UNRECOGNIZED_OPCODE;
+                LogicalAddress logicaladdress =header.from.toInt();
+                OpCode feature = msg.opCode();
+                HdmiCecSink::_instance->sendFeatureAbort(logicaladdress, feature,reason);
+	     }
+	     else
+	     {
+		LOGINFO("Command: Abort broadcast msg so ignore\n");
+	     }
        }
        void HdmiCecSinkProcessor::process (const Polling &msg, const Header &header)                                 {
              printHeader(header);
@@ -1658,6 +1669,14 @@ namespace WPEFramework
                     _instance->smConnection->sendTo(LogicalAddress::AUDIO_SYSTEM,MessageEncoder().encode(RequestShortAudioDescriptor(formatid,audioFormatCode,numberofdescriptor)), 1100);
 
 		}
+		void HdmiCecSink::sendFeatureAbort(const LogicalAddress logicalAddress, const OpCode feature, const AbortReason reason)
+	        {
+
+                       if(!HdmiCecSink::_instance)
+                               return;
+		       LOGINFO(" Sending FeatureAbort to %s for opcode %s with reason %s ",logicalAddress.toString().c_str(),feature.toString().c_str(),reason.toString().c_str());
+                       _instance->smConnection->sendTo(logicalAddress, MessageEncoder().encode(FeatureAbort(feature,reason)), 1000);
+                 }
 	void HdmiCecSink::pingDevices(std::vector<int> &connected , std::vector<int> &disconnected)
         {
         	int i;

--- a/HdmiCecSink/HdmiCecSink.h
+++ b/HdmiCecSink/HdmiCecSink.h
@@ -518,6 +518,7 @@ private:
                         void Send_ShortAudioDescriptor_Event(JsonArray audiodescriptor);
 		        void Process_ShortAudioDescriptor_msg(const ReportShortAudioDescriptor  &msg);
 			void sendDeviceUpdateInfo(const int logicalAddress);
+			void sendFeatureAbort(const LogicalAddress logicalAddress, const OpCode feature, const AbortReason reason);
 			int m_numberOfDevices; /* Number of connected devices othethan own device */
         private:
             // We do not allow this plugin to be copied !!


### PR DESCRIPTION
Reason for change: Support for HDMI-CEC Abort Command
Test Procedure: none
Risks: low

Signed-off-by: Bijas Babu bijas.babu@sky.uk

RDK-29647 : HDMI-CEC Abort Command

Reason for change: change to ignore the broadcast abortmsg
Test Procedure: none
Risks: low

Signed-off-by: Bijas Babu bijas.babu@sky.uk