### PR TITLE
DELIA-50464:Script not populating last fw details

### DIFF
--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -152,7 +152,7 @@ namespace WPEFramework {
 
         string task_names_foreground[]={
             "/lib/rdk/RFCbase.sh",
-            "/lib/rdk/deviceInitiatedFWDnld.sh 0 1 >> /opt/logs/swupdate.log",
+            "/lib/rdk/swupdate_utility.sh >> /opt/logs/swupdate.log",
             "/lib/rdk/Start_uploadSTBLogs.sh"
         };
 
@@ -228,7 +228,7 @@ namespace WPEFramework {
                 LOGINFO("AutoReboot is not present \n");
             }
 
-           LOGINFO("Rebooting the device !!");
+           LOGINFO("Requesting SystemReboot !!");
 
             system(rebootCommand.c_str());
 


### PR DESCRIPTION
Reason for change:Initially we were calling the deviceInitiatedFWDnld.sh
for image upgrade maintenance.On bootup, there are few fields esp. last fw image
details that are populated as a part of swupdate_utility.sh. This was missing.
So we use the same logic to call the swupdate_utility.sh
directly from the plugin.
Test Procedure : Refer Ticket.
Risk: High