### PR TITLE
RDKTV-3205 : fix crash in HdmiCecSink

### DIFF
--- a/HdmiCecSink/HdmiCecSink.h
+++ b/HdmiCecSink/HdmiCecSink.h
@@ -240,7 +240,7 @@ namespace WPEFramework {
 
 			DeviceNode() {
 				int i;
-				for (i; i < LogicalAddress::UNREGISTERED; i++ )
+				for (i = 0; i < LogicalAddress::UNREGISTERED; i++ )
 				{
 					m_childsLogicalAddr[i] = LogicalAddress::UNREGISTERED;
 				}


### PR DESCRIPTION
Reason for change: Crash occurs during HdmiCecSink constructor,
because of an uninitialized variable.
Test Procedure: Dunfell build, monitor wpeframework start.
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>