### PR TITLE
RDKTV-6041 : fix DisplaySettings

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -222,6 +222,8 @@ namespace WPEFramework {
         DisplaySettings::~DisplaySettings()
         {
             //LOGINFO("dtor");
+
+            lock_guard<mutex> lck(m_callMutex);
         }
 
         void DisplaySettings::InitAudioPorts() 


### PR DESCRIPTION
Reason for change: Stop timer defore destructed.
Test Procedure: See no crash on restart or reboot.
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>