### PR TITLE
LLAMA-2016 Intermittently after softreboot volume control is not working

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -235,6 +235,26 @@ namespace WPEFramework {
 
         }
 
+        void DisplaySettings::AudioPortsReInitialize()
+        {
+            LOGINFO("Entering DisplaySettings::AudioPortsReInitialize");
+            uint32_t ret = Core::ERROR_NONE;
+            try
+            {
+                device::List<device::AudioOutputPort> aPorts = device::Host::getInstance().getAudioOutputPorts();
+                for (size_t i = 0; i < aPorts.size(); i++)
+                {
+                     device::AudioOutputPort &vPort = aPorts.at(i);
+                     vPort.reInitializeAudioOutputPort();
+                 }
+            }
+            catch(const device::Exception& err)
+            {
+                LOGWARN("Audio Port : AudioPortsReInitialize failed\n");
+                LOG_DEVICE_EXCEPTION0();
+            }
+        }
+     
         void DisplaySettings::InitAudioPorts() 
         {   //sample servicemanager response: {"success":true,"supportedAudioPorts":["HDMI0"]}
             //LOGINFOMETHOD();
@@ -424,7 +444,8 @@ namespace WPEFramework {
                 IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_AUDIO_OUT_HOTPLUG, dsHdmiEventHandler) );
 		IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_AUDIO_FORMAT_UPDATE, audioFormatUpdateEventHandler) );
                 IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_PWRMGR_NAME, IARM_BUS_PWRMGR_EVENT_MODECHANGED, powerEventHandler) );
-
+                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_AUDIO_PORT_STATE, audioPortStateEventHandler) );
+ 
                 res = IARM_Bus_Call(IARM_BUS_PWRMGR_NAME, IARM_BUS_PWRMGR_API_GetPowerState, (void *)&param, sizeof(param));
                 if (res == IARM_RESULT_SUCCESS)
                 {
@@ -460,6 +481,7 @@ namespace WPEFramework {
                 IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_AUDIO_OUT_HOTPLUG) );
 		IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_PWRMGR_NAME, IARM_BUS_DSMGR_EVENT_AUDIO_FORMAT_UPDATE) );
                 IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_PWRMGR_NAME, IARM_BUS_PWRMGR_EVENT_MODECHANGED) );
+                IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_AUDIO_PORT_STATE) );
             }
 
             try
@@ -782,7 +804,36 @@ namespace WPEFramework {
 		    break;
            }
         }
-
+        
+        void DisplaySettings::audioPortStateEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
+        {
+            dsAudioPortState_t audioPortState = dsAUDIOPORT_STATE_UNINITIALIZED;
+            LOGINFO("%s \n", __FUNCTION__);
+            switch (eventId) {
+                case IARM_BUS_DSMGR_EVENT_AUDIO_PORT_STATE:
+                {
+                   IARM_Bus_DSMgr_EventData_t *eventData = (IARM_Bus_DSMgr_EventData_t *)data;
+                   audioPortState = eventData->data.AudioPortStateInfo.audioPortState;
+                   LOGINFO("Received IARM_BUS_DSMGR_EVENT_AUDIO_PORT_STATE. Audio Port Init State: %d \n", audioPortState);
+                   try
+                   {   if( audioPortState == dsAUDIOPORT_STATE_INITIALIZED)
+                       {
+                           DisplaySettings::_instance->AudioPortsReInitialize();
+                           DisplaySettings::_instance->InitAudioPorts();
+                       }
+                  }
+                  catch(const device::Exception& err)
+                  {
+                     LOG_DEVICE_EXCEPTION0();
+                  }
+                }
+                break;
+                default:
+                  LOGERR("Invalid event ID\n");
+                  break;
+           }  
+        }  
+ 
         void setResponseArray(JsonObject& response, const char* key, const vector<string>& items)
         {
             JsonArray arr;

--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -134,6 +134,7 @@ namespace WPEFramework {
 	    uint32_t setSurroundVirtualizer2(const JsonObject& parameters, JsonObject& response);
 
             void InitAudioPorts();
+            void AudioPortsReInitialize();
             //End methods
 
             //Begin events
@@ -164,6 +165,7 @@ namespace WPEFramework {
             static void dsHdmiEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
 	    static void audioFormatUpdateEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
             static void powerEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
+            static void audioPortStateEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
             void getConnectedVideoDisplaysHelper(std::vector<string>& connectedDisplays);
 	    void audioFormatToString(dsAudioFormat_t audioFormat, JsonObject &response);
             bool checkPortName(std::string& name) const;


### PR DESCRIPTION
Reason for change: Event based resetting of the audio port in the Thunder pluging
In case the plugin come before the Dsmgr.
Test Procedure: Build and Verify.
Risks: Low

Signed-off-by: Shafi <shafi.ahmed@sky.uk>