### PR TITLE
RDKTV-9191: fix uploadLogs

### DIFF
--- a/helpers/uploadlogs.cpp
+++ b/helpers/uploadlogs.cpp
@@ -40,11 +40,11 @@ namespace
     {
         err_t ret = OK;
         string mac = Utils::cRunScript(". /lib/rdk/utils.sh && getMacAddressOnly");
-        removeCharsFromString(mac, "\n\r: ");
+        removeCharsFromString(mac, "\n\r ");
         if (mac.empty())
             ret = FilenameFail;
         else
-            filename = mac + "_Logs_" + currentDateTimeUtc("+%m-%d-%y-%I-%M%p") + ".tgz";
+            filename = mac + "_Logs_" + currentDateTimeUtc("%m-%d-%y-%I-%M%p") + ".tgz";
         return ret;
     }
 


### PR DESCRIPTION
Reason for change: Remove unnecessary "+", keep colons.
Test Procedure: Invoke org.rdk.System.2.uploadLogs.
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>