### PR TITLE
RDK-32936 : SystemServices::requestReboot() will now use IARM_BUS_PWR…

### DIFF
--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -465,13 +465,10 @@ namespace WPEFramework {
                 JsonObject& response)
         {
             int32_t nfxResult = E_NOK;
-            string rebootCommand = "";
-            string rebootReason = "";
-            string customReason = "";
-            string otherReason = "";
+            string customReason = "No custom reason provided";
+            string otherReason = "No other reason supplied";
             bool result = false;
 
-            //TODO: Replace system command
             nfxResult = system("pgrep nrdPluginApp");
             if (E_OK == nfxResult) {
                 LOGINFO("SystemService shutting down Netflix...\n");
@@ -484,53 +481,26 @@ namespace WPEFramework {
                             process. nfxResult = %ld\n", (long int)nfxResult);
                 }
             }
-            if (Utils::fileExists("/rebootNow.sh")) {
-                rebootCommand = "/rebootNow.sh";
-            } else if (Utils::fileExists("/lib/rdk/rebootNow.sh")) {
-                rebootCommand = "/lib/rdk/rebootNow.sh";
-            } else {
-                LOGINFO("rebootNow.sh is not present in /lib/rdk or \
-                        /root\n");
+
+            if (parameters.HasLabel("rebootReason")) {
+                customReason = parameters["rebootReason"].String();
+                otherReason = customReason;
             }
 
-            if (!(rebootCommand.empty())) {
-                rebootReason = "System Plugin";
-                customReason = "No custom reason provided";
-                otherReason = "No other reason supplied";
+            IARM_Bus_PWRMgr_RebootParam_t rebootParam;
+            strncpy(rebootParam.requestor, "System Plugin", sizeof(rebootParam.requestor));
+            strncpy(rebootParam.reboot_reason_custom, customReason.c_str(), sizeof(rebootParam.reboot_reason_custom));
+            strncpy(rebootParam.reboot_reason_other, otherReason.c_str(), sizeof(rebootParam.reboot_reason_other));
+            LOGINFO("requestSystemReboot: custom reason: %s, other reason: %s\n", rebootParam.reboot_reason_custom,
+                rebootParam.reboot_reason_other);
 
-                if (parameters.HasLabel("rebootReason")) {
-                    customReason = parameters["rebootReason"].String();
-                    otherReason = customReason;
-                }
-
-                rebootCommand += " -s \"" + rebootReason + "\"";
-                rebootCommand += " -r \"" + customReason + "\"";
-                rebootCommand += " -o \"" + otherReason + "\"";
-                rebootCommand += " &";
-
-                LOGINFO("IARM_BUS RunScript: '%s'\n", rebootCommand.c_str());
-                IARM_Bus_SYSMgr_RunScript_t runScriptParam;
-                runScriptParam.return_value = -1;
-                strcpy(runScriptParam.script_path, rebootCommand.c_str());
-                IARM_Result_t iarmcallstatus = IARM_Bus_Call(IARM_BUS_SYSMGR_NAME,
-                        IARM_BUS_SYSMGR_API_RunScript,
-                        &runScriptParam, sizeof(runScriptParam));
-
-                nfxResult = !runScriptParam.return_value;
-                response["IARM_Bus_Call_STATUS"] = nfxResult;
-                result = true;
-
-                /* Trigger rebootRequest event if IARMCALL is success. */
-                if (IARM_RESULT_SUCCESS == iarmcallstatus) {
-                    SystemServices::_instance->onRebootRequest(customReason);
-                } else {
-                    LOGERR("iarmcallstatus = %d; onRebootRequest event will not be fired.\n",
-                            iarmcallstatus);
-                }
-            } else {
-                LOGINFO("Rebooting failed as rebootNow.sh is not present\n");
-                populateResponseWithError(SysSrv_FileNotPresent, response);
+            IARM_Result_t iarmcallstatus = IARM_Bus_Call(IARM_BUS_PWRMGR_NAME,
+                    IARM_BUS_PWRMGR_API_Reboot, &rebootParam, sizeof(rebootParam));
+            if(IARM_RESULT_SUCCESS != iarmcallstatus) {
+                LOGWARN("requestSystemReboot: IARM_BUS_PWRMGR_API_Reboot failed with code %d.\n", iarmcallstatus); 
             }
+            response["IARM_Bus_Call_STATUS"] = static_cast <int32_t> (iarmcallstatus);
+            result = true;
             returnResponse(result);
         }//end of requestSystemReboot
 


### PR DESCRIPTION
…MGR_API_Reboot

Reason for change: all reboots will now go via pwrmgr, which
implements IARM_BUS_PWRMGR_API_Reboot. This give pwrmgr an opportunity
to set up things like frontpanel lights, splashscreen in a way that
meets product requirements. Note that the code that generates
onRebootRequest event has been removed from this function. This event
will be generated downstream by pwrmgr instead.

Test Procedure: trigger reboot via
SystemServices::requestSystemReboot(), verify that device reboots.

Risks: low

Signed-off-by: csojan <chaithents@tataelxsi.co.in>