### PR TITLE
RDKTV-6107: Cec Changes for SystemAudioModeRequest

### DIFF
--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -66,7 +66,7 @@
 #define HDMICECSINK_NUMBER_TV_ADDR 					2
 #define HDMICECSINK_UPDATE_POWER_STATUS_INTERVA_MS    (60 * 1000)
 #define HDMISINK_ARCPORT                               1
-#define HDMISINK_ARC_START_STOP_MAX_WAIT_MS           3000
+#define HDMISINK_ARC_START_STOP_MAX_WAIT_MS           4000
 
 
 #define SAD_FMT_CODE_AC3 2
@@ -864,6 +864,14 @@ namespace WPEFramework
             JsonObject params;
             params["logicalAddress"] = JsonValue(logicalAddress);
             sendNotify(eventString[HDMICECSINK_EVENT_DEVICE_INFO_UPDATED], params);
+        }
+	void HdmiCecSink::systemAudioModeRequest()
+        {
+            if(!HdmiCecSink::_instance)
+             return;
+             LOGINFO(" Send systemAudioModeRequest ");
+           _instance->smConnection->sendTo(LogicalAddress::AUDIO_SYSTEM,MessageEncoder().encode(SystemAudioModeRequest(physical_addr)), 1100);
+
         }
        uint32_t HdmiCecSink::setEnabledWrapper(const JsonObject& parameters, JsonObject& response)
        {
@@ -2583,8 +2591,9 @@ namespace WPEFramework
             {
                LOGINFO("ARC is either initiation in progress or already initiated");
                return;
-            }				
-           _instance->requestArcInitiation();
+            }
+            _instance->systemAudioModeRequest();
+	    _instance->requestArcInitiation();
  
           // start initiate ARC timer 3 sec
             if (m_arcStartStopTimer.isActive())

--- a/HdmiCecSink/HdmiCecSink.h
+++ b/HdmiCecSink/HdmiCecSink.h
@@ -519,6 +519,7 @@ private:
 		        void Process_ShortAudioDescriptor_msg(const ReportShortAudioDescriptor  &msg);
 			void sendDeviceUpdateInfo(const int logicalAddress);
 			void sendFeatureAbort(const LogicalAddress logicalAddress, const OpCode feature, const AbortReason reason);
+			void systemAudioModeRequest();
 			int m_numberOfDevices; /* Number of connected devices othethan own device */
         private:
             // We do not allow this plugin to be copied !!


### PR DESCRIPTION
Reason for change: Support for SystemAudioModeRequest to bring the AVR/Sounbar out of standdby and to the right mode
Test Procedure: none
Risks: low

Signed-off-by: Bijas Babu bijas.babu@sky.uk

RDKTV-6107: Corrected the symbol error

Reason for change: Support for SystemAudioModeRequest
Test Procedure: none
Risks: low

Signed-off-by: Bijas Babu bijas.babu@sky.uk