### PR TITLE
RDK-32545, RDK-33171, RDK-33172: Bluetooth Audio Output Mute & Volume…

### DIFF
--- a/Bluetooth/Bluetooth.cpp
+++ b/Bluetooth/Bluetooth.cpp
@@ -56,6 +56,8 @@ const string WPEFramework::Plugin::Bluetooth::METHOD_SET_EVENT_RESPONSE = "respo
 const string WPEFramework::Plugin::Bluetooth::METHOD_GET_DEVICE_INFO = "getDeviceInfo";
 const string WPEFramework::Plugin::Bluetooth::METHOD_GET_AUDIO_INFO = "getAudioInfo";
 const string WPEFramework::Plugin::Bluetooth::METHOD_GET_API_VERSION_NUMBER = "getApiVersionNumber";
+const string WPEFramework::Plugin::Bluetooth::METHOD_GET_DEVICE_VOLUME_MUTE_INFO = "getDeviceVolumeMuteInfo";
+const string WPEFramework::Plugin::Bluetooth::METHOD_SET_DEVICE_VOLUME_MUTE_INFO = "setDeviceVolumeMuteInfo";
 
 const string WPEFramework::Plugin::Bluetooth::EVT_STATUS_CHANGED = "onStatusChanged";
 const string WPEFramework::Plugin::Bluetooth::EVT_PAIRING_REQUEST = "onPairingRequest";
@@ -106,6 +108,7 @@ const string WPEFramework::Plugin::Bluetooth::CMD_AUDIO_CTRL_RESTART = "RESTART"
 const string WPEFramework::Plugin::Bluetooth::CMD_AUDIO_CTRL_VOLUME_UP = "VOLUME_UP";
 const string WPEFramework::Plugin::Bluetooth::CMD_AUDIO_CTRL_VOLUME_DOWN = "VOLUME_DOWN";
 const string WPEFramework::Plugin::Bluetooth::CMD_AUDIO_CTRL_MUTE = "AUDIO_MUTE";
+const string WPEFramework::Plugin::Bluetooth::CMD_AUDIO_CTRL_UNMUTE = "AUDIO_UNMUTE";
 
 namespace WPEFramework
 {
@@ -155,6 +158,8 @@ namespace WPEFramework
             registerMethod(METHOD_SET_EVENT_RESPONSE, &Bluetooth::setEventResponseWrapper, this);
             registerMethod(METHOD_GET_DEVICE_INFO, &Bluetooth::getDeviceInfoWrapper, this);
             registerMethod(METHOD_GET_AUDIO_INFO, &Bluetooth::getMediaTrackInfoWrapper, this);
+            registerMethod(METHOD_GET_DEVICE_VOLUME_MUTE_INFO, &Bluetooth::getDeviceVolumeMuteInfoWrapper, this);
+            registerMethod(METHOD_SET_DEVICE_VOLUME_MUTE_INFO, &Bluetooth::setDeviceVolumeMuteInfoWrapper, this);
 
             Utils::IARM::init();
 
@@ -633,8 +638,12 @@ namespace WPEFramework
                 /* could manipulate this action with skip track by setting Repeat - To confirm */
             } //TODO
             else if (audioCtrlCmd == CMD_AUDIO_CTRL_MUTE) {
-                rc = BTRMGR_RESULT_GENERIC_FAILURE;
-                /* release data path and reacquire on unmute - to confirm */
+                    LOGERR(" mute set calling ");
+                    rc = BTRMGR_MediaControl (0, deviceHandle, BTRMGR_MEDIA_CTRL_MUTE);
+            }
+            else if (audioCtrlCmd == CMD_AUDIO_CTRL_UNMUTE) {
+                     LOGERR(" un mute set calling ");
+                     rc = BTRMGR_MediaControl (0, deviceHandle, BTRMGR_MEDIA_CTRL_UNMUTE);
             }
             else if (audioCtrlCmd == CMD_AUDIO_CTRL_VOLUME_UP) {
                     rc = BTRMGR_MediaControl (0, deviceHandle, BTRMGR_MEDIA_CTRL_VOLUMEUP);
@@ -652,6 +661,83 @@ namespace WPEFramework
 
             return BTRMGR_RESULT_SUCCESS == rc;
         }
+
+        bool Bluetooth::setDeviceVolumeMuteProperties(long long int  deviceID, const string &discProfile, unsigned char ui8volume, unsigned char mute)
+        {
+             BTRMGR_Result_t rc = BTRMGR_RESULT_SUCCESS;
+             BTRMgrDeviceHandle deviceHandle = (BTRMgrDeviceHandle) deviceID;
+             BTRMGR_DeviceOperationType_t lenDevOpDiscType = BTRMGR_DEVICE_OP_TYPE_AUDIO_OUTPUT;
+
+             if (Utils::String::contains(discProfile, "LOUDSPEAKER") ||
+                 Utils::String::contains(discProfile, "HEADPHONES") ||
+                 Utils::String::contains(discProfile, "WEARABLE HEADSET") ||
+                 Utils::String::contains(discProfile, "HIFI AUDIO DEVICE")) {
+                 lenDevOpDiscType = BTRMGR_DEVICE_OP_TYPE_AUDIO_OUTPUT;
+             }
+             else if (Utils::String::contains(discProfile, "SMARTPHONE") ||
+                      Utils::String::contains(discProfile, "TABLET")) {
+                      lenDevOpDiscType = BTRMGR_DEVICE_OP_TYPE_AUDIO_INPUT;
+             }
+             else if (Utils::String::contains(discProfile, "KEYBOARD") ||
+                      Utils::String::contains(discProfile, "MOUSE") ||
+                      Utils::String::contains(discProfile, "JOYSTICK")) {
+                      lenDevOpDiscType = BTRMGR_DEVICE_OP_TYPE_HID;
+             }
+             else if (Utils::String::contains(discProfile, "LE TILE") ||
+                      Utils::String::contains(discProfile, "LE")) {
+                      lenDevOpDiscType = BTRMGR_DEVICE_OP_TYPE_LE;
+             }
+             else if (Utils::String::contains(discProfile, "DEFAULT")) {
+                      lenDevOpDiscType = BTRMGR_DEVICE_OP_TYPE_UNKNOWN;
+             }
+
+             rc = BTRMGR_SetDeviceVolumeMute (0, deviceHandle, lenDevOpDiscType, ui8volume, mute);
+             return BTRMGR_RESULT_SUCCESS == rc;
+        }
+
+        JsonObject Bluetooth::getDeviceVolumeMuteProperties(long long int  deviceID, const string &discProfile)
+        {
+             BTRMGR_Result_t rc = BTRMGR_RESULT_SUCCESS;
+             BTRMgrDeviceHandle deviceHandle = (BTRMgrDeviceHandle) deviceID;
+             BTRMGR_DeviceOperationType_t lenDevOpDiscType = BTRMGR_DEVICE_OP_TYPE_AUDIO_OUTPUT;
+	     unsigned char ui8volume;
+	     unsigned char mute;
+	     JsonObject volumeInfo;
+
+             if (Utils::String::contains(discProfile, "LOUDSPEAKER") ||
+                 Utils::String::contains(discProfile, "HEADPHONES") ||
+                 Utils::String::contains(discProfile, "WEARABLE HEADSET") ||
+                 Utils::String::contains(discProfile, "HIFI AUDIO DEVICE")) {
+                 lenDevOpDiscType = BTRMGR_DEVICE_OP_TYPE_AUDIO_OUTPUT;
+             }
+             else if (Utils::String::contains(discProfile, "SMARTPHONE") ||
+                      Utils::String::contains(discProfile, "TABLET")) {
+                      lenDevOpDiscType = BTRMGR_DEVICE_OP_TYPE_AUDIO_INPUT;
+             }
+             else if (Utils::String::contains(discProfile, "KEYBOARD") ||
+                      Utils::String::contains(discProfile, "MOUSE") ||
+                      Utils::String::contains(discProfile, "JOYSTICK")) {
+                      lenDevOpDiscType = BTRMGR_DEVICE_OP_TYPE_HID;
+             }
+             else if (Utils::String::contains(discProfile, "LE TILE") ||
+                      Utils::String::contains(discProfile, "LE")) {
+                      lenDevOpDiscType = BTRMGR_DEVICE_OP_TYPE_LE;
+             }
+             else if (Utils::String::contains(discProfile, "DEFAULT")) {
+                      lenDevOpDiscType = BTRMGR_DEVICE_OP_TYPE_UNKNOWN;
+             }
+
+             rc = BTRMGR_GetDeviceVolumeMute (0, deviceHandle, lenDevOpDiscType, &ui8volume, &mute);
+             if (BTRMGR_RESULT_SUCCESS != rc) {
+                 LOGERR("Failed to get the volume info");
+             } else {
+	         volumeInfo ["volume"] = std::to_string(ui8volume);
+	         volumeInfo ["mute"]   = mute ? true : false ;
+	     }
+
+             return volumeInfo;
+        }
+
 
         bool Bluetooth::setEventResponse(long long int  deviceID, const string &eventType, const string &respValue)
         {
@@ -1436,6 +1522,95 @@ namespace WPEFramework
                 successFlag = setAudioControlCommand(deviceID, audioCtrlCmd);
             } else {
                 LOGERR("Please specify parameters. Example: \"params\": {\"deviceID\": \"271731989589742\", \"command\": \"PLAY\"}");
+                successFlag = false;
+            }
+            returnResponse(successFlag);
+        }
+
+
+        uint32_t Bluetooth::getDeviceVolumeMuteInfoWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool successFlag;
+            string deviceIDStr;
+            long long int deviceID = 0;
+            bool deviceIDDefined = false;
+            string deviceTypeStr;
+            bool deviceTypeDefined = false;
+            char ui8volume = 0;
+	    char mute;
+
+
+            if (parameters.HasLabel("deviceID"))
+            {
+                getStringParameter("deviceID", deviceIDStr);
+                deviceID = stoll(deviceIDStr);
+                deviceIDDefined = true;
+            }
+            if (parameters.HasLabel("deviceType"))
+            {
+                getStringParameter("deviceType", deviceTypeStr);
+                deviceTypeDefined = true;
+            }
+            if (deviceIDDefined && deviceTypeDefined)
+            {
+                LOGINFO("Making a call with deviceID=%llu ", deviceID);
+                response ["volumeinfo"] = getDeviceVolumeMuteProperties(deviceID, deviceTypeStr);
+                successFlag = true;
+            } else {
+                LOGERR("Please specify parameters. Example: \"params\": {\"deviceID\": \"271731989589742\", \"deviceType\": \"HEADPHONES\"}");
+                successFlag = false;
+            }
+            returnResponse(successFlag);
+        }
+
+        uint32_t Bluetooth::setDeviceVolumeMuteInfoWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool successFlag;
+            string deviceIDStr;
+            long long int deviceID = 0;
+            bool deviceIDDefined = false;
+            string deviceTypeStr;
+            bool deviceTypeDefined = false;
+            unsigned char ui8volume = 0;
+            int ivolume = 0;
+            bool volumeDefined = false;
+            unsigned char mute;
+            int imute = 0;
+            bool muteDefined = false;
+
+
+            if (parameters.HasLabel("deviceID"))
+            {
+                getStringParameter("deviceID", deviceIDStr);
+                deviceID = stoll(deviceIDStr);
+                deviceIDDefined = true;
+            }
+            if (parameters.HasLabel("deviceType"))
+            {
+                getStringParameter("deviceType", deviceTypeStr);
+                deviceTypeDefined = true;
+            }
+            if (parameters.HasLabel("volume"))
+            {
+                getNumberParameterObject(parameters, "volume", ivolume);
+                ui8volume = static_cast<unsigned char>(ivolume);
+                volumeDefined = true;
+            }
+            if (parameters.HasLabel("mute"))
+            {
+                getNumberParameterObject(parameters, "mute", imute);
+                mute = static_cast<unsigned char>(imute);
+                muteDefined = true;
+            }
+
+            if (deviceIDDefined && deviceTypeDefined && volumeDefined && muteDefined)
+            {
+                LOGINFO("Making a call with deviceID=%llu ", deviceID);
+                successFlag = setDeviceVolumeMuteProperties(deviceID, deviceTypeStr, ui8volume, mute);
+            } else {
+                LOGERR("Please specify parameters. Example: \"params\": {\"deviceID\": \"271731989589742\", \"deviceType\": \"HEADPHONES\", \"volume\": \"0-255\", \"mute\": \"0-1\"}");
                 successFlag = false;
             }
             returnResponse(successFlag);

--- a/Bluetooth/Bluetooth.h
+++ b/Bluetooth/Bluetooth.h
@@ -96,6 +96,8 @@ namespace WPEFramework {
             uint32_t setEventResponseWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t getDeviceInfoWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t getMediaTrackInfoWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t getDeviceVolumeMuteInfoWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t setDeviceVolumeMuteInfoWrapper(const JsonObject& parameters, JsonObject& response);
             // Registered methods end
 
         private: /*internal methods*/
@@ -120,6 +122,9 @@ namespace WPEFramework {
             bool setEventResponse(long long int  deviceID, const string &eventType, const string &respValue);
             JsonObject getDeviceInfo(long long int deviceID);
             JsonObject getMediaTrackInfo(long long int deviceID);
+            bool setDeviceVolumeMuteProperties(long long int  deviceID, const string &discProfile, unsigned char ui8volume, unsigned char mute);
+            JsonObject getDeviceVolumeMuteProperties(long long int  deviceID, const string &discProfile);
+
         public:
             static const short API_VERSION_NUMBER_MAJOR;
             static const short API_VERSION_NUMBER_MINOR;
@@ -145,6 +150,8 @@ namespace WPEFramework {
             static const string METHOD_GET_DEVICE_INFO;
             static const string METHOD_GET_AUDIO_INFO;
             static const string METHOD_GET_API_VERSION_NUMBER;
+            static const string METHOD_GET_DEVICE_VOLUME_MUTE_INFO;
+            static const string METHOD_SET_DEVICE_VOLUME_MUTE_INFO;
             static const string EVT_STATUS_CHANGED;
             static const string EVT_PAIRING_REQUEST;
             static const string EVT_REQUEST_FAILED;
@@ -205,6 +212,7 @@ namespace WPEFramework {
             static const string CMD_AUDIO_CTRL_VOLUME_UP;
             static const string CMD_AUDIO_CTRL_VOLUME_DOWN;
             static const string CMD_AUDIO_CTRL_MUTE;
+            static const string CMD_AUDIO_CTRL_UNMUTE;
 
             uint32_t m_apiVersionNumber;
             // Assuming that there will be only one threaded call at a time (which is the case for Bluetooth)


### PR DESCRIPTION
… Control

Reason for change: Thunder apis for the volume up/down and mute/unmute control
 of the paired BT audio out device.
Test Procedure: tested with curl commands passing new methods
Risks: Low
Signed-off-by: Sudheer Reddy Sirigireddy <SudheerReddy_Sirigireddy@cable.comcast.com>