### PR TITLE
XRE-17445: Dial param missing in app launch

### DIFF
--- a/XCast/RtXcastConnector.cpp
+++ b/XCast/RtXcastConnector.cpp
@@ -74,8 +74,6 @@ rtError RtXcastConnector::onApplicationLaunchRequestCallback(int numArgs, const 
         RtNotifier * observer = static_cast<RtNotifier *> (context);
         rtObjectRef appObject = args[0].toObject();
         rtString appName = appObject.get<rtString>("applicationName");
-        if (!strcmp(appName.cString(),"Netflix"))
-            appName = "NetflixApp";
         rtString rtparamIsUrl = appObject.get<rtString>("isUrl");
         if (0 == strcmp(rtparamIsUrl.cString(), "false")) {
 
@@ -89,6 +87,8 @@ rtError RtXcastConnector::onApplicationLaunchRequestCallback(int numArgs, const 
                                          rtAddDataUrl.cString());
         }
         else {
+            if (!strcmp(appName.cString(),"Netflix"))
+                appName = "NetflixApp";
             rtString rtparams = appObject.get<rtString>("parameters");
             observer->onXcastApplicationLaunchRequest(appName.cString() , rtparams.cString());
         }

--- a/XCast/XCast.cpp
+++ b/XCast/XCast.cpp
@@ -519,11 +519,15 @@ void XCast::onXcastApplicationLaunchRequestWithLaunchParam (string appName,
                                strAddDataUrl.c_str(), url);
         }
 
+
         string strUrl = std::string (url);
-        if (appName == "NetflixApp")
+        if (appName == "Netflix") {
+            appName.assign("NetflixApp");
             urlParam["pluginUrl"]=strUrl;
-        else
+        }
+        else {
             urlParam["url"]=strUrl;
+        }
 
         params["applicationName"]= appName;
         params["parameters"]= urlParam;


### PR DESCRIPTION
Reason for change:
Dial param missing in app launch
Test Procedure: None
Risks: Low

Change-Id: I7703c00c614ea4f8087ba87ea9b9dc11cc569650
Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>