### PR TITLE
DELIA-49722 : setAudio Delay accepting negative values (cherry picking #1308)

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -2786,6 +2786,12 @@ namespace WPEFramework {
                 LOGERR("Failed to parse audioDelay '%s'", sAudioDelayMs.c_str());
                 returnResponse(false);
             }
+            
+            if ( audioDelayMs < 0 )
+            {
+                LOGERR("audioDelay '%s', Should be a postiive value", sAudioDelayMs.c_str());
+                returnResponse(false);
+            }
 
             bool success = true;
             string audioPort = parameters["audioPort"].String();//empty value will browse all ports


### PR DESCRIPTION
Reason for change: Throw error for negative Delays
Test Procedure: Refer JIRA
Risks: Low
Signed-off-by: Akhil Baby Sarada <Akhil_Sarada@comcast.com>