### PR TITLE
DELIA-49650 : xcast mem leak

### DIFF
--- a/XCast/RtXcastConnector.cpp
+++ b/XCast/RtXcastConnector.cpp
@@ -234,11 +234,7 @@ int RtXcastConnector::connectToRemoteService()
 RtXcastConnector::~RtXcastConnector()
 {
     LOGINFO("Dtr");
-    if(_instance != nullptr)
-    {
-        delete _instance;
-        _instance = nullptr;
-    }
+    _instance = nullptr;
     m_observer = nullptr;
 }
 


### PR DESCRIPTION
Reason for change: Free dynamically allocated memory in RtXcastConnector::getInstance() .
Test Procedure: Refer Jira
Risks: Low
Signed-off-by:Anaswara KookkalAnaswara_Kookkal@comcast.com