### PR TITLE
RDKTV-7412 firmware state file should be cleared after the reboot

### DIFF
--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -292,6 +292,9 @@ namespace WPEFramework {
 
                 setMode(mode, response);
             }
+             
+            SystemServices::FwUpdateState_LatestEvent=FirmwareUpdateStateUninitialized;
+
             /**
              * @brief Invoking Plugin API register to WPEFRAMEWORK.
              */
@@ -1879,52 +1882,9 @@ namespace WPEFramework {
                 JsonObject& response)
         {
             bool retStatus = false;
-            FirmwareUpdateState fwUpdateState = FirmwareUpdateStateUninitialized;
-            std::vector<string> lines;
-            if (!Utils::fileExists(FWDNLDSTATUS_FILE_NAME)) {
-                populateResponseWithError(SysSrv_FileNotPresent, response);
-                returnResponse(retStatus);
-            }
-            if (getFileContent(FWDNLDSTATUS_FILE_NAME, lines)) {
-                for (std::vector<std::string>::const_iterator i = lines.begin();
-                        i != lines.end(); ++i) {
-                    std::string line = *i;
-                    std::size_t found = line.find("FwUpdateState|");
-                    std::string delimiter = "|";
-                    size_t pos = 0;
-                    std::string token;
-                    if (std::string::npos != found) {
-                        while ((pos = line.find(delimiter)) != std::string::npos) {
-                            token = line.substr(0, pos);
-                            line.erase(0, pos + delimiter.length());
-                        }
-                        line = std::regex_replace(line, std::regex("^ +| +$"), "$1");
-
-                        if (!strcmp(line.c_str(), "Requesting")) {
-                            fwUpdateState = FirmwareUpdateStateRequesting;
-                        } else if (!strcmp(line.c_str(), "Downloading")) {
-                            fwUpdateState = FirmwareUpdateStateDownloading;
-                        } else if (!strcmp(line.c_str(), "Failed")) {
-                            fwUpdateState = FirmwareUpdateStateFailed;
-                        } else if (!strcmp(line.c_str(), "Download complete")) {
-                            fwUpdateState = FirmwareUpdateStateDownloadComplete;
-                        } else if (!strcmp(line.c_str(), "Validation complete")) {
-                            fwUpdateState = FirmwareUpdateStateValidationComplete;
-                        } else if (!strcmp(line.c_str(), "Preparing to reboot")) {
-                            fwUpdateState = FirmwareUpdateStatePreparingReboot;
-                        } else if (!strcmp(line.c_str(), "No upgrade needed")) {
-                            fwUpdateState = FirmwareUpdateStateNoUpgradeNeeded;
-                        } else if (!strcmp(line.c_str(), "Uninitialized")){
-                            fwUpdateState = FirmwareUpdateStateUninitialized;
-                        }
-                    }
-                }
-                response["firmwareUpdateState"] = (int)fwUpdateState;
-                retStatus = true;
-            } else {
-                LOGERR("Could not read file %s\n", FWDNLDSTATUS_FILE_NAME);
-                populateResponseWithError(SysSrv_FileNotPresent, response);
-            }
+            FirmwareUpdateState fwUpdateState =(FirmwareUpdateState)FwUpdateState_LatestEvent;
+            response["firmwareUpdateState"] = (int)fwUpdateState;
+            retStatus = true;
             returnResponse(retStatus);
         }
 
@@ -3321,6 +3281,7 @@ namespace WPEFramework {
                     {
                         LOGWARN("IARMEvt: IARM_BUS_SYSMGR_SYSSTATE_FIRMWARE_UPDATE_STATE = '%d'\n", state);
                         if (SystemServices::_instance) {
+                            SystemServices::_instance->FwUpdateState_LatestEvent=state;
                             SystemServices::_instance->onFirmwareUpdateStateChange(state);
                         } else {
                             LOGERR("SystemServices::_instance is NULL.\n");

--- a/SystemServices/SystemServices.h
+++ b/SystemServices/SystemServices.h
@@ -108,8 +108,8 @@ namespace WPEFramework {
                 static std::string m_currentMode;
                 static cTimer m_operatingModeTimer;
                 static int m_remainingDuration;
-                Utils::ThreadRAII m_getFirmwareInfoThread;
-
+                Utils::ThreadRAII m_getFirmwareInfoThread; 
+                     
                 static void startModeTimer(int duration);
                 static void stopModeTimer();
                 static void updateDuration();
@@ -135,7 +135,8 @@ namespace WPEFramework {
                 void DeinitializeIARM();
 #endif /* defined(USE_IARMBUS) || defined(USE_IARM_BUS) */
 
-                /* Events : Begin */
+                /* Events : Begin */ 
+                int FwUpdateState_LatestEvent;
                 void onFirmwareUpdateInfoRecieved(string CallGUID);
                 void onSystemPowerStateChanged(string currentPowerState, string powerState);
                 void onSystemModeChanged(string mode);


### PR DESCRIPTION
Reason for change:global variable is used to update state
Test Procedure: build procedure
Risks: No

Signed-off-by: Michael Anand Michael_AmalAnand@comcast.com