### PR TITLE
RDKTV-9259: HdmiCecSink to separate systemAudioModeRequest from Arc s…

### DIFF
--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -2735,7 +2735,6 @@ namespace WPEFramework
 
              LOGINFO("Current ARC State : %d\n", m_currentArcRoutingState);
 
-            _instance->systemAudioModeRequest();
 	    _instance->requestArcInitiation();
  
           // start initiate ARC timer 3 sec
@@ -2875,6 +2874,7 @@ namespace WPEFramework
 			     case ARC_STATE_REQUEST_ARC_INITIATION :
                              { 
 				 
+                                 _instance->systemAudioModeRequest();
 				 _instance->Send_Request_Arc_Initiation_Message();
 				   
 			     }


### PR DESCRIPTION
…tart.

Reason for change: Separate out systemAudioModeRequest from Arc start.
Test Procedure: Build and Verify.
Risks: Low
Signed-off-by: bp-sramul089 <sunil.ramulu@sky.uk>

Change-Id: Ic4888877e742af5cffe541a07b2eae7515dbaaf5