### PR TITLE
HP40A-898: empty network interface fix. Cherry-pick from sprint/2102

### DIFF
--- a/amlogic.cmake
+++ b/amlogic.cmake
@@ -123,6 +123,10 @@ if (BUILD_LLAMA)
     add_definitions (-DPLUGIN_STATEOBSERVER)
 endif()
 
+if (BUILD_AML_STB)
+    add_definitions(-DNET_DEFINED_INTERFACES_ONLY)
+endif()
+
 if(SCREEN_CAPTURE)
     if(NOT DISABLE_SCREEN_CAPTURE)
 	    message("Yocto AMLOGIC build: Building Amlogic specific screen capturing")


### PR DESCRIPTION
Reason for change: Root cause details are added in ticket; please refer.
Fix logic is enable the build flag to filter out unsupported interfaces.
Cherry-picked sprint/2102 7a3562cc94e5586d2f362f3faffaae3af1047abc
Test Procedure: Please see ticket for details.
Risks: Low
Signed-off-by: Arun Madhavan <Arun_Madhavan@comcast.com>