### PR TITLE
RDK-31097 DeviceDiagnostics: add API to determine decoder status

### DIFF
--- a/DeviceDiagnostics/CMakeLists.txt
+++ b/DeviceDiagnostics/CMakeLists.txt
@@ -22,17 +22,25 @@ find_package(${NAMESPACE}Plugins REQUIRED)
 
 add_library(${MODULE_NAME} SHARED
         DeviceDiagnostics.cpp
-        Module.cpp)
+        Module.cpp
+        ../helpers/utils.cpp)
 
 set_target_properties(${MODULE_NAME} PROPERTIES
         CXX_STANDARD 11
         CXX_STANDARD_REQUIRED YES)
 
 find_package(Curl)
+find_package(IARMBus REQUIRED)
 
 target_include_directories(${MODULE_NAME} PRIVATE ${IARMBUS_INCLUDE_DIRS} ../helpers)
 
-target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins ${CURL_LIBRARY})
+target_link_libraries(${MODULE_NAME} PRIVATE
+    ${NAMESPACE}Plugins::${NAMESPACE}Plugins ${CURL_LIBRARY}
+    ${IARMBUS_LIBRARIES})
+
+if(BUILD_ENABLE_ERM)
+    target_link_libraries(${MODULE_NAME} PRIVATE essosrmgr)
+endif()
 
 install(TARGETS ${MODULE_NAME}
         DESTINATION lib/${STORAGE_DIRECTORY}/plugins)

--- a/DeviceDiagnostics/DeviceDiagnostics.h
+++ b/DeviceDiagnostics/DeviceDiagnostics.h
@@ -19,6 +19,12 @@
 
 #pragma once
 
+#include <thread>
+#include <mutex>
+#ifdef ENABLE_ERM
+#include <essos-resmgr.h>
+#endif
+
 #include "Module.h"
 
 #include "utils.h"
@@ -52,11 +58,26 @@ namespace WPEFramework {
             //End methods
 
             int getConfiguration(const std::string& postData, JsonObject& response);
+            uint32_t getAVDecoderStatus(const JsonObject& parameters, JsonObject& response);
+            int getMostActiveDecoderStatus();
+            void onDecoderStatusChange(int status);
+#ifdef ENABLE_ERM
+            static void *AVPollThread(void *arg);
+#endif
+
+        private:
+#ifdef ENABLE_ERM
+            std::thread m_AVPollThread;
+            std::mutex m_AVDecoderStatusLock;
+            EssRMgr* m_EssRMgr;
+            int m_pollThreadRun;
+#endif
 
         public:
             DeviceDiagnostics();
             virtual ~DeviceDiagnostics();
             virtual void Deinitialize(PluginHost::IShell* service) override;
+            virtual const string Initialize(PluginHost::IShell* service) override;
 
         public:
             static DeviceDiagnostics* _instance;

--- a/DeviceDiagnostics/DeviceDiagnostics.json
+++ b/DeviceDiagnostics/DeviceDiagnostics.json
@@ -17,7 +17,7 @@
             "type": "string",
             "example": "ACTIVE"
         },
-        "videoDecoderStatus":{
+        "AVDecoderStatus":{
             "summary": "The status",
             "enum": [
                 "ACTIVE",
@@ -45,24 +45,6 @@
         }
     },
     "methods": {
-        "getAudioDecoderStatus":{
-            "summary": "Gets the audio decoder status",
-            "result":{
-                "type":"object",
-                "properties": {
-                    "audioDecoderStatus": {
-                        "$ref": "#/definitions/audioDecoderStatus"
-                    },
-                    "success": {
-                        "$ref": "#/definitions/success"
-                    }
-                },
-                "required": [
-                    "audioDecoderStatus",
-                    "success"
-                ]
-            }
-        },
         "getConfiguration": {
             "summary": "Gets the values associated with the corresponding property names",
             "params": {
@@ -117,51 +99,37 @@
                 ]
             }
         },
-        "getVideoDecoderStatus":{
-            "summary": "Gets the video decoder status",
+        "getAVDecoderStatus":{
+            "summary": "Gets the most active status of any audio/video decoder/pipeline.",
             "result":{
                 "type":"object",
                 "properties": {
-                    "videoDecoderStatus": {
-                        "$ref": "#/definitions/videoDecoderStatus"
+                    "AVDecoderStatus": {
+                        "$ref": "#/definitions/AVDecoderStatus"
                     },
                     "success": {
                         "$ref": "#/definitions/success"
                     }
                 },
                 "required": [
-                    "videoDecoderStatus",
+                    "AVDecoderStatus",
                     "success"
                 ]
             }
         }
     },
     "events": {
-        "onAudioDecoderStatusChanged":{
-            "summary": "Triggered when the audio decoder status changes",
+        "onAVDecoderStatusChanged":{
+            "summary": "Triggered when the most active status of any audio/video decoder/pipeline changes.",
             "params": {
                 "type": "object",
                 "properties": {
-                    "audioDecoderStatus": {
-                        "$ref": "#/definitions/audioDecoderStatus"
+                    "AVDecoderStatus": {
+                        "$ref": "#/definitions/AVDecoderStatus"
                     }
                 },
                 "required": [
-                    "audioDecoderStatus"
-                ]
-            }
-        },
-        "onVideoDecoderStatusChanged":{
-            "summary": "Triggered when the video decoder status changes",
-            "params": {
-                "type": "object",
-                "properties": {
-                    "videoDecoderStatus": {
-                        "$ref": "#/definitions/videoDecoderStatus"
-                    }
-                },
-                "required": [
-                    "videoDecoderStatus"
+                    "AVDecoderStatus"
                 ]
             }
         }

--- a/DeviceDiagnostics/doc/DeviceDiagnosticsPlugin.md
+++ b/DeviceDiagnostics/doc/DeviceDiagnosticsPlugin.md
@@ -85,52 +85,9 @@ DeviceDiagnostics interface methods:
 
 | Method | Description |
 | :-------- | :-------- |
-| [getAudioDecoderStatus](#method.getAudioDecoderStatus) | Gets the audio decoder status |
 | [getConfiguration](#method.getConfiguration) | Gets the values associated with the corresponding property names |
-| [getVideoDecoderStatus](#method.getVideoDecoderStatus) | Gets the video decoder status |
+| [getAVDecoderStatus](#method.getAVDecoderStatus) | Gets the most active status of any audio/video decoder/pipeline |
 
-
-<a name="method.getAudioDecoderStatus"></a>
-## *getAudioDecoderStatus <sup>method</sup>*
-
-Gets the audio decoder status.
-
-### Parameters
-
-This method takes no parameters.
-
-### Result
-
-| Name | Type | Description |
-| :-------- | :-------- | :-------- |
-| result | object |  |
-| result.audioDecoderStatus | string | The status (must be one of the following: *ACTIVE*, *PAUSED*, *IDLE*) |
-| result.success | boolean | Whether the request succeeded |
-
-### Example
-
-#### Request
-
-```json
-{
-    "jsonrpc": "2.0",
-    "id": 1234567890,
-    "method": "org.rdk.DeviceDiagnostics.1.getAudioDecoderStatus"
-}
-```
-
-#### Response
-
-```json
-{
-    "jsonrpc": "2.0",
-    "id": 1234567890,
-    "result": {
-        "audioDecoderStatus": "ACTIVE",
-        "success": true
-    }
-}
-```
 
 <a name="method.getConfiguration"></a>
 ## *getConfiguration <sup>method</sup>*
@@ -191,10 +148,10 @@ Gets the values associated with the corresponding property names.
 }
 ```
 
-<a name="method.getVideoDecoderStatus"></a>
-## *getVideoDecoderStatus <sup>method</sup>*
+<a name="method.getAVDecoderStatus"></a>
+## *getAVDecoderStatus <sup>method</sup>*
 
-Gets the video decoder status.
+Gets the most active status of any audio/video decoder/pipeline.
 
 ### Parameters
 
@@ -205,7 +162,7 @@ This method takes no parameters.
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
 | result | object |  |
-| result.videoDecoderStatus | string | The status (must be one of the following: *ACTIVE*, *PAUSED*, *IDLE*) |
+| result.AVDecoderStatus | string | The status (must be one of the following: *ACTIVE*, *PAUSED*, *IDLE*) |
 | result.success | boolean | Whether the request succeeded |
 
 ### Example
@@ -216,7 +173,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 1234567890,
-    "method": "org.rdk.DeviceDiagnostics.1.getVideoDecoderStatus"
+    "method": "org.rdk.DeviceDiagnostics.1.getAVDecoderStatus"
 }
 ```
 
@@ -227,7 +184,7 @@ This method takes no parameters.
     "jsonrpc": "2.0",
     "id": 1234567890,
     "result": {
-        "videoDecoderStatus": "ACTIVE",
+        "AVDecoderStatus": "ACTIVE",
         "success": true
     }
 }
@@ -244,54 +201,29 @@ DeviceDiagnostics interface events:
 
 | Event | Description |
 | :-------- | :-------- |
-| [onAudioDecoderStatusChanged](#event.onAudioDecoderStatusChanged) | Triggered when the audio decoder status changes |
-| [onVideoDecoderStatusChanged](#event.onVideoDecoderStatusChanged) | Triggered when the video decoder status changes |
+| [onAVDecoderStatusChanged](#event.onAVDecoderStatusChanged) | Triggered when the most active status of any audio/video decoder/pipeline changes |
 
 
-<a name="event.onAudioDecoderStatusChanged"></a>
-## *onAudioDecoderStatusChanged <sup>event</sup>*
+<a name="event.onAVDecoderStatusChanged"></a>
+## *onAVDecoderStatusChanged <sup>event</sup>*
 
-Triggered when the audio decoder status changes.
-
-### Parameters
-
-| Name | Type | Description |
-| :-------- | :-------- | :-------- |
-| params | object |  |
-| params.audioDecoderStatus | string | The status (must be one of the following: *ACTIVE*, *PAUSED*, *IDLE*) |
-
-### Example
-
-```json
-{
-    "jsonrpc": "2.0",
-    "method": "client.events.1.onAudioDecoderStatusChanged",
-    "params": {
-        "audioDecoderStatus": "ACTIVE"
-    }
-}
-```
-
-<a name="event.onVideoDecoderStatusChanged"></a>
-## *onVideoDecoderStatusChanged <sup>event</sup>*
-
-Triggered when the video decoder status changes.
+Triggered when the most active status of any audio/video decoder/pipeline changes.
 
 ### Parameters
 
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
 | params | object |  |
-| params.videoDecoderStatus | string | The status (must be one of the following: *ACTIVE*, *PAUSED*, *IDLE*) |
+| params.AVDecoderStatus | string | The status (must be one of the following: *ACTIVE*, *PAUSED*, *IDLE*) |
 
 ### Example
 
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onVideoDecoderStatusChanged",
+    "method": "client.events.1.onAVDecoderStatusChanged",
     "params": {
-        "videoDecoderStatus": "ACTIVE"
+        "AVDecoderStatus": "ACTIVE"
     }
 }
 ```

--- a/services.cmake
+++ b/services.cmake
@@ -275,6 +275,9 @@ elseif(BUILD_AMLOGIC)
     include(amlogic.cmake)
 endif()
 
+if(BUILD_ENABLE_ERM)
+	add_definitions(-DENABLE_ERM)
+endif()
 
 
 


### PR DESCRIPTION
Adds new API according to specification in RDK-31097

Signed-off-by: Michał Łyszczek <michal.lyszczek@bofc.pl>

RDK-31097 DeviceDiagnostics: event value should be 200 not 0x200

Signed-off-by: Michał Łyszczek <michal.lyszczek@bofc.pl>

RDK-31097 DeviceDiagnostics: fix multiple issues after testing

- change event response from video to videoDecoderStatusChange,
    same for audio
- send event when most active decoder state has changed
- add some info logs, decoder updates from gstreamer are not too
    frequent, so this will not pollute logs too much.

Signed-off-by: Michał Łyszczek <michal.lyszczek@consult.red>

RDK-31097 DeviceDiagnostics: replace IARM with ERM api

This patch, replaces IARM api with ERM. Logic about most active
decoder is in ERM library, so thunder only reads it and returns
value as string to the caller. Since ERM does not support event
new thread is spawned to poll ERM for status change, and notify
clients once decoder status changes.

To avoid hoggin CPU, ERM is polled once every 30 seconds, and
because of that, once decoder status changes, event with that
information may be delayed for up to 30 seconds.

getAVDecoderStatus api will always return up to date value from
ERM library.

Signed-off-by: Michał Łyszczek <michal.lyszczek@consult.red>

RDK-31097 DeviceDiagnostics: update API documentation

Signed-off-by: Michał Łyszczek <michal.lyszczek@consult.red>