### PR TITLE
RDK-33039: Thunder API for ArchiveLogs

### DIFF
--- a/UsbAccess/UsbAccess.cpp
+++ b/UsbAccess/UsbAccess.cpp
@@ -22,14 +22,24 @@ const string WPEFramework::Plugin::UsbAccess::METHOD_CLEAR_LINK = "clearLink";
 const string WPEFramework::Plugin::UsbAccess::METHOD_GET_AVAILABLE_FIRMWARE_FILES = "getAvailableFirmwareFiles";
 const string WPEFramework::Plugin::UsbAccess::METHOD_GET_MOUNTED = "getMounted";
 const string WPEFramework::Plugin::UsbAccess::METHOD_UPDATE_FIRMWARE = "updateFirmware";
+const string WPEFramework::Plugin::UsbAccess::METHOD_ARCHIVE_LOGS = "ArchiveLogs";
 const string WPEFramework::Plugin::UsbAccess::LINK_URL_HTTP = "http://localhost:50050/usbdrive";
 const string WPEFramework::Plugin::UsbAccess::LINK_PATH = "/tmp/usbdrive";
 const string WPEFramework::Plugin::UsbAccess::EVT_ON_USB_MOUNT_CHANGED = "onUSBMountChanged";
+const string WPEFramework::Plugin::UsbAccess::EVT_ON_ARCHIVE_LOGS = "onArchiveLogs";
 const string WPEFramework::Plugin::UsbAccess::REGEX_BIN = "[\\w-]*\\.{0,1}[\\w-]*\\.bin";
 const string WPEFramework::Plugin::UsbAccess::REGEX_FILE =
         "[\\w-]*\\.{0,1}[\\w-]*\\.(png|jpg|jpeg|tiff|tif|bmp|mp4|mov|avi|mp3|wav|m4a|flac|mp4|aac|wma|txt|bin|enc|ts)";
 const string WPEFramework::Plugin::UsbAccess::PATH_DEVICE_PROPERTIES = "/etc/device.properties";
 const std::list<string> WPEFramework::Plugin::UsbAccess::ADDITIONAL_FW_PATHS {"UsbTestFWUpdate", "UsbProdFWUpdate"};
+const string WPEFramework::Plugin::UsbAccess::ARCHIVE_LOGS_SCRIPT = "/lib/rdk/usbLogUpload.sh";
+const WPEFramework::Plugin::UsbAccess::ArchiveLogsErrorMap WPEFramework::Plugin::UsbAccess::ARCHIVE_LOGS_ERRORS = {
+        {ScriptError,  "script error"},
+        {None,         "none"},
+        {Locked,       "Locked"},
+        {NoUSB,        "No USB"},
+        {WritingError, "Writing Error"}
+};
 
 namespace WPEFramework {
 namespace Plugin {
@@ -117,11 +127,15 @@ namespace Plugin {
         registerMethod(METHOD_GET_AVAILABLE_FIRMWARE_FILES, &UsbAccess::getAvailableFirmwareFilesWrapper, this, {2});
         registerMethod(METHOD_GET_MOUNTED, &UsbAccess::getMountedWrapper, this, {2});
         registerMethod(METHOD_UPDATE_FIRMWARE, &UsbAccess::updateFirmware, this, {2});
+        registerMethod(METHOD_ARCHIVE_LOGS, &UsbAccess::archiveLogs, this, {2});
     }
 
     UsbAccess::~UsbAccess()
     {
         UsbAccess::_instance = nullptr;
+
+        if (archiveLogsThread.joinable())
+            archiveLogsThread.join();
     }
 
     const string UsbAccess::Initialize(PluginHost::IShell * /* service */)
@@ -298,6 +312,48 @@ namespace Plugin {
         response["mounted"] = arr;
 
         returnResponse(result);
+    }
+
+    uint32_t UsbAccess::archiveLogs(const JsonObject& parameters, JsonObject& response)
+    {
+        LOGINFOMETHOD();
+
+        if (archiveLogsThread.joinable())
+            archiveLogsThread.join();
+
+        archiveLogsThread = std::thread(&UsbAccess::archiveLogsInternal, this);
+
+        returnResponse(true);
+    }
+
+    void UsbAccess::archiveLogsInternal()
+    {
+        ArchiveLogsError error = ScriptError;
+
+        std::list<string> paths;
+        getMounted(paths);
+        if (paths.empty())
+            error = NoUSB;
+        else
+        {
+            string script = (ARCHIVE_LOGS_SCRIPT + " " + *paths.begin());
+            int rc = runScript(script.c_str());
+            LOGINFO("'%s' exit code: %d", script.c_str(), rc);
+            error = static_cast<ArchiveLogsError>(rc);
+        }
+
+        onArchiveLogs(error);
+    }
+
+    void UsbAccess::onArchiveLogs(ArchiveLogsError error)
+    {
+        JsonObject params;
+        auto it = ARCHIVE_LOGS_ERRORS.find(error);
+        if (it == ARCHIVE_LOGS_ERRORS.end())
+            it = ARCHIVE_LOGS_ERRORS.find(ScriptError);
+        params["error"] = it->second;
+        params["success"] = (error == None);
+        sendNotify(EVT_ON_ARCHIVE_LOGS.c_str(), params);
     }
 
     // iarm

--- a/UsbAccess/UsbAccess.h
+++ b/UsbAccess/UsbAccess.h
@@ -4,6 +4,8 @@
 #include "utils.h"
 #include "AbstractPlugin.h"
 
+#include <thread>
+
 namespace WPEFramework {
 namespace Plugin {
 
@@ -29,8 +31,10 @@ namespace Plugin {
         static const string METHOD_GET_AVAILABLE_FIRMWARE_FILES;
         static const string METHOD_GET_MOUNTED;
         static const string METHOD_UPDATE_FIRMWARE;
+        static const string METHOD_ARCHIVE_LOGS;
         //events
         static const string EVT_ON_USB_MOUNT_CHANGED;
+        static const string EVT_ON_ARCHIVE_LOGS;
         //other
         static const string LINK_URL_HTTP;
         static const string LINK_PATH;
@@ -38,6 +42,17 @@ namespace Plugin {
         static const string REGEX_FILE;
         static const string PATH_DEVICE_PROPERTIES;
         static const std::list<string> ADDITIONAL_FW_PATHS;
+        static const string ARCHIVE_LOGS_SCRIPT;
+        enum ArchiveLogsError
+        {
+            ScriptError = -1,
+            None,
+            Locked,
+            NoUSB,
+            WritingError,
+        };
+        typedef std::map<ArchiveLogsError, string> ArchiveLogsErrorMap;
+        static const ArchiveLogsErrorMap ARCHIVE_LOGS_ERRORS;
 
     private/*registered methods (wrappers)*/:
 
@@ -48,6 +63,7 @@ namespace Plugin {
         uint32_t getAvailableFirmwareFilesWrapper(const JsonObject& parameters, JsonObject& response);
         uint32_t getMountedWrapper(const JsonObject& parameters, JsonObject& response);
         uint32_t updateFirmware(const JsonObject& parameters, JsonObject& response);
+        uint32_t archiveLogs(const JsonObject& parameters, JsonObject& response);
 
     private/*iarm*/:
         void InitializeIARM();
@@ -69,6 +85,10 @@ namespace Plugin {
 
         static bool getFileList(const string& path, FileList& files, const string& fileRegex, bool includeFolders);
         static bool getMounted(std::list<string>& paths);
+
+        void archiveLogsInternal();
+        void onArchiveLogs(ArchiveLogsError error);
+        std::thread archiveLogsThread;
     };
 
 } // namespace Plugin


### PR DESCRIPTION
Reason for change: New API that archives logs and saves them on USB.
Test Procedure: Test method ArchiveLogs and event onArchiveLogs
on org.rdk.UsbAccess.2.
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>