### PR TITLE
RDKTV-8109: No audio on TV speakers when ARC device in Standby

### DIFF
--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -175,6 +175,7 @@ namespace WPEFramework {
 	    uint32_t subscribeForHdmiCecSinkEvent(const char* eventName);
 	    bool setUpHdmiCecSinkArcRouting (bool arcEnable);
 	    bool requestShortAudioDescriptor();
+	    bool sendHdmiCecSinkAudioDevicePowerOn();
 	    void onTimer();
 
 	    TpTimer m_timer;

--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -57,6 +57,7 @@
 #define HDMICECSINK_METHOD_SETUP_ARC              "setupARCRouting"
 #define HDMICECSINK_METHOD_REQUEST_SHORT_AUDIO_DESCRIPTOR  "requestShortAudioDescriptor"
 #define HDMICECSINK_METHOD_SEND_STANDBY_MESSAGE            "sendStandbyMessage"
+#define HDMICECSINK_METHOD_SEND_AUDIO_DEVICE_POWER_ON "sendAudioDevicePowerOnMessage"
 
 #define TEST_ADD 0
 #define HDMICECSINK_REQUEST_MAX_RETRY 				3
@@ -469,6 +470,7 @@ namespace WPEFramework
           HdmiCecSink::_instance->Process_SetSystemAudioMode_msg(msg);
        }
 
+
 //=========================================== HdmiCecSink =========================================
 
        HdmiCecSink::HdmiCecSink()
@@ -505,6 +507,7 @@ namespace WPEFramework
 		   registerMethod(HDMICECSINK_METHOD_SET_MENU_LANGUAGE, &HdmiCecSink::setMenuLanguageWrapper, this);
                    registerMethod(HDMICECSINK_METHOD_REQUEST_SHORT_AUDIO_DESCRIPTOR, &HdmiCecSink::requestShortAudioDescriptorWrapper, this);
                    registerMethod(HDMICECSINK_METHOD_SEND_STANDBY_MESSAGE, &HdmiCecSink::sendStandbyMessageWrapper, this);
+		   registerMethod(HDMICECSINK_METHOD_SEND_AUDIO_DEVICE_POWER_ON, &HdmiCecSink::sendAudioDevicePowerOnMsgWrapper, this);
            logicalAddressDeviceType = "None";
            logicalAddress = 0xFF;
            
@@ -1256,6 +1259,14 @@ namespace WPEFramework
           sendStandbyMessage();
 	  returnResponse(true);
         }
+
+        uint32_t HdmiCecSink::sendAudioDevicePowerOnMsgWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+	    LOGINFO("%s invoked. \n",__FUNCTION__);
+            systemAudioModeRequest();
+	    returnResponse(true);
+        }
+
         bool HdmiCecSink::loadSettings()
         {
             Core::File file;
@@ -2608,11 +2619,8 @@ namespace WPEFramework
            if(!HdmiCecSink::_instance)
             return;
 
-            if(m_currentArcRoutingState == ARC_STATE_REQUEST_ARC_INITIATION || m_currentArcRoutingState == ARC_STATE_ARC_INITIATED)
-            {
-               LOGINFO("ARC is either initiation in progress or already initiated");
-               return;
-            }
+             LOGINFO("Current ARC State : %d\n", m_currentArcRoutingState);
+
             _instance->systemAudioModeRequest();
 	    _instance->requestArcInitiation();
  

--- a/HdmiCecSink/HdmiCecSink.h
+++ b/HdmiCecSink/HdmiCecSink.h
@@ -548,6 +548,7 @@ private:
 			uint32_t setMenuLanguageWrapper(const JsonObject& parameters, JsonObject& response);
                         uint32_t requestShortAudioDescriptorWrapper(const JsonObject& parameters, JsonObject& response);
                         uint32_t sendStandbyMessageWrapper(const JsonObject& parameters, JsonObject& response);
+			uint32_t sendAudioDevicePowerOnMsgWrapper(const JsonObject& parameters, JsonObject& response);
                         //End methods
             std::string logicalAddressDeviceType;
             bool cecSettingEnabled;


### PR DESCRIPTION
Reason for change:1) Remove ARC initiation status check from
HdmiCecSink. Will be managed by Displaysettings plugin
2) No need to start timer if HdmICecSink is activated
and subscribtion for cec events & ARC init can be done
directly in InitAudioPorts. To reduce time during bootup
& standby/on transitions
3) Some ARC devices send ARC intiation message
even when they are in standby state. Always wake up the device
before routing audio in cases when CEC ARC initiation handshake
is completed
Test Procedure: Refer Ticket
Risks: None

Signed-off-by: Deekshit Devadas deekshit.devadasy@sky.uk