### PR TITLE
RDKTV-1694: HDMI do not display resolution

### DIFF
--- a/HdmiInput/HdmiInput.cpp
+++ b/HdmiInput/HdmiInput.cpp
@@ -536,7 +536,7 @@ namespace WPEFramework
                         break;
 
                     case dsVIDEO_FRAMERATE_59dot94:
-                        params["frameRateN"] = 50000;
+                        params["frameRateN"] = 60000;
                         params["frameRateD"] = 1001;
                         break;
 


### PR DESCRIPTION
Reason for change: Fix frame rate error
Test Procedure: Verify hdmi input thunder event on
source resolution change
Risks: None

Signed-off-by: Deekshit Devadas <deekshit.devadasy@sky.uk>