### PR TITLE
ONEM-20928 hdcp status fixed, HDMI selection fixed.

### DIFF
--- a/DisplayInfo/DeviceSettings/PlatformImplementation.cpp
+++ b/DisplayInfo/DeviceSettings/PlatformImplementation.cpp
@@ -385,7 +385,7 @@ public:
             for (size_t i = 0; i < vPorts.size(); i++)
             {
                 device::VideoOutputPort &vPort = vPorts.at(i);
-                if (vPort.isDisplayConnected())
+                if (vPort.isDisplayConnected() && (vPort.getType() == device::VideoOutputPortType::kHDMI))
                 {
                     name = vPort.getName();
                     TRACE(Trace::Information, (_T("Connected video output port = %s"), name));

--- a/DisplayInfo/DisplayInfo.cpp
+++ b/DisplayInfo/DisplayInfo.cpp
@@ -168,7 +168,7 @@ namespace Plugin {
         }
 
         Exchange::IConnectionProperties::HDCPProtectionType hdcpProtection(Exchange::IConnectionProperties::HDCPProtectionType::HDCP_Unencrypted);
-        if (_connectionProperties->HDCPProtection(hdcpProtection) == Core::ERROR_NONE) {
+        if (static_cast<const Exchange::IConnectionProperties*>(_connectionProperties)->HDCPProtection(hdcpProtection) == Core::ERROR_NONE) {
             displayInfo.Hdcpprotection = static_cast<JsonData::DisplayInfo::DisplayinfoData::HdcpprotectionType>(hdcpProtection);
         }
 


### PR DESCRIPTION
PortName method narrowed down to HDMI types only. 
Rest of DisplayInfo has working assumption that video port is that type. 
On one of the platforms we have two connected ports HDMI0 and Component0 and PortName can mistakenly take the latter one.

Forcing HDCPConnection to getter by casting to const method.