### PR TITLE
RDK-31097 DeviceDiagnostics: add API to determine decoder status

### DIFF
--- a/DeviceDiagnostics/CMakeLists.txt
+++ b/DeviceDiagnostics/CMakeLists.txt
@@ -22,17 +22,21 @@ find_package(${NAMESPACE}Plugins REQUIRED)
 
 add_library(${MODULE_NAME} SHARED
         DeviceDiagnostics.cpp
-        Module.cpp)
+        Module.cpp
+        ../helpers/utils.cpp)
 
 set_target_properties(${MODULE_NAME} PROPERTIES
         CXX_STANDARD 11
         CXX_STANDARD_REQUIRED YES)
 
 find_package(Curl)
+find_package(IARMBus REQUIRED)
 
 target_include_directories(${MODULE_NAME} PRIVATE ${IARMBUS_INCLUDE_DIRS} ../helpers)
 
-target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins ${CURL_LIBRARY})
+target_link_libraries(${MODULE_NAME} PRIVATE
+    ${NAMESPACE}Plugins::${NAMESPACE}Plugins ${CURL_LIBRARY}
+    ${IARMBUS_LIBRARIES})
 
 install(TARGETS ${MODULE_NAME}
         DESTINATION lib/${STORAGE_DIRECTORY}/plugins)

--- a/DeviceDiagnostics/DeviceDiagnostics.cpp
+++ b/DeviceDiagnostics/DeviceDiagnostics.cpp
@@ -20,10 +20,22 @@
 #include "DeviceDiagnostics.h"
 
 #include <curl/curl.h>
+#include <libIBus.h>
 
 #include "utils.h"
 
 #define DEVICE_DIAGNOSTICS_METHOD_NAME_GET_CONFIGURATION  "getConfiguration"
+#define DEVICE_DIAGNOSTICS_METHOD_GET_VIDEO_DECODER_STATUS "getVideoDecoderStatus"
+#define DEVICE_DIAGNOSTICS_METHOD_GET_AUDIO_DECODER_STATUS "getAudioDecoderStatus"
+
+#define DEVICE_DIAGNOSTICS_EVT_ON_VIDEO_DECODER_STATUS_CHANGED "onVideoDecoderStatusChanged"
+#define DEVICE_DIAGNOSTICS_EVT_ON_AUDIO_DECODER_STATUS_CHANGED "onAudioDecoderStatusChanged"
+
+#define EVT_ON_VIDEO_DECODER_STATUS_CHANGED "onVideoDecoderStatusChanged"
+#define EVT_ON_AUDIO_DECODER_STATUS_CHANGED "onAudioDecoderStatusChanged"
+
+#define IARM_BUS_PLAYBACK_DIAG_STATUS_CHANGE_EVENT 0x200
+#define IARM_BUS_PLAYBACK_DIAG_BUS_NAME "PlaybackDiag"
 
 namespace WPEFramework
 {
@@ -34,6 +46,12 @@ namespace WPEFramework
         DeviceDiagnostics* DeviceDiagnostics::_instance = nullptr;
 
         const int curlTimeoutInSeconds = 30;
+        static const char *decoderStatusStr[] = {
+            "ACTIVE",
+            "PAUSED",
+            "IDLE",
+            NULL
+        };
 
         static size_t writeCurlResponse(void *ptr, size_t size, size_t nmemb, std::string stream)
         {
@@ -49,15 +67,36 @@ namespace WPEFramework
             DeviceDiagnostics::_instance = this;
 
             registerMethod(DEVICE_DIAGNOSTICS_METHOD_NAME_GET_CONFIGURATION, &DeviceDiagnostics::getConfigurationWrapper, this);
+            registerMethod(DEVICE_DIAGNOSTICS_METHOD_GET_VIDEO_DECODER_STATUS, &DeviceDiagnostics::getVideoDecoderStatus, this);
+            registerMethod(DEVICE_DIAGNOSTICS_METHOD_GET_AUDIO_DECODER_STATUS, &DeviceDiagnostics::getAudioDecoderStatus, this);
         }
 
         DeviceDiagnostics::~DeviceDiagnostics()
         {
         }
 
+        /* virtual */ const string DeviceDiagnostics::Initialize(PluginHost::IShell* service)
+        {
+            if (Utils::IARM::init())
+            {
+                IARM_Result_t res;
+                IARM_CHECK(IARM_Bus_RegisterEventHandler(IARM_BUS_PLAYBACK_DIAG_BUS_NAME,
+                            IARM_BUS_PLAYBACK_DIAG_STATUS_CHANGE_EVENT,
+                            DeviceDiagnostics::decoderStatusHandler));
+            }
+        }
+
         void DeviceDiagnostics::Deinitialize(PluginHost::IShell* /* service */)
         {
             DeviceDiagnostics::_instance = nullptr;
+
+            if (Utils::IARM::isConnected())
+            {
+                IARM_Result_t res;
+                IARM_CHECK(IARM_Bus_UnRegisterEventHandler(IARM_BUS_PLAYBACK_DIAG_BUS_NAME,
+                            IARM_BUS_PLAYBACK_DIAG_STATUS_CHANGE_EVENT));
+            }
+
         }
 
         uint32_t DeviceDiagnostics::getConfigurationWrapper(const JsonObject& parameters, JsonObject& response)
@@ -93,6 +132,145 @@ namespace WPEFramework
                 returnResponse(true);
 
             returnResponse(false);
+        }
+        /* Searches m_{video,audio}DecoderStatus for most active decoder.
+         * Most active status is "Active" followed by "Paused" and then
+         * "Idle". Key of decoder, that status was returned for, is stored
+         * in m_mast{Video,Audio}DecoderStatus.
+         *
+         * decoderName can be "video" or "audio"
+         *
+         * When there are no decoders in map, IDLE state will be returned.
+         */
+        std::string DeviceDiagnostics::getMostActiveDecoderStatus(const std::string &decoderName)
+        {
+            std::unordered_map<std::string, DecoderStatusInfo> *decoderStatus;
+            std::string *lastDecoder;
+            DecoderStatus mostActiveStatus = DECODER_STATUS_IDLE;
+
+            if (decoderName == "video") {
+                decoderStatus = &m_videoDecoderStatus;
+                lastDecoder = &m_lastVideoDecoder;
+            } else {
+                decoderStatus = &m_audioDecoderStatus;
+                lastDecoder = &m_lastAudioDecoder;
+            }
+
+            for (auto const &status: *decoderStatus) {
+                if (status.second.status <= mostActiveStatus) {
+                    mostActiveStatus = status.second.status;
+                    *lastDecoder = status.first;
+                }
+            }
+
+            return decoderStatusStr[mostActiveStatus];
+        }
+
+        /* Called each time IARM event with decoder status is received from
+         * gstreamer.
+         *
+         * This function will create new, update or delete entry in
+         * m_{video,audio}DecoderStatus, depending on received state
+         * of decoder. If we update decoder that was most recently
+         * read by user via "getDecoderStatus" api, event is emitted
+         * to notify user about decoder status change.
+         */
+        void DeviceDiagnostics::decoderStatusHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
+        {
+            typedef struct _IARM_BUS_Diag_EventData_t {
+                char pipeline_id[64];
+                char pipeline_name[64];
+                char decoder[16];
+                char status[16];
+                char action[16];
+            } IARM_Bus_Diag_EventData_t;
+
+            IARM_Bus_Diag_EventData_t *eventData = (IARM_Bus_Diag_EventData_t *)data;
+            struct DecoderStatusInfo decoderInfo;
+            std::string *lastDecoder;
+            std::unordered_map<std::string, DecoderStatusInfo> *decoderStatus;
+
+            DeviceDiagnostics* t = DeviceDiagnostics::_instance;
+            if (t == nullptr)
+                return;
+
+            if (strcmp(eventData->decoder, "video") == 0) {
+                decoderStatus = &t->m_videoDecoderStatus;
+                lastDecoder = &t->m_lastVideoDecoder;
+            } else if (strcmp(eventData->decoder, "audio") == 0) {
+                decoderStatus = &t->m_audioDecoderStatus;
+                lastDecoder = &t->m_lastAudioDecoder;
+            } else {
+                LOGERR("invalid decoder '%s' received on IARM, ignoring event",
+                        eventData->decoder);
+                return;
+            }
+
+            if (strcmp(eventData->action, "DELETE") == 0)
+            {
+                /* remove this decoder from map */
+                decoderStatus->erase(std::string(eventData->pipeline_id));
+                return;
+            }
+
+            if (strcmp(eventData->action, "UPDATE") == 0) {
+                if (decoderStatus->find(eventData->pipeline_id) == decoderStatus->end()) {
+                    /* trying to update nonexisting pipeline,
+                     * according to RDK-31097 that's an error
+                     */
+                    LOGERR("decoder id '%s' does not exist and action is UPDATE; "
+                            "decoder status ignored", eventData->pipeline_id);
+                    return;
+                }
+            }
+
+            decoderInfo.pipeName = eventData->pipeline_name;
+
+            if (strcmp(eventData->status, "IDLE") == 0)
+                decoderInfo.status = DECODER_STATUS_IDLE;
+            else if (strcmp(eventData->status, "PAUSED") == 0)
+                decoderInfo.status = DECODER_STATUS_PAUSED;
+            else if (strcmp(eventData->status, "ACTIVE") == 0)
+                decoderInfo.status = DECODER_STATUS_ACTIVE;
+            else
+            {
+                LOGERR("invalid decoder status '%s' for pipeline '%s'",
+                        eventData->status, eventData->pipeline_name);
+                return;
+            }
+
+            (*decoderStatus)[std::string(eventData->pipeline_id)] = decoderInfo;
+
+            /* this pipeline has been most recently read, send event
+             * to inform caller status has changed */
+            if (strcmp(eventData->pipeline_id, lastDecoder->c_str()) == 0)
+                t->onDecoderStatusChange(eventData->decoder, eventData->status);
+        }
+
+        void DeviceDiagnostics::onDecoderStatusChange(const std::string &decoder, const std::string &status)
+        {
+            JsonObject params;
+            if (decoder == "video") {
+                params["videoDecoderStatus"] = status;
+                sendNotify(EVT_ON_VIDEO_DECODER_STATUS_CHANGED, params);
+            } else {
+                params["audioDecoderStatus"] = status;
+                sendNotify(EVT_ON_AUDIO_DECODER_STATUS_CHANGED, params);
+            }
+        }
+
+        uint32_t DeviceDiagnostics::getVideoDecoderStatus(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            response["video"] = getMostActiveDecoderStatus("video");
+            returnResponse(true);
+        }
+
+        uint32_t DeviceDiagnostics::getAudioDecoderStatus(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            response["audio"] = getMostActiveDecoderStatus("audio");
+            returnResponse(true);
         }
 
         int DeviceDiagnostics::getConfiguration(const std::string& postData, JsonObject& out)

--- a/DeviceDiagnostics/DeviceDiagnostics.h
+++ b/DeviceDiagnostics/DeviceDiagnostics.h
@@ -52,11 +52,35 @@ namespace WPEFramework {
             //End methods
 
             int getConfiguration(const std::string& postData, JsonObject& response);
+            uint32_t getVideoDecoderStatus(const JsonObject& parameters, JsonObject& response);
+            uint32_t getAudioDecoderStatus(const JsonObject& parameters, JsonObject& response);
+            static void decoderStatusHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
+            std::string getMostActiveDecoderStatus(const std::string &decoderName);
+            void onDecoderStatusChange(const std::string &decoder, const std::string &status);
+
+        private:
+            enum DecoderStatus {
+                DECODER_STATUS_ACTIVE = 0,
+                DECODER_STATUS_PAUSED,
+                DECODER_STATUS_IDLE,
+                DECODER_STATUS_MAX
+            };
+
+            struct DecoderStatusInfo
+            {
+                std::string pipeName;
+                DecoderStatus status;
+            };
+            std::unordered_map<std::string, DecoderStatusInfo> m_videoDecoderStatus;
+            std::unordered_map<std::string, DecoderStatusInfo> m_audioDecoderStatus;
+            std::string m_lastVideoDecoder;
+            std::string m_lastAudioDecoder;
 
         public:
             DeviceDiagnostics();
             virtual ~DeviceDiagnostics();
             virtual void Deinitialize(PluginHost::IShell* service) override;
+            virtual const string Initialize(PluginHost::IShell* service) override;
 
         public:
             static DeviceDiagnostics* _instance;


### PR DESCRIPTION
Adds new API according to specification in RDK-31097

Signed-off-by: Michał Łyszczek <michal.lyszczek@bofc.pl>