### PR TITLE
RDKTV-9273 Skip network dependent maintenance in offline

### DIFF
--- a/MaintenanceManager/CMakeLists.txt
+++ b/MaintenanceManager/CMakeLists.txt
@@ -39,11 +39,11 @@ list(APPEND CMAKE_MODULE_PATH
 find_package(IARMBus)
 if (IARMBus_FOUND)
     target_include_directories(${MODULE_NAME} PRIVATE ${IARMBUS_INCLUDE_DIRS})
-    target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins ${IARMBUS_LIBRARIES})
+    target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins ${NAMESPACE}SecurityUtil ${IARMBUS_LIBRARIES})
 else (IARMBus_FOUND)
     message ("Module IARMBus required.")
     target_include_directories(${MODULE_NAME} PRIVATE ${IARMBUS_INCLUDE_DIRS})
-    target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins ${IARMBUS_LIBRARIES})
+    target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins ${NAMESPACE}SecurityUtil ${IARMBUS_LIBRARIES})
 endif(IARMBus_FOUND)
 
 target_include_directories(${MODULE_NAME} PRIVATE ../helpers)

--- a/MaintenanceManager/MaintenanceManager.h
+++ b/MaintenanceManager/MaintenanceManager.h
@@ -127,6 +127,10 @@ namespace WPEFramework {
                 std::condition_variable task_thread;
                 std::thread m_thread;
 
+                std::unordered_map<string, bool> m_task_map;    
+                        
+
+                bool isDeviceOnline();
                 void task_execution_thread();
                 void requestSystemReboot();
                 void maintenanceManagerOnBootup();


### PR DESCRIPTION
Reason for change: When TV is offline mode some of the maintenance activity
is taking 2.5hours to complete the maintenance and blocking the TV to go to
deep sleep, this fails the energy certification test

Test Procedure: Keep the TV in offline mode and see TV is going to deepsleep
in 15min
Risks: Medium

Signed-off-by: sputhi200 <Sujeesh_Puthiya@comcast.com>
(cherry picked from commit a4fa820e1de2e140c08737070bd669e55adb71e3)