### PR TITLE
DELIA-49667: WPEFramework Observing crash stoi

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -1811,6 +1811,12 @@ namespace WPEFramework {
                 returnIfParamNotFound(parameters, "level");
                 string sVolumeLeveller = parameters["level"].String();
                 int VolumeLeveller = 0;
+                bool isIntiger = Utils::isValidInt ((char*)sVolumeLeveller.c_str());
+                if (false == isIntiger) {
+                    LOGWARN("level should be an integer");
+                    returnResponse(false);
+                }
+
                 try {
                         VolumeLeveller = stoi(sVolumeLeveller);
                 }catch (const device::Exception& err) {
@@ -1897,6 +1903,11 @@ namespace WPEFramework {
                returnIfParamNotFound(parameters, "boost");
                string sSurroundVirtualizer = parameters["boost"].String();
                int surroundVirtualizer = 0;
+               bool isIntiger = Utils::isValidInt ((char*)sSurroundVirtualizer.c_str());
+               if (false == isIntiger) {
+                   LOGWARN("boost should be an integer");
+                   returnResponse(false);
+               }
 
                try {
                   surroundVirtualizer = stoi(sSurroundVirtualizer);
@@ -2049,6 +2060,11 @@ namespace WPEFramework {
                 returnIfParamNotFound(parameters, "DRCMode");
                 string sDRCMode = parameters["DRCMode"].String();
                 int DRCMode = 0;
+                bool isIntiger = Utils::isValidInt ((char*)sDRCMode.c_str());
+                if (false == isIntiger) {
+                    LOGWARN("DRCMode should be an integer");
+                    returnResponse(false);
+                }
                 try {
                         DRCMode = stoi(sDRCMode);
                 }catch (const device::Exception& err) {


### PR DESCRIPTION
Reason for change:
WPEFramework Observing crash stoi
valid int check added
Test Procedure: None
Risks: Low

Change-Id: I421b804ecc37f78b3894097b44bd2a037f9e6170
Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>
(cherry picked from commit 49104a6ad8269bef76829f43bfb02a8663b33708)