### PR TITLE
RDKTV-7090,RDKTV-RDKTV-6644: ARC device not detected after power on

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -62,6 +62,7 @@ using namespace std;
 #define HDMICECSINK_ARC_INITIATION_EVENT "arcInitiationEvent"
 #define HDMICECSINK_ARC_TERMINATION_EVENT "arcTerminationEvent"
 #define HDMICECSINK_SHORT_AUDIO_DESCRIPTOR_EVENT "shortAudiodesciptorEvent"
+#define HDMICECSINK_SYSTEM_AUDIO_MODE_EVENT "setSystemAudioMode"
 #define SERVER_DETAILS  "127.0.0.1:9998"
 #define WARMING_UP_TIME_IN_SECONDS 5
 #define HDMICECSINK_PLUGIN_ACTIVATION_TIME 2
@@ -268,7 +269,8 @@ namespace WPEFramework {
 
                         //Start the timer only if the device supports HDMI_ARC
                         LOGINFO("Starting the timer");
-                        m_timer.start(RECONNECTION_TIME_IN_MILLISECONDS);
+                        m_timer.start();
+			m_timer.setInterval(RECONNECTION_TIME_IN_MILLISECONDS);
                     }
                     else {
                         JsonObject aPortHdmiEnableResult;
@@ -3213,6 +3215,9 @@ namespace WPEFramework {
                 } else if(strcmp(eventName, HDMICECSINK_SHORT_AUDIO_DESCRIPTOR_EVENT) == 0) {
                     err =m_client->Subscribe<JsonObject>(1000, eventName
                             , &DisplaySettings::onShortAudioDescriptorEventHandler, this);
+                } else if(strcmp(eventName, HDMICECSINK_SYSTEM_AUDIO_MODE_EVENT) == 0) {
+                    err =m_client->Subscribe<JsonObject>(1000, eventName
+                            , &DisplaySettings::onSystemAudioModeEventHandler, this);
                 }
                 else {
                      err = Core::ERROR_UNAVAILABLE;
@@ -3333,8 +3338,35 @@ namespace WPEFramework {
             }
         }
 
-
         // 5.
+        void DisplaySettings::onSystemAudioModeEventHandler(const JsonObject& parameters) {
+            string message;
+            string value;
+
+            parameters.ToString(message);
+            LOGINFO("[System Audio Mode Event], %s : %s", __FUNCTION__, C_STR(message));
+
+            if (parameters.HasLabel("audioMode")) {
+                value = parameters["audioMode"].String();
+                if(!value.compare("On")) {
+                    m_hdmiInAudioDeviceConnected = true;
+                    LOGINFO("%s :  audioMode ON !!!\n", __FUNCTION__);
+                    connectedAudioPortUpdated(dsAUDIOPORT_TYPE_HDMI_ARC, true);
+                }
+		else if(!value.compare("Off")) {
+                    LOGINFO("%s :  audioMode OFF !!!\n", __FUNCTION__);
+		    m_hdmiInAudioDeviceConnected = false;
+		    connectedAudioPortUpdated(dsAUDIOPORT_TYPE_HDMI_ARC, false);
+                }
+                else{
+                    LOGERR("%s: Invalid audio mode sent by HdmiCecSink !!!\n",__FUNCTION__);
+                }
+            } else {
+                LOGERR("Field 'audioMode' could not be found in the event's payload.");
+            }
+        }
+
+        // 6.
         void DisplaySettings::onTimer()
         {
             // lock to prevent: parallel onTimer runs, destruction during onTimer
@@ -3354,7 +3386,7 @@ namespace WPEFramework {
             bool pluginActivated = Utils::isPluginActivated(HDMICECSINK_CALLSIGN);
             LOGWARN ("DisplaySettings::onTimer pluginActivated:%d line:%d", pluginActivated, __LINE__);
             if(!m_subscribed) {
-                if (pluginActivated && (subscribeForHdmiCecSinkEvent(HDMICECSINK_ARC_INITIATION_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_ARC_TERMINATION_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_SHORT_AUDIO_DESCRIPTOR_EVENT)== Core::ERROR_NONE))
+                if (pluginActivated && (subscribeForHdmiCecSinkEvent(HDMICECSINK_ARC_INITIATION_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_ARC_TERMINATION_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_SHORT_AUDIO_DESCRIPTOR_EVENT)== Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_SYSTEM_AUDIO_MODE_EVENT) == Core::ERROR_NONE))
                 {
                     m_subscribed = true;
                     if (m_timer.isActive()) {
@@ -3364,32 +3396,6 @@ namespace WPEFramework {
                     LOGINFO("Subscription completed.");
 		    sleep(WARMING_UP_TIME_IN_SECONDS);
 
-                    JsonObject aPortArcEnableResult;
-                    JsonObject aPortArcEnableParam;
-		    JsonObject aPortConfig;
-
-                    aPortArcEnableParam.Set(_T("audioPort"),"HDMI_ARC0");
-		    aPortConfig = getAudioOutputPortConfig();
-                    bool arcEnable = false;
-		    uint32_t ret = Core::ERROR_NONE;
-
-		    if (aPortConfig.HasLabel("HDMI_ARC")) {
-                        try {
-                                arcEnable = aPortConfig["HDMI_ARC"].Boolean();
-                        }catch (...) {
-                                LOGERR("HDMI_ARC status read error");
-                        }
-                    }
-
-                    aPortArcEnableParam.Set(_T("enable"),arcEnable);
-                    ret = setEnableAudioPort (aPortArcEnableParam, aPortArcEnableResult);
-                    if(ret != Core::ERROR_NONE) {
-                        LOGWARN("Audio Port : [HDMI_ARC0] enable: %d failed ! error code%d\n", arcEnable, ret);
-                    }
-                    else {
-                        LOGINFO("Audio Port : [HDMI_ARC0] initialized successfully, enable: %d\n", arcEnable);
-                    }
-
                 } else {
                     LOGERR("Could not subscribe this time, one more attempt in %d msec. Plugin is %s", RECONNECTION_TIME_IN_MILLISECONDS, pluginActivated ? "ACTIVE" : "BLOCKED");
                     if (!pluginActivated)
@@ -3398,11 +3404,57 @@ namespace WPEFramework {
                     }
                 }
             } else {
-                // Not supposed to be here
+                //Standby ON transitions case
                 LOGINFO("Already subscribed. Stopping the timer.");
                 if (m_timer.isActive()) {
                     m_timer.stop();
                 }
+            }
+
+            if(m_subscribed) {
+                JsonObject aPortArcEnableResult;
+                JsonObject aPortArcEnableParam;
+                JsonObject aPortConfig;
+
+                aPortArcEnableParam.Set(_T("audioPort"),"HDMI_ARC0");
+                aPortConfig = getAudioOutputPortConfig();
+                bool arcEnable = false;
+                uint32_t ret = Core::ERROR_NONE;
+
+                if (aPortConfig.HasLabel("HDMI_ARC")) {
+                    try {
+                            arcEnable = aPortConfig["HDMI_ARC"].Boolean();
+                    }catch (...) {
+                            LOGERR("HDMI_ARC status read error");
+                    }
+                }
+
+                aPortArcEnableParam.Set(_T("enable"),arcEnable);
+                ret = setEnableAudioPort (aPortArcEnableParam, aPortArcEnableResult);
+                if(ret != Core::ERROR_NONE) {
+                    LOGWARN("Audio Port : [HDMI_ARC0] enable: %d failed ! error code%d\n", arcEnable, ret);
+                }
+                else {
+                    LOGINFO("Audio Port : [HDMI_ARC0] initialized successfully, enable: %d\n", arcEnable);
+                }
+
+		//Connected Audio Ports status update is necessary on bootup / power state transitions
+                try {
+                    int types = dsAUDIOARCSUPPORT_NONE;
+                    device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort("HDMI_ARC0");
+                    aPort.getSupportedARCTypes(&types);
+                    if(types & dsAUDIOARCSUPPORT_eARC) {
+                        m_hdmiInAudioDeviceConnected = true;
+                        connectedAudioPortUpdated(dsAUDIOPORT_TYPE_HDMI_ARC, true);
+                    }
+                    else if (types & dsAUDIOARCSUPPORT_ARC) {
+                        //Dummy ARC intiation request
+                        setUpHdmiCecSinkArcRouting(true);
+                    }
+               }
+               catch (const device::Exception& err){
+                    LOG_DEVICE_EXCEPTION1(string("HDMI_ARC0"));
+               }
             }
         }
          // Event management end

--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -144,6 +144,7 @@ namespace WPEFramework {
 	    void onARCInitiationEventHandler(const JsonObject& parameters);
             void onARCTerminationEventHandler(const JsonObject& parameters);
 	    void onShortAudioDescriptorEventHandler(const JsonObject& parameters);
+	    void onSystemAudioModeEventHandler(const JsonObject& parameters);
             //End events
         public:
             DisplaySettings();

--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -92,6 +92,7 @@ enum {
 	HDMICECSINK_EVENT_ARC_TERMINATION_EVENT,
         HDMICECSINK_EVENT_SHORT_AUDIODESCRIPTOR_EVENT,
         HDMICECSINK_EVENT_STANDBY_MSG_EVENT,
+	HDMICECSINK_EVENT_SYSTEM_AUDIO_MODE,
 };
 
 static char *eventString[] = {
@@ -107,7 +108,8 @@ static char *eventString[] = {
         "arcInitiationEvent",
         "arcTerminationEvent",
         "shortAudiodesciptorEvent",
-        "standbyMessageReceived"
+        "standbyMessageReceived",
+        "setSystemAudioMode"
 };
 	
 
@@ -459,6 +461,14 @@ namespace WPEFramework
              LOGINFO("Command: ReportShortAudioDescriptor %s : %d \n",GetOpName(msg.opCode()),numberofdescriptor);
             HdmiCecSink::_instance->Process_ShortAudioDescriptor_msg(msg);
        }
+
+       void HdmiCecSinkProcessor::process (const SetSystemAudioMode &msg, const Header &header)
+       {
+             printHeader(header);
+             LOGINFO("Command: SetSystemAudioMode  %s audio status %d audio status is  %s \n",GetOpName(msg.opCode()),msg.status.toInt(),msg.status.toString().c_str());
+          HdmiCecSink::_instance->Process_SetSystemAudioMode_msg(msg);
+       }
+
 //=========================================== HdmiCecSink =========================================
 
        HdmiCecSink::HdmiCecSink()
@@ -851,6 +861,16 @@ namespace WPEFramework
 	    }
 	   HdmiCecSink::_instance->Send_ShortAudioDescriptor_Event(audiodescriptor);
         }
+
+        void HdmiCecSink::Process_SetSystemAudioMode_msg(const SetSystemAudioMode &msg)
+        {
+            JsonObject params;
+            if(!HdmiCecSink::_instance)
+               return;
+            params["audioMode"] = msg.status.toString().c_str();
+            sendNotify(eventString[HDMICECSINK_EVENT_SYSTEM_AUDIO_MODE], params);
+         }
+
          void  HdmiCecSink::sendDeviceUpdateInfo(const int logicalAddress)
          {
             JsonObject params;
@@ -2459,11 +2479,7 @@ namespace WPEFramework
             }
             msgProcessor = new HdmiCecSinkProcessor(*smConnection);
             msgFrameListener = new HdmiCecSinkFrameListener(*msgProcessor);
-
-           /* Get updated in the startArc */
-            m_ArcUiSettingState = false;
             cecEnableStatus = true;
-
             if(smConnection)
             {
            		LOGWARN("Start Thread %p", smConnection );
@@ -2588,7 +2604,6 @@ namespace WPEFramework
                LOGINFO("ARC is either initiation in progress or already initiated");
                return;
             }
-            m_ArcUiSettingState = true;
             _instance->systemAudioModeRequest();
 	    _instance->requestArcInitiation();
  
@@ -2619,7 +2634,6 @@ namespace WPEFramework
             }
             if(!HdmiCecSink::_instance)
                 return;
-           m_ArcUiSettingState = false;
 	    if(m_currentArcRoutingState == ARC_STATE_REQUEST_ARC_TERMINATION || m_currentArcRoutingState == ARC_STATE_ARC_TERMINATED)
             {
                LOGINFO("ARC is either Termination  in progress or already Terminated");
@@ -2657,28 +2671,18 @@ namespace WPEFramework
             if(!HdmiCecSink::_instance)
 	    return;
 
-            LOGINFO("Got : INITIATE_ARC  and current Arcstate is %d m_ArcUiSettingState %d ",_instance->m_currentArcRoutingState,m_ArcUiSettingState);
+            LOGINFO("Got : INITIATE_ARC  and current Arcstate is %d\n",_instance->m_currentArcRoutingState);
             std::lock_guard<std::mutex> lock(_instance->m_arcRoutingStateMutex);
 
             if (m_arcStartStopTimer.isActive())
             {
                m_arcStartStopTimer.stop();
             }
-            if(  m_ArcUiSettingState)
-            {   
 	          _instance->m_currentArcRoutingState = ARC_STATE_ARC_INITIATED;
                   _instance->m_semSignaltoArcRoutingThread.release();
                   LOGINFO("Got : ARC_INITIATED  and notify Device setting");
                   params["status"] = string("success");
                   sendNotify(eventString[HDMICECSINK_EVENT_ARC_INITIATION_EVENT], params); 
-           }
-           else
-          {
-              LOGINFO(" ARC UI setting is not Enabled so send ARC Terminated event and set the state to ARC_STATE_ARC_TERMINATED");
-             //need to send report ARC Terminated
-                HdmiCecSink::_instance->m_currentArcRoutingState = ARC_STATE_ARC_TERMINATED;
-                _instance->m_semSignaltoArcRoutingThread.release();
-          }
 	  
 
        }
@@ -2687,7 +2691,7 @@ namespace WPEFramework
             JsonObject params;
             std::lock_guard<std::mutex> lock(m_arcRoutingStateMutex);
 
-            LOGINFO("Command: TERMINATE_ARC current arc state %d m_ArcUiSettingState %d\n",HdmiCecSink::_instance->m_currentArcRoutingState,m_ArcUiSettingState);
+            LOGINFO("Command: TERMINATE_ARC current arc state %d \n",HdmiCecSink::_instance->m_currentArcRoutingState);
                 if (m_arcStartStopTimer.isActive())
                 {
                       m_arcStartStopTimer.stop();

--- a/HdmiCecSink/HdmiCecSink.h
+++ b/HdmiCecSink/HdmiCecSink.h
@@ -84,6 +84,7 @@ namespace WPEFramework {
                 void process (const InitiateArc &msg, const Header &header);
                 void process (const TerminateArc &msg, const Header &header);
                 void process (const ReportShortAudioDescriptor  &msg, const Header &header);
+		void process (const SetSystemAudioMode &msg, const Header &header);
         private:
             Connection conn;
             void printHeader(const Header &header)
@@ -517,6 +518,7 @@ private:
                         void requestShortaudioDescriptor();
                         void Send_ShortAudioDescriptor_Event(JsonArray audiodescriptor);
 		        void Process_ShortAudioDescriptor_msg(const ReportShortAudioDescriptor  &msg);
+			void Process_SetSystemAudioMode_msg(const SetSystemAudioMode &msg);
 			void sendFeatureAbort(const LogicalAddress logicalAddress, const OpCode feature, const AbortReason reason);
 			void sendDeviceUpdateInfo(const int logicalAddress);
 			void systemAudioModeRequest();
@@ -563,7 +565,6 @@ private:
             std::mutex m_pollMutex;
             /* ARC related */
             std::thread m_arcRoutingThread;
-	    bool m_ArcUiSettingState;
 	    uint32_t m_currentArcRoutingState;
 	    std::mutex m_arcRoutingStateMutex;
 	    binary_semaphore m_semSignaltoArcRoutingThread;


### PR DESCRIPTION
Reason for change:1) Added support for system audio mode
cec message
2) Updated displaysettings plugin to listen for system audio
mode event from hdmicecsink and update ARC connectivity
status
3) Handle TV standby on scenario. Update HDMI_ARC0 port
connection status on bootup and power state transitions
Test Procedure: Refer Ticket
Risks: None

Signed-off-by: Deekshit Devadas deekshit.devadasy@sky.uk