### PR TITLE
RDK-32487: HDMI compatibility mode support

### DIFF
--- a/HdmiInput/HdmiInput.cpp
+++ b/HdmiInput/HdmiInput.cpp
@@ -37,6 +37,8 @@
 #define HDMIINPUT_METHOD_READ_EDID "readEDID"
 #define HDMIINPUT_METHOD_READ_RAWHDMISPD "getRawHDMISPD"
 #define HDMIINPUT_METHOD_READ_HDMISPD "getHDMISPD"
+#define HDMIINPUT_METHOD_SET_EDID_VERSION "setEdidVersion"
+#define HDMIINPUT_METHOD_GET_EDID_VERSION "getEdidVersion"
 #define HDMIINPUT_METHOD_START_HDMI_INPUT "startHdmiInput"
 #define HDMIINPUT_METHOD_STOP_HDMI_INPUT "stopHdmiInput"
 #define HDMIINPUT_METHOD_SCALE_HDMI_INPUT "setVideoRectangle"
@@ -70,6 +72,8 @@ namespace WPEFramework
             registerMethod(HDMIINPUT_METHOD_READ_RAWHDMISPD, &HdmiInput::getRawHDMISPDWrapper, this, {2});
             registerMethod(HDMIINPUT_METHOD_READ_HDMISPD, &HdmiInput::getHDMISPDWrapper, this, {2});
 	    //version2 api end
+            registerMethod(HDMIINPUT_METHOD_SET_EDID_VERSION, &HdmiInput::setEdidVersionWrapper, this, {2});
+            registerMethod(HDMIINPUT_METHOD_GET_EDID_VERSION, &HdmiInput::getEdidVersionWrapper, this, {2});
             registerMethod(HDMIINPUT_METHOD_START_HDMI_INPUT, &HdmiInput::startHdmiInput, this);
             registerMethod(HDMIINPUT_METHOD_STOP_HDMI_INPUT, &HdmiInput::stopHdmiInput, this);
             registerMethod(HDMIINPUT_METHOD_SCALE_HDMI_INPUT, &HdmiInput::setVideoRectangleWrapper, this);
@@ -744,6 +748,107 @@ namespace WPEFramework
                 LOG_DEVICE_EXCEPTION1(std::to_string(iPort));
             }
             return spdbase64;
+        }
+
+        uint32_t HdmiInput::setEdidVersionWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            int portId = 0;
+
+            LOGINFOMETHOD();
+            returnIfParamNotFound(parameters, "portId");
+            returnIfParamNotFound(parameters, "version");
+            string sPortId = parameters["portId"].String();
+            string sVersion = parameters["version"].String();
+            try {
+                portId = stoi(sPortId);
+            }catch (const device::Exception& err) {
+                LOG_DEVICE_EXCEPTION1(sPortId);
+                returnResponse(false);
+            }
+
+            int edidVer = -1;
+            if (strcmp (sVersion.c_str(), "HDMI1.4") == 0) {
+                edidVer = HDMI_EDID_VER_14;
+            }
+            else if (strcmp (sVersion.c_str(), "HDMI2.0") == 0) {
+                edidVer = HDMI_EDID_VER_20;
+            }
+
+            if (edidVer < 0) {
+                returnResponse(false);
+            }
+            bool result = setEdidVersion (portId, edidVer);
+            if (result == false) {
+                returnResponse(false);
+            }
+            else {
+                returnResponse(true);
+            }
+        }
+
+        int HdmiInput::setEdidVersion(int iPort, int iEdidVer)
+        {
+            bool ret = true;
+            try
+            {
+                device::HdmiInput::getInstance().setEdidVersion (iPort, iEdidVer);
+                LOGWARN("HdmiInput::setEdidVersion EDID Version:%d", iEdidVer);
+            }
+            catch (const device::Exception& err)
+            {
+                LOG_DEVICE_EXCEPTION1(std::to_string(iPort));
+                ret = false;
+            }
+            return ret;
+        }
+
+        uint32_t HdmiInput::getEdidVersionWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            string sPortId = parameters["portId"].String();
+            int portId = 0;
+
+            LOGINFOMETHOD();
+            returnIfParamNotFound(parameters, "portId");
+            try {
+                portId = stoi(sPortId);
+            }catch (const device::Exception& err) {
+                LOG_DEVICE_EXCEPTION1(sPortId);
+                returnResponse(false);
+            }
+
+            int edidVer = getEdidVersion (portId);
+            switch (edidVer)
+            {
+                case HDMI_EDID_VER_14:
+                    response["edidVersion"] = "HDMI1.4";
+                    break;
+                case HDMI_EDID_VER_20:
+                    response["edidVersion"] = "HDMI2.0";
+                    break;
+            }
+
+            if (edidVer < 0) {
+                returnResponse(false);
+            }
+            else {
+                returnResponse(true);
+            }
+        }
+
+        int HdmiInput::getEdidVersion(int iPort)
+        {
+            int edidVersion = -1;
+
+            try
+            {
+                device::HdmiInput::getInstance().getEdidVersion (iPort, &edidVersion);
+                LOGWARN("HdmiInput::getEdidVersion EDID Version:%d", &edidVersion);
+            }
+            catch (const device::Exception& err)
+            {
+                LOG_DEVICE_EXCEPTION1(std::to_string(iPort));
+            }
+            return edidVersion;
         }
 
     } // namespace Plugin

--- a/HdmiInput/HdmiInput.h
+++ b/HdmiInput/HdmiInput.h
@@ -58,6 +58,8 @@ namespace WPEFramework {
             uint32_t readEDIDWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t getRawHDMISPDWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t getHDMISPDWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t setEdidVersionWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t getEdidVersionWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t startHdmiInput(const JsonObject& parameters, JsonObject& response);
             uint32_t stopHdmiInput(const JsonObject& parameters, JsonObject& response);
 
@@ -69,6 +71,8 @@ namespace WPEFramework {
             std::string readEDID(int iPort);
             std::string getRawHDMISPD(int iPort);
             std::string getHDMISPD(int iPort);
+            int setEdidVersion(int iPort, int iEdidVer);
+            int getEdidVersion(int iPort);
 
 
             bool setVideoRectangle(int x, int y, int width, int height);


### PR DESCRIPTION
To support HDMI compatibility, adding set and get apis for HDMI version.
Supported versions - HDMI2.0 and HDMI1.4
Default value - HDMI2.0
**Commands:**
TOKEN_tmp=`/usr/bin/WPEFrameworkSecurityUtility | cut -d'"' -f4`
curl -H "Content-Type: application/json" -H "Authorization: Bearer ${TOKEN_tmp}" -d '{"jsonrpc":"2.0", "id":3, "method":"org.rdk.HdmiInput.2.setEdidVersion", "params":{"portId":"1", "version":"HDMI1.4"}}' http://127.0.0.1:9998/jsonrpc
curl -H "Content-Type: application/json" -H "Authorization: Bearer ${TOKEN_tmp}" -d '{"jsonrpc":"2.0", "id":3, "method":"org.rdk.HdmiInput.2.getEdidVersion", "params":{"portId":"0"}}' http://127.0.0.1:9998/jsonrpc