### PR TITLE
AMLOGIC-1457: Remove Unnecessary videoPort from llama

### DIFF
--- a/DisplayInfo/DeviceSettings/PlatformImplementation.cpp
+++ b/DisplayInfo/DeviceSettings/PlatformImplementation.cpp
@@ -174,7 +174,8 @@ public:
         return (Core::ERROR_NONE);
         try
         {
-            device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort("HDMI0");
+            std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+            device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str());
             device::AudioStereoMode mode = vPort.getAudioOutputPort().getStereoMode(true);
             if (mode == device::AudioStereoMode::kPassThru)
                 value = true;
@@ -190,7 +191,8 @@ public:
     {
         try
         {
-            device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort("HDMI0");
+            std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+            device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str());
             connected = vPort.isDisplayConnected();
         }
         catch (const device::Exception& err)
@@ -284,7 +286,8 @@ public:
     {
         try
         {
-            ::device::VideoOutputPort vPort = ::device::Host::getInstance().getVideoOutputPort("HDMI0");
+            std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+            ::device::VideoOutputPort vPort = ::device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str());
             if (vPort.isDisplayConnected())
             {
                 std::vector<uint8_t> edidVec;
@@ -313,7 +316,8 @@ public:
     {
         try
         {
-            ::device::VideoOutputPort vPort = ::device::Host::getInstance().getVideoOutputPort("HDMI0");
+            std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+            ::device::VideoOutputPort vPort = ::device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str());
             if (vPort.isDisplayConnected())
             {
                 std::vector<uint8_t> edidVec;
@@ -344,7 +348,8 @@ public:
         try
         {
             vector<uint8_t> edidVec2;
-            device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort("HDMI0");
+            std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+            device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str());
             if (vPort.isDisplayConnected())
             {
                 vPort.getDisplay().getEDIDBytes(edidVec2);
@@ -415,7 +420,8 @@ public:
         int capabilities = static_cast<int>(dsHDRSTANDARD_NONE);
         try
         {
-            device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort("HDMI0");
+            std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+            device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str());
             if (vPort.isDisplayConnected()) {
                 vPort.getTVHDRCapabilities(&capabilities);
             }
@@ -475,7 +481,8 @@ public:
         bool isHdr = false;
         try
         {
-            device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort("HDMI0");
+            std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+            device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str());
             if (vPort.isDisplayConnected()) {
                 isHdr = vPort.IsOutputHDR();
             }
@@ -508,7 +515,8 @@ private:
         uint32_t ret =  (Core::ERROR_NONE);
         try
         {
-            device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort("HDMI0");
+            std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+            device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str());
             device::VideoResolution resolution = vPort.getResolution();
             device::PixelResolution pr = resolution.getPixelResolution();
             device::FrameRate fr = resolution.getFrameRate();

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -702,7 +702,8 @@ namespace WPEFramework {
         uint32_t DisplaySettings::getSupportedResolutions(const JsonObject& parameters, JsonObject& response)
         {   //sample servicemanager response:{"success":true,"supportedResolutions":["720p","1080i","1080p60"]}
             LOGINFOMETHOD();
-            string videoDisplay = parameters.HasLabel("videoDisplay") ? parameters["videoDisplay"].String() : "HDMI0";
+            std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+            string videoDisplay = parameters.HasLabel("videoDisplay") ? parameters["videoDisplay"].String() : strVideoPort;
             vector<string> supportedResolutions;
             try
             {
@@ -747,7 +748,8 @@ namespace WPEFramework {
         uint32_t DisplaySettings::getSupportedTvResolutions(const JsonObject& parameters, JsonObject& response)
         {   //sample servicemanager response:{"success":true,"supportedTvResolutions":["480i","480p","576i","720p","1080i","1080p"]}
             LOGINFOMETHOD();
-            string videoDisplay = parameters.HasLabel("videoDisplay") ? parameters["videoDisplay"].String() : "HDMI0";
+            std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+            string videoDisplay = parameters.HasLabel("videoDisplay") ? parameters["videoDisplay"].String() : strVideoPort;
             vector<string> supportedTvResolutions;
             try
             {
@@ -849,7 +851,8 @@ namespace WPEFramework {
 
                 if (Utils::String::stringContains(audioPort, "HDMI0"))
                 {
-                    device::VideoOutputPort vPort = device::VideoOutputPortConfig::getInstance().getPort("HDMI0");
+                    std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+                    device::VideoOutputPort vPort = device::VideoOutputPortConfig::getInstance().getPort(strVideoPort.c_str());
                     int surroundMode = vPort.getDisplay().getSurroundMode();
                     if (vPort.isDisplayConnected() && surroundMode)
                     {
@@ -933,7 +936,8 @@ namespace WPEFramework {
         uint32_t DisplaySettings::getCurrentResolution(const JsonObject& parameters, JsonObject& response)
         {   //sample servicemanager response:{"success":true,"resolution":"720p"}
             LOGINFOMETHOD();
-            string videoDisplay = parameters.HasLabel("videoDisplay") ? parameters["videoDisplay"].String() : "HDMI0";
+            std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+            string videoDisplay = parameters.HasLabel("videoDisplay") ? parameters["videoDisplay"].String() : strVideoPort;
             bool success = true;
             try
             {
@@ -992,7 +996,8 @@ namespace WPEFramework {
                 /* Check if HDMI is connected - Return (default) Stereo Mode if not connected */
                 if (audioPort.empty())
                 {
-                    if (device::Host::getInstance().getVideoOutputPort("HDMI0").isDisplayConnected())
+                    std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+                    if (device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str()).isDisplayConnected())
                     {
                         audioPort = "HDMI0";
                     }
@@ -1028,7 +1033,8 @@ namespace WPEFramework {
                         if (aPort.getStereoAuto() || mode == device::AudioStereoMode::kSurround)
                         {
                             LOGINFO("HDMI0 is in Auto Mode");
-                            int surroundMode = device::Host::getInstance().getVideoOutputPort("HDMI0").getDisplay().getSurroundMode();
+                            std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+                            int surroundMode = device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str()).getDisplay().getSurroundMode();
                             if ( surroundMode & dsSURROUNDMODE_DDPLUS)
                             {
                                 LOGINFO("HDMI0 has surround DDPlus");
@@ -1158,7 +1164,8 @@ namespace WPEFramework {
                             aPort.setStereoAuto(stereoAuto, persist);
                             if (stereoAuto)
                             {
-                                if (device::Host::getInstance().getVideoOutputPort("HDMI0").getDisplay().getSurroundMode())
+                                std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+                                if (device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str()).getDisplay().getSurroundMode())
                                     mode = device::AudioStereoMode::kSurround;
                                 else
                                     mode = device::AudioStereoMode::kStereo;
@@ -1247,7 +1254,8 @@ namespace WPEFramework {
             try
             {
                 vector<uint8_t> edidVec2;
-                device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort("HDMI0");
+                std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+                device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str());
                 if (vPort.isDisplayConnected())
                 {
                     vPort.getDisplay().getEDIDBytes(edidVec2);
@@ -1325,7 +1333,8 @@ namespace WPEFramework {
         {   //sample servicemanager response:
             LOGINFOMETHOD();
 
-            string videoDisplay = parameters.HasLabel("videoDisplay") ? parameters["videoDisplay"].String() : "HDMI0";
+            std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+            string videoDisplay = parameters.HasLabel("videoDisplay") ? parameters["videoDisplay"].String() : strVideoPort;
             bool active = true;
             try
             {
@@ -1349,7 +1358,8 @@ namespace WPEFramework {
 
             try
             {
-                device::VideoOutputPort vPort = device::VideoOutputPortConfig::getInstance().getPort("HDMI0");
+                std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+                device::VideoOutputPort vPort = device::VideoOutputPortConfig::getInstance().getPort(strVideoPort.c_str());
                 if (vPort.isDisplayConnected())
                     vPort.getTVHDRCapabilities(&capabilities);
             }
@@ -1545,7 +1555,8 @@ namespace WPEFramework {
             bool success = true;
             try
             {
-                device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort("HDMI0");
+                std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+                device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str());
                 if (vPort.isDisplayConnected())
                 {
                     int videoEOTF, matrixCoefficients, colorSpace, colorDepth, quantizationRange;
@@ -2617,7 +2628,8 @@ namespace WPEFramework {
                 /* Check if HDMI is connected - Return (default) Stereo Mode if not connected */
                 if (audioPort.empty())
                 {
-                    if (device::Host::getInstance().getVideoOutputPort("HDMI0").isDisplayConnected())
+                    std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+                    if (device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str()).isDisplayConnected())
                     {
                         audioPort = "HDMI0";
                     }
@@ -2681,7 +2693,8 @@ namespace WPEFramework {
                 /* Check if HDMI is connected - Return (default) Stereo Mode if not connected */
                 if (audioPort.empty())
                 {
-                    if (device::Host::getInstance().getVideoOutputPort("HDMI0").isDisplayConnected())
+                    std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+                    if (device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str()).isDisplayConnected())
                         audioPort = "HDMI0";
                     else
                     {
@@ -2731,7 +2744,8 @@ namespace WPEFramework {
                 /* Check if HDMI is connected - Return (default) Stereo Mode if not connected */
                 if (audioPort.empty())
                 {
-                    if (device::Host::getInstance().getVideoOutputPort("HDMI0").isDisplayConnected())
+                    std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+                    if (device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str()).isDisplayConnected())
                     {
                         audioPort = "HDMI0";
                     }
@@ -2798,7 +2812,8 @@ namespace WPEFramework {
                 /* Check if HDMI is connected - Return (default) Stereo Mode if not connected */
                 if (audioPort.empty())
                 {
-                    if (device::Host::getInstance().getVideoOutputPort("HDMI0").isDisplayConnected())
+                    std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+                    if (device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str()).isDisplayConnected())
                     {
                         audioPort = "HDMI0";
                     }
@@ -3389,7 +3404,8 @@ namespace WPEFramework {
 			int capabilities = dsHDRSTANDARD_NONE;
             try
             {
-                device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort("HDMI0");
+                std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+                device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str());
                 if (vPort.isDisplayConnected()) {
                     vPort.getTVHDRCapabilities(&capabilities);
                     response["capabilities"] = capabilities;
@@ -3413,7 +3429,8 @@ namespace WPEFramework {
 			bool success = true;
             try
             {
-                device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort("HDMI0");
+                std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+                device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str());
                 if (vPort.isDisplayConnected()) {
                     response["defaultResolution"] = vPort.getDefaultResolution().getName();
                 }

--- a/HdcpProfile/HdcpProfile.cpp
+++ b/HdcpProfile/HdcpProfile.cpp
@@ -25,6 +25,7 @@
 #include "videoOutputPortConfig.hpp"
 #include "dsMgr.h"
 #include "manager.hpp"
+#include "host.hpp"
 
 #include "utils.h"
 
@@ -105,7 +106,8 @@ namespace WPEFramework
 
             try
             {
-            device::VideoOutputPort vPort = device::VideoOutputPortConfig::getInstance().getPort("HDMI0");
+                std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+                device::VideoOutputPort vPort = device::VideoOutputPortConfig::getInstance().getPort(strVideoPort.c_str());
                 hdcpProtocol = (dsHdcpProtocolVersion_t)vPort.getHDCPProtocol();
             }
             catch (const std::exception e)
@@ -143,7 +145,8 @@ namespace WPEFramework
 
             try
             {
-                device::VideoOutputPort vPort = device::VideoOutputPortConfig::getInstance().getPort("HDMI0");
+                std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+                device::VideoOutputPort vPort = device::VideoOutputPortConfig::getInstance().getPort(strVideoPort.c_str());
                 isConnected        = vPort.isDisplayConnected();
                 hdcpProtocol       = (dsHdcpProtocolVersion_t)vPort.getHDCPProtocol();
                 eHDCPEnabledStatus = vPort.getHDCPStatus();

--- a/HdmiCec_2/HdmiCec_2.cpp
+++ b/HdmiCec_2/HdmiCec_2.cpp
@@ -351,7 +351,8 @@ namespace WPEFramework
            {
                //TODO(MROLLINS) this is probably per process so we either need to be running in our own process or be carefull no other plugin is calling it
                device::Manager::Initialize();
-               device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort("HDMI0");
+               std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+               device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str());
                if (vPort.isDisplayConnected())
                {
                    vector<uint8_t> edidVec;
@@ -545,7 +546,8 @@ namespace WPEFramework
                 getLogicalAddress();
                 try
                 {
-                   device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort("HDMI0");
+                   std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+                   device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str());
                    if (vPort.isDisplayConnected())
                    {
                      vector<uint8_t> edidVec;

--- a/PlayerInfo/DeviceSettings/PlatformImplementation.cpp
+++ b/PlayerInfo/DeviceSettings/PlatformImplementation.cpp
@@ -153,7 +153,8 @@ public:
         string currentResolution = "0";
         try
         {
-            device::VideoOutputPort &vPort = device::Host::getInstance().getVideoOutputPort("HDMI0");
+            std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+            device::VideoOutputPort &vPort = device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str());
             currentResolution = vPort.getResolution().getName();
             TRACE(Trace::Information, (_T("Current video playback resolution = %s"), currentResolution));
         }


### PR DESCRIPTION
Reason for change:
Remove Unnecessary videoPort from llama
Test Procedure: None
Risks: Low

Change-Id: Id2b0dded0c5b0fd1d5da513b761b6cbf8d32412f
Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>