### PR TITLE
AMLOGIC-1457: Remove Unnecessary videoPort from llama

### DIFF
--- a/DisplayInfo/DeviceSettings/PlatformImplementation.cpp
+++ b/DisplayInfo/DeviceSettings/PlatformImplementation.cpp
@@ -174,7 +174,8 @@ public:
         return (Core::ERROR_NONE);
         try
         {
-            device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort("HDMI0");
+            std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+            device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str());
             device::AudioStereoMode mode = vPort.getAudioOutputPort().getStereoMode(true);
             if (mode == device::AudioStereoMode::kPassThru)
                 value = true;
@@ -190,7 +191,8 @@ public:
     {
         try
         {
-            device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort("HDMI0");
+            std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+            device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str());
             connected = vPort.isDisplayConnected();
         }
         catch (const device::Exception& err)
@@ -284,7 +286,8 @@ public:
     {
         try
         {
-            ::device::VideoOutputPort vPort = ::device::Host::getInstance().getVideoOutputPort("HDMI0");
+            std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+            ::device::VideoOutputPort vPort = ::device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str());
             if (vPort.isDisplayConnected())
             {
                 std::vector<uint8_t> edidVec;
@@ -313,7 +316,8 @@ public:
     {
         try
         {
-            ::device::VideoOutputPort vPort = ::device::Host::getInstance().getVideoOutputPort("HDMI0");
+            std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+            ::device::VideoOutputPort vPort = ::device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str());
             if (vPort.isDisplayConnected())
             {
                 std::vector<uint8_t> edidVec;
@@ -344,7 +348,8 @@ public:
         try
         {
             vector<uint8_t> edidVec2;
-            device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort("HDMI0");
+            std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+            device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str());
             if (vPort.isDisplayConnected())
             {
                 vPort.getDisplay().getEDIDBytes(edidVec2);
@@ -415,7 +420,8 @@ public:
         int capabilities = static_cast<int>(dsHDRSTANDARD_NONE);
         try
         {
-            device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort("HDMI0");
+            std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+            device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str());
             if (vPort.isDisplayConnected()) {
                 vPort.getTVHDRCapabilities(&capabilities);
             }
@@ -475,7 +481,8 @@ public:
         bool isHdr = false;
         try
         {
-            device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort("HDMI0");
+            std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+            device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str());
             if (vPort.isDisplayConnected()) {
                 isHdr = vPort.IsOutputHDR();
             }
@@ -508,7 +515,8 @@ private:
         uint32_t ret =  (Core::ERROR_NONE);
         try
         {
-            device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort("HDMI0");
+            std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+            device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str());
             device::VideoResolution resolution = vPort.getResolution();
             device::PixelResolution pr = resolution.getPixelResolution();
             device::FrameRate fr = resolution.getFrameRate();

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -672,7 +672,8 @@ namespace WPEFramework {
         uint32_t DisplaySettings::getSupportedResolutions(const JsonObject& parameters, JsonObject& response)
         {   //sample servicemanager response:{"success":true,"supportedResolutions":["720p","1080i","1080p60"]}
             LOGINFOMETHOD();
-            string videoDisplay = parameters.HasLabel("videoDisplay") ? parameters["videoDisplay"].String() : "HDMI0";
+            std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+            string videoDisplay = parameters.HasLabel("videoDisplay") ? parameters["videoDisplay"].String() : strVideoPort;
             vector<string> supportedResolutions;
             try
             {
@@ -717,7 +718,8 @@ namespace WPEFramework {
         uint32_t DisplaySettings::getSupportedTvResolutions(const JsonObject& parameters, JsonObject& response)
         {   //sample servicemanager response:{"success":true,"supportedTvResolutions":["480i","480p","576i","720p","1080i","1080p"]}
             LOGINFOMETHOD();
-            string videoDisplay = parameters.HasLabel("videoDisplay") ? parameters["videoDisplay"].String() : "HDMI0";
+            std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+            string videoDisplay = parameters.HasLabel("videoDisplay") ? parameters["videoDisplay"].String() : strVideoPort;
             vector<string> supportedTvResolutions;
             try
             {
@@ -819,7 +821,8 @@ namespace WPEFramework {
 
                 if (Utils::String::stringContains(audioPort, "HDMI0"))
                 {
-                    device::VideoOutputPort vPort = device::VideoOutputPortConfig::getInstance().getPort("HDMI0");
+                    std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+                    device::VideoOutputPort vPort = device::VideoOutputPortConfig::getInstance().getPort(strVideoPort.c_str());
                     int surroundMode = vPort.getDisplay().getSurroundMode();
                     if (vPort.isDisplayConnected() && surroundMode)
                     {
@@ -903,7 +906,8 @@ namespace WPEFramework {
         uint32_t DisplaySettings::getCurrentResolution(const JsonObject& parameters, JsonObject& response)
         {   //sample servicemanager response:{"success":true,"resolution":"720p"}
             LOGINFOMETHOD();
-            string videoDisplay = parameters.HasLabel("videoDisplay") ? parameters["videoDisplay"].String() : "HDMI0";
+            std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+            string videoDisplay = parameters.HasLabel("videoDisplay") ? parameters["videoDisplay"].String() : strVideoPort;
             bool success = true;
             try
             {
@@ -962,7 +966,8 @@ namespace WPEFramework {
                 /* Check if HDMI is connected - Return (default) Stereo Mode if not connected */
                 if (audioPort.empty())
                 {
-                    if (device::Host::getInstance().getVideoOutputPort("HDMI0").isDisplayConnected())
+                    std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+                    if (device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str()).isDisplayConnected())
                     {
                         audioPort = "HDMI0";
                     }
@@ -998,7 +1003,8 @@ namespace WPEFramework {
                         if (aPort.getStereoAuto() || mode == device::AudioStereoMode::kSurround)
                         {
                             LOGINFO("HDMI0 is in Auto Mode");
-                            int surroundMode = device::Host::getInstance().getVideoOutputPort("HDMI0").getDisplay().getSurroundMode();
+                            std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+                            int surroundMode = device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str()).getDisplay().getSurroundMode();
                             if ( surroundMode & dsSURROUNDMODE_DDPLUS)
                             {
                                 LOGINFO("HDMI0 has surround DDPlus");
@@ -1128,7 +1134,8 @@ namespace WPEFramework {
                             aPort.setStereoAuto(stereoAuto, persist);
                             if (stereoAuto)
                             {
-                                if (device::Host::getInstance().getVideoOutputPort("HDMI0").getDisplay().getSurroundMode())
+                                std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+                                if (device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str()).getDisplay().getSurroundMode())
                                     mode = device::AudioStereoMode::kSurround;
                                 else
                                     mode = device::AudioStereoMode::kStereo;
@@ -1217,7 +1224,8 @@ namespace WPEFramework {
             try
             {
                 vector<uint8_t> edidVec2;
-                device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort("HDMI0");
+                std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+                device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str());
                 if (vPort.isDisplayConnected())
                 {
                     vPort.getDisplay().getEDIDBytes(edidVec2);
@@ -1295,7 +1303,8 @@ namespace WPEFramework {
         {   //sample servicemanager response:
             LOGINFOMETHOD();
 
-            string videoDisplay = parameters.HasLabel("videoDisplay") ? parameters["videoDisplay"].String() : "HDMI0";
+            std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+            string videoDisplay = parameters.HasLabel("videoDisplay") ? parameters["videoDisplay"].String() : strVideoPort;
             bool active = true;
             try
             {
@@ -1319,7 +1328,8 @@ namespace WPEFramework {
 
             try
             {
-                device::VideoOutputPort vPort = device::VideoOutputPortConfig::getInstance().getPort("HDMI0");
+                std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+                device::VideoOutputPort vPort = device::VideoOutputPortConfig::getInstance().getPort(strVideoPort.c_str());
                 if (vPort.isDisplayConnected())
                     vPort.getTVHDRCapabilities(&capabilities);
             }
@@ -1515,7 +1525,8 @@ namespace WPEFramework {
             bool success = true;
             try
             {
-                device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort("HDMI0");
+                std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+                device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str());
                 if (vPort.isDisplayConnected())
                 {
                     int videoEOTF, matrixCoefficients, colorSpace, colorDepth, quantizationRange;
@@ -2587,7 +2598,8 @@ namespace WPEFramework {
                 /* Check if HDMI is connected - Return (default) Stereo Mode if not connected */
                 if (audioPort.empty())
                 {
-                    if (device::Host::getInstance().getVideoOutputPort("HDMI0").isDisplayConnected())
+                    std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+                    if (device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str()).isDisplayConnected())
                     {
                         audioPort = "HDMI0";
                     }
@@ -2651,7 +2663,8 @@ namespace WPEFramework {
                 /* Check if HDMI is connected - Return (default) Stereo Mode if not connected */
                 if (audioPort.empty())
                 {
-                    if (device::Host::getInstance().getVideoOutputPort("HDMI0").isDisplayConnected())
+                    std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+                    if (device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str()).isDisplayConnected())
                         audioPort = "HDMI0";
                     else
                     {
@@ -2701,7 +2714,8 @@ namespace WPEFramework {
                 /* Check if HDMI is connected - Return (default) Stereo Mode if not connected */
                 if (audioPort.empty())
                 {
-                    if (device::Host::getInstance().getVideoOutputPort("HDMI0").isDisplayConnected())
+                    std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+                    if (device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str()).isDisplayConnected())
                     {
                         audioPort = "HDMI0";
                     }
@@ -2768,7 +2782,8 @@ namespace WPEFramework {
                 /* Check if HDMI is connected - Return (default) Stereo Mode if not connected */
                 if (audioPort.empty())
                 {
-                    if (device::Host::getInstance().getVideoOutputPort("HDMI0").isDisplayConnected())
+                    std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+                    if (device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str()).isDisplayConnected())
                     {
                         audioPort = "HDMI0";
                     }
@@ -3334,7 +3349,8 @@ namespace WPEFramework {
 			int capabilities = dsHDRSTANDARD_NONE;
             try
             {
-                device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort("HDMI0");
+                std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+                device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str());
                 if (vPort.isDisplayConnected()) {
                     vPort.getTVHDRCapabilities(&capabilities);
                     response["capabilities"] = capabilities;
@@ -3358,7 +3374,8 @@ namespace WPEFramework {
 			bool success = true;
             try
             {
-                device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort("HDMI0");
+                std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+                device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str());
                 if (vPort.isDisplayConnected()) {
                     response["defaultResolution"] = vPort.getDefaultResolution().getName();
                 }

--- a/HdcpProfile/HdcpProfile.cpp
+++ b/HdcpProfile/HdcpProfile.cpp
@@ -25,6 +25,7 @@
 #include "videoOutputPortConfig.hpp"
 #include "dsMgr.h"
 #include "manager.hpp"
+#include "host.hpp"
 
 #include "utils.h"
 
@@ -105,7 +106,8 @@ namespace WPEFramework
 
             try
             {
-            device::VideoOutputPort vPort = device::VideoOutputPortConfig::getInstance().getPort("HDMI0");
+                std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+                device::VideoOutputPort vPort = device::VideoOutputPortConfig::getInstance().getPort(strVideoPort.c_str());
                 hdcpProtocol = (dsHdcpProtocolVersion_t)vPort.getHDCPProtocol();
             }
             catch (const std::exception e)
@@ -143,7 +145,8 @@ namespace WPEFramework
 
             try
             {
-                device::VideoOutputPort vPort = device::VideoOutputPortConfig::getInstance().getPort("HDMI0");
+                std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+                device::VideoOutputPort vPort = device::VideoOutputPortConfig::getInstance().getPort(strVideoPort.c_str());
                 isConnected        = vPort.isDisplayConnected();
                 hdcpProtocol       = (dsHdcpProtocolVersion_t)vPort.getHDCPProtocol();
                 eHDCPEnabledStatus = vPort.getHDCPStatus();

--- a/HdmiCec_2/HdmiCec_2.cpp
+++ b/HdmiCec_2/HdmiCec_2.cpp
@@ -351,7 +351,8 @@ namespace WPEFramework
            {
                //TODO(MROLLINS) this is probably per process so we either need to be running in our own process or be carefull no other plugin is calling it
                device::Manager::Initialize();
-               device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort("HDMI0");
+               std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+               device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str());
                if (vPort.isDisplayConnected())
                {
                    vector<uint8_t> edidVec;
@@ -545,7 +546,8 @@ namespace WPEFramework
                 getLogicalAddress();
                 try
                 {
-                   device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort("HDMI0");
+                   std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+                   device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str());
                    if (vPort.isDisplayConnected())
                    {
                      vector<uint8_t> edidVec;

--- a/PlayerInfo/DeviceSettings/PlatformImplementation.cpp
+++ b/PlayerInfo/DeviceSettings/PlatformImplementation.cpp
@@ -153,7 +153,8 @@ public:
         string currentResolution = "0";
         try
         {
-            device::VideoOutputPort &vPort = device::Host::getInstance().getVideoOutputPort("HDMI0");
+            std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+            device::VideoOutputPort &vPort = device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str());
             currentResolution = vPort.getResolution().getName();
             TRACE(Trace::Information, (_T("Current video playback resolution = %s"), currentResolution));
         }


### PR DESCRIPTION
Reason for change:
Remove Unnecessary videoPort from llama
Test Procedure: None
Risks: Low

Change-Id: I53f51cac3c1bac82ff9edc984375a47cf6f06bd0
Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>