### PR TITLE
RDKCI-678 DeviceDiagnostics: fix function no returning value

### DIFF
--- a/DeviceDiagnostics/DeviceDiagnostics.cpp
+++ b/DeviceDiagnostics/DeviceDiagnostics.cpp
@@ -84,6 +84,8 @@ namespace WPEFramework
                             IARM_BUS_PLAYBACK_DIAG_STATUS_CHANGE_EVENT,
                             DeviceDiagnostics::decoderStatusHandler));
             }
+
+            return "";
         }
 
         void DeviceDiagnostics::Deinitialize(PluginHost::IShell* /* service */)


### PR DESCRIPTION
DeviceDiagnostics::Initialize is supposed to return std::string,
but it does not invoke return; statement at all.

Signed-off-by: Michał Łyszczek <michal.lyszczek@bofc.pl>