### PR TITLE
RDKTV-8323: HDMI ARC/eARC Power State Handling

### DIFF
--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <mutex>
+#include <condition_variable>
 #include "Module.h"
 #include "utils.h"
 #include "dsTypes.h"
@@ -174,15 +175,32 @@ namespace WPEFramework {
 	    uint32_t subscribeForHdmiCecSinkEvent(const char* eventName);
 	    bool setUpHdmiCecSinkArcRouting (bool arcEnable);
 	    bool requestShortAudioDescriptor();
+	    bool sendHdmiCecSinkAudioDevicePowerOn();
+	    static void  cecArcRoutingThread();
 	    void onTimer();
 
 	    TpTimer m_timer;
             bool m_subscribed;
             std::mutex m_callMutex;
+	    std::thread m_arcRoutingThread;
+	    std::mutex m_arcRoutingStateMutex;
+	    bool m_cecArcRoutingThreadRun; 
+	    std::condition_variable arcRoutingCV;
 	    bool m_hdmiInAudioDeviceConnected;
+        bool m_arcAudioEnabled;
 	    JsonObject m_audioOutputPortConfig;
             JsonObject getAudioOutputPortConfig() { return m_audioOutputPortConfig; }
             static IARM_Bus_PWRMgr_PowerState_t m_powerState;
+
+            enum {
+                ARC_STATE_REQUEST_ARC_INITIATION,
+                ARC_STATE_ARC_INITIATED,
+                ARC_STATE_REQUEST_ARC_TERMINATION,
+                ARC_STATE_ARC_TERMINATED,
+                ARC_STATE_ARC_EXIT
+            };
+
+            int m_currentArcRoutingState; 
 
         public:
             static DisplaySettings* _instance;

--- a/HdmiCecSink/HdmiCecSink.h
+++ b/HdmiCecSink/HdmiCecSink.h
@@ -548,6 +548,7 @@ private:
 			uint32_t setMenuLanguageWrapper(const JsonObject& parameters, JsonObject& response);
                         uint32_t requestShortAudioDescriptorWrapper(const JsonObject& parameters, JsonObject& response);
                         uint32_t sendStandbyMessageWrapper(const JsonObject& parameters, JsonObject& response);
+			uint32_t sendAudioDevicePowerOnMsgWrapper(const JsonObject& parameters, JsonObject& response);
                         //End methods
             std::string logicalAddressDeviceType;
             bool cecSettingEnabled;


### PR DESCRIPTION
Reason for change:1) Added a separate cec ARC routing
thread for co-ordinated CEC ARC requests & events
handling
2) Added support for Audio Device Power On HdmiCecsink
method invocation in Displaysettings
3) Remove ARC initiation status check from
HdmiCecSink. Will be managed by Displaysettings plugin
4) No need to start timer if HdmICecSink is activated
and subscribtion for cec events & ARC init can be done
directly in InitAudioPorts. This will reduce time during bootup
& standby/on transitions
5) Some ARC devices send ARC intiation message
even when they are in standby state. Always send audio device
power on to hdmicecsink to wake up the device before routing audio
in cases when CEC ARC initiation handshake is completed
6) Request ARC Initiation from TV side if connected ARC Device
only sends systemAudioMode ON and doesn't initate ARC from it's
side
7) Cleanup ARC state when TV goes to Standby and start fresh
on TV ON. To recover from cases when ARC device doesn't send
systemAudioMode OFF or Terminate ARC when going to standby on
getting standby message from TV side.

Test Procedure: Refer Ticket
Risks: None

Signed-off-by: Deekshit Devadas deekshit.devadasy@sky.uk