### PR TITLE
LLAMA-2016 Intermittently after softreboot volume control is not working

### DIFF
--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -134,6 +134,7 @@ namespace WPEFramework {
 	    uint32_t setSurroundVirtualizer2(const JsonObject& parameters, JsonObject& response);
 
             void InitAudioPorts();
+            void AudioPortsReInitialize();
             //End methods
 
             //Begin events
@@ -164,6 +165,7 @@ namespace WPEFramework {
             static void dsHdmiEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
 	    static void audioFormatUpdateEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
             static void powerEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
+            static void audioPortStateEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
             void getConnectedVideoDisplaysHelper(std::vector<string>& connectedDisplays);
 	    void audioFormatToString(dsAudioFormat_t audioFormat, JsonObject &response);
             bool checkPortName(std::string& name) const;


### PR DESCRIPTION
Reason for change: Event based resetting of the audio port in the Thunder pluging
In case the plugin come before the Dsmgr.
Test Procedure: Build and Verify.
Risks: Low

Signed-off-by: Shafi <shafi.ahmed@sky.uk>