### PR TITLE
XIONE-4741 XIONE-3015: HdmiCec_2 init not happening properly

### DIFF
--- a/HdmiCec_2/HdmiCec_2.cpp
+++ b/HdmiCec_2/HdmiCec_2.cpp
@@ -326,11 +326,7 @@ namespace WPEFramework
        HdmiCec_2::HdmiCec_2()
        : AbstractPlugin()
        {
-           LOGWARN("Initlaizing CEC_2");
-           HdmiCec_2::_instance = this;
-           smConnection = NULL;
-           InitializeIARM();
-
+           LOGWARN("ctor");
            registerMethod(HDMICEC2_METHOD_SET_ENABLED, &HdmiCec_2::setEnabledWrapper, this);
            registerMethod(HDMICEC2_METHOD_GET_ENABLED, &HdmiCec_2::getEnabledWrapper, this);
            registerMethod(HDMICEC2_METHOD_OTP_SET_ENABLED, &HdmiCec_2::setOTPEnabledWrapper, this);
@@ -340,6 +336,22 @@ namespace WPEFramework
            registerMethod(HDMICEC2_METHOD_SET_VENDOR_ID, &HdmiCec_2::setVendorIdWrapper, this);
            registerMethod(HDMICEC2_METHOD_GET_VENDOR_ID, &HdmiCec_2::getVendorIdWrapper, this);
            registerMethod(HDMICEC2_METHOD_PERFORM_OTP_ACTION, &HdmiCec_2::performOTPActionWrapper, this);
+
+       }
+
+       HdmiCec_2::~HdmiCec_2()
+       {
+           LOGWARN("dtor");
+       }
+ 
+       const string HdmiCec_2::Initialize(PluginHost::IShell* /* service */)
+       {
+           LOGWARN("Initlaizing CEC_2");
+           HdmiCec_2::_instance = this;
+           smConnection = NULL;
+           InitializeIARM();
+           //Initialize cecEnableStatus to false in ctor
+           cecEnableStatus = false;
 
            logicalAddressDeviceType = "None";
            logicalAddress = 0xFF;
@@ -393,15 +405,16 @@ namespace WPEFramework
                    LOGWARN("Exception while enabling CEC settings .\r\n");
                }
             }
+
+           // On success return empty, to indicate there is no error text.
+           return (string());
        }
 
-       HdmiCec_2::~HdmiCec_2()
-       {
-       }
 
        void HdmiCec_2::Deinitialize(PluginHost::IShell* /* service */)
        {
            HdmiCec_2::_instance = nullptr;
+           smConnection = NULL;
            DeinitializeIARM();
        }
 
@@ -1084,22 +1097,27 @@ namespace WPEFramework
             bool ret = false; 
             if((true == cecEnableStatus) && (cecOTPSettingEnabled == true))
             {
-                try
-                {
-                    LOGINFO("Command: sending ImageViewOn TV \r\n");
-                    smConnection->sendTo(LogicalAddress(LogicalAddress::TV), MessageEncoder().encode(ImageViewOn()), 5000);
-                    usleep(10000);
-                    LOGINFO("Command: sending ActiveSource  physical_addr :%s \r\n",physical_addr.toString().c_str());
-                    smConnection->sendTo(LogicalAddress(LogicalAddress::BROADCAST), MessageEncoder().encode(ActiveSource(physical_addr)), 5000);
-                    usleep(10000);
-                    isDeviceActiveSource = true;
-                    LOGINFO("Command: sending GiveDevicePowerStatus \r\n");
-                    smConnection->sendTo(LogicalAddress::TV, MessageEncoder().encode(GiveDevicePowerStatus()), 5000);
-                    ret = true;
+                if (smConnection)  {
+                    try
+                    {
+                        LOGINFO("Command: sending ImageViewOn TV \r\n");
+                        smConnection->sendTo(LogicalAddress(LogicalAddress::TV), MessageEncoder().encode(ImageViewOn()), 5000);
+                        usleep(10000);
+                        LOGINFO("Command: sending ActiveSource  physical_addr :%s \r\n",physical_addr.toString().c_str());
+                        smConnection->sendTo(LogicalAddress(LogicalAddress::BROADCAST), MessageEncoder().encode(ActiveSource(physical_addr)), 5000);
+                        usleep(10000);
+                        isDeviceActiveSource = true;
+                        LOGINFO("Command: sending GiveDevicePowerStatus \r\n");
+                        smConnection->sendTo(LogicalAddress::TV, MessageEncoder().encode(GiveDevicePowerStatus()), 5000);
+                        ret = true;
+                    }
+                    catch(...)
+                    {
+                        LOGWARN("Exception while processing performOTPAction");
+                    }
                 }
-                catch(...)
-                {
-                    LOGWARN("Exception while processing performOTPAction");
+                else {
+                    LOGWARN("smConnection is NULL");
                 }
             }
             else

--- a/HdmiCec_2/HdmiCec_2.h
+++ b/HdmiCec_2/HdmiCec_2.h
@@ -102,6 +102,7 @@ namespace WPEFramework {
         public:
             HdmiCec_2();
             virtual ~HdmiCec_2();
+            virtual const string Initialize(PluginHost::IShell* service) override;
             virtual void Deinitialize(PluginHost::IShell* service) override;
             static HdmiCec_2* _instance;
         private:


### PR DESCRIPTION
Reason for change:
HdmiCec_2 init not happening properly
Test Procedure: None
Risks: Low

Change-Id: I2892b63227d0135b40b36d2b610e42374f29c669
Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>