### PR TITLE
RDKTV-6181,RDKTV-6182: ARC Issues in samsung soundbar

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -2986,8 +2986,15 @@ namespace WPEFramework {
                     try
                     {
                         device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort("HDMI_ARC0");
-                        LOGINFO("onARCInitiationEventHandler: Enable ARC\n");
-                        aPort.enableARC(dsAUDIOARCSUPPORT_ARC, true);
+                        JsonObject aPortConfig;
+                        aPortConfig = getAudioOutputPortConfig();
+                       if(aPortConfig["HDMI_ARC"].Boolean()) {
+                            LOGINFO("onARCInitiationEventHandler: Enable ARC\n");
+                            aPort.enableARC(dsAUDIOARCSUPPORT_ARC, true);
+                       }
+                       else {
+                           LOGINFO("onARCInitiationEventHandler: HDMI_ARC0 Port not enabled. Skip Audio Routing !!!\n");
+                       }
                     }
                     catch (const device::Exception& err)
                     {

--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -2457,7 +2457,9 @@ namespace WPEFramework
             }
             msgProcessor = new HdmiCecSinkProcessor(*smConnection);
             msgFrameListener = new HdmiCecSinkFrameListener(*msgProcessor);
-            
+
+           /* Get updated in the startArc */
+            m_ArcUiSettingState = false;
             cecEnableStatus = true;
 
             if(smConnection)
@@ -2583,8 +2585,9 @@ namespace WPEFramework
             {
                LOGINFO("ARC is either initiation in progress or already initiated");
                return;
-            }				
-           _instance->requestArcInitiation();
+            }
+            m_ArcUiSettingState = true;
+	    _instance->requestArcInitiation();
  
           // start initiate ARC timer 3 sec
             if (m_arcStartStopTimer.isActive())
@@ -2613,6 +2616,7 @@ namespace WPEFramework
             }
             if(!HdmiCecSink::_instance)
                 return;
+           m_ArcUiSettingState = false;
 	    if(m_currentArcRoutingState == ARC_STATE_REQUEST_ARC_TERMINATION || m_currentArcRoutingState == ARC_STATE_ARC_TERMINATED)
             {
                LOGINFO("ARC is either Termination  in progress or already Terminated");
@@ -2650,23 +2654,28 @@ namespace WPEFramework
             if(!HdmiCecSink::_instance)
 	    return;
 
-	    LOGINFO("Got : INITIATE_ARC  and current Arcstate is %d",_instance->m_currentArcRoutingState);
+            LOGINFO("Got : INITIATE_ARC  and current Arcstate is %d m_ArcUiSettingState %d ",_instance->m_currentArcRoutingState,m_ArcUiSettingState);
             std::lock_guard<std::mutex> lock(_instance->m_arcRoutingStateMutex);
-	
-            if( _instance->m_currentArcRoutingState == ARC_STATE_REQUEST_ARC_INITIATION )
+
+            if (m_arcStartStopTimer.isActive())
+            {
+               m_arcStartStopTimer.stop();
+            }
+            if(  m_ArcUiSettingState)
             {   
-	           if (m_arcStartStopTimer.isActive())
-                   {
-                      m_arcStartStopTimer.stop();
-                   }
-                    
-	           _instance->m_currentArcRoutingState = ARC_STATE_ARC_INITIATED;
-	
+	          _instance->m_currentArcRoutingState = ARC_STATE_ARC_INITIATED;
                   _instance->m_semSignaltoArcRoutingThread.release();
                   LOGINFO("Got : ARC_INITIATED  and notify Device setting");
                   params["status"] = string("success");
                   sendNotify(eventString[HDMICECSINK_EVENT_ARC_INITIATION_EVENT], params); 
            }
+           else
+          {
+              LOGINFO(" ARC UI setting is not Enabled so send ARC Terminated event and set the state to ARC_STATE_ARC_TERMINATED");
+             //need to send report ARC Terminated
+                HdmiCecSink::_instance->m_currentArcRoutingState = ARC_STATE_ARC_TERMINATED;
+                _instance->m_semSignaltoArcRoutingThread.release();
+          }
 	  
 
        }
@@ -2674,11 +2683,8 @@ namespace WPEFramework
        {
             JsonObject params;
             std::lock_guard<std::mutex> lock(m_arcRoutingStateMutex);
-	
-            LOGINFO("Command: TERMINATE_ARC current arc state %d\n",HdmiCecSink::_instance->m_currentArcRoutingState);
-            if( (HdmiCecSink::_instance->m_currentArcRoutingState == ARC_STATE_REQUEST_ARC_TERMINATION) || 
-                                 (HdmiCecSink::_instance->m_currentArcRoutingState == ARC_STATE_ARC_INITIATED) )
-            {
+
+            LOGINFO("Command: TERMINATE_ARC current arc state %d m_ArcUiSettingState %d\n",HdmiCecSink::_instance->m_currentArcRoutingState,m_ArcUiSettingState);
                 if (m_arcStartStopTimer.isActive())
                 {
                       m_arcStartStopTimer.stop();
@@ -2690,8 +2696,6 @@ namespace WPEFramework
                 LOGINFO("Got : ARC_TERMINATED  and notify Device setting");
                 params["status"] = string("success");
                 sendNotify(eventString[HDMICECSINK_EVENT_ARC_TERMINATION_EVENT], params);
-            }
-
         }
         void HdmiCecSink::threadArcRouting()
         {

--- a/HdmiCecSink/HdmiCecSink.h
+++ b/HdmiCecSink/HdmiCecSink.h
@@ -561,6 +561,7 @@ private:
             std::mutex m_pollMutex;
             /* ARC related */
             std::thread m_arcRoutingThread;
+	    bool m_ArcUiSettingState;
 	    uint32_t m_currentArcRoutingState;
 	    std::mutex m_arcRoutingStateMutex;
 	    binary_semaphore m_semSignaltoArcRoutingThread;


### PR DESCRIPTION
Reason for change: Remove enforcement of ARC intiation
from TV side. Acknowledge ARC intiation requests from the
connected downstream device
Test Procedure: HDMI ARC/eARC tests
Risks: None

Signed-off-by: Deekshit Devadas <deekshit.devadasy@sky.uk>

RDKTV-6181,RDKTV-6182: ARC Issues in samsung soundbar

Reason for change: Remove enforcement of ARC intiation
from TV side. Acknowledge ARC intiation requests from the
connected downstream device
Cleanup checkin
Test Procedure: HDMI ARC/eARC tests
Risks: None

Signed-off-by: Deekshit Devadas <deekshit.devadasy@sky.uk>