### PR TITLE
RDK-31414 Display Settings Thunder events and methods

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -153,10 +153,6 @@ namespace WPEFramework {
             registerMethod("getSupportedAudioModes", &DisplaySettings::getSupportedAudioModes, this);
             registerMethod("getZoomSetting", &DisplaySettings::getZoomSetting, this);
             registerMethod("setZoomSetting", &DisplaySettings::setZoomSetting, this);
-            registerMethod("setfrmmode", &DisplaySettings::setfrmmode, this);
-            registerMethod("getfrmmode", &DisplaySettings::getfrmmode, this);
-            registerMethod("getDisplayframerate", &DisplaySettings::getDisplayframerate, this);
-            registerMethod("setDisplayframerate", &DisplaySettings::setDisplayframerate, this);
 	    registerMethod("getCurrentResolution", &DisplaySettings::getCurrentResolution, this);
             registerMethod("setCurrentResolution", &DisplaySettings::setCurrentResolution, this);
             registerMethod("getSoundMode", &DisplaySettings::getSoundMode, this);
@@ -934,96 +930,6 @@ namespace WPEFramework {
             returnResponse(success);
         }
 	
-	uint32_t DisplaySettings::setfrmmode(const JsonObject& parameters, JsonObject& response)
-        {   
-            LOGINFOMETHOD();
-            returnIfParamNotFound(parameters, "frmmode");
-
-            string sPortId = parameters["frmmode"].String();
-            int frfmode = 0;
-            try {
-                frfmode = stoi(sPortId);
-            }catch (const device::Exception& err) {
-                LOG_DEVICE_EXCEPTION1(sPortId);
-                returnResponse(false);
-            }
-
-            bool success = true;
-            try
-            {
-                device::VideoDevice &device = device::Host::getInstance().getVideoDevices().at(0);
-                device.setFRFMode(frfmode);
-            }
-            catch (const device::Exception& err)
-            {
-                LOG_DEVICE_EXCEPTION1(sPortId);
-                success = false;
-            }
-            returnResponse(success);
-        }
-	
-	uint32_t DisplaySettings::getfrmmode(const JsonObject& parameters, JsonObject& response)
-        {   
-            LOGINFOMETHOD();
-
-            int frmmode = dsHDRSTANDARD_NONE;
-            bool success = true;
-            try
-            {
-                    device::VideoDevice &device = device::Host::getInstance().getVideoDevices().at(0);
-                    device.getFRFMode(&frmmode);
-            }
-            catch(const device::Exception& err)
-            {
-                    LOG_DEVICE_EXCEPTION0();
-		    success = false;
-            }
-
-            response["auto-frm-mode"] = frmmode;
-            returnResponse(success);
-        }
-	
-	uint32_t DisplaySettings::setDisplayframerate(const JsonObject& parameters, JsonObject& response)
-        {   
-            LOGINFOMETHOD();
-            returnIfParamNotFound(parameters, "framerate");
-
-            string sFramerate = parameters["framerate"].String();
-
-            bool success = true;
-            try
-            {
-                device::VideoDevice &device = device::Host::getInstance().getVideoDevices().at(0);
-                device.setDisplayframerate(sFramerate.c_str());
-            }
-            catch (const device::Exception& err)
-            {
-                LOG_DEVICE_EXCEPTION1(sFramerate);
-                success = false;
-            }
-            returnResponse(success);
-        }
-
-	uint32_t DisplaySettings::getDisplayframerate(const JsonObject& parameters, JsonObject& response)
-        {   
-            LOGINFOMETHOD();
-            char sFramerate[20] ={0};
-            bool success = true;
-            try
-            {
-                device::VideoDevice &device = device::Host::getInstance().getVideoDevices().at(0);
-                device.getCurrentDisframerate(sFramerate);
-            }
-            catch (const device::Exception& err)
-            {
-               LOG_DEVICE_EXCEPTION1(std::string(sFramerate));
-                success = false;
-            }
-
-            response["framerate"] = std::string(sFramerate);
-            returnResponse(success);
-        }
-
         uint32_t DisplaySettings::getCurrentResolution(const JsonObject& parameters, JsonObject& response)
         {   //sample servicemanager response:{"success":true,"resolution":"720p"}
             LOGINFOMETHOD();

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -153,7 +153,11 @@ namespace WPEFramework {
             registerMethod("getSupportedAudioModes", &DisplaySettings::getSupportedAudioModes, this);
             registerMethod("getZoomSetting", &DisplaySettings::getZoomSetting, this);
             registerMethod("setZoomSetting", &DisplaySettings::setZoomSetting, this);
-            registerMethod("getCurrentResolution", &DisplaySettings::getCurrentResolution, this);
+            registerMethod("setfrmmode", &DisplaySettings::setfrmmode, this);
+            registerMethod("getfrmmode", &DisplaySettings::getfrmmode, this);
+            registerMethod("getDisplayframerate", &DisplaySettings::getDisplayframerate, this);
+            registerMethod("setDisplayframerate", &DisplaySettings::setDisplayframerate, this);
+	    registerMethod("getCurrentResolution", &DisplaySettings::getCurrentResolution, this);
             registerMethod("setCurrentResolution", &DisplaySettings::setCurrentResolution, this);
             registerMethod("getSoundMode", &DisplaySettings::getSoundMode, this);
             registerMethod("setSoundMode", &DisplaySettings::setSoundMode, this);
@@ -927,6 +931,96 @@ namespace WPEFramework {
                 LOG_DEVICE_EXCEPTION1(zoomSetting);
                 success = false;
             }
+            returnResponse(success);
+        }
+	
+	uint32_t DisplaySettings::setfrmmode(const JsonObject& parameters, JsonObject& response)
+        {   
+            LOGINFOMETHOD();
+            returnIfParamNotFound(parameters, "frmmode");
+
+            string sPortId = parameters["frmmode"].String();
+            int frfmode = 0;
+            try {
+                frfmode = stoi(sPortId);
+            }catch (const device::Exception& err) {
+                LOG_DEVICE_EXCEPTION1(sPortId);
+                returnResponse(false);
+            }
+
+            bool success = true;
+            try
+            {
+                device::VideoDevice &device = device::Host::getInstance().getVideoDevices().at(0);
+                device.setFRFMode(frfmode);
+            }
+            catch (const device::Exception& err)
+            {
+                LOG_DEVICE_EXCEPTION1(sPortId);
+                success = false;
+            }
+            returnResponse(success);
+        }
+	
+	uint32_t DisplaySettings::getfrmmode(const JsonObject& parameters, JsonObject& response)
+        {   
+            LOGINFOMETHOD();
+
+            int frmmode = dsHDRSTANDARD_NONE;
+            bool success = true;
+            try
+            {
+                    device::VideoDevice &device = device::Host::getInstance().getVideoDevices().at(0);
+                    device.getFRFMode(&frmmode);
+            }
+            catch(const device::Exception& err)
+            {
+                    LOG_DEVICE_EXCEPTION0();
+		    success = false;
+            }
+
+            response["auto-frm-mode"] = frmmode;
+            returnResponse(success);
+        }
+	
+	uint32_t DisplaySettings::setDisplayframerate(const JsonObject& parameters, JsonObject& response)
+        {   
+            LOGINFOMETHOD();
+            returnIfParamNotFound(parameters, "framerate");
+
+            string sFramerate = parameters["framerate"].String();
+
+            bool success = true;
+            try
+            {
+                device::VideoDevice &device = device::Host::getInstance().getVideoDevices().at(0);
+                device.setDisplayframerate(sFramerate.c_str());
+            }
+            catch (const device::Exception& err)
+            {
+                LOG_DEVICE_EXCEPTION1(sFramerate);
+                success = false;
+            }
+            returnResponse(success);
+        }
+
+	uint32_t DisplaySettings::getDisplayframerate(const JsonObject& parameters, JsonObject& response)
+        {   
+            LOGINFOMETHOD();
+            char sFramerate[20] ={0};
+            bool success = true;
+            try
+            {
+                device::VideoDevice &device = device::Host::getInstance().getVideoDevices().at(0);
+                device.getCurrentDisframerate(sFramerate);
+            }
+            catch (const device::Exception& err)
+            {
+               LOG_DEVICE_EXCEPTION1(std::string(sFramerate));
+                success = false;
+            }
+
+            response["framerate"] = std::string(sFramerate);
             returnResponse(success);
         }
 

--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -29,6 +29,7 @@
 #include "irMgr.h"
 #include "pwrMgr.h"
 
+
 namespace WPEFramework {
 
     namespace Plugin {
@@ -67,10 +68,6 @@ namespace WPEFramework {
             uint32_t getSupportedAudioModes(const JsonObject& parameters, JsonObject& response);
             uint32_t getZoomSetting(const JsonObject& parameters, JsonObject& response);
             uint32_t setZoomSetting(const JsonObject& parameters, JsonObject& response);
-            uint32_t setfrmmode(const JsonObject& parameters, JsonObject& response);
-            uint32_t getfrmmode(const JsonObject& parameters, JsonObject& response);
-            uint32_t getDisplayframerate(const JsonObject& parameters, JsonObject& response);
-            uint32_t setDisplayframerate(const JsonObject& parameters, JsonObject& response);
 	    uint32_t getCurrentResolution(const JsonObject& parameters, JsonObject& response);
             uint32_t setCurrentResolution(const JsonObject& parameters, JsonObject& response);
             uint32_t getSoundMode(const JsonObject& parameters, JsonObject& response);

--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -67,7 +67,11 @@ namespace WPEFramework {
             uint32_t getSupportedAudioModes(const JsonObject& parameters, JsonObject& response);
             uint32_t getZoomSetting(const JsonObject& parameters, JsonObject& response);
             uint32_t setZoomSetting(const JsonObject& parameters, JsonObject& response);
-            uint32_t getCurrentResolution(const JsonObject& parameters, JsonObject& response);
+            uint32_t setfrmmode(const JsonObject& parameters, JsonObject& response);
+            uint32_t getfrmmode(const JsonObject& parameters, JsonObject& response);
+            uint32_t getDisplayframerate(const JsonObject& parameters, JsonObject& response);
+            uint32_t setDisplayframerate(const JsonObject& parameters, JsonObject& response);
+	    uint32_t getCurrentResolution(const JsonObject& parameters, JsonObject& response);
             uint32_t setCurrentResolution(const JsonObject& parameters, JsonObject& response);
             uint32_t getSoundMode(const JsonObject& parameters, JsonObject& response);
             uint32_t setSoundMode(const JsonObject& parameters, JsonObject& response);

--- a/FrameRate/CMakeLists.txt
+++ b/FrameRate/CMakeLists.txt
@@ -29,9 +29,16 @@ set_target_properties(${MODULE_NAME} PROPERTIES
         CXX_STANDARD 11
         CXX_STANDARD_REQUIRED YES)
 
+find_package(DS)
+find_package(IARMBus)
+
+add_definitions(-DDS_FOUND)
+
+target_include_directories(${MODULE_NAME} PRIVATE ${DS_INCLUDE_DIRS})
+target_include_directories(${MODULE_NAME} PRIVATE ${IARMBUS_INCLUDE_DIRS})
 target_include_directories(${MODULE_NAME} PRIVATE ../helpers)
 
-target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins)
+target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins ${NAMESPACE}SecurityUtil ${IARMBUS_LIBRARIES} ${DS_LIBRARIES} "-ltr181api")
 
 install(TARGETS ${MODULE_NAME}
         DESTINATION lib/${STORAGE_DIRECTORY}/plugins)

--- a/FrameRate/FrameRate.cpp
+++ b/FrameRate/FrameRate.cpp
@@ -28,10 +28,10 @@
 #define METHOD_START_FPS_COLLECTION "startFpsCollection"
 #define METHOD_STOP_FPS_COLLECTION "stopFpsCollection"
 #define METHOD_UPDATE_FPS_COLLECTION "updateFps"
-#define METHOD_SET_FRAME_MODE "setfrmmode"
-#define METHOD_GET_FRAME_MODE "getfrmmode"
-#define METHOD_GET_DISPLAY_FRAME_RATE "getDisplayframerate"
-#define METHOD_SET_DISPLAY_FRAME_RATE "setDisplayframerate"
+#define METHOD_SET_FRAME_MODE "setFrmMode"
+#define METHOD_GET_FRAME_MODE "getFrmMode"
+#define METHOD_GET_DISPLAY_FRAME_RATE "getDisplayFrameRate"
+#define METHOD_SET_DISPLAY_FRAME_RATE "setDisplayFrameRate"
 
 // Events
 #define EVENT_FPS_UPDATE "onFpsEvent"
@@ -63,10 +63,10 @@ namespace WPEFramework
             Register(METHOD_START_FPS_COLLECTION, &FrameRate::startFpsCollectionWrapper, this);
             Register(METHOD_STOP_FPS_COLLECTION, &FrameRate::stopFpsCollectionWrapper, this);
             Register(METHOD_UPDATE_FPS_COLLECTION, &FrameRate::updateFpsWrapper, this);
-            registerMethod(METHOD_SET_FRAME_MODE, &FrameRate::setfrmmode, this, {2});
-            registerMethod(METHOD_GET_FRAME_MODE, &FrameRate::getfrmmode, this, {2});
-            registerMethod(METHOD_GET_DISPLAY_FRAME_RATE, &FrameRate::getDisplayframerate, this, {2});
-            registerMethod(METHOD_SET_DISPLAY_FRAME_RATE, &FrameRate::setDisplayframerate, this, {2});
+            registerMethod(METHOD_SET_FRAME_MODE, &FrameRate::setFrmMode, this, {2});
+            registerMethod(METHOD_GET_FRAME_MODE, &FrameRate::getFrmMode, this, {2});
+            registerMethod(METHOD_GET_DISPLAY_FRAME_RATE, &FrameRate::getDisplayFrameRate, this, {2});
+            registerMethod(METHOD_SET_DISPLAY_FRAME_RATE, &FrameRate::setDisplayFrameRate, this, {2});
 
             m_reportFpsTimer.connect( std::bind( &FrameRate::onReportFpsTimer, this ) );
         }
@@ -130,7 +130,7 @@ namespace WPEFramework
             returnResponse(true);
         }
         
-        uint32_t FrameRate::setfrmmode(const JsonObject& parameters, JsonObject& response)
+        uint32_t FrameRate::setFrmMode(const JsonObject& parameters, JsonObject& response)
         {
             std::lock_guard<std::mutex> guard(m_callMutex);
 
@@ -160,7 +160,7 @@ namespace WPEFramework
             returnResponse(success);
         }
 
-        uint32_t FrameRate::getfrmmode(const JsonObject& parameters, JsonObject& response)
+        uint32_t FrameRate::getFrmMode(const JsonObject& parameters, JsonObject& response)
         {
             std::lock_guard<std::mutex> guard(m_callMutex);
 
@@ -183,7 +183,7 @@ namespace WPEFramework
             returnResponse(success);
         }
 
-        uint32_t FrameRate::setDisplayframerate(const JsonObject& parameters, JsonObject& response)
+        uint32_t FrameRate::setDisplayFrameRate(const JsonObject& parameters, JsonObject& response)
         {
             std::lock_guard<std::mutex> guard(m_callMutex);
 
@@ -206,7 +206,7 @@ namespace WPEFramework
             returnResponse(success);
         }
 
-        uint32_t FrameRate::getDisplayframerate(const JsonObject& parameters, JsonObject& response)
+        uint32_t FrameRate::getDisplayFrameRate(const JsonObject& parameters, JsonObject& response)
         {
             std::lock_guard<std::mutex> guard(m_callMutex);
 

--- a/FrameRate/FrameRate.cpp
+++ b/FrameRate/FrameRate.cpp
@@ -26,6 +26,10 @@
 #define METHOD_START_FPS_COLLECTION "startFpsCollection"
 #define METHOD_STOP_FPS_COLLECTION "stopFpsCollection"
 #define METHOD_UPDATE_FPS_COLLECTION "updateFps"
+#define METHOD_SET_FRAME_MODE "setfrmmode"
+#define METHOD_GET_FRAME_MODE "getfrmmode"
+#define METHOD_GET_DISPLAY_FRAME_RATE "getDisplayframerate"
+#define METHOD_SET_DISPLAY_FRAME_RATE "setDisplayframerate"
 
 // Events
 #define EVENT_FPS_UPDATE "onFpsEvent"
@@ -36,6 +40,8 @@
 #define DEFAULT_MIN_FPS_VALUE 60
 #define DEFAULT_MAX_FPS_VALUE -1
 
+const short WPEFramework::Plugin::FrameRate::API_VERSION_NUMBER_MAJOR = 2;
+
 namespace WPEFramework
 {
     namespace Plugin
@@ -45,7 +51,7 @@ namespace WPEFramework
         FrameRate* FrameRate::_instance = nullptr;
 
         FrameRate::FrameRate()
-        : AbstractPlugin()
+        : AbstractPlugin(FrameRate::API_VERSION_NUMBER_MAJOR)
           , m_fpsCollectionFrequencyInMs(DEFAULT_FPS_COLLECTION_TIME_IN_MILLISECONDS)
           , m_minFpsValue(DEFAULT_MIN_FPS_VALUE), m_maxFpsValue(DEFAULT_MAX_FPS_VALUE)
           , m_totalFpsValues(0), m_numberOfFpsUpdates(0), m_fpsCollectionInProgress(false), m_lastFpsValue(-1)
@@ -56,7 +62,11 @@ namespace WPEFramework
             Register(METHOD_START_FPS_COLLECTION, &FrameRate::startFpsCollectionWrapper, this);
             Register(METHOD_STOP_FPS_COLLECTION, &FrameRate::stopFpsCollectionWrapper, this);
             Register(METHOD_UPDATE_FPS_COLLECTION, &FrameRate::updateFpsWrapper, this);
-            
+            Register(METHOD_SET_FRAME_MODE, &FrameRate::setfrmmode, this);
+            Register(METHOD_GET_FRAME_MODE, &FrameRate::getfrmmode, this);
+            Register(METHOD_GET_DISPLAY_FRAME_RATE, &FrameRate::getDisplayframerate, this, {2});
+            Register(METHOD_SET_DISPLAY_FRAME_RATE, &FrameRate::setDisplayframerate, this, {2});
+
             m_reportFpsTimer.connect( std::bind( &FrameRate::onReportFpsTimer, this ) );
         }
 
@@ -119,11 +129,110 @@ namespace WPEFramework
             returnResponse(true);
         }
         
+        uint32_t FrameRate::setfrmmode(const JsonObject& parameters, JsonObject& response)
+        {
+            std::lock_guard<std::mutex> guard(m_callMutex);
+
+            LOGINFOMETHOD();
+            returnIfParamNotFound(parameters, "frmmode");
+
+            string sPortId = parameters["frmmode"].String();
+            int frfmode = 0;
+            try {
+                frfmode = stoi(sPortId);
+            }catch (const device::Exception& err) {
+                LOG_DEVICE_EXCEPTION1(sPortId);
+                returnResponse(false);
+            }
+
+            bool success = true;
+            try
+            {
+                device::VideoDevice &device = device::Host::getInstance().getVideoDevices().at(0);
+                device.setFRFMode(frfmode);
+            }
+            catch (const device::Exception& err)
+            {
+                LOG_DEVICE_EXCEPTION1(sPortId);
+                success = false;
+            }
+            returnResponse(success);
+        }
+
+        uint32_t FrameRate::getfrmmode(const JsonObject& parameters, JsonObject& response)
+        {
+            std::lock_guard<std::mutex> guard(m_callMutex);
+
+            LOGINFOMETHOD();
+
+            int frmmode = dsHDRSTANDARD_NONE;
+            bool success = true;
+            try
+            {
+                device::VideoDevice &device = device::Host::getInstance().getVideoDevices().at(0);
+                device.getFRFMode(&frmmode);
+            }
+            catch(const device::Exception& err)
+            {
+                LOG_DEVICE_EXCEPTION0();
+                success = false;
+            }
+
+            response["auto-frm-mode"] = frmmode;
+            returnResponse(success);
+        }
+
+        uint32_t FrameRate::setDisplayframerate(const JsonObject& parameters, JsonObject& response)
+        {
+            std::lock_guard<std::mutex> guard(m_callMutex);
+
+            LOGINFOMETHOD();
+            returnIfParamNotFound(parameters, "framerate");
+
+            string sFramerate = parameters["framerate"].String();
+
+            bool success = true;
+            try
+            {
+                device::VideoDevice &device = device::Host::getInstance().getVideoDevices().at(0);
+                device.setDisplayframerate(sFramerate.c_str());
+            }
+            catch (const device::Exception& err)
+            {
+                LOG_DEVICE_EXCEPTION1(sFramerate);
+                success = false;
+            }
+            returnResponse(success);
+        }
+
+        uint32_t FrameRate::getDisplayframerate(const JsonObject& parameters, JsonObject& response)
+        {
+            std::lock_guard<std::mutex> guard(m_callMutex);
+
+            LOGINFOMETHOD();
+            char sFramerate[20] ={0};
+            bool success = true;
+            try
+            {
+                device::VideoDevice &device = device::Host::getInstance().getVideoDevices().at(0);
+                device.getCurrentDisframerate(sFramerate);
+            }
+            catch (const device::Exception& err)
+            {
+                LOG_DEVICE_EXCEPTION1(std::string(sFramerate));
+                success = false;
+            }
+
+            response["framerate"] = std::string(sFramerate);
+            returnResponse(success);
+        }
+
+
         /**
-        * @brief This function is used to get the amount of collection interval per milliseconds.
-        *
-        * @return Integer value of Amount of milliseconds per collection interval .
-        */
+         * @brief This function is used to get the amount of collection interval per milliseconds.
+         *
+         * @return Integer value of Amount of milliseconds per collection interval .
+         */
         int FrameRate::getCollectionFrequency()
         {
             return m_fpsCollectionFrequencyInMs;

--- a/FrameRate/FrameRate.cpp
+++ b/FrameRate/FrameRate.cpp
@@ -18,8 +18,10 @@
 **/
 
 #include "FrameRate.h"
-
+#include "host.hpp"
+#include "exception.hpp"
 #include "utils.h"
+#include "dsError.h"
 
 // Methods
 #define METHOD_SET_COLLECTION_FREQUENCY "setCollectionFrequency"
@@ -40,7 +42,6 @@
 #define DEFAULT_MIN_FPS_VALUE 60
 #define DEFAULT_MAX_FPS_VALUE -1
 
-const short WPEFramework::Plugin::FrameRate::API_VERSION_NUMBER_MAJOR = 2;
 
 namespace WPEFramework
 {
@@ -51,7 +52,7 @@ namespace WPEFramework
         FrameRate* FrameRate::_instance = nullptr;
 
         FrameRate::FrameRate()
-        : AbstractPlugin(FrameRate::API_VERSION_NUMBER_MAJOR)
+        : AbstractPlugin(2)
           , m_fpsCollectionFrequencyInMs(DEFAULT_FPS_COLLECTION_TIME_IN_MILLISECONDS)
           , m_minFpsValue(DEFAULT_MIN_FPS_VALUE), m_maxFpsValue(DEFAULT_MAX_FPS_VALUE)
           , m_totalFpsValues(0), m_numberOfFpsUpdates(0), m_fpsCollectionInProgress(false), m_lastFpsValue(-1)
@@ -62,10 +63,10 @@ namespace WPEFramework
             Register(METHOD_START_FPS_COLLECTION, &FrameRate::startFpsCollectionWrapper, this);
             Register(METHOD_STOP_FPS_COLLECTION, &FrameRate::stopFpsCollectionWrapper, this);
             Register(METHOD_UPDATE_FPS_COLLECTION, &FrameRate::updateFpsWrapper, this);
-            Register(METHOD_SET_FRAME_MODE, &FrameRate::setfrmmode, this);
-            Register(METHOD_GET_FRAME_MODE, &FrameRate::getfrmmode, this);
-            Register(METHOD_GET_DISPLAY_FRAME_RATE, &FrameRate::getDisplayframerate, this, {2});
-            Register(METHOD_SET_DISPLAY_FRAME_RATE, &FrameRate::setDisplayframerate, this, {2});
+            registerMethod(METHOD_SET_FRAME_MODE, &FrameRate::setfrmmode, this, {2});
+            registerMethod(METHOD_GET_FRAME_MODE, &FrameRate::getfrmmode, this, {2});
+            registerMethod(METHOD_GET_DISPLAY_FRAME_RATE, &FrameRate::getDisplayframerate, this, {2});
+            registerMethod(METHOD_SET_DISPLAY_FRAME_RATE, &FrameRate::setDisplayframerate, this, {2});
 
             m_reportFpsTimer.connect( std::bind( &FrameRate::onReportFpsTimer, this ) );
         }

--- a/FrameRate/FrameRate.h
+++ b/FrameRate/FrameRate.h
@@ -55,7 +55,11 @@ namespace WPEFramework {
             uint32_t startFpsCollectionWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t stopFpsCollectionWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t updateFpsWrapper(const JsonObject& parameters, JsonObject& response);
-            //End methods
+            uint32_t setfrmmode(const JsonObject& parameters, JsonObject& response);
+	    uint32_t getfrmmode(const JsonObject& parameters, JsonObject& response);
+	    uint32_t getDisplayframerate(const JsonObject& parameters, JsonObject& response);
+	    uint32_t setDisplayframerate(const JsonObject& parameters, JsonObject& response);
+	    //End methods
             
             int getCollectionFrequency();
             void setCollectionFrequency(int frequencyInMs);

--- a/FrameRate/FrameRate.h
+++ b/FrameRate/FrameRate.h
@@ -55,10 +55,10 @@ namespace WPEFramework {
             uint32_t startFpsCollectionWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t stopFpsCollectionWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t updateFpsWrapper(const JsonObject& parameters, JsonObject& response);
-            uint32_t setfrmmode(const JsonObject& parameters, JsonObject& response);
-	    uint32_t getfrmmode(const JsonObject& parameters, JsonObject& response);
-	    uint32_t getDisplayframerate(const JsonObject& parameters, JsonObject& response);
-	    uint32_t setDisplayframerate(const JsonObject& parameters, JsonObject& response);
+            uint32_t setFrmMode(const JsonObject& parameters, JsonObject& response);
+	    uint32_t getFrmMode(const JsonObject& parameters, JsonObject& response);
+	    uint32_t getDisplayFrameRate(const JsonObject& parameters, JsonObject& response);
+	    uint32_t setDisplayFrameRate(const JsonObject& parameters, JsonObject& response);
 	    //End methods
             
             int getCollectionFrequency();


### PR DESCRIPTION
**RDK-31414** **Display Settings Thunder events and methods**
Reason for change: Display Settings Thunder  methods for framerate get and set
Test Procedure: Build and Verify.
Risks: Low
Signed-off-by: Ranjithkumar <ranjith.kumar@sky.uk>