### PR TITLE
XIONE-1555: ContinueWatching API fails

### DIFF
--- a/ContinueWatching/ContinueWatching.cpp
+++ b/ContinueWatching/ContinueWatching.cpp
@@ -111,6 +111,16 @@ namespace WPEFramework {
 			bool ret=false;
 			string tokenData = getAppToken(appName.c_str());
 			if(!(tokenData.empty())){
+                                //Form a json string from the saved token by prepending: "application_token : " & adding quotes if necessary
+                                int i=0;
+                                while(isspace(tokenData[i]))
+                                        i++;
+                                if(tokenData[i] == '{')
+                                        tokenData = "{\"application_token\" : " + tokenData + " }";
+                                else
+                                        tokenData = "{\"application_token\" : \"" + tokenData + "\" }";
+
+                                LOGINFO("tokenData: %s\n", tokenData.c_str());
 				if (!token.FromString(tokenData, error)) {
         	        		LOGERR("getApplicationToken :Failed to parse tokendata");      
 				}

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -776,8 +776,6 @@ namespace WPEFramework {
                 removeCharsFromString(queryParams, "[\"]");
             }
 
-            string queryOriginal = queryParams;
-
             // there is no /tmp/.make from /lib/rdk/getDeviceDetails.sh, but it can be taken from /etc/device.properties
             if (queryParams.empty() || queryParams == "make") {
 
@@ -833,12 +831,6 @@ namespace WPEFramework {
             }
 #endif
 
-            //Since there is no friendly_id available yet, returning hardcoded values based on model_number
-            if (queryParams == "friendly_id") {
-                queryParams = "model_number";
-            }
-
-
             std::string cmd = DEVICE_INFO_SCRIPT;
             if (!queryParams.empty()) {
                 cmd += " ";
@@ -880,26 +872,10 @@ namespace WPEFramework {
                     }
                 } else {
                     retAPIStatus = true;
-
                     Utils::String::trim(res);
-                    if (queryOriginal == "friendly_id") {
-                        model_number = res;
-                    } else {
-                        response[queryParams.c_str()] = res;
-                    }
-                }
-
-                if (queryParams.empty() || queryOriginal == "friendly_id") {
-                    if (model_number == "PLTL11AEI") {
-                        response["friendly_id"] = "CAD11";
-                    } else if (model_number == "HSTP11MWR") {
-                        response["friendly_id"] = "43A6GX";
-                    } else {
-                        response["friendly_id"] = "";
-                    }
+		    response[queryParams.c_str()] = res;
                 }
             }
-
             returnResponse(retAPIStatus);
         }
 


### PR DESCRIPTION
Reason for change: Return token correctly
Test Procedure: Run curl commands from ticket.
Risks: Low

Signed-off-by: Mark Vandenbriele <mark.vandenbriele@consult.red>