### PR TITLE
Rdkcom 2153 remove legacy md

### DIFF
--- a/AVInput/doc/AVInput.md
+++ b/AVInput/doc/AVInput.md
@@ -1,1 +1,0 @@
-[AVInput Docs](https://wiki.rdkcentral.com/display/RDK/AV+Input)

--- a/ActivityMonitor/doc/ActivityMonitor.md
+++ b/ActivityMonitor/doc/ActivityMonitor.md
@@ -1,1 +1,0 @@
-[Activity Monitor docs](https://wiki.rdkcentral.com/display/RDK/ActivityMonitor)

--- a/Bluetooth/doc/Bluetooth.md
+++ b/Bluetooth/doc/Bluetooth.md
@@ -1,2 +1,0 @@
-[Bluetooth](https://wiki.rdkcentral.com/display/RDK/Bluetooth)
-

--- a/ContinueWatching/doc/ContinueWatching.md
+++ b/ContinueWatching/doc/ContinueWatching.md
@@ -1,2 +1,0 @@
-[Continue Watching](https://wiki.rdkcentral.com/display/RDK/Continue+Watching)
-

--- a/ControlService/doc/ControlService.md
+++ b/ControlService/doc/ControlService.md
@@ -1,2 +1,0 @@
-[Control Service](https://wiki.rdkcentral.com/display/RDK/Control+Service)
-

--- a/DataCapture/doc/DataCapture.md
+++ b/DataCapture/doc/DataCapture.md
@@ -1,2 +1,0 @@
-[DataCapture](https://wiki.rdkcentral.com/display/RDK/DataCapture)
-

--- a/DeviceDiagnostics/doc/DeviceDiagnostics.md
+++ b/DeviceDiagnostics/doc/DeviceDiagnostics.md
@@ -1,2 +1,0 @@
-[DeviceDiagnostics](https://wiki.rdkcentral.com/display/RDK/Device+Diagnostics)
-

--- a/DisplaySettings/DisplaySettings.json
+++ b/DisplaySettings/DisplaySettings.json
@@ -1994,22 +1994,6 @@
                 ]
             }
         },
-        "audioMuteStatusChanged":{
-            "summary": "Triggered when the mute setting changes for the current audio port",
-            "params": {
-                "type":"object",
-                "properties": {
-                    "muteStatus": {
-                        "summary": "`true` if muted, otherwise `false`",
-                        "type": "boolean",
-                        "example": true
-                    }
-                },
-                "required": [
-                    "muteStatus"
-                ]
-            }
-        },
         "connectedAudioPortUpdated":{
             "summary": "Triggered when the connected audio port is updated",
             "params": {

--- a/DisplaySettings/doc/DisplaySettings.md
+++ b/DisplaySettings/doc/DisplaySettings.md
@@ -1,2 +1,0 @@
-[DisplaySettings](https://wiki.rdkcentral.com/display/RDK/Display+Settings)
-

--- a/DisplaySettings/doc/DisplaySettingsPlugin.md
+++ b/DisplaySettings/doc/DisplaySettingsPlugin.md
@@ -3559,7 +3559,6 @@ DisplaySettings interface events:
 | Event | Description |
 | :-------- | :-------- |
 | [activeInputChanged](#event.activeInputChanged) | Triggered on active input change (RxSense) |
-| [audioMuteStatusChanged](#event.audioMuteStatusChanged) | Triggered when the mute setting changes for the current audio port |
 | [connectedAudioPortUpdated](#event.connectedAudioPortUpdated) | Triggered when the connected audio port is updated |
 | [connectedVideoDisplaysUpdated](#event.connectedVideoDisplaysUpdated) | Triggered when the connected video display is updated and returns the connected video displays |
 | [resolutionChanged](#event.resolutionChanged) | Triggered when the resolution is changed by the user and returns the current resolution |
@@ -3587,30 +3586,6 @@ Triggered on active input change (RxSense).
     "method": "client.events.1.activeInputChanged",
     "params": {
         "activeInput": true
-    }
-}
-```
-
-<a name="event.audioMuteStatusChanged"></a>
-## *audioMuteStatusChanged <sup>event</sup>*
-
-Triggered when the mute setting changes for the current audio port.
-
-### Parameters
-
-| Name | Type | Description |
-| :-------- | :-------- | :-------- |
-| params | object |  |
-| params.muteStatus | boolean | `true` if muted, otherwise `false` |
-
-### Example
-
-```json
-{
-    "jsonrpc": "2.0",
-    "method": "client.events.1.audioMuteStatusChanged",
-    "params": {
-        "muteStatus": true
     }
 }
 ```

--- a/FireboltMediaPlayer/doc/FireboltMediaPlayer.md
+++ b/FireboltMediaPlayer/doc/FireboltMediaPlayer.md
@@ -1,1 +1,0 @@
-[FireboltMediaPlayer](https://etwiki.sys.comcast.net/x/Y4YfJg)

--- a/FrameRate/doc/FrameRate.md
+++ b/FrameRate/doc/FrameRate.md
@@ -1,2 +1,0 @@
-[FrameRate](https://wiki.rdkcentral.com/display/RDK/Frame+Rate)
-

--- a/FrontPanel/doc/FrontPanel.md
+++ b/FrontPanel/doc/FrontPanel.md
@@ -1,2 +1,0 @@
-[FrontPanel](https://wiki.rdkcentral.com/display/RDK/FrontPanel)
-

--- a/HdcpProfile/doc/HDCPProfile.md
+++ b/HdcpProfile/doc/HDCPProfile.md
@@ -1,2 +1,0 @@
-[HDCPProfile](https://wiki.rdkcentral.com/display/RDK/HDCPProfile)
-

--- a/HdmiCec/doc/HDMICEC.md
+++ b/HdmiCec/doc/HDMICEC.md
@@ -1,2 +1,0 @@
-[HDMI CEC](https://wiki.rdkcentral.com/display/RDK/HDMI++CEC)
-

--- a/HdmiInput/doc/HDMIInput.md
+++ b/HdmiInput/doc/HDMIInput.md
@@ -1,2 +1,0 @@
-[HDMI Input](https://wiki.rdkcentral.com/display/RDK/HDMI++Input)
-

--- a/LoggingPreferences/doc/LoggingPreferences.md
+++ b/LoggingPreferences/doc/LoggingPreferences.md
@@ -1,2 +1,0 @@
-[Logging Preferences](https://wiki.rdkcentral.com/display/RDK/Logging++Preferences)
-

--- a/MaintenanceManager/doc/MaintenanceManager.md
+++ b/MaintenanceManager/doc/MaintenanceManager.md
@@ -1,1 +1,0 @@
-[MaintenanceManager](https://wiki.rdkcentral.com/display/RDK/MaintenanceManager)

--- a/Network/doc/Network.md
+++ b/Network/doc/Network.md
@@ -1,2 +1,0 @@
-[Network](https://wiki.rdkcentral.com/display/RDK/Network)
-

--- a/RDKShell/doc/RDKShell.md
+++ b/RDKShell/doc/RDKShell.md
@@ -1,2 +1,0 @@
-[RDKShell](https://wiki.rdkcentral.com/display/RDK/RDK+Shell)
-

--- a/RemoteActionMapping/doc/RemoteActionMapping.md
+++ b/RemoteActionMapping/doc/RemoteActionMapping.md
@@ -1,2 +1,0 @@
-[RemoteActionMapping](https://wiki.rdkcentral.com/display/RDK/Remote+Action+Mapping)
-

--- a/ScreenCapture/doc/ScreenCapture.md
+++ b/ScreenCapture/doc/ScreenCapture.md
@@ -1,2 +1,0 @@
-[Screen Capture](https://wiki.rdkcentral.com/display/RDK/Screen+Capture)
-

--- a/StateObserver/doc/StateObserver.md
+++ b/StateObserver/doc/StateObserver.md
@@ -1,2 +1,0 @@
-[State Observer](https://wiki.rdkcentral.com/display/RDK/State+Observer)
-

--- a/SystemServices/doc/System.md
+++ b/SystemServices/doc/System.md
@@ -1,2 +1,0 @@
-[System](https://wiki.rdkcentral.com/pages/viewpage.action?pageId=105516014)
-

--- a/Timer/doc/Timer.md
+++ b/Timer/doc/Timer.md
@@ -1,2 +1,0 @@
-[Sleep/Wake Timer](https://wiki.rdkcentral.com/pages/viewpage.action?pageId=105516016)
-

--- a/UserPreferences/doc/UserPreferences.md
+++ b/UserPreferences/doc/UserPreferences.md
@@ -1,2 +1,0 @@
-[User Preferences](https://wiki.rdkcentral.com/display/RDK/User+Preferences)
-

--- a/Warehouse/doc/Warehouse.md
+++ b/Warehouse/doc/Warehouse.md
@@ -1,2 +1,0 @@
-[Warehouse](https://wiki.rdkcentral.com/display/RDK/Warehouse)
-

--- a/WifiManager/doc/Wifi.md
+++ b/WifiManager/doc/Wifi.md
@@ -1,2 +1,0 @@
-[Wifi](https://wiki.rdkcentral.com/display/RDK/Wifi)
-

--- a/XCast/doc/XCast.md
+++ b/XCast/doc/XCast.md
@@ -1,2 +1,0 @@
-[Xcast](https://wiki.rdkcentral.com/display/RDK/XCast)
-


### PR DESCRIPTION
This commit removes MD files that contain URLs to documentation pages on RDK Central. Use the documentation that is in the repo instead which is generated from the JSON definition files.