### PR TITLE
    RDKTV-9364 : Crash in hdmicecsink

### DIFF
--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -945,6 +945,12 @@ namespace WPEFramework
         }
 	void HdmiCecSink::systemAudioModeRequest()
         {
+	     if ( cecEnableStatus != true  )
+	     {
+               LOGINFO("systemAudioModeRequest: Cec is disabled-> EnableCEC first");
+              return;
+             } 
+
             if(!HdmiCecSink::_instance)
              return;
             if(!(_instance->smConnection))
@@ -1803,7 +1809,13 @@ namespace WPEFramework
 
                 void HdmiCecSink::requestShortaudioDescriptor()
 	        {
-			if(!HdmiCecSink::_instance)
+		        if ( cecEnableStatus != true  )
+                        {
+                             LOGINFO("requestShortaudioDescriptor: cec is disabled-> EnableCEC first");
+                             return;
+                        }
+
+		        if(!HdmiCecSink::_instance)
 				return;
 
                         if(!(_instance->smConnection))


### PR DESCRIPTION
    Reason for change: Fix for the crash in hdmicecsink when cec is disabled the
    Test Procedure: none
    Risks: low

    Signed-off-by: Bijas Babu bijas.babu@sky.uk