### PR TITLE
RDK-32981: Move Store Mode file

### DIFF
--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -81,7 +81,7 @@ using namespace std;
 
 #define OPTOUT_TELEMETRY_STATUS "/opt/tmtryoptout"
 
-#define STORE_DEMO_FILE "/media/apps/store-mode-video/videoFile.mp4"
+#define STORE_DEMO_FILE "/opt/persistent/store-mode-video/videoFile.mp4"
 #define STORE_DEMO_LINK "http://127.0.0.1:50050/store-mode-video/videoFile.mp4"
 
 /**


### PR DESCRIPTION
Reason for change: File location change.
Test Procedure: Returned for video file at
"/opt/persistent/store-mode-video/videoFile.mp4"
location.
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>