### PR TITLE
XIONE-4778 : Remove padding bytes from EDID data

### DIFF
--- a/DisplayInfo/DeviceSettings/PlatformImplementation.cpp
+++ b/DisplayInfo/DeviceSettings/PlatformImplementation.cpp
@@ -367,16 +367,7 @@ public:
         uint16_t size = min(edidVec.size(), (size_t)numeric_limits<uint16_t>::max());
         if(edidVec.size() > (size_t)numeric_limits<uint16_t>::max())
             LOGERR("Size too large to use ToString base64 wpe api");
-        string edidbase64;
-        // Align input string size to multiple of 3
-        int paddingSize = 0;
-        for (; paddingSize < (3-size%3);paddingSize++)
-        {
-            edidVec.push_back(0x00);
-        }
-        size += paddingSize;
         int i = 0;
-
         for (i; i < length && i < size; i++)
         {
             data[i] = edidVec[i];


### PR DESCRIPTION
Reason for change: Remove padding bytes from EDID data
to pass NTS test case
Test Procedure: Check ticket
Risks: Low
Signed-off-by: Vinod Jacob <vinod_jacob@comcast.com>

Gerrit verification passed: https://gerrit.teamccp.com/#/c/525970/

Dev Test resuslts look good
`curl -H "Authorization: Bearer `WPEFrameworkSecurityUtility | cut -d '"' -f 4`" --header "Content-Type: application/json"   --request POST   --data  '{"jsonrpc":"2.0","id":"3","method": "DisplayInfo.1.edid", "params":{"length":300}}' http://127.0.0.1:9998/jsonrpc
{"jsonrpc":"2.0","id":3,"result":{"length":256,"data":"AP///////wBNeQEAAQEBAf8fAQOAXjZ4Cu6Ro1RMmSYPUFShCAAxQEVAYUBxQIGAAQEBAQEBCOgAMPJwWoCwWIoAQIRjAAAeAjqAGHE4LUBYLEUAQIRjAAAeAAAA/QAXPh6IPAAKICAgICAgAAAA/ABTS1kKICAgICAgICAgARACA1/xV2FgEB8EEwUUAwISICEiFQFdXl9lZmprLAlXAxUDUFcHAGd+AGcDDAAQALg8Z9hdxAF4iAPiAM/jBcAA4wYNAeQPAwB47gFG0AAmGQkArVJEqSMM5hFG0AAAAGYhULBRABswQHA2AECEYwAAHgAAAAAAAAAAAAAAAAAAUQ=="}}
`