### PR TITLE
RDKTV-6150: New TV gets ENT-41010 in activation

### DIFF
--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -1790,11 +1790,14 @@ namespace WPEFramework {
             std::vector<string> lines;
 
 	    if (!Utils::fileExists(FWDNLDSTATUS_FILE_NAME)) {
-		    populateResponseWithError(SysSrv_FileNotPresent, response);
-		    returnResponse(retStat);
+                //If firmware download file doesn't exist we can still return the current version
+                response["currentFWVersion"] = getStbVersionString();
+                response["downloadedFWVersion"] = downloadedFWVersion;
+                response["downloadedFWLocation"] = downloadedFWLocation;
+                response["isRebootDeferred"] = isRebootDeferred;
+                retStat = true;
 	    }
-
-            if (getFileContent(FWDNLDSTATUS_FILE_NAME, lines)) {
+            else if (getFileContent(FWDNLDSTATUS_FILE_NAME, lines)) {
                 for (std::vector<std::string>::const_iterator i = lines.begin();
                         i != lines.end(); ++i) {
                     std::string line = *i;

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -1799,6 +1799,7 @@ namespace WPEFramework {
                 if(ver == "unknown")
                 {
                     response["currentFWVersion"] = "";
+                    retStat = false;
                 }
                 else
                 {

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -1796,9 +1796,14 @@ namespace WPEFramework {
                 response["isRebootDeferred"] = isRebootDeferred;
                 retStat = true;
                 string ver =  getStbVersionString();
-                if(ver != "unknown")
-                {  response["currentFWVersion"] = ver;
-                   retStat = true;
+                if(ver == "unknown")
+                {
+                    response["currentFWVersion"] = "";
+                }
+                else
+                {
+                    response["currentFWVersion"] = ver;
+                    retStat = true;
                 }
 	    }
             else if (getFileContent(FWDNLDSTATUS_FILE_NAME, lines)) {

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -1791,11 +1791,15 @@ namespace WPEFramework {
 
 	    if (!Utils::fileExists(FWDNLDSTATUS_FILE_NAME)) {
                 //If firmware download file doesn't exist we can still return the current version
-                response["currentFWVersion"] = getStbVersionString();
                 response["downloadedFWVersion"] = downloadedFWVersion;
                 response["downloadedFWLocation"] = downloadedFWLocation;
                 response["isRebootDeferred"] = isRebootDeferred;
                 retStat = true;
+                string ver =  getStbVersionString();
+                if(ver != "unknown")
+                {  response["currentFWVersion"] = ver;
+                   retStat = true;
+                }
 	    }
             else if (getFileContent(FWDNLDSTATUS_FILE_NAME, lines)) {
                 for (std::vector<std::string>::const_iterator i = lines.begin();


### PR DESCRIPTION
Reason for change: Prevent reboot cycle on initial update.
Test Procedure: Update without /opt/fwdnldstatus.txt.
Risks: Low

Signed-off-by: Mark Vandenbriele <mark.vandenbriele@consult.red>