### PR TITLE
RDKTV-6230: Wpeframework logs are flooded fix

### DIFF
--- a/XCast/RtXcastConnector.cpp
+++ b/XCast/RtXcastConnector.cpp
@@ -233,7 +233,6 @@ int RtXcastConnector::connectToRemoteService()
 
 RtXcastConnector::~RtXcastConnector()
 {
-    LOGINFO("Dtr");
     _instance = nullptr;
     m_observer = nullptr;
 }


### PR DESCRIPTION
Reason for change:
Wpeframework logs are flooded fix
Test Procedure: None
Risks: Low

Change-Id: I265d7666a33b33e6d381d0c749a16ba0701eb208
Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>