### PR TITLE
LLAMA-2068:Remove IARM Disconnect and Term

### DIFF
--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -310,9 +310,7 @@ namespace WPEFramework {
         void MaintenanceManager::InitializeIARM()
         {
             if (Utils::IARM::init()) {
-                LOGINFO();
                 IARM_Result_t res;
-                IARM_CHECK(IARM_Bus_Connect());
                 // Register for the Maintenance Notification Events
                 IARM_CHECK(IARM_Bus_RegisterEventHandler(IARM_BUS_MAINTENANCE_MGR_NAME, IARM_BUS_MAINTENANCEMGR_EVENT_UPDATE, _MaintenanceMgrEventHandler));
                 //Register for setMaintenanceStartTime
@@ -523,8 +521,6 @@ namespace WPEFramework {
                 IARM_CHECK(IARM_Bus_UnRegisterEventHandler(IARM_BUS_MAINTENANCE_MGR_NAME, IARM_BUS_MAINTENANCEMGR_EVENT_UPDATE));
                 IARM_CHECK(IARM_Bus_UnRegisterEventHandler(IARM_BUS_MAINTENANCE_MGR_NAME, IARM_BUS_DCM_NEW_START_TIME_EVENT));
                 MaintenanceManager::_instance = nullptr;
-                IARM_CHECK(IARM_Bus_Disconnect());
-                IARM_CHECK(IARM_Bus_Term());
             }
 
             if(m_thread.joinable()){


### PR DESCRIPTION
Reason for change: IARM_Bus_Disconnect() and IARM_Bus_Term()) are no
longer required during deinitiaize.
Test Procedure: Activate/Deactivate the plugin.
Risk: High

(cherry picked from commit de15bcf3ba832c3f6e7b2cdab2fb1bab618742df)