### PR TITLE
RDKTV-8323: HDMI ARC/eARC Power State Handling

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -220,6 +220,10 @@ namespace WPEFramework {
 
 	    m_subscribed = false; //HdmiCecSink event subscription
 	    m_hdmiInAudioDeviceConnected = false;
+        m_arcAudioEnabled = false;
+	    m_currentArcRoutingState = ARC_STATE_ARC_TERMINATED;
+	    m_cecArcRoutingThreadRun = false;
+	    m_arcRoutingThread = std::thread(cecArcRoutingThread);
 	    m_timer.connect(std::bind(&DisplaySettings::onTimer, this));
         }
 
@@ -228,6 +232,7 @@ namespace WPEFramework {
             //LOGINFO("dtor");
 
             lock_guard<mutex> lck(m_callMutex);
+
         }
 
         void DisplaySettings::InitAudioPorts() 
@@ -267,10 +272,65 @@ namespace WPEFramework {
                             m_timer.stop();
                         }
 
+			bool isPluginActivated = Utils::isPluginActivated(HDMICECSINK_CALLSIGN);
 
-                        //Start the timer only if the device supports HDMI_ARC
-                        LOGINFO("Starting the timer");
-                        m_timer.start(RECONNECTION_TIME_IN_MILLISECONDS);
+			if(isPluginActivated) {
+			    if(!m_subscribed) {
+			        if((subscribeForHdmiCecSinkEvent(HDMICECSINK_ARC_INITIATION_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_ARC_TERMINATION_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_SHORT_AUDIO_DESCRIPTOR_EVENT)== Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_SYSTEM_AUDIO_MODE_EVENT) == Core::ERROR_NONE)) {
+                                    m_subscribed = true;
+                                    LOGINFO("%s: HdmiCecSink event subscription completed.\n",__FUNCTION__);
+			        }
+			    }
+
+			    if(m_subscribed) {
+				JsonObject aPortArcEnableResult;
+				JsonObject aPortArcEnableParam;
+				aPortArcEnableParam.Set(_T("audioPort"),"HDMI_ARC0");
+				bool arcEnable = m_audioOutputPortConfig["HDMI_ARC"].Boolean();
+                                aPortArcEnableParam.Set(_T("enable"), arcEnable);
+                                ret = setEnableAudioPort (aPortArcEnableParam, aPortArcEnableResult);
+                                if(ret != Core::ERROR_NONE) {
+                                    LOGWARN("%s: Audio Port : [HDMI_ARC0] enable: %d failed ! error code%d\n", __FUNCTION__, arcEnable, ret);
+                                }
+                                else {
+                                    LOGINFO("%s: Audio Port : [HDMI_ARC0] initialized successfully, enable: %d\n", __FUNCTION__, arcEnable);
+                                }
+
+                                //Connected Audio Ports status update is necessary on bootup / power state transitions
+                                try {
+                                    int types = dsAUDIOARCSUPPORT_NONE;
+                                    device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort("HDMI_ARC0");
+                                    aPort.getSupportedARCTypes(&types);
+                                    if(types & dsAUDIOARCSUPPORT_eARC) {
+                                        m_hdmiInAudioDeviceConnected = true;
+                                        connectedAudioPortUpdated(dsAUDIOPORT_TYPE_HDMI_ARC, true);
+                                    }
+                                    else if (types & dsAUDIOARCSUPPORT_ARC) {
+                                        //Dummy ARC intiation request
+                                       {
+                                        std::lock_guard<std::mutex> lock(m_arcRoutingStateMutex);
+                                        if(m_currentArcRoutingState == ARC_STATE_ARC_TERMINATED) {
+                                            LOGINFO("%s: Send dummy ARC initiation request... \n", __FUNCTION__);
+                                            m_currentArcRoutingState = ARC_STATE_REQUEST_ARC_INITIATION;
+                                            m_cecArcRoutingThreadRun = true;
+                                            arcRoutingCV.notify_one();
+                                        }
+                                       }
+                                    }
+                                    else {
+                                        LOGINFO("%s: Connected Device doesn't have ARC/eARC capability... \n", __FUNCTION__);
+                                    }
+                                }
+                                catch (const device::Exception& err){
+                                    LOG_DEVICE_EXCEPTION1(string("HDMI_ARC0"));
+                                }
+                            }
+			}
+			else {
+                            //Start the timer only if the device supports HDMI_ARC
+                            LOGINFO("Starting the timer");
+                            m_timer.start(RECONNECTION_TIME_IN_MILLISECONDS);
+			}
                     }
                     else {
                         JsonObject aPortHdmiEnableResult;
@@ -322,6 +382,26 @@ namespace WPEFramework {
 
         void DisplaySettings::Deinitialize(PluginHost::IShell* /* service */)
         {
+
+            std::lock_guard<std::mutex> lock(m_arcRoutingStateMutex);
+            m_currentArcRoutingState = ARC_STATE_ARC_EXIT;
+	    m_cecArcRoutingThreadRun = true;
+            arcRoutingCV.notify_one();
+
+            try
+            {
+                if (m_arcRoutingThread.joinable())
+                        m_arcRoutingThread.join();
+            }
+            catch(const std::system_error& e)
+            {
+                LOGERR("system_error exception in thread join %s", e.what());
+            }
+            catch(const std::exception& e)
+            {
+                LOGERR("exception in thread join %s", e.what());
+            }
+
             DeinitializeIARM();
             DisplaySettings::_instance = nullptr;
         }
@@ -548,7 +628,7 @@ namespace WPEFramework {
 	                return;
             }
 
-		    if(hdmiin_hotplug_port == HDMI_IN_ARC_PORT_ID) { //HDMI ARC/eARC connected
+		    if(hdmiin_hotplug_port == HDMI_IN_ARC_PORT_ID) { //HDMI ARC/eARC Port Handling
 			bool arc_port_enabled =  false;
 
                         JsonObject audioOutputPortConfig = DisplaySettings::_instance->getAudioOutputPortConfig();
@@ -594,14 +674,18 @@ namespace WPEFramework {
                                         DisplaySettings::_instance->connectedAudioPortUpdated(dsAUDIOPORT_TYPE_HDMI_ARC, hdmiin_hotplug_conn);
                                         LOGINFO("dsHdmiEventHandler: Enable eARC\n");
                                         aPort.enableARC(dsAUDIOARCSUPPORT_eARC, true);
+                                        DisplaySettings::_instance->m_arcAudioEnabled = true;
                                     }
                                     else if(types & dsAUDIOARCSUPPORT_ARC)  {
-                                        if (!DisplaySettings::_instance->setUpHdmiCecSinkArcRouting(true)) {
-                                            LOGERR("dsHdmiEventHandler: setUpHdmiCecSinkArcRouting failed !!!\n");;
+                                      {
+                                        std::lock_guard<std::mutex> lock(DisplaySettings::_instance->m_arcRoutingStateMutex);
+                                        if(DisplaySettings::_instance->m_currentArcRoutingState == ARC_STATE_ARC_TERMINATED) {
+                                            LOGINFO("%s: Send ARC initiation request... \n", __FUNCTION__);
+                                            DisplaySettings::_instance->m_currentArcRoutingState = ARC_STATE_REQUEST_ARC_INITIATION;
+                                            DisplaySettings::_instance->m_cecArcRoutingThreadRun = true;
+                                            DisplaySettings::_instance->arcRoutingCV.notify_one();
                                         }
-                                        else {
-                                            LOGINFO("dsHdmiEventHandler: setUpHdmiCecSinkArcRouting successful");
-                                        }
+                                      }
                                     }
                                     else {
 				        LOGINFO("dsHdmiEventHandler: Skip HDMI ARC/eARC handling. Connected device does not support ARC/eARC \n");
@@ -612,6 +696,11 @@ namespace WPEFramework {
                                         DisplaySettings::_instance->m_hdmiInAudioDeviceConnected = false;
                                         DisplaySettings::_instance->connectedAudioPortUpdated(dsAUDIOPORT_TYPE_HDMI_ARC, hdmiin_hotplug_conn);
                                         aPort.enableARC(dsAUDIOARCSUPPORT_ARC, false);
+                                        DisplaySettings::_instance->m_arcAudioEnabled = false;
+                                       {
+                                        std::lock_guard<std::mutex> lock(DisplaySettings::_instance->m_arcRoutingStateMutex);
+                                        DisplaySettings::_instance->m_currentArcRoutingState = ARC_STATE_ARC_TERMINATED;
+                                       }
                                 }
                             }
                             catch (const device::Exception& err)
@@ -619,29 +708,50 @@ namespace WPEFramework {
                                 LOG_DEVICE_EXCEPTION1(string("HDMI_ARC0"));
                             }
                         }
-                        else {
+                        else { //HDMI ARC/eARC UI settings not enabled
                             LOGINFO("dsHdmiEventHandler: Skip HDMI_ARC Hotplug handling !!! HDMI_ARC port not enabled. \n");
                             int types = dsAUDIOARCSUPPORT_NONE;
                            try {
                                 device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort("HDMI_ARC0");
                                aPort.getSupportedARCTypes(&types);
+
+                               if(hdmiin_hotplug_conn) {
+                                   if(types & dsAUDIOARCSUPPORT_eARC) {
+                                       DisplaySettings::_instance->m_hdmiInAudioDeviceConnected = true;
+                                       DisplaySettings::_instance->connectedAudioPortUpdated(dsAUDIOPORT_TYPE_HDMI_ARC, hdmiin_hotplug_conn);
+                                   }
+                                   else if (types & dsAUDIOARCSUPPORT_ARC) {
+                                       //Dummy ARC intiation request
+                                      {
+                                        std::lock_guard<std::mutex> lock(DisplaySettings::_instance->m_arcRoutingStateMutex);
+                                        if(DisplaySettings::_instance->m_currentArcRoutingState == ARC_STATE_ARC_TERMINATED) {
+                                            LOGINFO("%s: Send dummy ARC initiation request... \n", __FUNCTION__);
+                                            DisplaySettings::_instance->m_currentArcRoutingState = ARC_STATE_REQUEST_ARC_INITIATION;
+                                            DisplaySettings::_instance->m_cecArcRoutingThreadRun = true;
+                                            DisplaySettings::_instance->arcRoutingCV.notify_one();
+                                        }
+                                        else {
+                                            LOGINFO("%s: ARC state either in initiation/initiated ... \n", __FUNCTION__);
+                                        }
+                                      }
+                                   }
+                                   else {
+                                       LOGINFO("%s: Connected Device doesn't have ARC/eARC capability... \n", __FUNCTION__);
+                                   }
+                               }
+                               else {
+                                   DisplaySettings::_instance->m_hdmiInAudioDeviceConnected = false;
+                                   DisplaySettings::_instance->connectedAudioPortUpdated(dsAUDIOPORT_TYPE_HDMI_ARC, hdmiin_hotplug_conn);
+                                   aPort.enableARC(dsAUDIOARCSUPPORT_ARC, false);
+                                   DisplaySettings::_instance->m_arcAudioEnabled = false;
+                                   {
+                                     std::lock_guard<std::mutex> lock(DisplaySettings::_instance->m_arcRoutingStateMutex);
+                                     DisplaySettings::_instance->m_currentArcRoutingState = ARC_STATE_ARC_TERMINATED;
+                                   }
+                               }
                            }
                            catch (const device::Exception& err){
                                    LOG_DEVICE_EXCEPTION1(string("HDMI_ARC0"));
-                           }
-                           if(hdmiin_hotplug_conn) {
-                               if(types & dsAUDIOARCSUPPORT_eARC) {
-                                   DisplaySettings::_instance->m_hdmiInAudioDeviceConnected = true;
-                                   DisplaySettings::_instance->connectedAudioPortUpdated(dsAUDIOPORT_TYPE_HDMI_ARC, hdmiin_hotplug_conn);
-                               }
-                               else if (types & dsAUDIOARCSUPPORT_ARC) {
-                                   //Dummy ARC intiation request
-                                   DisplaySettings::_instance->setUpHdmiCecSinkArcRouting(true);
-                               }
-                           }
-                           else {
-                                   DisplaySettings::_instance->m_hdmiInAudioDeviceConnected = false;
-                                   DisplaySettings::_instance->connectedAudioPortUpdated(dsAUDIOPORT_TYPE_HDMI_ARC, hdmiin_hotplug_conn);
                            }
 	                }
 
@@ -3062,6 +3172,35 @@ namespace WPEFramework {
             return success;
 	}
 
+        bool DisplaySettings::sendHdmiCecSinkAudioDevicePowerOn ()
+        {
+            bool success = true;
+
+            if (Utils::isPluginActivated(HDMICECSINK_CALLSIGN)) {
+                auto hdmiCecSinkPlugin = getHdmiCecSinkPlugin();
+                if (!hdmiCecSinkPlugin) {
+                    LOGERR("HdmiCecSink Initialisation failed\n");
+                }
+                else {
+                    JsonObject hdmiCecSinkResult;
+                    JsonObject param;
+
+                    LOGINFO("%s: Send Audio Device Power On !!!\n");
+                    hdmiCecSinkPlugin->Invoke<JsonObject, JsonObject>(2000, "sendAudioDevicePowerOnMessage", param, hdmiCecSinkResult);
+                    if (!hdmiCecSinkResult["success"].Boolean()) {
+                        success = false;
+                        LOGERR("HdmiCecSink Plugin returned error\n");
+                    }
+                }
+            }
+            else {
+                success = false;
+                LOGERR("HdmiCecSink plugin not ready\n");
+            }
+
+            return success;
+        }
+
         bool DisplaySettings::requestShortAudioDescriptor()
         {
             bool success = true;
@@ -3138,8 +3277,8 @@ namespace WPEFramework {
                     device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
 
                     aPort.getSupportedARCTypes(&types);
-                    LOGINFO("DisplaySettings::setEnableAudioPort Configuring User set Audio mode before starting ARC/eARC Playback...\n");
-                    if(aPort.isConnected()) {
+                    if((aPort.isConnected()) && (m_hdmiInAudioDeviceConnected == true)) {
+                        LOGINFO("DisplaySettings::setEnableAudioPort Configuring User set Audio mode before starting ARC/eARC Playback...\n");
                         if(aPort.getStereoAuto() == true) {
                             if(types & dsAUDIOARCSUPPORT_eARC) {
                                 aPort.setStereoAuto(true,true);
@@ -3164,28 +3303,45 @@ namespace WPEFramework {
                         if(pEnable) {
                             LOGINFO("DisplaySettings::setEnableAudioPort Enable eARC !!!");
                             aPort.enableARC(dsAUDIOARCSUPPORT_eARC, true);
+                            m_arcAudioEnabled = true;
                         }
                         else{
                             LOGINFO("DisplaySettings::setEnableAudioPort Disable eARC !!!");
                             aPort.enableARC(dsAUDIOARCSUPPORT_eARC, false);
+                            m_arcAudioEnabled = false;
                         }
                     }
                     else if(types & dsAUDIOARCSUPPORT_ARC) {
                        LOGINFO("%s: Device Type ARC. m_hdmiInAudioDeviceConnected: %d , pEnable: %d \n",__FUNCTION__,m_hdmiInAudioDeviceConnected, pEnable);
                        if( m_hdmiInAudioDeviceConnected == true ) {
                            if(pEnable) {
-                               LOGINFO("%s: CEC ARC handshake already completed. Enable ARC \n",__FUNCTION__);
+                               LOGINFO("%s: CEC ARC handshake already completed. Enable ARC... \n",__FUNCTION__);
+			       // For certain ARC devices, we get ARC initiate message even when ARC device is in standby
+			       // Wake up the device always before audio routing
+			       sendHdmiCecSinkAudioDevicePowerOn();
                                aPort.enableARC(dsAUDIOARCSUPPORT_ARC, true);
+                               m_arcAudioEnabled = true;
 			   }
 			   else {
                                LOGINFO("%s: Disable ARC \n",__FUNCTION__);
                                aPort.enableARC(dsAUDIOARCSUPPORT_ARC, false);
+                               m_arcAudioEnabled = false;
                            }
                        }
                        else {
                             if (pEnable) {
                                 LOGINFO("%s: setUpHdmiCecSinkArcRouting true. Audio routing after CEC ARC handshake \n",__FUNCTION__);
-				setUpHdmiCecSinkArcRouting (true);
+                                {
+                                    std::lock_guard<std::mutex> lock(m_arcRoutingStateMutex);
+                                    if(m_currentArcRoutingState == ARC_STATE_ARC_TERMINATED) {
+                                        m_currentArcRoutingState = ARC_STATE_REQUEST_ARC_INITIATION;
+                                        m_cecArcRoutingThreadRun = true;
+                                        arcRoutingCV.notify_one();
+                                    }
+                                    else {
+                                        LOGINFO("%s: ARC State is already either initiating/intitiated... \n", __FUNCTION__);
+                                    }
+                                }
                             }
                             else {
                                 LOGINFO("%s: No handling required\n");
@@ -3289,12 +3445,81 @@ namespace WPEFramework {
                 if (eventData->data.state.newState == IARM_BUS_PWRMGR_POWERSTATE_ON) {
                     DisplaySettings::_instance->InitAudioPorts();
                 }
+
+		else {
+		    LOGINFO("%s: Current Power state: %d\n",__FUNCTION__,eventData->data.state.newState);
+                {
+		            std::lock_guard<std::mutex> lock(DisplaySettings::_instance->m_arcRoutingStateMutex);
+                    LOGINFO("%s: Cleanup ARC/eARC state\n",__FUNCTION__);
+                    if(DisplaySettings::_instance->m_currentArcRoutingState != ARC_STATE_ARC_TERMINATED)
+                        DisplaySettings::_instance->m_currentArcRoutingState = ARC_STATE_ARC_TERMINATED;
+
+                    if(DisplaySettings::_instance->m_hdmiInAudioDeviceConnected !=  false)
+                        DisplaySettings::_instance->m_hdmiInAudioDeviceConnected =  false;
+                }
+                    if(DisplaySettings::_instance->m_arcAudioEnabled == true) {
+                        device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort("HDMI_ARC0");
+                        LOGINFO("%s: Disable ARC/eARC Audio\n",__FUNCTION__);
+                        aPort.enableARC(dsAUDIOARCSUPPORT_ARC, false);
+                        DisplaySettings::_instance->m_arcAudioEnabled = false;
+                    }
+		}
             }
             break;
 
             default: break;
             }
         }
+
+
+	//Displaysettings ARC Routing thread
+	void DisplaySettings::cecArcRoutingThread() {
+            LOGINFO("%s: ARC Routing Thread Start\n",__FUNCTION__);
+	    bool threadExit = false;
+	    int arcState = ARC_STATE_ARC_TERMINATED;
+
+            if(!DisplaySettings::_instance)
+                 return;
+	    
+	    std::unique_lock<std::mutex> lock(DisplaySettings::_instance->m_arcRoutingStateMutex);
+	    while(1) {
+
+		LOGINFO("%s: Debug:  ARC Routing Thread wait \n",__FUNCTION__);
+		DisplaySettings::_instance->arcRoutingCV.wait(lock, []{return (DisplaySettings::_instance->m_cecArcRoutingThreadRun == true);});
+
+                if(threadExit == true) {
+                    break;
+		}
+
+		arcState = DisplaySettings::_instance->m_currentArcRoutingState;
+
+		switch(arcState) {
+
+                    case ARC_STATE_REQUEST_ARC_INITIATION:
+                        LOGINFO("%s: Send ARC Initiation request \n",__FUNCTION__);
+                        DisplaySettings::_instance->setUpHdmiCecSinkArcRouting(true);
+                        break;
+
+                    case ARC_STATE_REQUEST_ARC_TERMINATION:
+			LOGINFO("%s: Send ARC Termination request \n",__FUNCTION__);
+			DisplaySettings::_instance->setUpHdmiCecSinkArcRouting(false);
+			break;
+
+                    case ARC_STATE_ARC_EXIT:
+			threadExit = true;
+			break;
+
+                    //TODO: DD Handle Arc routing logic completely in this separate thread
+                    default:
+			LOGINFO("%s: Default case - arcState : %d \n",__FUNCTION__, arcState);
+			break;
+		}
+
+		DisplaySettings::_instance->m_cecArcRoutingThreadRun = false;
+	    }
+
+	    LOGINFO("%s: ARC Routing Thread Stop\n",__FUNCTION__);
+	}
 
         // Event management
         // 1.
@@ -3349,21 +3574,32 @@ namespace WPEFramework {
 
             if (parameters.HasLabel("status")) {
                 value = parameters["status"].String();
+                {
+                  std::lock_guard<std::mutex> lock(m_arcRoutingStateMutex);
+                  m_currentArcRoutingState = ARC_STATE_ARC_INITIATED;
+                }
 		if(!value.compare("success")) {
                     try
                     {
                         device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort("HDMI_ARC0");
                         JsonObject aPortConfig;
                         aPortConfig = getAudioOutputPortConfig();
-			m_hdmiInAudioDeviceConnected = true;
-			connectedAudioPortUpdated(dsAUDIOPORT_TYPE_HDMI_ARC, true);
-                       if(aPortConfig["HDMI_ARC"].Boolean()) {
+			if(m_hdmiInAudioDeviceConnected ==  false) {
+                            m_hdmiInAudioDeviceConnected = true;
+			    connectedAudioPortUpdated(dsAUDIOPORT_TYPE_HDMI_ARC, true);
+			}
+			else {
+                            LOGINFO("onARCInitiationEventHandler: not notifying the UI as m_hdmiInAudioDeviceConnected = true !!!\n");
+                        }
+
+                        if(aPortConfig["HDMI_ARC"].Boolean()) {
                             LOGINFO("onARCInitiationEventHandler: Enable ARC\n");
                             aPort.enableARC(dsAUDIOARCSUPPORT_ARC, true);
-                       }
-                       else {
+                            m_arcAudioEnabled = true;
+                        }
+                        else {
                            LOGINFO("onARCInitiationEventHandler: HDMI_ARC0 Port not enabled. Skip Audio Routing !!!\n");
-                       }
+                        }
                     }
                     catch (const device::Exception& err)
                     {
@@ -3372,6 +3608,10 @@ namespace WPEFramework {
 		}
 		else{
                     LOGERR("CEC ARC Initiaition Failed !!!");
+                    {
+                      std::lock_guard<std::mutex> lock(m_arcRoutingStateMutex);
+                      m_currentArcRoutingState = ARC_STATE_ARC_TERMINATED;
+                    }
 		}
             } else {
                 LOGERR("Field 'status' could not be found in the event's payload.");
@@ -3388,6 +3628,10 @@ namespace WPEFramework {
 
             if (parameters.HasLabel("status")) {
                 value = parameters["status"].String();
+                {
+                    std::lock_guard<std::mutex> lock(m_arcRoutingStateMutex);
+                    m_currentArcRoutingState = ARC_STATE_ARC_TERMINATED;
+                }
                 if(!value.compare("success")) {
 		    try 
 		    {
@@ -3398,6 +3642,7 @@ namespace WPEFramework {
                             device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort("HDMI_ARC0");
                             LOGINFO("onARCTerminationEventHandler: Disable ARC\n");
                             aPort.enableARC(dsAUDIOARCSUPPORT_ARC, false);
+                            m_arcAudioEnabled = false;
 			}
 			else {
 			    LOGINFO("onARCTerminationEventHandler: Skip Disable ARC and not notifying the UI as  m_hdmiInAudioDeviceConnected = false\n");
@@ -3466,8 +3711,15 @@ namespace WPEFramework {
                 if(!value.compare("On")) {
 //DD Do not update connection status as it necessarily doesn't mean ARC device connected
 //                    m_hdmiInAudioDeviceConnected = true;
-                    LOGINFO("%s :  audioMode ON !!!\n", __FUNCTION__);
 //                    connectedAudioPortUpdated(dsAUDIOPORT_TYPE_HDMI_ARC, true);
+                    LOGINFO("%s :  audioMode ON !!!\n", __FUNCTION__);
+                    if((m_currentArcRoutingState == ARC_STATE_ARC_TERMINATED) && (m_hdmiInAudioDeviceConnected == false)) {
+			LOGINFO("%s :  m_hdmiInAudioDeviceConnected = false. ARC state is terminated.  Trigger ARC Initiation request !!!\n", __FUNCTION__);
+                        std::lock_guard<std::mutex> lock(m_arcRoutingStateMutex);
+    		        m_currentArcRoutingState = ARC_STATE_REQUEST_ARC_INITIATION;
+			m_cecArcRoutingThreadRun = true;
+		        arcRoutingCV.notify_one();
+		    }
                 }
 		else if(!value.compare("Off")) {
                     LOGINFO("%s :  audioMode OFF !!!\n", __FUNCTION__);
@@ -3478,6 +3730,11 @@ namespace WPEFramework {
                             device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort("HDMI_ARC0");
                             LOGINFO("onSystemAudioModeEventHandler: Disable ARC\n");
                             aPort.enableARC(dsAUDIOARCSUPPORT_ARC, false);
+                            m_arcAudioEnabled = false;
+                            {
+                              std::lock_guard<std::mutex> lock(m_arcRoutingStateMutex);
+                              m_currentArcRoutingState = ARC_STATE_ARC_TERMINATED;
+                            }
 		        }
                         else {
                             LOGINFO("onSystemAudioModeEventHandler: Skip Disable ARC and not notifying the UI as  m_hdmiInAudioDeviceConnected = false\n");
@@ -3579,7 +3836,18 @@ namespace WPEFramework {
                     }
                     else if (types & dsAUDIOARCSUPPORT_ARC) {
                         //Dummy ARC intiation request
-                        setUpHdmiCecSinkArcRouting(true);
+                      {
+                        std::lock_guard<std::mutex> lock(m_arcRoutingStateMutex);
+                        if(m_currentArcRoutingState == ARC_STATE_ARC_TERMINATED) {
+                            LOGINFO("%s: Send dummy ARC initiation request... \n", __FUNCTION__);
+                            m_currentArcRoutingState = ARC_STATE_REQUEST_ARC_INITIATION;
+                            m_cecArcRoutingThreadRun = true;
+                            arcRoutingCV.notify_one();
+                        }
+                      }
+                    }
+                    else {
+                        LOGINFO("%s: Connected Device doesn't have ARC/eARC capability... \n", __FUNCTION__);
                     }
                }
                catch (const device::Exception& err){

--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <mutex>
+#include <condition_variable>
 #include "Module.h"
 #include "utils.h"
 #include "dsTypes.h"
@@ -175,15 +176,32 @@ namespace WPEFramework {
 	    uint32_t subscribeForHdmiCecSinkEvent(const char* eventName);
 	    bool setUpHdmiCecSinkArcRouting (bool arcEnable);
 	    bool requestShortAudioDescriptor();
+	    bool sendHdmiCecSinkAudioDevicePowerOn();
+	    static void  cecArcRoutingThread();
 	    void onTimer();
 
 	    TpTimer m_timer;
             bool m_subscribed;
             std::mutex m_callMutex;
+	    std::thread m_arcRoutingThread;
+	    std::mutex m_arcRoutingStateMutex;
+	    bool m_cecArcRoutingThreadRun; 
+	    std::condition_variable arcRoutingCV;
 	    bool m_hdmiInAudioDeviceConnected;
+        bool m_arcAudioEnabled;
 	    JsonObject m_audioOutputPortConfig;
             JsonObject getAudioOutputPortConfig() { return m_audioOutputPortConfig; }
             static IARM_Bus_PWRMgr_PowerState_t m_powerState;
+
+            enum {
+                ARC_STATE_REQUEST_ARC_INITIATION,
+                ARC_STATE_ARC_INITIATED,
+                ARC_STATE_REQUEST_ARC_TERMINATION,
+                ARC_STATE_ARC_TERMINATED,
+                ARC_STATE_ARC_EXIT
+            };
+
+            int m_currentArcRoutingState; 
 
         public:
             static DisplaySettings* _instance;

--- a/HdmiCecSink/HdmiCecSink.h
+++ b/HdmiCecSink/HdmiCecSink.h
@@ -548,6 +548,7 @@ private:
 			uint32_t setMenuLanguageWrapper(const JsonObject& parameters, JsonObject& response);
                         uint32_t requestShortAudioDescriptorWrapper(const JsonObject& parameters, JsonObject& response);
                         uint32_t sendStandbyMessageWrapper(const JsonObject& parameters, JsonObject& response);
+			uint32_t sendAudioDevicePowerOnMsgWrapper(const JsonObject& parameters, JsonObject& response);
                         //End methods
             std::string logicalAddressDeviceType;
             bool cecSettingEnabled;


### PR DESCRIPTION
Reason for change:1) Added a separate cec ARC routing
thread for co-ordinated CEC ARC requests & events
handling
2) Added support for Audio Device Power On HdmiCecsink
method invocation in Displaysettings
3) Remove ARC initiation status check from
HdmiCecSink. Will be managed by Displaysettings plugin
4) No need to start timer if HdmICecSink is activated
and subscribtion for cec events & ARC init can be done
directly in InitAudioPorts. This will reduce time during bootup
& standby/on transitions
5) Some ARC devices send ARC intiation message
even when they are in standby state. Always send audio device
power on to hdmicecsink to wake up the device before routing audio
in cases when CEC ARC initiation handshake is completed
6) Request ARC Initiation from TV side if connected ARC Device
only sends systemAudioMode ON and doesn't initate ARC from it's
side
7) Cleanup ARC state when TV goes to Standby and start fresh
on TV ON. To recover from cases when ARC device doesn't send
systemAudioMode OFF or Terminate ARC when going to standby on
getting standby message from TV side.

Test Procedure: Refer Ticket
Risks: None

Signed-off-by: Deekshit Devadas deekshit.devadasy@sky.uk