### PR TITLE
RDK-32327: Asynchronous notification of HDMI-CEC <Standby> message

### DIFF
--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -56,6 +56,7 @@
 #define HDMICECSINK_METHOD_REQUEST_ACTIVE_SOURCE "requestActiveSource"
 #define HDMICECSINK_METHOD_SETUP_ARC              "setupARCRouting"
 #define HDMICECSINK_METHOD_REQUEST_SHORT_AUDIO_DESCRIPTOR  "requestShortAudioDescriptor"
+#define HDMICECSINK_METHOD_SEND_STANDBY_MESSAGE            "sendStandbyMessage"
 
 #define TEST_ADD 0
 #define HDMICECSINK_REQUEST_MAX_RETRY 				3
@@ -90,6 +91,7 @@ enum {
         HDMICECSINK_EVENT_ARC_INITIATION_EVENT,
 	HDMICECSINK_EVENT_ARC_TERMINATION_EVENT,
         HDMICECSINK_EVENT_SHORT_AUDIODESCRIPTOR_EVENT,
+        HDMICECSINK_EVENT_STANDBY_MSG_EVENT,
 };
 
 static char *eventString[] = {
@@ -105,6 +107,7 @@ static char *eventString[] = {
         "arcInitiationEvent",
         "arcTerminationEvent",
         "shortAudiodesciptorEvent",
+        "standbyMessageReceived"
 };
 	
 
@@ -192,6 +195,7 @@ namespace WPEFramework
        {
              printHeader(header);
 			 LOGINFO("Command: Standby from %s\n", header.from.toString().c_str());
+             HdmiCecSink::_instance->SendStandbyMsgEvent(header.from.toInt());
        }
        void HdmiCecSinkProcessor::process (const GetCECVersion &msg, const Header &header)
        {
@@ -490,6 +494,7 @@ namespace WPEFramework
                    registerMethod(HDMICECSINK_METHOD_SETUP_ARC, &HdmiCecSink::setArcEnableDisableWrapper, this);
 		   registerMethod(HDMICECSINK_METHOD_SET_MENU_LANGUAGE, &HdmiCecSink::setMenuLanguageWrapper, this);
                    registerMethod(HDMICECSINK_METHOD_REQUEST_SHORT_AUDIO_DESCRIPTOR, &HdmiCecSink::requestShortAudioDescriptorWrapper, this);
+                   registerMethod(HDMICECSINK_METHOD_SEND_STANDBY_MESSAGE, &HdmiCecSink::sendStandbyMessageWrapper, this);
            logicalAddressDeviceType = "None";
            logicalAddress = 0xFF;
            
@@ -689,7 +694,6 @@ namespace WPEFramework
 						else
 						{
 							HdmiCecSink::_instance->m_currentActiveSource = -1;
-							HdmiCecSink::_instance->sendStandbyMessage();	
 						}
 					}
 			}
@@ -720,7 +724,7 @@ namespace WPEFramework
 				return;
 			}
 
-			_instance->smConnection->sendTo(LogicalAddress(LogicalAddress::BROADCAST), MessageEncoder().encode(Standby()), 5000);	
+			_instance->smConnection->sendTo(LogicalAddress(LogicalAddress::BROADCAST), MessageEncoder().encode(Standby()), 1000);	
        } 
 
 	   void HdmiCecSink::wakeupFromStandby()
@@ -873,6 +877,15 @@ namespace WPEFramework
            _instance->smConnection->sendTo(LogicalAddress::AUDIO_SYSTEM,MessageEncoder().encode(SystemAudioModeRequest(physical_addr)), 1100);
 
         }
+
+        void HdmiCecSink::SendStandbyMsgEvent(const int logicalAddress)
+        {
+            JsonObject params;
+	    if(!HdmiCecSink::_instance)
+		return;
+	    params["logicalAddress"] = JsonValue(logicalAddress);
+            sendNotify(eventString[HDMICECSINK_EVENT_STANDBY_MSG_EVENT], params);
+       }
        uint32_t HdmiCecSink::setEnabledWrapper(const JsonObject& parameters, JsonObject& response)
        {
            LOGINFOMETHOD();
@@ -1221,6 +1234,11 @@ namespace WPEFramework
 			requestShortaudioDescriptor();
 			returnResponse(true);
 	}
+        uint32_t HdmiCecSink::sendStandbyMessageWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+          sendStandbyMessage();
+	  returnResponse(true);
+        }
         bool HdmiCecSink::loadSettings()
         {
             Core::File file;
@@ -2223,13 +2241,6 @@ namespace WPEFramework
 						 {
 							_instance->requestActiveSource(); 
 						 }
-						 else
-						 {
-						 	/* send standby message if TV is in Standby */
-						 	_instance->sendStandbyMessage();
-						 }
-
-						 
 
 						_instance->m_sleepTime = HDMICECSINK_PING_INTERVAL_MS;
 						_instance->m_pollThreadState = POLL_THREAD_STATE_IDLE;

--- a/HdmiCecSink/HdmiCecSink.h
+++ b/HdmiCecSink/HdmiCecSink.h
@@ -520,6 +520,7 @@ private:
 			void sendDeviceUpdateInfo(const int logicalAddress);
 			void sendFeatureAbort(const LogicalAddress logicalAddress, const OpCode feature, const AbortReason reason);
 			void systemAudioModeRequest();
+                        void SendStandbyMsgEvent(const int logicalAddress);
 			int m_numberOfDevices; /* Number of connected devices othethan own device */
         private:
             // We do not allow this plugin to be copied !!
@@ -544,8 +545,8 @@ private:
                         uint32_t setArcEnableDisableWrapper(const JsonObject& parameters, JsonObject& response);
 			uint32_t setMenuLanguageWrapper(const JsonObject& parameters, JsonObject& response);
                         uint32_t requestShortAudioDescriptorWrapper(const JsonObject& parameters, JsonObject& response);
-			
-            //End methods
+                        uint32_t sendStandbyMessageWrapper(const JsonObject& parameters, JsonObject& response);
+                        //End methods
             std::string logicalAddressDeviceType;
             bool cecSettingEnabled;
             bool cecOTPSettingEnabled;


### PR DESCRIPTION
Reason for change: Standby message
Test Procedure: none
Risks: low

Signed-off-by: Bijas Babu bijas.babu@sky.uk

RDK-32327: Asynchronous notification of HDMI-CEC <Standby> message

Reason for change: Added logical address in the event notificationStandby message

Test Procedure: none
Risks: low

Signed-off-by: Bijas Babu bijas.babu@sky.uk

RDK-32327: Asynchronous notification of HDMI-CEC <Standby> message

Reason for change: Now application initiate the sending of the standby message.So removed that sending from  RDK.

Test Procedure: none
Risks: low

Signed-off-by: Bijas Babu bijas.babu@sky.uk