### PR TITLE
DELIA-51420 Reboot reason is set as FIRMWARE FAILED during Maintenanc…

### DIFF
--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -499,7 +499,7 @@ namespace WPEFramework {
             }
 
             IARM_Bus_PWRMgr_RebootParam_t rebootParam;
-            strncpy(rebootParam.requestor, "System Plugin", sizeof(rebootParam.requestor));
+            strncpy(rebootParam.requestor, "SystemServices", sizeof(rebootParam.requestor));
             strncpy(rebootParam.reboot_reason_custom, customReason.c_str(), sizeof(rebootParam.reboot_reason_custom));
             strncpy(rebootParam.reboot_reason_other, otherReason.c_str(), sizeof(rebootParam.reboot_reason_other));
             LOGINFO("requestSystemReboot: custom reason: %s, other reason: %s\n", rebootParam.reboot_reason_custom,


### PR DESCRIPTION
…eReboot

Reason for change: Update the source of the reboot request
Test Procedure: build procedure
Risks:None

Signed-off-by: Michael Anand Michael_AmalAnand@comcast.com