### PR TITLE
RDK-29959:New Plugin MaintenanceManager.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,10 @@ if(PLUGIN_SYSTEMSERVICES)
     add_subdirectory(SystemServices)
 endif()
 
+if(PLUGIN_MAINTENANCEMANAGER)
+    add_subdirectory(MaintenanceManager)
+endif()
+
 if(PLUGIN_HOMENETWORKING)
     add_subdirectory(HomeNetworking)
 endif()

--- a/MaintenanceManager/CMakeLists.txt
+++ b/MaintenanceManager/CMakeLists.txt
@@ -1,0 +1,55 @@
+# If not stated otherwise in this file or this component's license file the
+# following copyright and licenses apply:
+#
+# Copyright 2021 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set(PLUGIN_NAME MaintenanceManager)
+set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
+
+find_package(${NAMESPACE}Plugins REQUIRED)
+
+add_library(${MODULE_NAME} SHARED
+        MaintenanceManager.cpp
+        Module.cpp
+        ../helpers/cTimer.cpp
+        ../helpers/cSettings.cpp
+        ../helpers/powerstate.cpp
+        ../helpers/SystemServicesHelper.cpp
+        ../helpers/utils.cpp)
+
+set_target_properties(${MODULE_NAME} PROPERTIES
+        CXX_STANDARD 11
+        CXX_STANDARD_REQUIRED YES)
+
+list(APPEND CMAKE_MODULE_PATH
+        "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")
+
+find_package(IARMBus)
+if (IARMBus_FOUND)
+    target_include_directories(${MODULE_NAME} PRIVATE ${IARMBUS_INCLUDE_DIRS})
+    target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins ${IARMBUS_LIBRARIES})
+else (IARMBus_FOUND)
+    message ("Module IARMBus required.")
+    target_include_directories(${MODULE_NAME} PRIVATE ${IARMBUS_INCLUDE_DIRS})
+    target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins ${IARMBUS_LIBRARIES})
+endif(IARMBus_FOUND)
+
+target_include_directories(${MODULE_NAME} PRIVATE ../helpers)
+target_include_directories(${MODULE_NAME} PRIVATE ./)
+
+install(TARGETS ${MODULE_NAME}
+        DESTINATION lib/${STORAGE_DIRECTORY}/plugins)
+
+write_config(${PLUGIN_NAME})

--- a/MaintenanceManager/MaintenanceManager.config
+++ b/MaintenanceManager/MaintenanceManager.config
@@ -1,0 +1,3 @@
+set (autostart true)
+set (preconditions Platform)
+set (callsign "org.rdk.MaintenanceManager")

--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -1,0 +1,737 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2021 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+/**
+ * @file  MaintenanceManager.cpp
+ * @author Livin Sunny
+ * @brief Thunder Plugin based Implementation for RDK MaintenanceManager service API's.
+ * @reference RDK-29959.
+ */
+#include <stdlib.h>
+#include <errno.h>
+#include <cstdio>
+#include <regex>
+#include <fstream>
+#include <string>
+#include <vector>
+#include <map>
+#include <sstream>
+#include <ctime>
+#include <iomanip>
+#include <bits/stdc++.h>
+#include <algorithm>
+
+#include "MaintenanceManager.h"
+#include "utils.h"
+
+#if defined(USE_IARMBUS) || defined(USE_IARM_BUS)
+#include "libIARM.h"
+
+#endif /* USE_IARMBUS || USE_IARM_BUS */
+
+#if defined(HAS_API_SYSTEM) && defined(HAS_API_POWERSTATE)
+#include "powerstate.h"
+#endif /* HAS_API_SYSTEM && HAS_API_POWERSTATE */
+
+#ifdef ENABLE_DEVICE_MANUFACTURER_INFO
+#include "mfrMgr.h"
+#endif
+
+#ifdef ENABLE_DEEP_SLEEP
+#include "deepSleepMgr.h"
+#endif
+
+#include "maintenanceMGR.h"
+
+using namespace std;
+
+#define API_VERSION_NUMBER_MAJOR 1
+#define API_VERSION_NUMBER_MINOR 0
+
+string notifyStatusToString(Maint_notify_status_t &status)
+{
+    string ret_status="";
+    switch(status){
+        case MAINTENANCE_IDLE:
+            ret_status="MAINTENANCE_IDLE";
+            break;
+        case MAINTENANCE_STARTED:
+            ret_status="MAINTENANCE_STARTED";
+            break;
+        case MAINTENANCE_ERROR:
+            ret_status="MAINTENANCE_ERROR";
+            break;
+        case MAINTENANCE_COMPLETE:
+            ret_status="MAINTENANCE_COMPLETE";
+            break;
+        case MAINTENANCE_INCOMPLETE:
+            ret_status="MAINTENANCE_INCOMPLETE";
+            break;
+        default:
+            ret_status="MAINTENANCE_ERROR";
+    }
+    return ret_status;
+}
+
+string moduleStatusToString(IARM_Maint_module_status_t &status)
+{
+    string ret_status="";
+    switch(status){
+        case MAINT_DCM_COMPLETE:
+            ret_status="MAINTENANCE_DCM_COMPLETE";
+            break;
+        case MAINT_DCM_ERROR:
+            ret_status="MAINTENANCE_DCM_ERROR";
+            break;
+        case MAINT_RFC_COMPLETE:
+            ret_status="MAINTENANCE_RFC_COMPLETE";
+            break;
+        case MAINT_RFC_ERROR:
+            ret_status="MAINTENANCE_RFC_ERROR";
+            break;
+        case MAINT_LOGUPLOAD_COMPLETE:
+            ret_status="MAINTENANCE_LOGUPLOAD_COMPLETE";
+            break;
+        case MAINT_LOGUPLOAD_ERROR:
+            ret_status="MAINTENANCE_LOGUPLOAD_ERROR";
+            break;
+        case MAINT_PINGTELEMETRY_COMPLETE:
+            ret_status="MAINTENANCE_PINGTELEMETRY_COMPLETE";
+            break;
+        case MAINT_PINGTELEMETRY_ERROR:
+            ret_status="MAINTENANCE_PINGTELEMETRY_ERROR";
+            break;
+        case MAINT_FWDOWNLOAD_COMPLETE:
+            ret_status="MAINTENANCE_FWDONLOAD_COMPLETE";
+            break;
+        case MAINT_FWDOWNLOAD_ERROR:
+            ret_status="MAINTENANCE_FWDONLOAD_ERROR";
+            break;
+        case MAINT_REBOOT_REQUIRED:
+            ret_status="MAINTENANCE_REBOOT_REQUIRED";
+            break;
+        case MAINT_FWDOWNLOAD_ABORTED:
+            ret_status="MAINTENANCE_FWDOWNLOAD_ABORTED";
+            break;
+        case MAINT_CRITICAL_UPDATE:
+            ret_status="MAINTENANCE_CRITICAL_UPDATE";
+            break;
+        default:
+            ret_status="MAINTENANCE_EMPTY";
+    }
+    return ret_status;
+}
+/**
+ * @brief WPEFramework class for Maintenance Manager
+ */
+namespace WPEFramework {
+    namespace Plugin {
+        //Prototypes
+        SERVICE_REGISTRATION(MaintenanceManager,API_VERSION_NUMBER_MAJOR,API_VERSION_NUMBER_MINOR);
+        /* Global time variable */
+        MaintenanceManager* MaintenanceManager::_instance = nullptr;
+
+        cSettings MaintenanceManager::m_setting(MAINTENANCE_MGR_RECORD_FILE);
+        //TODO  this need to moved to a seperate class and vector based.
+
+        string task_names_foreground[]={
+            "/lib/rdk/RFCbase.sh",
+            "/lib/rdk/swupdate_utility.sh >> /opt/logs/swupdate.log",
+            "/lib/rdk/Start_uploadSTBLogs.sh"
+        };
+
+        /**
+         * Register MaintenanceManager module as wpeframework plugin
+         */
+        MaintenanceManager::MaintenanceManager()
+            :AbstractPlugin()
+        {
+            MaintenanceManager::_instance = this;
+
+            /**
+             * @brief Invoking Plugin API register to WPEFRAMEWORK.
+             */
+#ifdef DEBUG
+            registerMethod("sampleMaintenanceManagerAPI", &MaintenanceManager::sampleAPI, this);
+#endif /* DEBUG */
+            registerMethod("getMaintenanceActivityStatus", &MaintenanceManager::getMaintenanceActivityStatus,this);
+            registerMethod("getMaintenanceStartTime", &MaintenanceManager::getMaintenanceStartTime,this);
+            registerMethod("setMaintenanceMode", &MaintenanceManager::setMaintenanceMode,this);
+            registerMethod("startMaintenance", &MaintenanceManager::startMaintenance,this);
+        }
+
+
+        string MaintenanceManager::getLastRebootReason(){
+
+            char rebootInfo[1024] = {'\0'};
+            bool retAPIStatus = false;
+            string reboot_reason="";
+            string reason="";
+
+            if (Utils::fileExists(SYSTEM_SERVICE_PREVIOUS_REBOOT_INFO_FILE)) {
+                retAPIStatus = getFileContentToCharBuffer(SYSTEM_SERVICE_PREVIOUS_REBOOT_INFO_FILE, rebootInfo );
+            }
+
+            if (retAPIStatus && strlen(rebootInfo)) {
+                string dataBuf(rebootInfo);
+                JsonObject rebootInfoJson;
+                rebootInfoJson.FromString(rebootInfo);
+                reason = rebootInfoJson["reason"].String();
+            }
+
+            reboot_reason = reason;
+            return reboot_reason;
+        }
+
+        bool MaintenanceManager::checkAutoRebootFlag(){
+            LOGINFO("DBG Check AutoReboot Flag");
+            bool ret=false;
+            const string autoreboot_parameter="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.AutoReboot.Enable";
+            const string baseCommand = "tr181Set -g ";
+            const string redirection = " 2>&1";
+            string cmdResponse="";
+            string cmdParams = "";
+            cmdParams = baseCommand + autoreboot_parameter + redirection + "\0";
+            LOGINFO("executing %s\n", cmdParams.c_str());
+            cmdResponse = Utils::cRunScript(cmdParams.c_str());
+            LOGINFO("TR181 response is %s",cmdResponse.c_str());
+            if(!(cmdResponse.empty() && !cmdResponse.compare("true"))){
+                    ret=true;
+            }
+            return ret;
+        }
+
+        void MaintenanceManager::requestSystemReboot(){
+            bool result = false;
+
+            string rebootCommand="";
+
+            if (Utils::fileExists("/lib/rdk/AutoReboot.sh")) {
+                rebootCommand = "/lib/rdk/AutoReboot.sh &";
+            } else {
+                LOGINFO("AutoReboot is not present \n");
+            }
+
+           LOGINFO("Requesting SystemReboot !!");
+
+            system(rebootCommand.c_str());
+
+        }
+        void MaintenanceManager::task_execution_thread(){
+            LOGINFO("INSIDE thread task execution");
+            int task_count=3;
+            int i=0;
+
+            /* Check if the last reboot was MAITENANCE REBOOT */
+            string reboot_reason=getLastRebootReason();
+            if (!reboot_reason.compare("MAINTENANCE_REBOOT")){
+                g_is_reboot_pending="false";
+            }
+
+            LOGINFO("Reboot_Pending :%s",g_is_reboot_pending.c_str());
+
+            string cmd="";
+
+            MaintenanceManager::_instance->onMaintenanceStatusChange(MAINTENANCE_STARTED);
+            /*  In an unsolicited maintenance we make sure only after
+             *  after DCM task activities are started.
+             */
+
+            /* we add the task in a loop */
+            std::unique_lock<std::mutex> lck(m_callMutex);
+            if (UNSOLICITED_MAINTENANCE == g_maintenance_type){
+                LOGINFO("UNSOLICITED_MAINTENANCE");
+                for ( i=0;i< task_count ;i++ ){
+                    task_thread.wait(lck);
+                    cmd=task_names_foreground[i].c_str();
+                    cmd+=" &";
+                    cmd+="\0";
+                    system(cmd.c_str());
+                }
+                LOGINFO("Worker Thread Completed");
+            }
+            /* Here in Solicited we start with RFC so no
+             * need to wait for any DCM events */
+            else if( SOLICITED_MAINTENANCE == g_maintenance_type ){
+                    LOGINFO("SOLICITED_MAINTENANCE");
+                    cmd=task_names_foreground[0].c_str();
+                    cmd+=" &";
+                    cmd+="\0";
+                    system(cmd.c_str());
+                    cmd="";
+                    for (i=1;i<task_count;i++){
+                        task_thread.wait(lck);
+                        cmd=task_names_foreground[i].c_str();
+                        cmd+=" &";
+                        cmd+="\0";
+                        system(cmd.c_str());
+                    }
+            }
+        }
+
+        MaintenanceManager::~MaintenanceManager()
+        {
+            MaintenanceManager::_instance = nullptr;
+        }
+
+        const string MaintenanceManager::Initialize(PluginHost::IShell*)
+        {
+#if defined(USE_IARMBUS) || defined(USE_IARM_BUS)
+            InitializeIARM();
+#endif /* defined(USE_IARMBUS) || defined(USE_IARM_BUS) */
+            /* On Success; return empty to indicate no error text. */
+            return (string());
+        }
+
+        void MaintenanceManager::Deinitialize(PluginHost::IShell*)
+        {
+#if defined(USE_IARMBUS) || defined(USE_IARM_BUS)
+            DeinitializeIARM();
+#endif /* defined(USE_IARMBUS) || defined(USE_IARM_BUS) */
+        }
+
+#if defined(USE_IARMBUS) || defined(USE_IARM_BUS)
+        void MaintenanceManager::InitializeIARM()
+        {
+            if (Utils::IARM::init()) {
+                LOGINFO();
+                IARM_Result_t res;
+                IARM_CHECK(IARM_Bus_Connect());
+                // Register for the Maintenance Notification Events
+                IARM_CHECK(IARM_Bus_RegisterEventHandler(IARM_BUS_MAINTENANCE_MGR_NAME, IARM_BUS_MAINTENANCEMGR_EVENT_UPDATE, _MaintenanceMgrEventHandler));
+                //Register for setMaintenanceStartTime
+                IARM_CHECK(IARM_Bus_RegisterEventHandler(IARM_BUS_MAINTENANCE_MGR_NAME, IARM_BUS_DCM_NEW_START_TIME_EVENT,_MaintenanceMgrEventHandler));
+
+                maintenanceManagerOnBootup();
+            }
+        }
+
+        void MaintenanceManager::maintenanceManagerOnBootup() {
+            /* on boot up we set these things */
+            MaintenanceManager::g_currentMode = FOREGROUND_MODE;
+
+            MaintenanceManager::g_notify_status=MAINTENANCE_IDLE;
+            MaintenanceManager::g_epoch_time="";
+
+            /* to know the maintenance is solicited or unsolicited */
+            g_maintenance_type=UNSOLICITED_MAINTENANCE;
+
+            MaintenanceManager::g_is_critical_maintenance="false";
+            MaintenanceManager::g_is_reboot_pending="false";
+            MaintenanceManager::g_lastSuccessful_maint_time="";
+            MaintenanceManager::g_task_status=0;
+
+            /* we post just to tell that we are in idle at this moment */
+            MaintenanceManager::_instance->onMaintenanceStatusChange(g_notify_status);
+
+            int32_t exec_status=E_NOK;
+
+            /* we call dcmscript to get the new start time */
+            if (Utils::fileExists("/lib/rdk/StartDCM_maintaince.sh")) {
+                exec_status = system("/lib/rdk/StartDCM_maintaince.sh &");
+                if ( E_OK == exec_status ){
+                    LOGINFO("DBG:Succesfully executed StartDCM_maintaince.sh \n");
+                }
+                else {
+                    LOGINFO("DBG:Failed to execute StartDCM_maintaince.sh !! \n");
+                }
+            }
+            else {
+                LOGINFO("DBG: Unable to find StartDCM_maintaince.sh \n");
+            }
+
+            /* we moved every thing to a thread */
+            /* only when dcm is getting a DCM_SUCCESS/DCM_ERROR we say
+             * Maintenance is started until then we say MAITENANCE_IDLE */
+            m_thread = std::thread(&MaintenanceManager::task_execution_thread, _instance);
+        }
+
+        void MaintenanceManager::_MaintenanceMgrEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
+        {
+            if (MaintenanceManager::_instance){
+                LOGWARN("IARM event Received with %d !", eventId);
+                MaintenanceManager::_instance->iarmEventHandler(owner, eventId, data, len);
+            }
+            else
+                LOGWARN("WARNING - cannot handle IARM events without MaintenanceManager plugin instance!");
+        }
+
+        void MaintenanceManager::iarmEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
+        {
+            Maint_notify_status_t m_notify_status=MAINTENANCE_STARTED;
+            IARM_Bus_MaintMGR_EventData_t *module_event_data=(IARM_Bus_MaintMGR_EventData_t*)data;
+            IARM_Maint_module_status_t module_status;
+            time_t successfulTime;
+            string str_successfulTime="";
+
+            LOGINFO("Event-ID = %d \n",eventId);
+            IARM_Bus_MaintMGR_EventId_t event = (IARM_Bus_MaintMGR_EventId_t)eventId;
+            LOGINFO("Maintenance Event= %d \n",event);
+
+            if (!strcmp(owner, IARM_BUS_MAINTENANCE_MGR_NAME)) {
+                if ( IARM_BUS_DCM_NEW_START_TIME_EVENT == eventId ) {
+                    /* we got a new start time from DCM script */
+                    string l_time(module_event_data->data.startTimeUpdate.start_time);
+                    LOGINFO("DCM_NEW_START_TIME_EVENT Start Time %s \n", l_time.c_str());
+                    /* Store it in a Global structure */
+                    g_epoch_time=l_time;
+                }
+                else if ( IARM_BUS_MAINTENANCEMGR_EVENT_UPDATE == eventId ) {
+                    module_status = module_event_data->data.maintenance_module_status.status;
+                    LOGINFO("MaintMGR Status %d \n",module_status);
+                    string status_string=moduleStatusToString(module_status);
+                    LOGINFO("MaintMGR Status %s \n", status_string.c_str());
+                    switch (module_status) {
+                        case MAINT_RFC_COMPLETE :
+                            SET_STATUS(g_task_status,RFC_SUCCESS);
+                            SET_STATUS(g_task_status,RFC_COMPLETE);
+                            task_thread.notify_one();
+                            break;
+                        case MAINT_DCM_COMPLETE :
+                            SET_STATUS(g_task_status,DCM_SUCCESS);
+                            SET_STATUS(g_task_status,DCM_COMPLETE);
+                            task_thread.notify_one();
+                            break;
+                        case MAINT_FWDOWNLOAD_COMPLETE :
+                            SET_STATUS(g_task_status,DIFD_SUCCESS);
+                            SET_STATUS(g_task_status,DIFD_COMPLETE);
+                            task_thread.notify_one();
+                            break;
+                       case MAINT_LOGUPLOAD_COMPLETE :
+                            SET_STATUS(g_task_status,LOGUPLOAD_SUCCESS);
+                            SET_STATUS(g_task_status,LOGUPLOAD_COMPLETE);
+                            break;
+                        case MAINT_REBOOT_REQUIRED :
+                            SET_STATUS(g_task_status,REBOOT_REQUIRED);
+                            g_is_reboot_pending="true";
+                            break;
+                        case MAINT_CRITICAL_UPDATE:
+                            g_is_critical_maintenance="true";
+                            break;
+                        case MAINT_FWDOWNLOAD_ABORTED:
+                            SET_STATUS(g_task_status,TASK_SKIPPED);
+                            break;
+                        case MAINT_DCM_ERROR:
+                            SET_STATUS(g_task_status,DCM_COMPLETE);
+                            task_thread.notify_one();
+                            LOGINFO("Error encountered in one of the task \n");
+                            break;
+                        case MAINT_RFC_ERROR:
+                            SET_STATUS(g_task_status,RFC_COMPLETE);
+                            task_thread.notify_one();
+                            LOGINFO("Error encountered in one of the task \n");
+                            break;
+                        case MAINT_LOGUPLOAD_ERROR:
+                            SET_STATUS(g_task_status,LOGUPLOAD_COMPLETE);
+                            LOGINFO("Error encountered in one of the task \n");
+                            break;
+                       case MAINT_FWDOWNLOAD_ERROR:
+                            SET_STATUS(g_task_status,DIFD_COMPLETE);
+                            task_thread.notify_one();
+                            LOGINFO("Error encountered in one of the task \n");
+                            break;
+                    }
+                }
+                else{
+                    LOGINFO("Unknown Maintenance Status!!");
+                }
+
+                LOGINFO(" BITFIELD Status : %x",g_task_status);
+                /* Send the updated status only if all task completes execution
+                 * until that we say maintenance started */
+                if ( (g_task_status & TASKS_COMPLETED ) == TASKS_COMPLETED ){
+                    if ( (g_task_status & ALL_TASKS_SUCCESS) == ALL_TASKS_SUCCESS ){ // all tasks success
+                        LOGINFO("DBG:Maintenance Successfully Completed!!");
+                        m_notify_status=MAINTENANCE_COMPLETE;
+                        /*  we store the time in persistant location */
+                        successfulTime=time(nullptr);
+                        tm ltime=*localtime(&successfulTime);
+                        time_t epoch_time=mktime(&ltime);
+                        str_successfulTime=to_string(epoch_time);
+                        LOGINFO("last succesful time is :%s", str_successfulTime.c_str());
+                        /* Remove any old completion time */
+                        m_setting.remove("LastSuccessfulCompletionTime");
+                        m_setting.setValue("LastSuccessfulCompletionTime",str_successfulTime);
+
+                        MaintenanceManager::_instance->onMaintenanceStatusChange(m_notify_status);
+                        /* we go for a reboot by check if reboot required is true
+                         * & AutoReboot.Enable is true */
+                        if ( !g_is_reboot_pending.compare("true") && checkAutoRebootFlag()){
+                            /* which means reboot is required */
+                                requestSystemReboot();
+                        }
+                    }
+                    /* Check other than all success case which means we have errors */
+                    else if ((g_task_status & ALL_TASKS_SUCCESS)!= ALL_TASKS_SUCCESS) {
+                        if ((g_task_status & MAINTENANCE_TASK_SKIPPED ) == MAINTENANCE_TASK_SKIPPED ){
+                            LOGINFO("DBG:There are Skipped Task. Incomplete");
+                            m_notify_status=MAINTENANCE_INCOMPLETE;
+                            /*Check if there any chance to reboot
+                             * say we receive a reboot required from rfc */
+                        }
+                        else {
+                            LOGINFO("DBG:There are Errors");
+                            m_notify_status=MAINTENANCE_ERROR;
+                        }
+
+                        MaintenanceManager::_instance->onMaintenanceStatusChange(m_notify_status);
+                        if ( !g_is_reboot_pending.compare("true") && checkAutoRebootFlag()){
+                            /* even though we end up in skipped task /error
+                             * check if we have the reboot required is recevied */
+                            requestSystemReboot();
+
+                        }
+                    }
+
+                    if(m_thread.joinable()){
+                        m_thread.join();
+                    }
+                }
+                else {
+                    LOGINFO("Still task are not completed!!!! So status is MAINTENANCE_STARTED");
+                }
+            }
+            else {
+                LOGWARN("Ignoring unexpected event - owner: %s, eventId: %d!!", owner, eventId);
+            }
+        }
+        void MaintenanceManager::DeinitializeIARM()
+        {
+            if (Utils::IARM::isConnected()){
+                IARM_Result_t res;
+                IARM_CHECK(IARM_Bus_UnRegisterEventHandler(IARM_BUS_MAINTENANCE_MGR_NAME, IARM_BUS_MAINTENANCEMGR_EVENT_UPDATE));
+                IARM_CHECK(IARM_Bus_UnRegisterEventHandler(IARM_BUS_MAINTENANCE_MGR_NAME, IARM_BUS_DCM_NEW_START_TIME_EVENT));
+                MaintenanceManager::_instance = nullptr;
+                IARM_CHECK(IARM_Bus_Disconnect());
+                IARM_CHECK(IARM_Bus_Term());
+            }
+
+            if(m_thread.joinable()){
+                m_thread.join();
+            }
+        }
+#endif /* defined(USE_IARMBUS) || defined(USE_IARM_BUS) */
+
+#ifdef DEBUG
+        /**
+         * @brief : sampleAPI
+         */
+        uint32_t MaintenanceManager::sampleAPI(const JsonObject& parameters,
+                JsonObject& response)
+        {
+            response["sampleAPI"] = "Success";
+            /* Kept for debug purpose/future reference. */
+            sendNotify(EVT_ONMAINTMGRSAMPLEEVENT, parameters);
+            returnResponse(true);
+        }
+#endif /* DEBUG */
+
+        /*
+         * @brief This function returns the status of the current
+         * or previous maintenance activity.
+         * @param1[in]: {"jsonrpc":"2.0","id":"3","method":"org.rdk.MaintenanceManager.2.GetMaintenanceActivityStatus",
+         *                  "params":{}}''
+         * @param2[out]: {"jsonrpc":"2.0","id":3,"result":{"status":MAINTENANCE_IDLE,"LastSuccessfulCompletionTime":
+                              -1,"isCriticalMaintenance":true,"isRebootPending":true,}}
+         * @return: Core::<StatusCode>
+         */
+
+        uint32_t MaintenanceManager::getMaintenanceActivityStatus(const JsonObject& parameters,
+                JsonObject& response)
+                {
+                    bool result = false;
+                    string isCriticalMaintenance = "false";
+                    string isRebootPending = "false";
+                    string LastSuccessfulCompletionTime = "NA"; /* TODO : check max size to hold this */
+                    string getMaintenanceStatusString = "\0";
+
+                    std::lock_guard<std::mutex> guard(m_callMutex);
+
+                    /* Check if we have a critical maintenance */
+                    if (!g_is_critical_maintenance.empty()){
+                        isCriticalMaintenance=g_is_critical_maintenance;
+                    }
+
+                    if (!g_is_reboot_pending.empty()){
+                        isRebootPending=g_is_reboot_pending;
+                    }
+
+                    /* Get the last SuccessfulCompletion time from Persistant location */
+                    if (m_setting.contains("LastSuccessfulCompletionTime")){
+                        LastSuccessfulCompletionTime=m_setting.getValue("LastSuccessfulCompletionTime").String();
+                    }
+
+                    response["maintenanceStatus"] = notifyStatusToString(g_notify_status);
+                    response["LastSuccessfulCompletionTime"] = LastSuccessfulCompletionTime;
+                    response["isCriticalMaintenance"] = isCriticalMaintenance;
+                    response["isRebootPending"] = isRebootPending;
+                    result = true;
+
+                    returnResponse(result);
+                }
+        /*
+         * @brief This function returns the start time of the maintenance activity.
+         * @param1[in]: {"jsonrpc":"2.0","id":"3","method":"org.rdk.MaintenanceManager.2.GetMaintenanceStartTime","params":{}}''
+         * @param2[out]: {"jsonrpc":"2.0","id":3,"result":{"time":03:45","success":true}}
+         * @return: Core::<StatusCode>
+         */
+        uint32_t MaintenanceManager::getMaintenanceStartTime (const JsonObject& parameters,
+                JsonObject& response)
+        {
+            bool result = false;
+            string starttime="";
+            unsigned long int start_time=0;
+            if(!g_epoch_time.empty()) {
+
+                response["maintenanceStartTime"] = stoi(g_epoch_time.c_str());
+                result=true;
+            }
+            else {
+                string starttime = Utils::cRunScript("/lib/rdk/getMaintenanceStartTime.sh &");
+                if (!starttime.empty()){
+                    response["maintenanceStartTime"]=stoi(starttime.c_str());
+                    result=true;
+                }
+            }
+
+            returnResponse(result);
+        }
+
+        /*
+         * @brief This function returns the current status of the current
+         * or previous maintenance activity.
+         * @param1[in]: {"jsonrpc":"2.0","id":"3","method":"org.rdk.MaintenanceManager.2.SetMaintenanceMode",
+         *                  "params":{"Mode":FOREGROUND}}''
+         * @param2[out]: {"jsonrpc":"2.0","id":3,"result":{"success":<bool>}}
+         * @return: Core::<StatusCode>
+         */
+
+        uint32_t MaintenanceManager::setMaintenanceMode(const JsonObject& parameters,
+                JsonObject& response)
+        {
+            bool result = false;
+            string new_mode = "";
+            string old_mode = g_currentMode;
+            string bg_flag = "false";
+
+            /*  we set the default value to FG */
+            if ( parameters.HasLabel("maintenanceMode") ){
+                /* Get the value */
+                new_mode = parameters["maintenanceMode"].String();
+
+                LOGINFO("SetMaintenanceMode new_mode = %s\n",new_mode.c_str());
+                std::lock_guard<std::mutex> guard(m_callMutex);
+                /* check if maintenance is on progress or not */
+                /* if in progress restrict the same */
+                if ( MAINTENANCE_STARTED != g_notify_status ){
+                    if ( BACKGROUND_MODE != new_mode && FOREGROUND_MODE != new_mode )  {
+                        LOGERR("value of new mode is incorrect, therefore \
+                                current mode '%s' not changed.\n", old_mode.c_str());
+                        returnResponse(false);
+                    }
+                    if ( BACKGROUND_MODE == new_mode ) {
+                        g_currentMode = new_mode;
+                        bg_flag="true";
+                        m_setting.setValue("background_flag",bg_flag);
+                    }
+                    else {
+                        /* foreground */
+                        g_currentMode =new_mode;
+                        m_setting.remove("background_flag");
+                        bg_flag="false";
+                        m_setting.setValue("background_flag",bg_flag);
+                    }
+                    result = true;
+
+                }
+                else{
+                    LOGERR("Maintenance is in Progress, Mode change not allowed");
+                    result =false;
+                }
+            }
+            else {
+                /* havent got the correct label */
+                LOGERR("SetMaintenanceMode Missing Key Values\n");
+                populateResponseWithError(SysSrv_MissingKeyValues,response);
+            }
+
+            returnResponse(result);
+        }
+
+        /*
+         * @brief This function starts the maintenance activity.
+         * @param1[in]: {"jsonrpc":"2.0","id":"3","method":"org.rdk.MaintenanceManager.2.StartMaintenance",
+         *                  "params":{}}''
+         * @param2[out]:{"jsonrpc":"2.0","id":3,"result":{"success":<bool>}}
+         * @return: Core::<StatusCode>
+         */
+
+        uint32_t MaintenanceManager::startMaintenance(const JsonObject& parameters,
+                JsonObject& response)
+                {
+                    bool result = false;
+                    int32_t exec_status=E_NOK;
+                    Maint_notify_status_t notify_status = MAINTENANCE_IDLE;
+                    /* check what mode we currently have */
+                    string current_mode="";
+                    bool skip_task=false;
+                    string abort_flag="";
+
+                    /* only one maintenance at a time */
+                    if ( MAINTENANCE_STARTED != g_notify_status  ){
+
+                        /*reset the status to 0*/
+                        g_task_status=0;
+                        g_maintenance_type=SOLICITED_MAINTENANCE;
+
+                        /* we dont touch the dcm so
+                         * we say DCM is success and complete */
+                        SET_STATUS(g_task_status,DCM_SUCCESS);
+                        SET_STATUS(g_task_status,DCM_COMPLETE);
+
+                        /* isRebootPending will be set to true
+                         * irrespective of XConf configuration */
+                        g_is_reboot_pending="true";
+
+                        /* we set this to false */
+                        g_is_critical_maintenance="false";
+
+                        /* notify that we started the maintenance */
+                        MaintenanceManager::_instance->onMaintenanceStatusChange(MAINTENANCE_STARTED);
+
+                        m_thread = std::thread(&MaintenanceManager::task_execution_thread, _instance);
+
+                        result=true;
+                    }
+                    else {
+                        LOGINFO("Already a maintenance is in Progress. Please wait for it to complete !!");
+                    }
+                    returnResponse(result);
+                }
+
+        void MaintenanceManager::onMaintenanceStatusChange(Maint_notify_status_t status) {
+            JsonObject params;
+            /* we store the updated value as well */
+            g_notify_status=status;
+            params["maintenanceStatus"]=notifyStatusToString(status);
+            sendNotify(EVT_ONMAINTENANCSTATUSCHANGE, params);
+        }
+
+   } /* namespace Plugin */
+} /* namespace WPEFramework */

--- a/MaintenanceManager/MaintenanceManager.h
+++ b/MaintenanceManager/MaintenanceManager.h
@@ -1,0 +1,182 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2021 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+#ifndef MAINTENANCEMANAGER_H
+#define MAINTENANCEMANAGER_H
+
+#include <stdint.h>
+#include <thread>
+
+#include "Module.h"
+#include "tracing/Logging.h"
+#include "utils.h"
+#include "AbstractPlugin.h"
+#include "SystemServicesHelper.h"
+#if defined(USE_IARMBUS) || defined(USE_IARM_BUS)
+#include "libIARM.h"
+#include "libIBus.h"
+#include "irMgr.h"
+#include "libIBusDaemon.h"
+#include "pwrMgr.h"
+#include "maintenanceMGR.h" /* IARM INTERFACE HELPER */
+#endif /* USE_IARMBUS || USE_IARM_BUS */
+
+#include "sysMgr.h"
+#include "cTimer.h"
+#include "rfcapi.h"
+#include "cSettings.h"
+
+/* MaintenanceManager Services Triggered Events. */
+#define EVT_ONMAINTMGRSAMPLEEVENT           "onSampleEvent"
+#define EVT_ONMAINTENANCSTATUSCHANGE        "onMaintenanceStatusChange" /* Maintenance Status change */
+/* we have a persistant file to hold the record */
+#define MAINTENANCE_MGR_RECORD_FILE          "/opt/maintenance_mgr_record.conf"
+
+typedef enum {
+    MAINTENANCE_IDLE,
+    MAINTENANCE_STARTED,
+    MAINTENANCE_ERROR,
+    MAINTENANCE_COMPLETE,
+    MAINTENANCE_INCOMPLETE
+} Maint_notify_status_t;
+
+typedef enum{
+    SOLICITED_MAINTENANCE,
+    UNSOLICITED_MAINTENANCE
+}Maintenance_Type_t;
+
+#define FOREGROUND_MODE "FOREGROUND"
+#define BACKGROUND_MODE "BACKGROUND"
+
+#define TASKS_COMPLETED                0xAA
+#define ALL_TASKS_SUCCESS              0xFF
+#define MAINTENANCE_TASK_SKIPPED       0x200
+
+
+#define DCM_SUCCESS                     0
+#define DCM_COMPLETE                    1
+#define RFC_SUCCESS                     2
+#define RFC_COMPLETE                    3
+#define LOGUPLOAD_SUCCESS               4
+#define LOGUPLOAD_COMPLETE              5
+#define DIFD_SUCCESS                    6
+#define DIFD_COMPLETE                   7
+#define REBOOT_REQUIRED                 8
+#define TASK_SKIPPED                    9
+#define TASKS_STARTED                   10
+
+#define SET_STATUS(VALUE,N)     ((VALUE) |=  (1<<(N)))
+#define CLEAR_STATUS(VALUE,N)   ((VALUE) &= ~(1<<(N)))
+#define CHECK_STATUS(VALUE,N)   ((VALUE) & (1<<(N)))
+
+namespace WPEFramework {
+    namespace Plugin {
+
+        // This is a server for a JSONRPC communication channel.
+        // For a plugin to be capable to handle JSONRPC, inherit from PluginHost::JSONRPC.
+        // By inheriting from this class, the plugin realizes the interface PluginHost::IDispatcher.
+        // This realization of this interface implements, by default, the following methods on this plugin
+        // - exists
+        // - register
+        // - unregister
+        // Any other methood to be handled by this plugin  can be added can be added by using the
+        // templated methods Register on the PluginHost::JSONRPC class.
+        // As the registration/unregistration of notifications is realized by the class PluginHost::JSONRPC,
+        // this class exposes a public method called, Notify(), using this methods, all subscribed clients
+        // will receive a JSONRPC message as a notification, in case this method is called.
+
+        class MaintenanceManager : public AbstractPlugin {
+            private:
+                typedef Core::JSON::String JString;
+                typedef Core::JSON::ArrayType<JString> JStringArray;
+                typedef Core::JSON::Boolean JBool;
+
+                string g_currentMode;
+                string g_is_critical_maintenance;
+                string g_is_reboot_pending;
+                string g_lastSuccessful_maint_time;
+                string g_epoch_time;
+
+                IARM_Bus_MaintMGR_EventData_t *g_maintenance_data;
+
+                Maint_notify_status_t g_notify_status;
+
+                Maintenance_Type_t g_maintenance_type;
+
+                static cSettings m_setting;
+
+                uint16_t g_task_status;
+
+                std::mutex  m_callMutex;
+                std::condition_variable task_thread;
+                std::thread m_thread;
+
+                void task_execution_thread();
+                void requestSystemReboot();
+                void maintenanceManagerOnBootup();
+                bool checkAutoRebootFlag();
+                string getLastRebootReason();
+                void iarmEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
+                static void _MaintenanceMgrEventHandler(const char *owner,IARM_EventId_t eventId, void *data, size_t len);
+                // We do not allow this plugin to be copied !!
+                MaintenanceManager(const MaintenanceManager&) = delete;
+                MaintenanceManager& operator=(const MaintenanceManager&) = delete;
+
+            private:
+                class MaintenanceTask{
+                    private:
+                        std::string taskName;
+                        std::string taskScript;
+                    public:
+                        void startTask();
+                };
+            public:
+                MaintenanceManager();
+                virtual ~MaintenanceManager();
+
+                static MaintenanceManager* _instance;
+                virtual const string Initialize(PluginHost::IShell* service) override;
+                virtual void Deinitialize(PluginHost::IShell* service) override;
+                static int runScript(const std::string& script,
+                        const std::string& args, string *output = NULL,
+                        string *error = NULL, int timeout = 30000);
+
+#if defined(USE_IARMBUS) || defined(USE_IARM_BUS)
+                void InitializeIARM();
+                void DeinitializeIARM();
+#endif /* defined(USE_IARMBUS) || defined(USE_IARM_BUS) */
+
+                /* Events : Begin */
+                void onMaintenanceStatusChange(Maint_notify_status_t status);
+                /* Events : End */
+
+                /* Methods : Begin */
+#ifdef DEBUG
+                uint32_t sampleAPI(const JsonObject& parameters, JsonObject& response);
+#endif /* DEBUG */
+
+                uint32_t getMaintenanceActivityStatus(const JsonObject& parameters, JsonObject& response);
+                uint32_t getMaintenanceStartTime(const JsonObject& parameters, JsonObject& response);
+                uint32_t setMaintenanceMode(const JsonObject& parameters, JsonObject& response);
+                uint32_t startMaintenance(const JsonObject& parameters, JsonObject& response);
+        }; /* end of MaintenanceManager service class */
+    } /* end of plugin */
+} /* end of wpeframework */
+
+#endif //MAINTENANCEMANAGER_H

--- a/MaintenanceManager/Module.cpp
+++ b/MaintenanceManager/Module.cpp
@@ -1,0 +1,22 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2021 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+#include "Module.h"
+
+MODULE_NAME_DECLARATION(BUILD_REFERENCE)

--- a/MaintenanceManager/Module.h
+++ b/MaintenanceManager/Module.h
@@ -1,0 +1,29 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2021 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+#pragma once
+#ifndef MODULE_NAME
+#define MODULE_NAME MaintenanceManager
+#endif
+
+#include <plugins/plugins.h>
+#include <tracing/tracing.h>
+
+#undef EXTERNAL
+#define EXTERNAL

--- a/MaintenanceManager/README.md
+++ b/MaintenanceManager/README.md
@@ -1,0 +1,42 @@
+# MaintenanceManager
+
+## Versions
+`org.rdk.MaintenanceManager.1`
+
+## Methods:
+```
+curl --req POST --data '{"jsonrpc":"2.0","id":"3","method": "Controller.1.activate", "params": {"callsign":"org.rdk.MaintenanceManager"}}' http://127.0.0.1:9998/jsonrpc
+
+curl --header "Content-Type: application/json" --request POST --data '{"jsonrpc":"2.0","id":"3","method":"org.rdk.MaintenanceManager.1.getMaintenanceStartTime","params":{}}' http://127.0.0.1:9998/jsonrpc
+
+curl --header "Content-Type: application/json" --request POST --data '{"jsonrpc":"2.0","id":"3","method":"org.rdk.MaintenanceManager.1.setMaintenanceMode","params":{"maintenanceMode":BACKGROUND}}' http://127.0.0.1:9998/jsonrpc
+
+curl --header "Content-Type: application/json" --request POST --data '{"jsonrpc":"2.0","id":"3","method":"org.rdk.MaintenanceManager.1.getMaintenanceActivityStatus","params":{}}' http://127.0.0.1:9998/jsonrpc
+
+curl --header "Content-Type: application/json" --request POST --data '{"jsonrpc":"2.0","id":"3","method":"org.rdk.MaintenanceManager.1.startMaintenance","params":{}}' http://127.0.0.1:9998/jsonrpc
+
+```
+
+## Responses:
+```
+getMaintenanceStartTime
+{"jsonrpc":"2.0","id":3,"result":{"maintenanceStartTime":12345678,"success":true}}
+
+setMaintenanceMode
+{"jsonrpc":"2.0","id":3,"result":{"success":true}}
+
+getMaintenanceActivityStatus
+{"jsonrpc":"2.0","id":3,"result":{"maintenanceStatus":"MAINTENANCE_IDLE or MAINTENANCE_STARTED or MAINTENANCE_ERROR or MAINTENANCE_COMPLETE or MAINTENANCE_INCOMPLETE","lastSuccessfulCompletionTime": 12345678, "isCriticalMaintenanc: true/false, "isRebootPending": true/false, "success":true}}"}}
+
+startMaintenance
+{"jsonrpc":"2.0","id":3,"result":{"success":true}}
+```
+
+## Events
+```
+onMaintenanceStatusChange
+
+```
+
+## Full Reference
+https://etwiki.sys.comcast.net/display/RDKV/MaintenanceManager

--- a/MaintenanceManager/cmake/FindIARMBus.cmake
+++ b/MaintenanceManager/cmake/FindIARMBus.cmake
@@ -1,0 +1,47 @@
+# If not stated otherwise in this file or this component's license file the
+# following copyright and licenses apply:
+#
+# Copyright 2021 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# - Try to find IARMBus
+# Once done this will define
+#  IARMBUS_FOUND - System has IARMBus
+#  IARMBUS_INCLUDE_DIRS - The IARMBus include directories
+#  IARMBUS_LIBRARIES - The libraries needed to use IARMBus
+#  IARMBUS_FLAGS - The flags needed to use IARMBus
+#
+
+find_package(PkgConfig)
+
+find_library(IARMBUS_LIBRARIES NAMES IARMBus)
+find_path(IARMBUS_INCLUDE_DIRS NAMES libIARM.h PATH_SUFFIXES rdk/iarmbus)
+find_path(IARMIR_INCLUDE_DIRS NAMES irMgr.h PATH_SUFFIXES rdk/iarmmgrs/ir)
+find_path(IARMSYS_INCLUDE_DIRS NAMES sysMgr.h PATH_SUFFIXES rdk/iarmmgrs/sysmgr)
+find_path(IARMPWR_INCLUDE_DIRS NAMES pwrMgr.h PATH_SUFFIXES rdk/iarmmgrs-hal)
+
+
+set(IARMBUS_LIBRARIES ${IARMBUS_LIBRARIES} CACHE PATH "Path to IARMBus library")
+set(IARMBUS_INCLUDE_DIRS ${IARMBUS_INCLUDE_DIRS} ${IARMIR_INCLUDE_DIRS} ${IARMSYS_INCLUDE_DIRS} ${IARMPWR_INCLUDE_DIRS} )
+set(IARMBUS_INCLUDE_DIRS ${IARMBUS_INCLUDE_DIRS} ${IARMIR_INCLUDE_DIRS} ${IARMSYS_INCLUDE_DIRS} ${IARMPWR_INCLUDE_DIRS}  CACHE PATH "Path to IARMBus include")
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(IARMBUS DEFAULT_MSG IARMBUS_INCLUDE_DIRS IARMBUS_LIBRARIES)
+
+mark_as_advanced(
+    IARMBUS_FOUND
+    IARMBUS_INCLUDE_DIRS
+    IARMBUS_LIBRARIES
+    IARMBUS_LIBRARY_DIRS
+    IARMBUS_FLAGS)

--- a/MaintenanceManager/doc/MaintenanceManager.md
+++ b/MaintenanceManager/doc/MaintenanceManager.md
@@ -1,0 +1,1 @@
+[MaintenanceManager](https://wiki.rdkcentral.com/display/RDK/MaintenanceManager)


### PR DESCRIPTION
Reason for change: Added new Plugin MaintenanceManager.
Test Procedure: Refer to Jira Ticket.

(cherry picked from commit d1aab72d803945cd33ceae7132feb68fd9cb03ef)

DELIA-49986: Handle status and abort flag

Handle all the status, abort flags.Update docs.

(cherry picked from commit cf3cf33fbe89dd25861b4dc419c5ffdca5d8d7a6)

DELIA-50086: Rework on MaintenanceManager

Reason for change: Added thread and other modifications as per design.
Test Procedure: Refer Main ticket

(cherry picked from commit 253cf924db4ad92025d715ac0b925c9997ebcab5)

RDKTV-6021: MaintenanceManager Fixes

Reason for change: Autoreboot was not happening earlier during
Solicited maintenance.Maintenance activity status shows started due to
older design.start maintenance api is blocked due to waiting for DCM.
removed the same.

(cherry picked from commit 74b7b4700cf6d171cd2aaf1b35d493cf46f45646)

DELIA-50464:Script not populating last fw details

Reason for change:Initially we were calling the deviceInitiatedFWDnld.sh
for image upgrade maintenance.On bootup, there are few fields esp. last fw image
details that are populated as a part of swupdate_utility.sh. This was missing.
So we use the same logic to call the swupdate_utility.sh
directly from the plugin.
Test Procedure : Refer Ticket.
Risk: High

(cherry picked from commit dd669728906be1de4ce2a47d9b05a91a256f407c)