### PR TITLE
RDKTV-6163: VG disabled on Hisense TV 4.11p4s1 (#1185)

### DIFF
--- a/TextToSpeech/impl/TTSSpeaker.cpp
+++ b/TextToSpeech/impl/TTSSpeaker.cpp
@@ -24,7 +24,7 @@
 #include <regex>
 
 #define INT_FROM_ENV(env, default_value) ((getenv(env) ? atoi(getenv(env)) : 0) > 0 ? atoi(getenv(env)) : default_value)
-#define TTS_CONFIGURATION_STORE "/opt/persistent/ttssetting.ini"
+#define TTS_CONFIGURATION_STORE "/opt/persistent/tts.setting.ini"
 #define UPDATE_AND_RETURN(o, n) if(o != n) { o = n; return true; }
 
 namespace WPEFramework {


### PR DESCRIPTION
Reason for change: Let TTS service read new tts.setting.ini instead old one. Going forward this will be default setting file.
Test Procedure: VG should work ,when user enable VG from setting
Risks: Low

Signed-off-by: Manoj Bhatta <manoj_bhatta@comcast.com>

Co-authored-by: Manoj Bhatta <manoj_bhatta@comcast.com>