### PR TITLE
RDKTV-6107: Corrected the symbol error

### DIFF
--- a/HdmiCecSink/HdmiCecSink.h
+++ b/HdmiCecSink/HdmiCecSink.h
@@ -84,7 +84,6 @@ namespace WPEFramework {
                 void process (const InitiateArc &msg, const Header &header);
                 void process (const TerminateArc &msg, const Header &header);
                 void process (const ReportShortAudioDescriptor  &msg, const Header &header);
-		void process (const SystemAudioModeRequest &msg, const Header &header);
         private:
             Connection conn;
             void printHeader(const Header &header)


### PR DESCRIPTION
Reason for change: Support for SystemAudioModeRequest
Test Procedure: none
Risks: low

Signed-off-by: Bijas Babu bijas.babu@sky.uk