### PR TITLE
DELIA-49722 : setAudioDelay accepting negative values

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -2685,6 +2685,12 @@ namespace WPEFramework {
                 LOGERR("Failed to parse audioDelay '%s'", sAudioDelayMs.c_str());
                 returnResponse(false);
             }
+            
+            if ( audioDelayMs < 0 )
+            {
+                LOGERR("audioDelay '%s', Should be a postiive value", sAudioDelayMs.c_str());
+                returnResponse(false);
+            }
 
             bool success = true;
             string audioPort = parameters["audioPort"].String();//empty value will browse all ports


### PR DESCRIPTION
Reason for change: Return error for negative values
Test Procedure: Refer JIRA
Risks: Low
Signed-off-by: Akhil Baby Sarada <Akhil_Sarada@comcast.com>