### PR TITLE
DELIA-48768 : ARC subscription log flooding

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -258,6 +258,17 @@ namespace WPEFramework {
                         else {
                             m_audioOutputPortConfig["HDMI_ARC"] = false;
                         }
+
+                        //Stop timer if its already running
+                        if(m_timer.isActive()) {
+                            m_timer.stop();
+                        }
+
+                        Utils::activatePlugin(HDMICECSINK_CALLSIGN);
+
+                        //Start the timer only if the device supports HDMI_ARC
+                        LOGINFO("Starting the timer");
+                        m_timer.start(RECONNECTION_TIME_IN_MILLISECONDS);
                     }
                     else {
                         JsonObject aPortHdmiEnableResult;
@@ -293,14 +304,6 @@ namespace WPEFramework {
         const string DisplaySettings::Initialize(PluginHost::IShell* /* service */)
         {
             InitializeIARM();
-
-            if(m_timer.isActive()) {
-                m_timer.stop();
-            }
-
-            Utils::activatePlugin(HDMICECSINK_CALLSIGN);
-            LOGINFO("Starting the timer");
-            m_timer.start(RECONNECTION_TIME_IN_MILLISECONDS);
 
             if (IARM_BUS_PWRMGR_POWERSTATE_ON == getSystemPowerState())
             {


### PR DESCRIPTION
Reason for change: Enable m_timer if only ARC is enabled
Test Procedure: Refer JIRA
Risks: Low
Signed-off-by: Akhil Baby Sarada <Akhil_Sarada@comcast.com>