### PR TITLE
DELIA-51034: thread safety for Utils::IARM

### DIFF
--- a/helpers/utils.h
+++ b/helpers/utils.h
@@ -185,15 +185,11 @@
 
 namespace Utils
 {
-    struct IARM
-    {
+    struct IARM {
         static bool init();
-        static bool isConnected() { return m_connected; }
+        static bool isConnected();
 
         static const char* NAME;
-
-    private:
-        static bool m_connected;
     };
 
     namespace String


### PR DESCRIPTION
Reason for change: Thread safety issues.
Test Procedure: Ask reporter.
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>