### PR TITLE
RDK-30925 : added getLastWakeupKey call. (#1011)

### DIFF
--- a/RDKShell/CMakeLists.txt
+++ b/RDKShell/CMakeLists.txt
@@ -25,6 +25,7 @@ find_package(IARMBus)
 add_library(${MODULE_NAME} SHARED
         RDKShell.cpp
         Module.cpp
+        ../helpers/tptimer.cpp
         ../helpers/utils.cpp
 )
 

--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -101,6 +101,7 @@ const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_GET_VIRTUAL_RESOLUT
 const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_SET_VIRTUAL_RESOLUTION = "setVirtualResolution";
 const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_ENABLE_VIRTUAL_DISPLAY = "enableVirtualDisplay";
 const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_GET_VIRTUAL_DISPLAY_ENABLED = "getVirtualDisplayEnabled";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_GET_LAST_WAKEUP_KEY = "getLastWakeupKey";
 
 const string WPEFramework::Plugin::RDKShell::RDKSHELL_EVENT_ON_USER_INACTIVITY = "onUserInactivity";
 const string WPEFramework::Plugin::RDKShell::RDKSHELL_EVENT_ON_APP_LAUNCHED = "onApplicationLaunched";
@@ -156,6 +157,8 @@ static uint32_t gWillDestroyEventWaitTime = RDKSHELL_WILLDESTROY_EVENT_WAITTIME;
 #define SYSTEM_SERVICE_CALLSIGN "org.rdk.System"
 #define RESIDENTAPP_CALLSIGN "ResidentApp"
 #define PERSISTENT_STORE_CALLSIGN "org.rdk.PersistentStore"
+
+#define RECONNECTION_TIME_IN_MILLISECONDS 10000
 
 enum FactoryAppLaunchStatus
 {
@@ -449,12 +452,6 @@ namespace WPEFramework {
                         subSystems->Release();
                     }*/
                 }
-                else if (currentState == PluginHost::IShell::ACTIVATED && service->Callsign() == SYSTEM_SERVICE_CALLSIGN)
-                {
-                   std::string serviceCallsign = service->Callsign();
-                   serviceCallsign.append(".1");
-                   gSystemServiceConnection = getThunderControllerClient(serviceCallsign);
-                }
                 else if (currentState == PluginHost::IShell::ACTIVATED && service->Callsign() == RESIDENTAPP_CALLSIGN)
                 {
                     if (sFactoryModeBlockResidentApp && !sForceResidentAppLaunch)
@@ -568,7 +565,7 @@ namespace WPEFramework {
         }
 
         RDKShell::RDKShell()
-                : AbstractPlugin(API_VERSION_NUMBER_MAJOR), mClientsMonitor(Core::Service<MonitorClients>::Create<MonitorClients>(this)), mEnableUserInactivityNotification(true), mCurrentService(nullptr)
+                : AbstractPlugin(API_VERSION_NUMBER_MAJOR), mClientsMonitor(Core::Service<MonitorClients>::Create<MonitorClients>(this)), mEnableUserInactivityNotification(true), mCurrentService(nullptr), mLastWakeupKeyCode(0), mLastWakeupKeyModifiers(0), mLastWakeupKeyTimestamp(0)
         {
             LOGINFO("ctor");
             RDKShell::_instance = this;
@@ -637,6 +634,9 @@ namespace WPEFramework {
             registerMethod(RDKSHELL_METHOD_SET_VIRTUAL_RESOLUTION, &RDKShell::setVirtualResolutionWrapper, this);
             registerMethod(RDKSHELL_METHOD_ENABLE_VIRTUAL_DISPLAY, &RDKShell::enableVirtualDisplayWrapper, this);
             registerMethod(RDKSHELL_METHOD_GET_VIRTUAL_DISPLAY_ENABLED, &RDKShell::getVirtualDisplayEnabledWrapper, this);
+            registerMethod(RDKSHELL_METHOD_GET_LAST_WAKEUP_KEY, &RDKShell::getLastWakeupKeyWrapper, this);            
+
+            m_timer.connect(std::bind(&RDKShell::onTimer, this));
         }
 
         RDKShell::~RDKShell()
@@ -884,6 +884,11 @@ namespace WPEFramework {
             {
                 gWillDestroyEventWaitTime = atoi(willDestroyWaitTimeValue); 
             }
+
+            m_timer.start(0);
+            m_timer.setInterval(RECONNECTION_TIME_IN_MILLISECONDS);
+            std::cout << "Started SystemServices connection timer" << std::endl;
+
             return "";
         }
 
@@ -1078,11 +1083,20 @@ namespace WPEFramework {
             if (parameters.HasLabel("powerState"))
             {
                 std::string powerState = parameters["powerState"].String();
+                std::string prevState = parameters["currentPowerState"].String();
                 if ((powerState.compare("STANDBY") == 0) || (powerState.compare("LIGHT_SLEEP") == 0) || (powerState.compare("DEEP_SLEEP") == 0))
                 {
                     std::cout << "Received power state change to sleep " << std::endl;
                     JsonObject request, response;
                     int32_t status = getThunderControllerClient("org.rdk.RDKShell.1")->Invoke(0, "launchResidentApp", request, response);
+                }
+ 
+                if ((prevState == "STANDBY" || prevState == "LIGHT_SLEEP" || prevState == "DEEP_SLEEP" || prevState == "OFF")
+                    && powerState == "ON")
+                {
+                    gRdkShellMutex.lock();
+                    CompositorController::getLastKeyPress(mLastWakeupKeyCode, mLastWakeupKeyModifiers, mLastWakeupKeyTimestamp);
+                    gRdkShellMutex.unlock();
                 }
             }
         }
@@ -3875,41 +3889,9 @@ namespace WPEFramework {
                 returnResponse(false);
             }
             sFactoryAppLaunchStatus = STARTED;
-            if (nullptr == gSystemServiceConnection)
-            {
-                std::string serviceCallsign(SYSTEM_SERVICE_CALLSIGN);
-                JsonObject activateParams;
-                activateParams.Set("callsign", serviceCallsign);
-                JsonObject activateResult;
-                auto thunderController = getThunderControllerClient();
-                int32_t activateStatus = thunderController->Invoke(3500, "activate", activateParams, activateResult);
-                std::cout << "activate system service status: " << activateStatus << std::endl;
-                if (activateStatus > 0)
-                {
-                    std::cout << "trying status one more time...\n";
-                    activateStatus = thunderController->Invoke(3500, "activate", activateParams, activateResult);
-                    std::cout << "activate system service status: " << activateStatus << std::endl;
-                    if (activateStatus > 0)
-                    {
-                        std::cout << "unable to activate system service " << std::endl;
-                    }
-                }
-                if (activateStatus == 0)
-                {
-                    serviceCallsign.append(".1");
-                    gSystemServiceConnection = getThunderControllerClient(serviceCallsign);
-                }
-            }
-            if (!gSystemServiceEventsSubscribed && (nullptr != gSystemServiceConnection))
-            {
-                std::string eventName("onSystemPowerStateChanged");
-                int32_t status = gSystemServiceConnection->Subscribe<JsonObject>(RDKSHELL_THUNDER_TIMEOUT, _T(eventName), &RDKShell::pluginEventHandler, this);
-                if (status == 0)
-                {
-                    std::cout << "RDKShell subscribed to onSystemPowerStateChanged event " << std::endl;
-                    gSystemServiceEventsSubscribed = true;
-                }
-            }
+
+            subscribeForSystemEvent("onSystemPowerStateChanged");
+
             if (parameters.HasLabel("startup"))
             {
                 bool startup = parameters["startup"].Boolean();
@@ -4546,6 +4528,30 @@ namespace WPEFramework {
             returnResponse(result);
         }
 
+        uint32_t RDKShell::getLastWakeupKeyWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+
+            if (0 != mLastWakeupKeyTimestamp)
+            {
+                JsonObject req, res;
+                uint32_t status = gSystemServiceConnection->Invoke(RDKSHELL_THUNDER_TIMEOUT, "getWakeupReason", req, res);
+                if (Core::ERROR_NONE == status && res.HasLabel("wakeupReason") && res["wakeupReason"].String() == "WAKEUP_REASON_RCU_BT")
+                {
+                    response["keyCode"] = JsonValue(mLastWakeupKeyCode);
+                    response["modifiers"] = JsonValue(mLastWakeupKeyModifiers);
+                    response["timestampInSeconds"] = JsonValue((long long)mLastWakeupKeyTimestamp);
+
+                    std::cout << "Got LastWakeupKey, keyCode: " << mLastWakeupKeyCode << " modifiers: " << mLastWakeupKeyModifiers << " timestampInSeconds: " << mLastWakeupKeyTimestamp << std::endl;
+                    returnResponse(true);
+                }
+                else
+                    mLastWakeupKeyTimestamp = 0;
+            }
+
+            response["message"] = "No last wakeup key";
+            returnResponse(false);
+        }
         // Registered methods end
 
         // Events begin
@@ -5463,6 +5469,92 @@ namespace WPEFramework {
             return ret;
         }
 
+        void RDKShell::onTimer()
+        {
+            if (gSystemServiceEventsSubscribed)
+            {
+                if (m_timer.isActive()) {
+                    m_timer.stop();
+                    std::cout << "Stopped SystemServices connection timer" << std::endl;
+                }
+            }
+            else
+            {
+                if (Core::ERROR_NONE == subscribeForSystemEvent("onSystemPowerStateChanged"))
+                {  
+                    m_timer.stop();
+                    std::cout << "Stopped SystemServices connection timer" << std::endl;
+                }
+            }
+        }
+
+        int32_t RDKShell::subscribeForSystemEvent(std::string event)
+        {
+            int32_t status = Core::ERROR_GENERAL;
+
+            if (!Utils::isPluginActivated(SYSTEM_SERVICE_CALLSIGN))
+            {
+                gSystemServiceConnection.reset();
+                gSystemServiceEventsSubscribed = false;
+
+                std::string serviceCallsign(SYSTEM_SERVICE_CALLSIGN);
+                JsonObject activateParams;
+                activateParams.Set("callsign", serviceCallsign);
+                JsonObject activateResult;
+                auto thunderController = getThunderControllerClient();
+                int32_t activateStatus = thunderController->Invoke(3500, "activate", activateParams, activateResult);
+                std::cout << "activate system service status: " << activateStatus << std::endl;
+                if (activateStatus > 0)
+                {
+                    std::cout << "trying status one more time...\n";
+                    activateStatus = thunderController->Invoke(3500, "activate", activateParams, activateResult);
+                    std::cout << "activate system service status: " << activateStatus << std::endl;
+                    if (activateStatus > 0)
+                    {
+                        std::cout << "unable to activate system service " << std::endl;
+                    }
+                }
+            }
+
+            if (Utils::isPluginActivated(SYSTEM_SERVICE_CALLSIGN))
+            {
+                std::cout << "SystemService is already activated" << std::endl;
+
+                if (nullptr == gSystemServiceConnection)
+                {  
+                    std::string serviceCallsign = SYSTEM_SERVICE_CALLSIGN;
+                    serviceCallsign.append(".2");
+                    gSystemServiceConnection = RDKShell::getThunderControllerClient(serviceCallsign);
+                }
+            }
+
+            if (nullptr != gSystemServiceConnection)
+            {
+                if (!gSystemServiceEventsSubscribed)
+                {
+                    std::string eventName("onSystemPowerStateChanged");
+                    status = gSystemServiceConnection->Subscribe<JsonObject>(RDKSHELL_THUNDER_TIMEOUT, _T(eventName), &RDKShell::pluginEventHandler, this);
+
+                    if (Core::ERROR_NONE == status)
+                    {
+                        std::cout << "RDKShell subscribed to onSystemPowerStateChanged event " << std::endl;
+                        gSystemServiceEventsSubscribed = true;
+                    }
+                    else
+                    { 
+                        std::cout << "Subscribe for SystemServices event failed with " << status << std::endl;
+                        gSystemServiceConnection.reset();
+                    }
+
+                }
+                else
+                    std::cout << "Already Subscribed to SystemServices events" << std::endl;
+            }
+            else
+                std::cout << "No Connection to SystemServices" << std::endl;
+
+            return status;
+        }
         // Internal methods end
     } // namespace Plugin
 } // namespace WPEFramework

--- a/RDKShell/RDKShell.h
+++ b/RDKShell/RDKShell.h
@@ -26,6 +26,7 @@
 #include <rdkshell/rdkshell.h>
 #include <rdkshell/linuxkeys.h>
 #include "AbstractPlugin.h"
+#include "tptimer.h"
 
 namespace WPEFramework {
 
@@ -115,6 +116,7 @@ namespace WPEFramework {
             static const string RDKSHELL_METHOD_SET_VIRTUAL_RESOLUTION;
             static const string RDKSHELL_METHOD_ENABLE_VIRTUAL_DISPLAY;
             static const string RDKSHELL_METHOD_GET_VIRTUAL_DISPLAY_ENABLED;
+            static const string RDKSHELL_METHOD_GET_LAST_WAKEUP_KEY;
 
             // events
             static const string RDKSHELL_EVENT_ON_USER_INACTIVITY;
@@ -206,6 +208,7 @@ namespace WPEFramework {
             uint32_t setVirtualResolutionWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t enableVirtualDisplayWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t getVirtualDisplayEnabledWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t getLastWakeupKeyWrapper(const JsonObject& parameters, JsonObject& response);
 
         private/*internal methods*/:
             RDKShell(const RDKShell&) = delete;
@@ -263,6 +266,8 @@ namespace WPEFramework {
             bool getVirtualDisplayEnabled(const std::string& client, bool &enabled);
             void loadStartupConfig();
             void invokeStartupThunderApis();
+            int32_t subscribeForSystemEvent(std::string event);
+            void onTimer();
 
             void addFactoryModeEasterEggs();
             void removeFactoryModeEasterEggs();
@@ -341,6 +346,10 @@ namespace WPEFramework {
             std::shared_ptr<RdkShell::RdkShellEventListener> mEventListener;
             PluginHost::IShell* mCurrentService;
             //std::mutex m_callMutex;
+            uint32_t mLastWakeupKeyCode;
+            uint32_t mLastWakeupKeyModifiers;
+            uint64_t mLastWakeupKeyTimestamp;
+            TpTimer m_timer;
         };
 
         struct PluginData

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -3230,6 +3230,8 @@ namespace WPEFramework {
 
 			if(eventData->data.state.curState == IARM_BUS_PWRMGR_POWERSTATE_ON) {
 				curState = "ON";
+            } else if (eventData->data.state.curState == IARM_BUS_PWRMGR_POWERSTATE_OFF) {
+                curState = "OFF";
 			} else if ((eventData->data.state.curState == IARM_BUS_PWRMGR_POWERSTATE_STANDBY)||
 				   (eventData->data.state.curState == IARM_BUS_PWRMGR_POWERSTATE_STANDBY_LIGHT_SLEEP)) {
 				curState = "LIGHT_SLEEP";
@@ -3241,6 +3243,8 @@ namespace WPEFramework {
 
 			if(eventData->data.state.newState == IARM_BUS_PWRMGR_POWERSTATE_ON) {
 				newState = "ON";
+            } else if(eventData->data.state.newState == IARM_BUS_PWRMGR_POWERSTATE_OFF) {
+                newState = "OFF";
 			} else if((eventData->data.state.newState == IARM_BUS_PWRMGR_POWERSTATE_STANDBY)||
 				  (eventData->data.state.newState == IARM_BUS_PWRMGR_POWERSTATE_STANDBY_LIGHT_SLEEP)) {
                                 newState = "LIGHT_SLEEP";


### PR DESCRIPTION
* RDK-30925 : added getLastWakeupKey call.

* RDK-30925 : Used CompositorController::getLastKeyPress for getLastWakeupKey call.
Conflicts:
	RDKShell/RDKShell.cpp

(cherry picked from commit 2f0fdcc6ebfea294cec58176a899d9bb55208ff8)

RDK-30925 : added logging for getLastWakeupKey call.

(cherry picked from commit acf4f2ac8443770a195a13c5ed16f9bfedbe64f5)

RDKTV-4742 : Saved key, used to power on the device for getLastWakeup… (#1229)

* RDKTV-4742 : Saved key, used to power on the device for getLastWakeupKey call.

* RDKTV-4742 : Added delay for SystemServices activation. Got rid of gRdkShellMutex locks.

* RDKTV-4742 : Used 0 delay for SystemServices activation.

* RDKTV-4742 : Set gSystemServiceEventsSubscribed to false if SystemServices is not yet activated.
Conflicts:
	RDKShell/RDKShell.cpp
	RDKShell/RDKShell.h

(cherry picked from commit e50d906ed1a650d5a49628af68e2167af1517bc2)

RDKTV-4742 : Fixed "success":true for wrong wakeup reason. (#1279)

(cherry picked from commit ee3eb63e2508305745f9a133be564cc797b166a9)