### PR TITLE
RDK-31097 DeviceDiagnostics: fix multiple issues after testing

### DIFF
--- a/DeviceDiagnostics/DeviceDiagnostics.h
+++ b/DeviceDiagnostics/DeviceDiagnostics.h
@@ -42,6 +42,20 @@ namespace WPEFramework {
 		// will receive a JSONRPC message as a notification, in case this method is called.
         class DeviceDiagnostics : public AbstractPlugin {
         private:
+            enum DecoderStatus {
+                DECODER_STATUS_ACTIVE = 0,
+                DECODER_STATUS_PAUSED,
+                DECODER_STATUS_IDLE,
+                DECODER_STATUS_MAX
+            };
+
+            struct DecoderStatusInfo
+            {
+                std::string pipeName;
+                DecoderStatus status;
+            };
+
+        private:
 
             // We do not allow this plugin to be copied !!
             DeviceDiagnostics(const DeviceDiagnostics&) = delete;
@@ -55,26 +69,12 @@ namespace WPEFramework {
             uint32_t getVideoDecoderStatus(const JsonObject& parameters, JsonObject& response);
             uint32_t getAudioDecoderStatus(const JsonObject& parameters, JsonObject& response);
             static void decoderStatusHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
-            std::string getMostActiveDecoderStatus(const std::string &decoderName);
+            DecoderStatus getMostActiveDecoderStatus(const std::string &decoderName);
             void onDecoderStatusChange(const std::string &decoder, const std::string &status);
 
         private:
-            enum DecoderStatus {
-                DECODER_STATUS_ACTIVE = 0,
-                DECODER_STATUS_PAUSED,
-                DECODER_STATUS_IDLE,
-                DECODER_STATUS_MAX
-            };
-
-            struct DecoderStatusInfo
-            {
-                std::string pipeName;
-                DecoderStatus status;
-            };
             std::unordered_map<std::string, DecoderStatusInfo> m_videoDecoderStatus;
             std::unordered_map<std::string, DecoderStatusInfo> m_audioDecoderStatus;
-            std::string m_lastVideoDecoder;
-            std::string m_lastAudioDecoder;
 
         public:
             DeviceDiagnostics();


### PR DESCRIPTION
- change event response from video to videoDecoderStatusChange,
    same for audio
- send event on every decoder status upate, not only for decoders
    most recently read via getAudioDecoderStatus
- add some info logs, decoder updates from gstreamer are not too
    frequent, so this will not pollute logs too much.

Signed-off-by: Michał Łyszczek <michal.lyszczek@consult.red>