### PR TITLE
RDKTV-6644: ARC device not detected after power on

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -62,6 +62,7 @@ using namespace std;
 #define HDMICECSINK_ARC_INITIATION_EVENT "arcInitiationEvent"
 #define HDMICECSINK_ARC_TERMINATION_EVENT "arcTerminationEvent"
 #define HDMICECSINK_SHORT_AUDIO_DESCRIPTOR_EVENT "shortAudiodesciptorEvent"
+#define HDMICECSINK_SYSTEM_AUDIO_MODE_EVENT "setSystemAudioMode"
 #define SERVER_DETAILS  "127.0.0.1:9998"
 #define WARMING_UP_TIME_IN_SECONDS 5
 #define HDMICECSINK_PLUGIN_ACTIVATION_TIME 2
@@ -3207,6 +3208,9 @@ namespace WPEFramework {
                 } else if(strcmp(eventName, HDMICECSINK_SHORT_AUDIO_DESCRIPTOR_EVENT) == 0) {
                     err =m_client->Subscribe<JsonObject>(1000, eventName
                             , &DisplaySettings::onShortAudioDescriptorEventHandler, this);
+                } else if(strcmp(eventName, HDMICECSINK_SYSTEM_AUDIO_MODE_EVENT) == 0) {
+                    err =m_client->Subscribe<JsonObject>(1000, eventName
+                            , &DisplaySettings::onSystemAudioModeEventHandler, this);
                 }
                 else {
                      err = Core::ERROR_UNAVAILABLE;
@@ -3327,8 +3331,35 @@ namespace WPEFramework {
             }
         }
 
-
         // 5.
+        void DisplaySettings::onSystemAudioModeEventHandler(const JsonObject& parameters) {
+            string message;
+            string value;
+
+            parameters.ToString(message);
+            LOGINFO("[System Audio Mode Event], %s : %s", __FUNCTION__, C_STR(message));
+
+            if (parameters.HasLabel("audioMode")) {
+                value = parameters["audioMode"].String();
+                if(!value.compare("On")) {
+                    m_hdmiInAudioDeviceConnected = true;
+                    LOGINFO("%s :  audioMode ON !!!\n", __FUNCTION__);
+                    connectedAudioPortUpdated(dsAUDIOPORT_TYPE_HDMI_ARC, true);
+                }
+		else if(!value.compare("Off")) {
+                    LOGINFO("%s :  audioMode OFF !!!\n", __FUNCTION__);
+		    m_hdmiInAudioDeviceConnected = false;
+		    connectedAudioPortUpdated(dsAUDIOPORT_TYPE_HDMI_ARC, false);
+                }
+                else{
+                    LOGERR("%s: Invalid audio mode sent by HdmiCecSink !!!\n",__FUNCTION__);
+                }
+            } else {
+                LOGERR("Field 'audioMode' could not be found in the event's payload.");
+            }
+        }
+
+        // 6.
         void DisplaySettings::onTimer()
         {
             // lock to prevent: parallel onTimer runs, destruction during onTimer
@@ -3348,7 +3379,7 @@ namespace WPEFramework {
             bool pluginActivated = Utils::isPluginActivated(HDMICECSINK_CALLSIGN);
             LOGWARN ("DisplaySettings::onTimer pluginActivated:%d line:%d", pluginActivated, __LINE__);
             if(!m_subscribed) {
-                if (pluginActivated && (subscribeForHdmiCecSinkEvent(HDMICECSINK_ARC_INITIATION_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_ARC_TERMINATION_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_SHORT_AUDIO_DESCRIPTOR_EVENT)== Core::ERROR_NONE))
+                if (pluginActivated && (subscribeForHdmiCecSinkEvent(HDMICECSINK_ARC_INITIATION_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_ARC_TERMINATION_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_SHORT_AUDIO_DESCRIPTOR_EVENT)== Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_SYSTEM_AUDIO_MODE_EVENT) == Core::ERROR_NONE))
                 {
                     m_subscribed = true;
                     if (m_timer.isActive()) {
@@ -3358,32 +3389,6 @@ namespace WPEFramework {
                     LOGINFO("Subscription completed.");
 		    sleep(WARMING_UP_TIME_IN_SECONDS);
 
-                    JsonObject aPortArcEnableResult;
-                    JsonObject aPortArcEnableParam;
-		    JsonObject aPortConfig;
-
-                    aPortArcEnableParam.Set(_T("audioPort"),"HDMI_ARC0");
-		    aPortConfig = getAudioOutputPortConfig();
-                    bool arcEnable = false;
-		    uint32_t ret = Core::ERROR_NONE;
-
-		    if (aPortConfig.HasLabel("HDMI_ARC")) {
-                        try {
-                                arcEnable = aPortConfig["HDMI_ARC"].Boolean();
-                        }catch (...) {
-                                LOGERR("HDMI_ARC status read error");
-                        }
-                    }
-
-                    aPortArcEnableParam.Set(_T("enable"),arcEnable);
-                    ret = setEnableAudioPort (aPortArcEnableParam, aPortArcEnableResult);
-                    if(ret != Core::ERROR_NONE) {
-                        LOGWARN("Audio Port : [HDMI_ARC0] enable: %d failed ! error code%d\n", arcEnable, ret);
-                    }
-                    else {
-                        LOGINFO("Audio Port : [HDMI_ARC0] initialized successfully, enable: %d\n", arcEnable);
-                    }
-
                 } else {
                     LOGERR("Could not subscribe this time, one more attempt in %d msec. Plugin is %s", RECONNECTION_TIME_IN_MILLISECONDS, pluginActivated ? "ACTIVE" : "BLOCKED");
                     if (!pluginActivated)
@@ -3392,10 +3397,38 @@ namespace WPEFramework {
                     }
                 }
             } else {
-                // Not supposed to be here
+                //Standby ON transitions case
                 LOGINFO("Already subscribed. Stopping the timer.");
                 if (m_timer.isActive()) {
                     m_timer.stop();
+                }
+            }
+
+            if(m_subscribed) {
+                JsonObject aPortArcEnableResult;
+                JsonObject aPortArcEnableParam;
+                JsonObject aPortConfig;
+
+                aPortArcEnableParam.Set(_T("audioPort"),"HDMI_ARC0");
+                aPortConfig = getAudioOutputPortConfig();
+                bool arcEnable = false;
+                uint32_t ret = Core::ERROR_NONE;
+
+                if (aPortConfig.HasLabel("HDMI_ARC")) {
+                    try {
+                            arcEnable = aPortConfig["HDMI_ARC"].Boolean();
+                    }catch (...) {
+                            LOGERR("HDMI_ARC status read error");
+                    }
+                }
+
+                aPortArcEnableParam.Set(_T("enable"),arcEnable);
+                ret = setEnableAudioPort (aPortArcEnableParam, aPortArcEnableResult);
+                if(ret != Core::ERROR_NONE) {
+                    LOGWARN("Audio Port : [HDMI_ARC0] enable: %d failed ! error code%d\n", arcEnable, ret);
+                }
+                else {
+                    LOGINFO("Audio Port : [HDMI_ARC0] initialized successfully, enable: %d\n", arcEnable);
                 }
             }
         }

--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -144,6 +144,7 @@ namespace WPEFramework {
 	    void onARCInitiationEventHandler(const JsonObject& parameters);
             void onARCTerminationEventHandler(const JsonObject& parameters);
 	    void onShortAudioDescriptorEventHandler(const JsonObject& parameters);
+	    void onSystemAudioModeEventHandler(const JsonObject& parameters);
             //End events
         public:
             DisplaySettings();

--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -92,6 +92,7 @@ enum {
 	HDMICECSINK_EVENT_ARC_TERMINATION_EVENT,
         HDMICECSINK_EVENT_SHORT_AUDIODESCRIPTOR_EVENT,
         HDMICECSINK_EVENT_STANDBY_MSG_EVENT,
+	HDMICECSINK_EVENT_SYSTEM_AUDIO_MODE,
 };
 
 static char *eventString[] = {
@@ -107,7 +108,8 @@ static char *eventString[] = {
         "arcInitiationEvent",
         "arcTerminationEvent",
         "shortAudiodesciptorEvent",
-        "standbyMessageReceived"
+        "standbyMessageReceived",
+        "setSystemAudioMode"
 };
 	
 
@@ -459,6 +461,14 @@ namespace WPEFramework
              LOGINFO("Command: ReportShortAudioDescriptor %s : %d \n",GetOpName(msg.opCode()),numberofdescriptor);
             HdmiCecSink::_instance->Process_ShortAudioDescriptor_msg(msg);
        }
+
+       void HdmiCecSinkProcessor::process (const SetSystemAudioMode &msg, const Header &header)
+       {
+             printHeader(header);
+             LOGINFO("Command: SetSystemAudioMode  %s audio status %d audio status is  %s \n",GetOpName(msg.opCode()),msg.status.toInt(),msg.status.toString().c_str());
+          HdmiCecSink::_instance->Process_SetSystemAudioMode_msg(msg);
+       }
+
 //=========================================== HdmiCecSink =========================================
 
        HdmiCecSink::HdmiCecSink()
@@ -851,6 +861,16 @@ namespace WPEFramework
 	    }
 	   HdmiCecSink::_instance->Send_ShortAudioDescriptor_Event(audiodescriptor);
         }
+
+        void HdmiCecSink::Process_SetSystemAudioMode_msg(const SetSystemAudioMode &msg)
+        {
+            JsonObject params;
+            if(!HdmiCecSink::_instance)
+               return;
+            params["audioMode"] = msg.status.toString().c_str();
+            sendNotify(eventString[HDMICECSINK_EVENT_SYSTEM_AUDIO_MODE], params);
+         }
+
          void  HdmiCecSink::sendDeviceUpdateInfo(const int logicalAddress)
          {
             JsonObject params;

--- a/HdmiCecSink/HdmiCecSink.h
+++ b/HdmiCecSink/HdmiCecSink.h
@@ -84,6 +84,7 @@ namespace WPEFramework {
                 void process (const InitiateArc &msg, const Header &header);
                 void process (const TerminateArc &msg, const Header &header);
                 void process (const ReportShortAudioDescriptor  &msg, const Header &header);
+		void process (const SetSystemAudioMode &msg, const Header &header);
         private:
             Connection conn;
             void printHeader(const Header &header)
@@ -517,6 +518,7 @@ private:
                         void requestShortaudioDescriptor();
                         void Send_ShortAudioDescriptor_Event(JsonArray audiodescriptor);
 		        void Process_ShortAudioDescriptor_msg(const ReportShortAudioDescriptor  &msg);
+			void Process_SetSystemAudioMode_msg(const SetSystemAudioMode &msg);
 			void sendFeatureAbort(const LogicalAddress logicalAddress, const OpCode feature, const AbortReason reason);
 			void sendDeviceUpdateInfo(const int logicalAddress);
 			void systemAudioModeRequest();


### PR DESCRIPTION
Reason for change:1) Added support for system audio mode
cec message
2) Updated displaysettings plugin to listen for system audio
mode event from hdmicecsink and update ARC connectivity
status
3) Handle TV standby on scenario. Initiate ARC on receiving
IARM power ON event
Test Procedure: Refer Ticket
Risks: None

Signed-off-by: Deekshit Devadas <deekshit.devadasy@sky.uk>