### PR TITLE
RDKTV-8011 Start the timer only after interval sets

### DIFF
--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -918,8 +918,8 @@ namespace WPEFramework {
                 gWillDestroyEventWaitTime = atoi(willDestroyWaitTimeValue); 
             }
 
-            m_timer.start(8000);
             m_timer.setInterval(RECONNECTION_TIME_IN_MILLISECONDS);
+            m_timer.start();
             std::cout << "Started SystemServices connection timer" << std::endl;
 
             return "";


### PR DESCRIPTION
Reason for change: Timer start earlier than expected
Test Procedure: Refer 8011
Risks: Low

Signed-off-by: sputhi200 <Sujeesh_Puthiya@comcast.com>