### PR TITLE
RDKTV-6181,RDKTV-6182: ARC Issues in samsung soundbar

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -2986,8 +2986,15 @@ namespace WPEFramework {
                     try
                     {
                         device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort("HDMI_ARC0");
-                        LOGINFO("onARCInitiationEventHandler: Enable ARC\n");
-                        aPort.enableARC(dsAUDIOARCSUPPORT_ARC, true);
+                        JsonObject aPortConfig;
+                        aPortConfig = getAudioOutputPortConfig();
+                       if(aPortConfig["HDMI_ARC"].Boolean()) {
+                            LOGINFO("onARCInitiationEventHandler: Enable ARC\n");
+                            aPort.enableARC(dsAUDIOARCSUPPORT_ARC, true);
+                       }
+                       else {
+                           LOGINFO("onARCInitiationEventHandler: HDMI_ARC0 Port not enabled. Skip Audio Routing !!!\n");
+                       }
                     }
                     catch (const device::Exception& err)
                     {

--- a/HdmiCecSink/HdmiCecSink.h
+++ b/HdmiCecSink/HdmiCecSink.h
@@ -562,6 +562,7 @@ private:
             std::mutex m_pollMutex;
             /* ARC related */
             std::thread m_arcRoutingThread;
+	    bool m_ArcUiSettingState;
 	    uint32_t m_currentArcRoutingState;
 	    std::mutex m_arcRoutingStateMutex;
 	    binary_semaphore m_semSignaltoArcRoutingThread;


### PR DESCRIPTION
Reason for change: Remove enforcement of ARC intiation
from TV side. Acknowledge ARC intiation requests from the
connected downstream device
Test Procedure: HDMI ARC/eARC tests
Risks: None

Signed-off-by: Deekshit Devadas <deekshit.devadasy@sky.uk>

RDKTV-6181,RDKTV-6182: ARC Issues in samsung soundbar

Reason for change: Remove enforcement of ARC intiation
from TV side. Acknowledge ARC intiation requests from the
connected downstream device
Cleanup checkin
Test Procedure: HDMI ARC/eARC tests
Risks: None

Signed-off-by: Deekshit Devadas <deekshit.devadasy@sky.uk>