### PR TITLE
DELIA-49845 : getSinkAtmosCapability not returning proper value

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -2862,7 +2862,7 @@ namespace WPEFramework {
                 {
                     device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort("HDMI0");
                     if (aPort.isConnected()) {
-                        aPort.getSinkDeviceAtmosCapability (atmosCapability);
+                        aPort.getSinkDeviceAtmosCapability (&atmosCapability);
                         response["atmos_capability"] = (int)atmosCapability;
                     }
                     else {


### PR DESCRIPTION
Reason for change: correcting parameter for getSinkDeviceAtmosCapability
Test Procedure: Refer JIRA
Risks: Low
Signed-off-by: Akhil Baby Sarada <Akhil_Sarada@comcast.com>