### PR TITLE
RDKTV-8238 Get the last wakeup key from IR remote (#1456)

### DIFF
--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -374,6 +374,7 @@ namespace WPEFramework {
             registerMethod(_T("getTimeZones"), &SystemServices::getTimeZones, this, {2});
 #ifdef ENABLE_DEEP_SLEEP
 	    registerMethod(_T("getWakeupReason"),&SystemServices::getWakeupReason, this, {2});
+            registerMethod(_T("getLastWakeupKeyCode"), &SystemServices::getLastWakeupKeyCode, this, {2});
 #endif
             registerMethod("uploadLogs", &SystemServices::uploadLogs, this, {2});
 
@@ -1557,6 +1558,39 @@ namespace WPEFramework {
 
             returnResponse(status);
         }
+
+         /***
+          * @brief Returns the deepsleep wakeup keycode.
+          * @param1[in]  : {"params":{"appName":"abc"}}
+          * @param2[out] : {"result":{"wakeupKeycode":<int>","success":<bool>}}
+          * @return      : Core::<StatusCode>
+          */
+
+         uint32_t SystemServices::getLastWakeupKeyCode(const JsonObject& parameters, JsonObject& response)
+         {
+              bool status = false;
+              IARM_Bus_DeepSleepMgr_WakeupKeyCode_Param_t param;
+              uint32_t wakeupKeyCode = 0;
+
+              IARM_Result_t res = IARM_Bus_Call(IARM_BUS_DEEPSLEEPMGR_NAME,
+                         IARM_BUS_DEEPSLEEPMGR_API_GetLastWakeupKeyCode, (void *)&param,
+                         sizeof(param));
+              if (IARM_RESULT_SUCCESS == res)
+              {
+                  status = true;
+                  wakeupKeyCode = param.keyCode;
+              }
+              else
+              {
+                  status = false;
+              }
+
+              LOGWARN("WakeupKeyCode : %d\n", wakeupKeyCode);
+              response["wakeupKeyCode"] = wakeupKeyCode;
+
+              returnResponse(status);
+         }
+
 #endif
 
         /***

--- a/SystemServices/SystemServices.h
+++ b/SystemServices/SystemServices.h
@@ -187,6 +187,7 @@ namespace WPEFramework {
                 uint32_t getAvailableStandbyModes(const JsonObject& parameters, JsonObject& response);
 #ifdef ENABLE_DEEP_SLEEP
 		uint32_t getWakeupReason(const JsonObject& parameters, JsonObject& response);
+                uint32_t getLastWakeupKeyCode(const JsonObject& parameters, JsonObject& response);
 #endif
                 uint32_t getXconfParams(const JsonObject& parameters, JsonObject& response);
                 uint32_t getSerialNumber(const JsonObject& parameters, JsonObject& response);


### PR DESCRIPTION
Reason for change: Get the last wakeup key on deep sleep wakeup

Test Procedure: Put the TV in deep sleep and wakeup using app/power key
and see in wpeframework log last key pressed key code is returning

Risks: Low
Signed-off-by: sputhi200 <Sujeesh_Puthiya@comcast.com>