### PR TITLE
RDKTV-7025: get/set Sound mode API fix

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -1044,9 +1044,9 @@ namespace WPEFramework {
                         else
                             modeString.append(mode.toString());
                     }
-		    else if(aPort.getType().getId() == device::AudioOutputPortType::kARC){
+		    else if((aPort.getType().getId() == device::AudioOutputPortType::kARC) || (aPort.getType().getId() == device::AudioOutputPortType::kSPDIF)){
                         if (aPort.getStereoAuto()) {
-                            LOGINFO("HDMI_ARC0 output mode Auto");
+                            LOGINFO("%s output mode Auto", audioPort.c_str());
                             modeString.append("AUTO");
 			}
 			else{


### PR DESCRIPTION
Reason for change: Fix for SPDIF auto
sound mode
Test Procedure: Verify set/get soundmode thunder
API
Risks: None

Signed-off-by: Deekshit Devadas <deekshit.devadasy@sky.uk>