### PR TITLE
RDKTV-6263:[PoC]Display splash screen on deepsleep wakeup

### DIFF
--- a/RDKShell/CMakeLists.txt
+++ b/RDKShell/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(${MODULE_NAME} SHARED
         RDKShell.cpp
         Module.cpp
         ../helpers/utils.cpp
+       ../helpers/tptimer.cpp
 )
 
 set_target_properties(${MODULE_NAME} PROPERTIES

--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -1121,7 +1121,7 @@ namespace WPEFramework {
           }
           else
           {
-             std::cout << "Could not subscribe this time, one more attempt in " << RECONNECTION_TIME_IN_MILLISECONDS << "ms.Plugin is " <<  pluginActivated  << std::endl;
+             std::cout << "Could not subscribe this time, one more attempt in " << REATTEMPT_TIME_IN_MILLISECONDS << "ms.Plugin is " <<  pluginActivated  << std::endl;
           }
         }
 

--- a/RDKShell/RDKShell.h
+++ b/RDKShell/RDKShell.h
@@ -22,6 +22,7 @@
 #include <mutex>
 #include "Module.h"
 #include "utils.h"
+#include "tptimer.h"
 #include <rdkshell/rdkshellevents.h>
 #include <rdkshell/rdkshell.h>
 #include <rdkshell/linuxkeys.h>
@@ -262,6 +263,9 @@ namespace WPEFramework {
             void invokeStartupThunderApis();
             void enableLogsFlushing(const bool enable);
             void getLogsFlushingEnabled(bool &enabled);
+            void onTimer();
+            uint32_t subscribeForSystemServiceEvent(const char* eventName);
+
 
             static std::shared_ptr<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement> > getThunderControllerClient(std::string callsign="", std::string localidentifier="");
             static std::shared_ptr<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement> > getPackagerPlugin();
@@ -336,6 +340,7 @@ namespace WPEFramework {
             MonitorClients* mClientsMonitor;
             std::shared_ptr<RdkShell::RdkShellEventListener> mEventListener;
             PluginHost::IShell* mCurrentService;
+            TpTimer m_timer;
             //std::mutex m_callMutex;
         };
 


### PR DESCRIPTION
Reason for change:To display splash screen on deepsleep wakeup until everything
is ready and application dismisses the splash screen.
Splash screen is loaded into video buffer before the device enters into deepsleep.
Test Procedure: Verify splash screen is displayed on deepsleep wakeup.
Risks: Low
Signed-off-by: Tony Paul <Tony_Paul@comcast.com>