### PR TITLE
RDK-32440: DisplaySettings TP upgrades for MS12 Audio Settings Phase4

### DIFF
--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -127,6 +127,10 @@ namespace WPEFramework {
             uint32_t getEnableAudioPort(const JsonObject& parameters, JsonObject& response);
 
 	    uint32_t getAudioFormat(const JsonObject& parameters, JsonObject& response);
+	    uint32_t getVolumeLeveller2(const JsonObject& parameters, JsonObject& response);
+	    uint32_t setVolumeLeveller2(const JsonObject& parameters, JsonObject& response);
+	    uint32_t getSurroundVirtualizer2(const JsonObject& parameters, JsonObject& response);
+	    uint32_t setSurroundVirtualizer2(const JsonObject& parameters, JsonObject& response);
 
             void InitAudioPorts();
             //End methods


### PR DESCRIPTION
Reason for change: Updated Auto mode support for
volume leveller and surround virtualizer
Test Procedure: Test v2 thunder plugin
APIs for volume leveller and surround virtualizer
Risks: None

Signed-off-by: Deekshit Devadas <deekshit.devadasy@sky.uk>