### PR TITLE
XIONE-4741: HdmiCec_2 init not happening properly

### DIFF
--- a/HdmiCec_2/HdmiCec_2.cpp
+++ b/HdmiCec_2/HdmiCec_2.cpp
@@ -330,7 +330,8 @@ namespace WPEFramework
            HdmiCec_2::_instance = this;
            smConnection = NULL;
            InitializeIARM();
-
+           //Initialize cecEnableStatus to false in ctor
+           cecEnableStatus = false;
            registerMethod(HDMICEC2_METHOD_SET_ENABLED, &HdmiCec_2::setEnabledWrapper, this);
            registerMethod(HDMICEC2_METHOD_GET_ENABLED, &HdmiCec_2::getEnabledWrapper, this);
            registerMethod(HDMICEC2_METHOD_OTP_SET_ENABLED, &HdmiCec_2::setOTPEnabledWrapper, this);
@@ -1084,22 +1085,27 @@ namespace WPEFramework
             bool ret = false; 
             if((true == cecEnableStatus) && (cecOTPSettingEnabled == true))
             {
-                try
-                {
-                    LOGINFO("Command: sending ImageViewOn TV \r\n");
-                    smConnection->sendTo(LogicalAddress(LogicalAddress::TV), MessageEncoder().encode(ImageViewOn()), 5000);
-                    usleep(10000);
-                    LOGINFO("Command: sending ActiveSource  physical_addr :%s \r\n",physical_addr.toString().c_str());
-                    smConnection->sendTo(LogicalAddress(LogicalAddress::BROADCAST), MessageEncoder().encode(ActiveSource(physical_addr)), 5000);
-                    usleep(10000);
-                    isDeviceActiveSource = true;
-                    LOGINFO("Command: sending GiveDevicePowerStatus \r\n");
-                    smConnection->sendTo(LogicalAddress::TV, MessageEncoder().encode(GiveDevicePowerStatus()), 5000);
-                    ret = true;
+                if (smConnection)  {
+                    try
+                    {
+                        LOGINFO("Command: sending ImageViewOn TV \r\n");
+                        smConnection->sendTo(LogicalAddress(LogicalAddress::TV), MessageEncoder().encode(ImageViewOn()), 5000);
+                        usleep(10000);
+                        LOGINFO("Command: sending ActiveSource  physical_addr :%s \r\n",physical_addr.toString().c_str());
+                        smConnection->sendTo(LogicalAddress(LogicalAddress::BROADCAST), MessageEncoder().encode(ActiveSource(physical_addr)), 5000);
+                        usleep(10000);
+                        isDeviceActiveSource = true;
+                        LOGINFO("Command: sending GiveDevicePowerStatus \r\n");
+                        smConnection->sendTo(LogicalAddress::TV, MessageEncoder().encode(GiveDevicePowerStatus()), 5000);
+                        ret = true;
+                    }
+                    catch(...)
+                    {
+                        LOGWARN("Exception while processing performOTPAction");
+                    }
                 }
-                catch(...)
-                {
-                    LOGWARN("Exception while processing performOTPAction");
+                else {
+                    LOGWARN("smConnection is NULL");
                 }
             }
             else


### PR DESCRIPTION
Reason for change:
HdmiCec_2 init not happening properly
Test Procedure: None
Risks: Low

Change-Id: If67408d42236347e14ebfd741da9996acb0d2bea
Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>