### PR TITLE
RDKTV-5234 : fix PlayerInfo

### DIFF
--- a/PlayerInfo/DeviceSettings/PlatformImplementation.cpp
+++ b/PlayerInfo/DeviceSettings/PlatformImplementation.cpp
@@ -117,6 +117,7 @@ public:
         gst_init(0, nullptr);
         UpdateAudioCodecInfo();
         UpdateVideoCodecInfo();
+        Utils::IARM::init();
         IARM_Result_t res;
         IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_AUDIO_MODE, AudioModeHandler) );
         PlayerInfoImplementation::_instance = this;


### PR DESCRIPTION
Reason for change: This plugin does not init correctly.
Test Procedure: Init plugin, see no iarm errors in log.
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>
(cherry picked from commit 7a3eb9155b85875f0f1d4a482afaf1dc19b5c6f9)