### PR TITLE
RDKTV-7118 RDKTV-7128 AMLOGIC-1457 : Unable to set Current Resolution

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -3527,7 +3527,9 @@ namespace WPEFramework {
                 }
                 if (!resolution.empty())
                 {
-                    if (Utils::String::stringContains(display,"HDMI"))
+                    std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+                    std::string videoPortName = strVideoPort.substr(0, strVideoPort.size()-1);
+                    if (Utils::String::stringContains(display, videoPortName.c_str()))
                     {
                         // only report first HDMI connected device is HDMI is connected
                         JsonObject params;


### PR DESCRIPTION
Reason for change: RDKTV-7118
Unable to set Current Resolution
getActiveInput_returns_false fix
Test Procedure: None
Risks: Low

Change-Id: I18058046c0f127e3e84470e9b9d84fe460ce9440
Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>