### PR TITLE
RDKTV-7404: No Dolby Indicator

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -152,6 +152,7 @@ namespace WPEFramework {
             registerMethod("getSupportedSettopResolutions", &DisplaySettings::getSupportedSettopResolutions, this);
             registerMethod("getSupportedAudioPorts", &DisplaySettings::getSupportedAudioPorts, this);
             registerMethod("getSupportedAudioModes", &DisplaySettings::getSupportedAudioModes, this);
+	    registerMethod("getAudioFormat", &DisplaySettings::getAudioFormat, this);
             registerMethod("getZoomSetting", &DisplaySettings::getZoomSetting, this);
             registerMethod("setZoomSetting", &DisplaySettings::setZoomSetting, this);
             registerMethod("getCurrentResolution", &DisplaySettings::getCurrentResolution, this);
@@ -336,6 +337,7 @@ namespace WPEFramework {
                 IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_HOTPLUG, dsHdmiEventHandler) );
 		IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_IN_HOTPLUG, dsHdmiEventHandler) );
                 IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_AUDIO_OUT_HOTPLUG, dsHdmiEventHandler) );
+		IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_AUDIO_FORMAT_UPDATE, audioFormatUpdateEventHandler) );
                 IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_PWRMGR_NAME, IARM_BUS_PWRMGR_EVENT_MODECHANGED, powerEventHandler) );
 
                 res = IARM_Bus_Call(IARM_BUS_PWRMGR_NAME, IARM_BUS_PWRMGR_API_GetPowerState, (void *)&param, sizeof(param));
@@ -371,6 +373,7 @@ namespace WPEFramework {
                 IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_HOTPLUG) );
 		IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_IN_HOTPLUG) );
                 IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_AUDIO_OUT_HOTPLUG) );
+		IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_PWRMGR_NAME, IARM_BUS_DSMGR_EVENT_AUDIO_FORMAT_UPDATE) );
                 IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_PWRMGR_NAME, IARM_BUS_PWRMGR_EVENT_MODECHANGED) );
             }
 
@@ -645,6 +648,28 @@ namespace WPEFramework {
                 //do nothing
                 break;
             }
+        }
+
+        void DisplaySettings::audioFormatUpdateEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
+        {
+            dsAudioFormat_t audioFormat = dsAUDIO_FORMAT_NONE;
+
+	    LOGINFO("%s \n", __FUNCTION__);
+            switch (eventId) {
+                case IARM_BUS_DSMGR_EVENT_AUDIO_FORMAT_UPDATE:
+                  {
+                    IARM_Bus_DSMgr_EventData_t *eventData = (IARM_Bus_DSMgr_EventData_t *)data;
+                    audioFormat = eventData->data.AudioFormatInfo.audioFormat;
+                    LOGINFO("Received IARM_BUS_DSMGR_EVENT_AUDIO_FORMAT_UPDATE. Audio format: %d \n", audioFormat);
+                    if(DisplaySettings::_instance) {
+                        DisplaySettings::_instance->notifyAudioFormatChange(audioFormat);
+                    }
+		  }
+                  break;
+		default:
+		    LOGERR("Invalid event ID\n");
+		    break;
+           }
         }
 
         void setResponseArray(JsonObject& response, const char* key, const vector<string>& items)
@@ -1612,6 +1637,81 @@ namespace WPEFramework {
                 }
                 returnResponse(success);
         }
+
+        void DisplaySettings::audioFormatToString(dsAudioFormat_t audioFormat, JsonObject & response)
+        {
+            std::vector<string> supportedAudioFormat = {"NONE", "PCM", "DOLBY AC3", "DOLBY EAC3",
+                                                         "DOLBY AC4", "DOLBY MAT", "DOLBY TRUEHD",
+                                                         "DOLBY EAC3 ATMOS","DOLBY TRUEHD ATMOS",
+                                                         "DOLBY MAT ATMOS","DOLBY AC4 ATMOS"};
+            switch (audioFormat)
+            {
+                   case dsAUDIO_FORMAT_NONE:
+                       response["currentAudioFormat"] = "NONE";
+                       break;
+                   case dsAUDIO_FORMAT_PCM:
+                       response["currentAudioFormat"] = "PCM";
+                       break;
+                   case dsAUDIO_FORMAT_DOLBY_AC3:
+                       response["currentAudioFormat"] = "DOLBY AC3";
+                       break;
+                   case dsAUDIO_FORMAT_DOLBY_EAC3:
+                       response["currentAudioFormat"] = "DOLBY EAC3";
+                       break;
+                   case dsAUDIO_FORMAT_DOLBY_AC4:
+                       response["currentAudioFormat"] = "DOLBY AC4";
+                       break;
+                   case dsAUDIO_FORMAT_DOLBY_MAT:
+                       response["currentAudioFormat"] = "DOLBY MAT";
+                       break;
+                   case dsAUDIO_FORMAT_DOLBY_TRUEHD:
+                       response["currentAudioFormat"] = "DOLBY TRUEHD";
+                       break;
+                   case dsAUDIO_FORMAT_DOLBY_EAC3_ATMOS:
+                       response["currentAudioFormat"] = "DOLBY EAC3 ATMOS";
+                       break;
+                   case dsAUDIO_FORMAT_DOLBY_TRUEHD_ATMOS:
+                       response["currentAudioFormat"] = "DOLBY TRUEHD ATMOS";
+                       break;
+                   case dsAUDIO_FORMAT_DOLBY_MAT_ATMOS:
+                       response["currentAudioFormat"] = "DOLBY MAT ATMOS";
+                       break;
+                   case dsAUDIO_FORMAT_DOLBY_AC4_ATMOS:
+                       response["currentAudioFormat"] = "DOLBY AC4 ATMOS";
+                       break;
+                   default:
+                       break;
+            }
+            setResponseArray(response, "supportedAudioFormat", supportedAudioFormat);
+	}
+
+        uint32_t DisplaySettings::getAudioFormat(const JsonObject& parameters, JsonObject& response)
+        {
+             LOGINFOMETHOD();
+	     bool success = true;
+             dsAudioFormat_t audioFormat = dsAUDIO_FORMAT_NONE;
+             try
+             {
+                 device::Host::getInstance().getCurrentAudioFormat(audioFormat);
+                 LOGINFO("current audio format: %d \n", audioFormat);
+                 audioFormatToString(audioFormat, response);
+                 success = true;
+             }
+             catch (const device::Exception& err)
+             {
+                 LOG_DEVICE_EXCEPTION0();
+		 success = false;
+		 audioFormatToString(dsAUDIO_FORMAT_NONE, response);
+             }
+	     returnResponse(success);
+        }
+
+	void DisplaySettings::notifyAudioFormatChange(dsAudioFormat_t audioFormat)
+	{
+	     JsonObject params;
+	     audioFormatToString(audioFormat, params);
+             sendNotify("audioFormatChanged", params);
+	}
 
 
         uint32_t DisplaySettings::getBassEnhancer(const JsonObject& parameters, JsonObject& response)
@@ -3303,6 +3403,7 @@ namespace WPEFramework {
                }
             }
         }
+
          // Event management end
 
         // Thunder plugins communication end

--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -22,6 +22,7 @@
 #include <mutex>
 #include "Module.h"
 #include "utils.h"
+#include "dsTypes.h"
 #include "tptimer.h"
 #include "AbstractPlugin.h"
 #include "libIBus.h"
@@ -124,6 +125,9 @@ namespace WPEFramework {
             uint32_t getSettopMS12Capabilities(const JsonObject& parameters, JsonObject& response);
             uint32_t getSettopAudioCapabilities(const JsonObject& parameters, JsonObject& response);
             uint32_t getEnableAudioPort(const JsonObject& parameters, JsonObject& response);
+
+	    uint32_t getAudioFormat(const JsonObject& parameters, JsonObject& response);
+
             void InitAudioPorts();
             //End methods
 
@@ -134,6 +138,7 @@ namespace WPEFramework {
             void activeInputChanged(bool activeInput);
             void connectedVideoDisplaysUpdated(int hdmiHotPlugEvent);
             void connectedAudioPortUpdated (int iAudioPortType, bool isPortConnected);
+	    void notifyAudioFormatChange(dsAudioFormat_t audioFormat);
 	    void onARCInitiationEventHandler(const JsonObject& parameters);
             void onARCTerminationEventHandler(const JsonObject& parameters);
 	    void onShortAudioDescriptorEventHandler(const JsonObject& parameters);
@@ -152,8 +157,10 @@ namespace WPEFramework {
             static void ResolutionPostChange(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
             static void DisplResolutionHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
             static void dsHdmiEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
+	    static void audioFormatUpdateEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
             static void powerEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
             void getConnectedVideoDisplaysHelper(std::vector<string>& connectedDisplays);
+	    void audioFormatToString(dsAudioFormat_t audioFormat, JsonObject &response);
             bool checkPortName(std::string& name) const;
             IARM_Bus_PWRMgr_PowerState_t getSystemPowerState();
 


### PR DESCRIPTION
Reason for change:1) Added support for audio format
update event
2) Added dsGetAudioFormat API
Test Procedure: Verify audio format method & event
notification
Risks: None

Signed-off-by: Deekshit Devadas <deekshit.devadasy@sky.uk>