### PR TITLE
[RDKTV-3218] As part of Cobalt-PreCertification updated the Speech Da…

### DIFF
--- a/TextToSpeech/TextToSpeech.cpp
+++ b/TextToSpeech/TextToSpeech.cpp
@@ -35,6 +35,7 @@ namespace Plugin {
     {
         ASSERT(_service == nullptr);
 
+        TTS::logger_init();
         _connectionId = 0;
         _service = service;
         _skipURL = static_cast<uint8_t>(_service->WebPrefix().length());

--- a/TextToSpeech/TextToSpeechImplementation.cpp
+++ b/TextToSpeech/TextToSpeechImplementation.cpp
@@ -43,6 +43,7 @@ namespace Plugin {
 
     TextToSpeechImplementation::TextToSpeechImplementation() : _adminLock()
     {
+	TTS::logger_init();
         if(!_ttsManager)
             _ttsManager = TTS::TTSManager::create(this);
     }

--- a/TextToSpeech/TextToSpeechJsonRpc.cpp
+++ b/TextToSpeech/TextToSpeechJsonRpc.cpp
@@ -180,9 +180,25 @@ namespace Plugin {
 
     void TextToSpeech::dispatchJsonEvent(const char *event, const string &data)
     {
-        TTSLOG_WARNING("Notify %s %s", event, data.c_str());
         JsonObject params;
         params.FromString(data);
+        int speechId     = params["speechid"].Number();
+        if(((std::string(event) == "onwillspeak") || (std::string(event) == "onspeechstart") || (std::string(event) == "onspeechcomplete"))) {
+	    switch (TTS::getLogLevel())
+            {
+                case TTS::LogLevel::FATAL_LEVEL :
+                case TTS::LogLevel::ERROR_LEVEL :
+                case TTS::LogLevel::WARNING_LEVEL :
+                case TTS::LogLevel::INFO_LEVEL :
+                case TTS::LogLevel::VERBOSE_LEVEL :
+                    TTSLOG_WARNING("Notify %s speechId : %d", event, speechId);
+                    break;
+                case TTS::LogLevel::TRACE_LEVEL:
+                    TTSLOG_TRACE("Notify %s %s", event, data.c_str());
+	    };
+        }
+        else
+            TTSLOG_WARNING("Notify %s speechId : %d", event, speechId);
         Notify(event, params);
     }
 

--- a/TextToSpeech/impl/TTSSpeaker.cpp
+++ b/TextToSpeech/impl/TTSSpeaker.cpp
@@ -193,7 +193,7 @@ TTSSpeaker::TTSSpeaker(TTSConfiguration &config) :
     m_pipelineConstructionFailures(0),
     m_maxPipelineConstructionFailures(INT_FROM_ENV("MAX_PIPELINE_FAILURE_THRESHOLD", 1)) {
 
-        setenv("GST_DEBUG", "2", 0);
+        setenv("GST_DEBUG", "2,httpsrc:1", 0);
         setenv("GST_REGISTRY_UPDATE", "no", 0);
         setenv("GST_REGISTRY_FORK", "no", 0);
 
@@ -818,7 +818,7 @@ std::string TTSSpeaker::constructURL(TTSConfiguration &config, SpeechData &d) {
     tts_request.append("&text=");
     tts_request.append(sanitizedString);
 
-    TTSLOG_WARNING("Constructured final URL is %s", tts_request.c_str());
+    TTSLOG_TRACE("Constructured final URL is %s", tts_request.c_str());
     return tts_request;
 }
 

--- a/TextToSpeech/impl/logger.cpp
+++ b/TextToSpeech/impl/logger.cpp
@@ -100,8 +100,13 @@ namespace TTS {
     {
         sync_stdout();
         const char* level = getenv("TTS_DEFAULT_LOG_LEVEL");
-        if (level)
+        if ((level != NULL) && (level[0] != '\0'))
             gDefaultLogLevel = static_cast<LogLevel>(atoi(level));
+    }
+
+    int getLogLevel()
+    {
+        return gDefaultLogLevel;
     }
 
     void log(LogLevel level,

--- a/TextToSpeech/impl/logger.h
+++ b/TextToSpeech/impl/logger.h
@@ -54,6 +54,11 @@ void logger_init();
     } while (0)
 
 /**
+ * @brief returns the LogLevel
+ */
+int getLogLevel();
+
+/**
  * @brief Log a message
  * The function is defined by logging backend.
  * Currently 2 variants are supported: TTS_logger (USE_TTS_LOGGER),


### PR DESCRIPTION
…ta Storage based on the log levels.

As part of speech text logging

- Changed the log level of httpsrc in GST_DEBUG environment variable.

- Corrected the code to reflect the log level based on the TTS_DEFAULT_LOG_LEVEL environment variable. 

- As part of event notification, log the speech text for TRACE level, otherwise only speech id is logged.