### PR TITLE
DELIA-50523: DIAL retry logic after every 60 sec

### DIFF
--- a/XCast/XCast.cpp
+++ b/XCast/XCast.cpp
@@ -386,7 +386,6 @@ void XCast::onLocateCastTimer()
         {
             LOGINFO("Retry after 60 sec...");
             m_locateCastTimer.setInterval(LOCATE_CAST_FINAL_TIMEOUT_IN_MILLIS);
-            m_locateCastTimer.stop();
         }
         return ;
     }// err != RT_OK


### PR DESCRIPTION
Reason for change:
DIAL retry logic after every 60 sec
Test Procedure: None
Risks: Low

Change-Id: I7b59fce381768b86efb46a104100091699ed303b
Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>