### PR TITLE
RDKTV-6021: MaintenanceManager Fixes

### DIFF
--- a/MaintenanceManager/MaintenanceManager.h
+++ b/MaintenanceManager/MaintenanceManager.h
@@ -57,7 +57,7 @@ typedef enum {
 } Maint_notify_status_t;
 
 typedef enum{
-    SOCLITED_MAINTENANCE,
+    SOLICITED_MAINTENANCE,
     UNSOLICITED_MAINTENANCE
 }Maintenance_Type_t;
 


### PR DESCRIPTION
Reason for change: Autoreboot was not happening earlier during
Solicited maintenance. Maintenance activity status shows started due to
older design. start maintenance API is blocked due to waiting for DCM.
removed the same. Fix for start time return as integer instead of string.