### PR TITLE
RDKTV-9417 : HDMI-CEC state does not persist

### DIFF
--- a/HdmiCec/HdmiCec.cpp
+++ b/HdmiCec/HdmiCec.cpp
@@ -322,7 +322,7 @@ namespace WPEFramework
             cecSetting.IElement::ToFile(file);
 
             file.Close();
-
+            Utils::syncPersistFile(CEC_SETTING_ENABLED_FILE);
             return;
         }
 

--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -1466,7 +1466,7 @@ namespace WPEFramework
             cecSetting.IElement::ToFile(file);
 
             file.Close();
-
+            Utils::syncPersistFile (CEC_SETTING_ENABLED_FILE);
             return;
         }
 
@@ -1487,6 +1487,7 @@ namespace WPEFramework
             cecSetting.IElement::ToFile(file);
 
             file.Close();
+            Utils::syncPersistFile (CEC_SETTING_ENABLED_FILE);
 
             return;
         }
@@ -1508,6 +1509,7 @@ namespace WPEFramework
             cecSetting.IElement::ToFile(file);
 
             file.Close();
+            Utils::syncPersistFile (CEC_SETTING_ENABLED_FILE);
 
             return;
         }

--- a/HdmiCec_2/HdmiCec_2.cpp
+++ b/HdmiCec_2/HdmiCec_2.cpp
@@ -831,6 +831,7 @@ namespace WPEFramework
             cecSetting.IElement::ToFile(file);
 
             file.Close();
+            Utils::syncPersistFile (CEC_SETTING_ENABLED_FILE);
 
             return;
         }
@@ -852,6 +853,7 @@ namespace WPEFramework
             cecSetting.IElement::ToFile(file);
 
             file.Close();
+            Utils::syncPersistFile (CEC_SETTING_ENABLED_FILE);
 
             return;
         }
@@ -873,6 +875,7 @@ namespace WPEFramework
             cecSetting.IElement::ToFile(file);
 
             file.Close();
+            Utils::syncPersistFile (CEC_SETTING_ENABLED_FILE);
 
             return;
         }
@@ -894,7 +897,7 @@ namespace WPEFramework
             cecSetting.IElement::ToFile(file);
 
             file.Close();
-
+            Utils::syncPersistFile (CEC_SETTING_ENABLED_FILE);
             return;
         }
 

--- a/helpers/utils.cpp
+++ b/helpers/utils.cpp
@@ -381,3 +381,14 @@ bool Utils::isValidInt(char* x)
     return Checked;
 }
 
+void Utils::syncPersistFile (char* strFileToFlush) {
+    FILE * fp = NULL;
+    fp = fopen(strFileToFlush, "r");
+    if (fp == NULL) {
+        printf("fopen NULL\n");
+        return;
+    }
+    fflush(fp);
+    fsync(fileno(fp));
+    fclose(fp);
+}

--- a/helpers/utils.h
+++ b/helpers/utils.h
@@ -350,6 +350,7 @@ namespace Utils
 
     bool getRFCConfig(char* paramName, RFC_ParamData_t& paramOutput);
     bool isValidInt(char* x);
+    void syncPersistFile (char* strFileToFlush);
 
     //class for std::thread RAII
     class ThreadRAII 


### PR DESCRIPTION
Reason for change:
HDMI-CEC_state_does_not_persist
Test Procedure: None
Risks: Low

Change-Id: Idb624734362d67eb528a38c1c9caa6c89f30ab7a
Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>