### PR TITLE
LLDEV-6370: Prevent handling of dummy temp IP addresses

### DIFF
--- a/Network/NetUtils.cpp
+++ b/Network/NetUtils.cpp
@@ -86,12 +86,12 @@ namespace WPEFramework {
             std::string value;
             if (envGetValue("DEFAULT_MOCA_IFACE_IP", value))
             {
-                LOGERR("%s: value: %s", __FUNCTION__, value.c_str());
+                LOGINFO("%s: value: %s", __FUNCTION__, value.c_str());
                 dummy_ip_list.push_back(value);
             }
             if (envGetValue("DEFAULT_WIFI_IFACE_IP", value))
             {
-                LOGERR("%s: value: %s", __FUNCTION__, value.c_str());
+                LOGINFO("%s: value: %s", __FUNCTION__, value.c_str());
                 dummy_ip_list.push_back(value);
             }
         }

--- a/Network/NetUtils.cpp
+++ b/Network/NetUtils.cpp
@@ -51,6 +51,7 @@ namespace WPEFramework {
         void NetUtils::InitialiseNetUtils()
         {
             _loadInterfaceDescriptions();
+            _loadDummyIpAddresses();
         }
 
         void NetUtils::_loadInterfaceDescriptions()
@@ -66,6 +67,33 @@ namespace WPEFramework {
 
             for (const auto& e : interface_descriptions)
                 LOGINFO ("%s %s", e.first.c_str(), e.second.c_str());
+        }
+
+        bool NetUtils::isDummyIpAddress(const std::string& address)
+        {
+            for (int i = 0; i < dummy_ip_list.size(); i++)
+            {
+                if (strcmp(dummy_ip_list[i].c_str(), address.c_str()) == 0)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        void NetUtils::_loadDummyIpAddresses()
+        {
+            std::string value;
+            if (envGetValue("DEFAULT_MOCA_IFACE_IP", value))
+            {
+                LOGERR("%s: value: %s", __FUNCTION__, value.c_str());
+                dummy_ip_list.push_back(value);
+            }
+            if (envGetValue("DEFAULT_WIFI_IFACE_IP", value))
+            {
+                LOGERR("%s: value: %s", __FUNCTION__, value.c_str());
+                dummy_ip_list.push_back(value);
+            }
         }
 
         const std::string& NetUtils::getInterfaceDescription(const std::string interface)
@@ -274,4 +302,6 @@ namespace WPEFramework {
             return std::find_if(endpoint.begin(), endpoint.end(), _isCharacterIllegal) == endpoint.end();
         }
     } // namespace Plugin
-} // namespace WPEFramework
+}
+
+ // namespace WPEFramework

--- a/Network/NetUtils.h
+++ b/Network/NetUtils.h
@@ -38,6 +38,7 @@ namespace WPEFramework {
         class NetUtils {
         private:
             void _loadInterfaceDescriptions();
+            void _loadDummyIpAddresses();
 
         public:
             NetUtils();
@@ -57,6 +58,7 @@ namespace WPEFramework {
 
             static void getTmpFilename(const char *in, std::string &out);
             static bool isValidEndpointURL(const std::string& endpoint);
+            bool isDummyIpAddress(const std::string& address);
 
         private:
             static bool _isCharacterIllegal(const int& c);
@@ -64,6 +66,7 @@ namespace WPEFramework {
             static unsigned int     m_counter;
             static std::mutex       m_counterProtect;
             std::map<std::string, std::string> interface_descriptions;
+            std::vector<std::string> dummy_ip_list;
         };
     } // namespace Plugin
 } // namespace WPEFramework

--- a/Network/Network.cpp
+++ b/Network/Network.cpp
@@ -337,8 +337,21 @@ namespace WPEFramework
 
                 if (IARM_RESULT_SUCCESS == IARM_Bus_Call(IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_NETSRVMGR_API_getSTBip_family, (void*)&param, sizeof(param)))
                 {
-                    response["ip"] = string(param.activeIfaceIpaddr, MAX_IP_ADDRESS_LEN - 1);
-                    result = true;
+                    string ip = string(param.activeIfaceIpaddr, MAX_IP_ADDRESS_LEN - 1);
+#ifdef	NO_DUMMY_IP_ADDRESSES
+                    if (m_netUtils.isDummyIpAddress(ip))
+                    {
+                        response["ip"] = "";
+                        result = false;
+                    }
+                    else
+                    {
+#endif
+                        response["ip"] = ip;
+                        result = true;
+#ifdef  NO_DUMMY_IP_ADDRESSES
+                    }
+#endif
                 }
                 else
                 {
@@ -580,7 +593,13 @@ namespace WPEFramework
                 response["interface"] = string(iarmData.interface);
                 response["ipversion"] = string(iarmData.ipversion);
                 response["autoconfig"] = iarmData.autoconfig;
-                response["ipaddr"] = string(iarmData.ipaddress,MAX_IP_ADDRESS_LEN - 1);
+                string ip = string(iarmData.ipaddress,MAX_IP_ADDRESS_LEN - 1);
+#ifdef	NO_DUMMY_IP_ADDRESSES
+                if (m_netUtils.isDummyIpAddress(ip))
+                    response["ipaddr"] = "";
+                else
+#endif
+                    response["ipaddr"] = ip;
                 response["netmask"] = string(iarmData.netmask,MAX_IP_ADDRESS_LEN - 1);
                 response["gateway"] = string(iarmData.gateway,MAX_IP_ADDRESS_LEN - 1);
                 response["primarydns"] = string(iarmData.primarydns,MAX_IP_ADDRESS_LEN - 1);
@@ -737,6 +756,10 @@ namespace WPEFramework
 #ifdef NET_DEFINED_INTERFACES_ONLY
                 if (m_netUtils.getInterfaceDescription(e->interface) == "")
                     break;
+#endif
+#ifdef	NO_DUMMY_IP_ADDRESSES
+                if (m_netUtils.isDummyIpAddress(e->ip_address))
+                        break;
 #endif
                 if (e->is_ipv6)
                 {

--- a/Network/Network.h
+++ b/Network/Network.h
@@ -92,6 +92,8 @@ namespace WPEFramework {
             JsonObject _doPing(const std::string& guid, const std::string& endPoint, int packets);
             JsonObject _doPingNamedEndpoint(const std::string& guid, const std::string& endpointName, int packets);
 
+            bool isDummyAValidSubnet(std::string address, std::string interface);
+
         public:
             Network();
             virtual ~Network();


### PR DESCRIPTION
Reason for change: Causes asnetwork EPG pings to fail
Test Procedure: Boot up with ethernet disconnected - confirm no
onIPAddress event posted for dummy address. Perform getIPSetup and
getSTBIPFamily - confirm failure returned. CHeck address for dummy
addresses in /etc/device.properties
Risks: Low
Signed-off-by: Kamal Mortoza <kamal.mortoza@sky.uk>