### PR TITLE
DELIA-51492 LLAMA-2652 maintenanceStartTime is not updated and mutex …

### DIFF
--- a/MaintenanceManager/MaintenanceManager.h
+++ b/MaintenanceManager/MaintenanceManager.h
@@ -116,7 +116,7 @@ namespace WPEFramework {
 
                 IARM_Bus_MaintMGR_EventData_t *g_maintenance_data;
 
-                Maint_notify_status_t g_notify_status;
+                Maint_notify_status_t m_notify_status;
 
                 Maintenance_Type_t g_maintenance_type;
 
@@ -125,6 +125,7 @@ namespace WPEFramework {
                 uint16_t g_task_status;
 
                 std::mutex  m_callMutex;
+                std::mutex  m_statusMutex;
                 std::condition_variable task_thread;
                 std::thread m_thread;
 


### PR DESCRIPTION
…handling

Reason for change: remove  RequestReboot as it is not in use
Test Procedure: build procedure
Risks: No

Signed-off-by: Michael Amal Michael_AmalAnand@comcast.com

DELIA-51492 maintenanceStartTime is not updated after maintenance finishes

Reason for change: maintenanceStartTime is not updated
Test Procedure: build procedure
Risks:None

Signed-off-by: Michael Anand Michael_AmalAnand@comcast.com