### PR TITLE
RDKTV-7170 : DEEPSLEEP and CEC wake up

### DIFF
--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -687,11 +687,7 @@ namespace WPEFramework
 					{
 						_instance->deviceList[_instance->m_logicalAddressAllocated].m_powerStatus = PowerStatus(powerState);
 
-						if ( powerState == DEVICE_POWER_STATE_ON )
-						{
-							HdmiCecSink::_instance->onPowerStateON();
-						}
-						else
+						if ( powerState != DEVICE_POWER_STATE_ON )
 						{
 							HdmiCecSink::_instance->m_currentActiveSource = -1;
 						}
@@ -704,12 +700,6 @@ namespace WPEFramework
                 }
            }
        }
-
-	  void HdmiCecSink::onPowerStateON()
-       {
-		/*NOP*/		
-       }
-
 	  void HdmiCecSink::sendStandbyMessage()
       {
       		if(!HdmiCecSink::_instance)

--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -707,13 +707,7 @@ namespace WPEFramework
 
 	  void HdmiCecSink::onPowerStateON()
        {
-#if 0	       
-       		if ( powerState == DEVICE_POWER_STATE_ON )
-       		{
-       			/*while wakeup From Standby, Ask for Active Source*/
-				_instance->requestActiveSource(); 
-       		}
-#endif		
+		/*NOP*/		
        }
 
 	  void HdmiCecSink::sendStandbyMessage()
@@ -2238,12 +2232,6 @@ namespace WPEFramework
 						_instance->smConnection->addFrameListener(_instance->msgFrameListener);
 						_instance->smConnection->sendTo(LogicalAddress(LogicalAddress::BROADCAST), 
 								MessageEncoder().encode(ReportPhysicalAddress(physical_addr, _instance->deviceList[_instance->m_logicalAddressAllocated].m_deviceType)), 5000);	
-#if 0
-						 if ( powerState == DEVICE_POWER_STATE_ON )
-						 {
-							_instance->requestActiveSource(); 
-						 }
-#endif
 						_instance->m_sleepTime = HDMICECSINK_PING_INTERVAL_MS;
 						_instance->m_pollThreadState = POLL_THREAD_STATE_IDLE;
 					}

--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -707,11 +707,13 @@ namespace WPEFramework
 
 	  void HdmiCecSink::onPowerStateON()
        {
+#if 0	       
        		if ( powerState == DEVICE_POWER_STATE_ON )
        		{
        			/*while wakeup From Standby, Ask for Active Source*/
 				_instance->requestActiveSource(); 
        		}
+#endif		
        }
 
 	  void HdmiCecSink::sendStandbyMessage()
@@ -2236,12 +2238,12 @@ namespace WPEFramework
 						_instance->smConnection->addFrameListener(_instance->msgFrameListener);
 						_instance->smConnection->sendTo(LogicalAddress(LogicalAddress::BROADCAST), 
 								MessageEncoder().encode(ReportPhysicalAddress(physical_addr, _instance->deviceList[_instance->m_logicalAddressAllocated].m_deviceType)), 5000);	
-
+#if 0
 						 if ( powerState == DEVICE_POWER_STATE_ON )
 						 {
 							_instance->requestActiveSource(); 
 						 }
-
+#endif
 						_instance->m_sleepTime = HDMICECSINK_PING_INTERVAL_MS;
 						_instance->m_pollThreadState = POLL_THREAD_STATE_IDLE;
 					}

--- a/HdmiCecSink/HdmiCecSink.h
+++ b/HdmiCecSink/HdmiCecSink.h
@@ -591,8 +591,7 @@ private:
             static void pwrMgrModeChangeEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
             void onCECDaemonInit();
             void cecStatusUpdated(void *evtStatus);
-            void onHdmiHotPlug(int portId, int connectStatus);
-			void onPowerStateON();
+            void onHdmiHotPlug(int portId, int connectStatus);			
 			void wakeupFromStandby();
             bool loadSettings();
             void persistSettings(bool enableStatus);


### PR DESCRIPTION
Reason for change: RDK request active source should come from app
Test Procedure: deepsleep wakeup, deepsleep cec wakeup
Risks: Create None
Signed-off-by: KRN11 karthickkumar.ravisankar@sky.uk