### PR TITLE
RDKTV-7412 firmware state file should be cleared after the reboot

### DIFF
--- a/SystemServices/SystemServices.h
+++ b/SystemServices/SystemServices.h
@@ -110,6 +110,8 @@ namespace WPEFramework {
                 static int m_remainingDuration;
                 Utils::ThreadRAII m_getFirmwareInfoThread;
 
+                int m_FwUpdateState_LatestEvent;
+
                 static void startModeTimer(int duration);
                 static void stopModeTimer();
                 static void updateDuration();


### PR DESCRIPTION
Reason for change:global variable is used to update state
Test Procedure: build procedure
Risks: No

Signed-off-by: Michael Anand Michael_AmalAnand@comcast.com