### PR TITLE
RDKTV-8238 Get the last wakeup key from IR remote

### DIFF
--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -33,6 +33,7 @@
 #include <interfaces/IBrowser.h>
 #include <plugins/System.h>
 #include <rdkshell/eastereggs.h>
+#include <rdkshell/linuxkeys.h>
 
 #ifdef RDKSHELL_READ_MAC_ON_STARTUP
 #include "FactoryProtectHal.h"
@@ -4827,28 +4828,26 @@ namespace WPEFramework {
 
         uint32_t RDKShell::getLastWakeupKeyWrapper(const JsonObject& parameters, JsonObject& response)
         {
-            LOGINFOMETHOD();
+             LOGINFOMETHOD();
+             std::string serviceCallsign = SYSTEM_SERVICE_CALLSIGN;
+             serviceCallsign.append(".2");
+             auto systemServiceConnection = RDKShell::getThunderControllerClient(serviceCallsign);
+             JsonObject req, res;
+             uint32_t status = systemServiceConnection->Invoke(RDKSHELL_THUNDER_TIMEOUT, "getLastWakeupKeyCode", req, res);
+             if (Core::ERROR_NONE == status && res.HasLabel("wakeupKeyCode"))
+             {
+                 unsigned int key = res["wakeupKeyCode"].Number();
+                 unsigned long flags = 0;
+                 uint32_t mappedKeyCode = key, mappedFlags = 0;
+                 bool ret = keyCodeFromWayland(key, flags, mappedKeyCode, mappedFlags);
+                 response["keyCode"] = JsonValue(mappedKeyCode);
+                 response["modifiers"] = JsonValue(mappedFlags);
+                 std::cout << "Got LastWakeupKey, keyCode: " << mappedKeyCode << " modifiers: " << mappedFlags << std::endl;
+                 returnResponse(true);
+             }
 
-            if (0 != mLastWakeupKeyTimestamp)
-            {
-                JsonObject req, res;
-                uint32_t status = gSystemServiceConnection->Invoke(RDKSHELL_THUNDER_TIMEOUT, "getWakeupReason", req, res);
-                if (Core::ERROR_NONE == status && res.HasLabel("wakeupReason") &&
-                    (res["wakeupReason"].String() == "WAKEUP_REASON_RCU_BT" || res["wakeupReason"].String() == "WAKEUP_REASON_IR"))
-                {
-                    response["keyCode"] = JsonValue(mLastWakeupKeyCode);
-                    response["modifiers"] = JsonValue(mLastWakeupKeyModifiers);
-                    response["timestampInSeconds"] = JsonValue((long long)mLastWakeupKeyTimestamp);
-
-                    std::cout << "Got LastWakeupKey, keyCode: " << mLastWakeupKeyCode << " modifiers: " << mLastWakeupKeyModifiers << " timestampInSeconds: " << mLastWakeupKeyTimestamp << std::endl;
-                    returnResponse(true);
-                }
-                else
-                    mLastWakeupKeyTimestamp = 0;
-            }
-
-            response["message"] = "No last wakeup key";
-            returnResponse(false);
+             response["message"] = "unable to get wakeup key from system service";
+             returnResponse(false);
         }
 
         uint32_t RDKShell::enableLogsFlushingWrapper(const JsonObject& parameters, JsonObject& response)

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -385,6 +385,7 @@ namespace WPEFramework {
             registerMethod(_T("getTimeZones"), &SystemServices::getTimeZones, this, {2});
 #ifdef ENABLE_DEEP_SLEEP
 	    registerMethod(_T("getWakeupReason"),&SystemServices::getWakeupReason, this, {2});
+            registerMethod(_T("getLastWakeupKeyCode"), &SystemServices::getLastWakeupKeyCode, this, {2});
 #endif
             registerMethod("uploadLogs", &SystemServices::uploadLogs, this, {2});
 
@@ -1556,6 +1557,39 @@ namespace WPEFramework {
 
             returnResponse(status);
         }
+
+         /***
+          * @brief Returns the deepsleep wakeup keycode.
+          * @param1[in]  : {"params":{"appName":"abc"}}
+          * @param2[out] : {"result":{"wakeupKeycode":<int>","success":<bool>}}
+          * @return      : Core::<StatusCode>
+          */
+
+         uint32_t SystemServices::getLastWakeupKeyCode(const JsonObject& parameters, JsonObject& response)
+         {
+              bool status = false;
+              IARM_Bus_DeepSleepMgr_WakeupKeyCode_Param_t param;
+              uint32_t wakeupKeyCode = 0;
+
+              IARM_Result_t res = IARM_Bus_Call(IARM_BUS_DEEPSLEEPMGR_NAME,
+                         IARM_BUS_DEEPSLEEPMGR_API_GetLastWakeupKeyCode, (void *)&param,
+                         sizeof(param));
+              if (IARM_RESULT_SUCCESS == res)
+              {
+                  status = true;
+                  wakeupKeyCode = param.keyCode;
+              }
+              else
+              {
+                  status = false;
+              }
+
+              LOGWARN("WakeupKeyCode : %d\n", wakeupKeyCode);
+              response["wakeupKeyCode"] = wakeupKeyCode;
+
+              returnResponse(status);
+         }
+
 #endif
 
         /***

--- a/SystemServices/SystemServices.h
+++ b/SystemServices/SystemServices.h
@@ -192,6 +192,7 @@ namespace WPEFramework {
                 uint32_t getAvailableStandbyModes(const JsonObject& parameters, JsonObject& response);
 #ifdef ENABLE_DEEP_SLEEP
 		uint32_t getWakeupReason(const JsonObject& parameters, JsonObject& response);
+                uint32_t getLastWakeupKeyCode(const JsonObject& parameters, JsonObject& response);
 #endif
                 uint32_t getXconfParams(const JsonObject& parameters, JsonObject& response);
                 uint32_t getSerialNumber(const JsonObject& parameters, JsonObject& response);


### PR DESCRIPTION
Reason for change: Get the last wakeup key on deep sleep wakeup

Test Procedure: Put the TV in deep sleep and wakeup using app/power key
and see in wpeframework log last key pressed key code is returning

Risks: Low
Signed-off-by: sputhi200 <Sujeesh_Puthiya@comcast.com>