### PR TITLE
DELIA-50579: Dial casting failed after switching interfaces

### DIFF
--- a/XCast/XCast.cpp
+++ b/XCast/XCast.cpp
@@ -85,7 +85,6 @@ XCast::XCast() : AbstractPlugin()
         registerMethod(METHOD_SET_FRIENDLYNAME, &XCast::setFriendlyName, this);
         
         m_locateCastTimer.connect( bind( &XCast::onLocateCastTimer, this ));
-        m_locateCastTimer.setSingleShot(true);
     }
 }
 
@@ -321,22 +320,22 @@ void XCast::onLocateCastTimer()
         if(locateCastObjectRetryCount == 1)
         {
             LOGINFO("Retry after 5 sec...");
-            m_locateCastTimer.start(LOCATE_CAST_FIRST_TIMEOUT_IN_MILLIS);
+            m_locateCastTimer.setInterval(LOCATE_CAST_FIRST_TIMEOUT_IN_MILLIS);
         }
         if(locateCastObjectRetryCount == 2)
         {
             LOGINFO("Retry after 15 sec...");
-            m_locateCastTimer.start(LOCATE_CAST_SECOND_TIMEOUT_IN_MILLIS);
+            m_locateCastTimer.setInterval(LOCATE_CAST_SECOND_TIMEOUT_IN_MILLIS);
         }
         if(locateCastObjectRetryCount == 3)
         {
             LOGINFO("Retry after 30 sec...");
-            m_locateCastTimer.start(LOCATE_CAST_THIRD_TIMEOUT_IN_MILLIS);
+            m_locateCastTimer.setInterval(LOCATE_CAST_THIRD_TIMEOUT_IN_MILLIS);
         }
         if(locateCastObjectRetryCount == 4)
         {
             LOGINFO("Retry after 60 sec...");
-            m_locateCastTimer.start(LOCATE_CAST_FINAL_TIMEOUT_IN_MILLIS);
+            m_locateCastTimer.setInterval(LOCATE_CAST_FINAL_TIMEOUT_IN_MILLIS);
         }
         return ;
     }// err != RT_OK


### PR DESCRIPTION
Reason for change: Dial casting failed after switching interfaces
timer restart patch
Test Procedure: Refer JIRA.
Risks: Low

Change-Id: Ia734d7b7dc75c10776a75a512e09bbcc09b0e42c
Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>