### PR TITLE
RDKCOM-2087, RDKCOM-1978, RDKCOM-2090: WiFiManager added new getSavedSSID method for retrieving saved SSID, Introducing Amlogic STB specific flag for Network plugin fixes.

### DIFF
--- a/WifiManager/WifiManager.h
+++ b/WifiManager/WifiManager.h
@@ -75,6 +75,7 @@ namespace WPEFramework {
             virtual uint32_t setSignalThresholdChangeEnabled(const JsonObject& parameters, JsonObject& response) override;
             virtual uint32_t isSignalThresholdChangeEnabled(const JsonObject& parameters, JsonObject& response) const;
             virtual uint32_t getSupportedSecurityModes(const JsonObject& parameters, JsonObject& response) override;
+            virtual uint32_t getSavedSSID(const JsonObject& parameters, JsonObject& response) override;
             //End methods
 
             //Begin events

--- a/WifiManager/WifiManagerInterface.h
+++ b/WifiManager/WifiManagerInterface.h
@@ -47,6 +47,7 @@ namespace WPEFramework {
             virtual uint32_t setSignalThresholdChangeEnabled(const JsonObject& parameters, JsonObject& response) = 0;
             virtual uint32_t isSignalThresholdChangeEnabled(const JsonObject& parameters, JsonObject& response) const = 0;
             virtual uint32_t getSupportedSecurityModes(const JsonObject& parameters, JsonObject& response) = 0;
+            virtual uint32_t getSavedSSID(const JsonObject& parameters, JsonObject& response) = 0;
             //End methods
 
             //Begin events

--- a/amlogic.cmake
+++ b/amlogic.cmake
@@ -123,6 +123,10 @@ if (BUILD_LLAMA)
     add_definitions (-DPLUGIN_STATEOBSERVER)
 endif()
 
+if (BUILD_AML_STB)
+    add_definitions(-DNET_DEFINED_INTERFACES_ONLY)
+endif()
+
 if(SCREEN_CAPTURE)
     if(NOT DISABLE_SCREEN_CAPTURE)
 	    message("Yocto AMLOGIC build: Building Amlogic specific screen capturing")


### PR DESCRIPTION
There is no get/set pair for SaveSSID method in WiFiManager plugin.
Bringing in a method for retrieving getSavedSSID.
Logic is: Utilize PersistentStore plugin to save and read saved credentials.