### PR TITLE
RDKTV-9417 : HDMI-CEC state does not persist

### DIFF
--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -1459,6 +1459,18 @@ namespace WPEFramework
             return cecSettingEnabled;
         }
 
+        void HdmiCecSink::syncPersistFile (char* strFileToFlush) {
+            FILE * fp = NULL;
+            fp = fopen(strFileToFlush, "r");
+            if (fp == NULL) {
+                printf("fopen NULL\n");
+                return;
+            }
+            fflush(fp);
+            fsync(fileno(fp));
+            fclose(fp);
+        }
+
         void HdmiCecSink::persistSettings(bool enableStatus)
         {
             Core::File file;
@@ -1476,7 +1488,7 @@ namespace WPEFramework
             cecSetting.IElement::ToFile(file);
 
             file.Close();
-
+            syncPersistFile (CEC_SETTING_ENABLED_FILE);
             return;
         }
 
@@ -1497,6 +1509,7 @@ namespace WPEFramework
             cecSetting.IElement::ToFile(file);
 
             file.Close();
+            syncPersistFile (CEC_SETTING_ENABLED_FILE);
 
             return;
         }
@@ -1518,6 +1531,7 @@ namespace WPEFramework
             cecSetting.IElement::ToFile(file);
 
             file.Close();
+            syncPersistFile (CEC_SETTING_ENABLED_FILE);
 
             return;
         }

--- a/HdmiCecSink/HdmiCecSink.h
+++ b/HdmiCecSink/HdmiCecSink.h
@@ -608,6 +608,7 @@ private:
             void onHdmiHotPlug(int portId, int connectStatus);
 	    void wakeupFromStandby();
             bool loadSettings();
+            void syncPersistFile (char* strFileToFlush);
             void persistSettings(bool enableStatus);
             void persistOTPSettings(bool enableStatus);
             void persistOSDName(const char *name);


### PR DESCRIPTION
Reason for change:
HDMI-CEC_state_does_not_persist
Test Procedure: None
Risks: Low

Change-Id: I459d842b3f776de70a3e2371e24e7a125236332b
Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>