### PR TITLE
ONEM-20194 - don't force westeros sink. Allow to predefine it with en…

### DIFF
--- a/FireboltMediaPlayer/impl/AampMediaPlayer/AampMediaPlayer.cpp
+++ b/FireboltMediaPlayer/impl/AampMediaPlayer/AampMediaPlayer.cpp
@@ -33,7 +33,7 @@ namespace WPEFramework {
             //temporary back door for AAMP configuration
             Core::SystemInfo::SetEnvironment(_T("AAMP_ENABLE_OPT_OVERRIDE"), _T("1"));
             //TODO: should be set accordingly to platform set-up
-            Core::SystemInfo::SetEnvironment(_T("AAMP_ENABLE_WESTEROS_SINK"), _T("1"));
+            Core::SystemInfo::SetEnvironment(_T("AAMP_ENABLE_WESTEROS_SINK"), _T("1"), false);
         }
 
         AampMediaPlayer::~AampMediaPlayer()


### PR DESCRIPTION
…vironment variable

This change allows to define own value of AAMP_ENABLE_WESTEROS_SINK prior starting the process, or rely on default value that remains as previously, set to 1.