### PR TITLE
DELIA-48768 : ARC subscription log flooding (Cherry picking change moved to main(#1053) to 2103)

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -249,6 +249,17 @@ namespace WPEFramework {
                         else {
                             m_audioOutputPortConfig["HDMI_ARC"] = false;
                         }
+
+                        //Stop timer if its already running
+                        if(m_timer.isActive()) {
+                            m_timer.stop();
+                        }
+
+                        Utils::activatePlugin(HDMICECSINK_CALLSIGN);
+
+                        //Start the timer only if the device supports HDMI_ARC
+                        LOGINFO("Starting the timer");
+                        m_timer.start(RECONNECTION_TIME_IN_MILLISECONDS);
                     }
                     else {
                         JsonObject aPortHdmiEnableResult;
@@ -285,14 +296,6 @@ namespace WPEFramework {
         {
             InitializeIARM();
 
-            if(m_timer.isActive()) {
-                m_timer.stop();
-            }
-
-            Utils::activatePlugin(HDMICECSINK_CALLSIGN);
-            LOGINFO("Starting the timer");
-            m_timer.start(RECONNECTION_TIME_IN_MILLISECONDS);
-
             if (IARM_BUS_PWRMGR_POWERSTATE_ON == getSystemPowerState())
             {
                 InitAudioPorts();
@@ -301,7 +304,6 @@ namespace WPEFramework {
             {
                 LOGWARN("Current power state %d", m_powerState);
             }
-
             // On success return empty, to indicate there is no error text.
             return (string());
         }


### PR DESCRIPTION
Reason for change: Enable m_timer if only ARC is enabled
Test Procedure: Refer JIRA
Risks: Low
Signed-off-by: Akhil Baby Sarada <Akhil_Sarada@comcast.com>