### PR TITLE
RDKTV-8702: TV Can't wakeup eARC device

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -292,6 +292,8 @@ namespace WPEFramework {
                                 }
 
                                 //Connected Audio Ports status update is necessary on bootup / power state transitions
+				sendHdmiCecSinkAudioDevicePowerOn();
+				LOGINFO("%s: Audio Port : [HDMI_ARC0] sendHdmiCecSinkAudioDevicePowerOn !!! \n", __FUNCTION__);
                                 try {
                                     int types = dsAUDIOARCSUPPORT_NONE;
                                     device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort("HDMI_ARC0");


### PR DESCRIPTION
Reason for change: Send Audio Device power on
message on bootup and TV power state transition.
This is required to wakeup devices which remains
undetected over HDMI when it's in standby
Test Procedure: TV Standby/On test with eARC
device connected.
Risks: None

Signed-off-by: Deekshit Devadas <deekshit.devadasy@sky.uk>