### PR TITLE
RDK-29274:Thunder APIs for AutoReboot

### DIFF
--- a/SystemServices/SystemServices.h
+++ b/SystemServices/SystemServices.h
@@ -41,6 +41,7 @@
 #include "sysMgr.h"
 #include "cSettings.h"
 #include "cTimer.h"
+#include "rfcapi.h"
 
 /* System Services Triggered Events. */
 #define EVT_ONSYSTEMSAMPLEEVENT           "onSampleEvent"
@@ -52,6 +53,7 @@
 #define EVT_ONMACADDRESSRETRIEVED         "onMacAddressesRetreived"
 #define EVT_ONREBOOTREQUEST               "onRebootRequest"
 #define EVT_ON_SYSTEM_CLOCK_SET           "onSystemClockSet"
+#define EVT_ONFWPENDINGREBOOT             "onFirmwarePendingReboot" /* Auto Reboot notifier */
 
 namespace WPEFramework {
     namespace Plugin {
@@ -142,6 +144,7 @@ namespace WPEFramework {
                 void onTemperatureThresholdChanged(string thresholdType,
                         bool exceed, float temperature);
                 void onRebootRequest(string reason);
+                void onFirmwarePendingReboot(int seconds); /* Event handler for Pending Reboot */
                 /* Events : End */
 
                 /* Methods : Begin */
@@ -220,6 +223,9 @@ namespace WPEFramework {
                 uint32_t getLastFirmwareFailureReason(const JsonObject& parameters, JsonObject& response);
                 uint32_t setOptOutTelemetry(const JsonObject& parameters,JsonObject& response);
                 uint32_t isOptOutTelemetry(const JsonObject& parameters,JsonObject& response);
+                uint32_t fireFirmwarePendingReboot(const JsonObject& parameters, JsonObject& response);
+                uint32_t setFirmwareRebootDelay(const JsonObject& parameters, JsonObject& response);
+                uint32_t setFirmwareAutoReboot(const JsonObject& parameters, JsonObject& response);
         }; /* end of system service class */
     } /* end of plugin */
 } /* end of wpeframework */


### PR DESCRIPTION
Reason for change: Added new method for
fwPendingReboot,fwAutoReboot & fwDelayReboot.
'{"jsonrpc":"2.0","id":"3","method":"org.rdk.System.2.fireFirmwarePendingReboot","params":{}}'
'{"jsonrpc":"2.0","id":"3","method":"org.rdk.System.2.setFirmwareRebootDelay","params":{"delaySeconds":int seconds}}'
'{"jsonrpc":"2.0","id":"3","method":"org.rdk.System.2.setFirmwareAutoReboot","params":{"enable":bool enableFwAutoreboot}}'
Test Procedure: Refer to Jira Ticket.

(cherry picked from commit e0ad193f168b823f46acc6fdf7a7f443544249e4)
(cherry picked from commit b86ae925eabed9aabb786a7b10940394921dd4d4)