### PR TITLE
DELIA-51199: Token is exposed in FireboltMediaPlayer

### DIFF
--- a/FireboltMediaPlayer/test/fmp_test_ui.html
+++ b/FireboltMediaPlayer/test/fmp_test_ui.html
@@ -98,7 +98,7 @@
 				port: 9998,
 				default: 1, // versioning
 				// If Security Agent enabled: generate on STB via /usr/bin/WPEFrameworkSecurityUtility 
-				token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.aHR0cDovL2xvY2FsaG9zdA.zrOGr8LOHB0MCGGQQFncIBTDapoM2Szk4-a5ohIOS9"
+				token: ""
 			};
 
 			log("Thunder Configuration: " + JSON.stringify(config));


### PR DESCRIPTION
Reason for change: Remove exposed security token. (The test UI is not a requirement
                   and testing is done via a terminal.)
Test Procedure: Test it builds
Risks: Low

Signed-off-by: <james.lofthouse@sky.uk>