### PR TITLE
RDKTV-7090,RDKTV-RDKTV-6644: ARC device not detected after power on

### DIFF
--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -144,6 +144,7 @@ namespace WPEFramework {
 	    void onARCInitiationEventHandler(const JsonObject& parameters);
             void onARCTerminationEventHandler(const JsonObject& parameters);
 	    void onShortAudioDescriptorEventHandler(const JsonObject& parameters);
+	    void onSystemAudioModeEventHandler(const JsonObject& parameters);
             //End events
         public:
             DisplaySettings();

--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -92,6 +92,7 @@ enum {
 	HDMICECSINK_EVENT_ARC_TERMINATION_EVENT,
         HDMICECSINK_EVENT_SHORT_AUDIODESCRIPTOR_EVENT,
         HDMICECSINK_EVENT_STANDBY_MSG_EVENT,
+	HDMICECSINK_EVENT_SYSTEM_AUDIO_MODE,
 };
 
 static char *eventString[] = {
@@ -107,7 +108,8 @@ static char *eventString[] = {
         "arcInitiationEvent",
         "arcTerminationEvent",
         "shortAudiodesciptorEvent",
-        "standbyMessageReceived"
+        "standbyMessageReceived",
+        "setSystemAudioModeEvent"
 };
 	
 
@@ -459,6 +461,14 @@ namespace WPEFramework
              LOGINFO("Command: ReportShortAudioDescriptor %s : %d \n",GetOpName(msg.opCode()),numberofdescriptor);
             HdmiCecSink::_instance->Process_ShortAudioDescriptor_msg(msg);
        }
+
+       void HdmiCecSinkProcessor::process (const SetSystemAudioMode &msg, const Header &header)
+       {
+             printHeader(header);
+             LOGINFO("Command: SetSystemAudioMode  %s audio status %d audio status is  %s \n",GetOpName(msg.opCode()),msg.status.toInt(),msg.status.toString().c_str());
+          HdmiCecSink::_instance->Process_SetSystemAudioMode_msg(msg);
+       }
+
 //=========================================== HdmiCecSink =========================================
 
        HdmiCecSink::HdmiCecSink()
@@ -851,6 +861,16 @@ namespace WPEFramework
 	    }
 	   HdmiCecSink::_instance->Send_ShortAudioDescriptor_Event(audiodescriptor);
         }
+
+        void HdmiCecSink::Process_SetSystemAudioMode_msg(const SetSystemAudioMode &msg)
+        {
+            JsonObject params;
+            if(!HdmiCecSink::_instance)
+               return;
+            params["audioMode"] = msg.status.toString().c_str();
+            sendNotify(eventString[HDMICECSINK_EVENT_SYSTEM_AUDIO_MODE], params);
+         }
+
          void  HdmiCecSink::sendDeviceUpdateInfo(const int logicalAddress)
          {
             JsonObject params;
@@ -2459,11 +2479,7 @@ namespace WPEFramework
             }
             msgProcessor = new HdmiCecSinkProcessor(*smConnection);
             msgFrameListener = new HdmiCecSinkFrameListener(*msgProcessor);
-
-           /* Get updated in the startArc */
-            m_ArcUiSettingState = false;
             cecEnableStatus = true;
-
             if(smConnection)
             {
            		LOGWARN("Start Thread %p", smConnection );
@@ -2588,7 +2604,6 @@ namespace WPEFramework
                LOGINFO("ARC is either initiation in progress or already initiated");
                return;
             }
-            m_ArcUiSettingState = true;
             _instance->systemAudioModeRequest();
 	    _instance->requestArcInitiation();
  
@@ -2619,7 +2634,6 @@ namespace WPEFramework
             }
             if(!HdmiCecSink::_instance)
                 return;
-           m_ArcUiSettingState = false;
 	    if(m_currentArcRoutingState == ARC_STATE_REQUEST_ARC_TERMINATION || m_currentArcRoutingState == ARC_STATE_ARC_TERMINATED)
             {
                LOGINFO("ARC is either Termination  in progress or already Terminated");
@@ -2657,28 +2671,18 @@ namespace WPEFramework
             if(!HdmiCecSink::_instance)
 	    return;
 
-            LOGINFO("Got : INITIATE_ARC  and current Arcstate is %d m_ArcUiSettingState %d ",_instance->m_currentArcRoutingState,m_ArcUiSettingState);
+            LOGINFO("Got : INITIATE_ARC  and current Arcstate is %d\n",_instance->m_currentArcRoutingState);
             std::lock_guard<std::mutex> lock(_instance->m_arcRoutingStateMutex);
 
             if (m_arcStartStopTimer.isActive())
             {
                m_arcStartStopTimer.stop();
             }
-            if(  m_ArcUiSettingState)
-            {   
 	          _instance->m_currentArcRoutingState = ARC_STATE_ARC_INITIATED;
                   _instance->m_semSignaltoArcRoutingThread.release();
                   LOGINFO("Got : ARC_INITIATED  and notify Device setting");
                   params["status"] = string("success");
                   sendNotify(eventString[HDMICECSINK_EVENT_ARC_INITIATION_EVENT], params); 
-           }
-           else
-          {
-              LOGINFO(" ARC UI setting is not Enabled so send ARC Terminated event and set the state to ARC_STATE_ARC_TERMINATED");
-             //need to send report ARC Terminated
-                HdmiCecSink::_instance->m_currentArcRoutingState = ARC_STATE_ARC_TERMINATED;
-                _instance->m_semSignaltoArcRoutingThread.release();
-          }
 	  
 
        }
@@ -2687,7 +2691,7 @@ namespace WPEFramework
             JsonObject params;
             std::lock_guard<std::mutex> lock(m_arcRoutingStateMutex);
 
-            LOGINFO("Command: TERMINATE_ARC current arc state %d m_ArcUiSettingState %d\n",HdmiCecSink::_instance->m_currentArcRoutingState,m_ArcUiSettingState);
+            LOGINFO("Command: TERMINATE_ARC current arc state %d \n",HdmiCecSink::_instance->m_currentArcRoutingState);
                 if (m_arcStartStopTimer.isActive())
                 {
                       m_arcStartStopTimer.stop();

--- a/HdmiCecSink/HdmiCecSink.h
+++ b/HdmiCecSink/HdmiCecSink.h
@@ -84,6 +84,7 @@ namespace WPEFramework {
                 void process (const InitiateArc &msg, const Header &header);
                 void process (const TerminateArc &msg, const Header &header);
                 void process (const ReportShortAudioDescriptor  &msg, const Header &header);
+		void process (const SetSystemAudioMode &msg, const Header &header);
         private:
             Connection conn;
             void printHeader(const Header &header)
@@ -517,6 +518,7 @@ private:
                         void requestShortaudioDescriptor();
                         void Send_ShortAudioDescriptor_Event(JsonArray audiodescriptor);
 		        void Process_ShortAudioDescriptor_msg(const ReportShortAudioDescriptor  &msg);
+			void Process_SetSystemAudioMode_msg(const SetSystemAudioMode &msg);
 			void sendFeatureAbort(const LogicalAddress logicalAddress, const OpCode feature, const AbortReason reason);
 			void sendDeviceUpdateInfo(const int logicalAddress);
 			void systemAudioModeRequest();
@@ -563,7 +565,6 @@ private:
             std::mutex m_pollMutex;
             /* ARC related */
             std::thread m_arcRoutingThread;
-	    bool m_ArcUiSettingState;
 	    uint32_t m_currentArcRoutingState;
 	    std::mutex m_arcRoutingStateMutex;
 	    binary_semaphore m_semSignaltoArcRoutingThread;


### PR DESCRIPTION
Reason for change:1) Added support for system audio mode
cec message
2) Updated displaysettings plugin to listen for system audio
mode event from hdmicecsink and update ARC connectivity
status
3) Handle TV standby on scenario. Update HDMI_ARC0 port
connection status on bootup and power state transitions
Test Procedure: Refer Ticket
Risks: None

Signed-off-by: Deekshit Devadas deekshit.devadasy@sky.uk