### PR TITLE
RDK-32544: Asynchronous notification of HDMI-CEC<Standby>message XiOne

### DIFF
--- a/HdmiCec_2/HdmiCec_2.h
+++ b/HdmiCec_2/HdmiCec_2.h
@@ -105,6 +105,7 @@ namespace WPEFramework {
             virtual const string Initialize(PluginHost::IShell* service) override;
             virtual void Deinitialize(PluginHost::IShell* service) override;
             static HdmiCec_2* _instance;
+            void SendStandbyMsgEvent(const int logicalAddress);
         private:
             // We do not allow this plugin to be copied !!
             HdmiCec_2(const HdmiCec_2&) = delete;
@@ -120,6 +121,8 @@ namespace WPEFramework {
             uint32_t setVendorIdWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t getVendorIdWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t performOTPActionWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t sendStandbyMessageWrapper(const JsonObject& parameters, JsonObject& response);
+
             //End methods
             std::string logicalAddressDeviceType;
             bool cecSettingEnabled;
@@ -151,6 +154,7 @@ namespace WPEFramework {
             void getPhysicalAddress();
             void getLogicalAddress();
             void cecAddressesChanged(int changeStatus);
+            bool sendStandbyMessage();
         };
 	} // namespace Plugin
 } // namespace WPEFramework


### PR DESCRIPTION
RDK-32544: Asynchronous notification of HDMI-CEC<Standby>message XiOne
Reason for change: Develop below apis for System Standby CEC Message
  1) Thunder API to receive the STANDBY CEC messages received from remote device.
  2) Thunder API sendStandbyMessage() to send STANDBY CEC messages to remote devices.
  3) Event to notify standbyMessageReceived the standby message received.

Test Procedure: Build and Verify
Risks: Medium
Signed-off-by: Anitha Susan Varghese <anitha.varghese@sky.uk>