### PR TITLE
RDKTV-9417 : HDMI-CEC state does not persist

### DIFF
--- a/HdmiCec/HdmiCec.cpp
+++ b/HdmiCec/HdmiCec.cpp
@@ -322,7 +322,7 @@ namespace WPEFramework
             cecSetting.IElement::ToFile(file);
 
             file.Close();
-
+            Utils::syncPersistFile(CEC_SETTING_ENABLED_FILE);
             return;
         }
 

--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -1476,7 +1476,7 @@ namespace WPEFramework
             cecSetting.IElement::ToFile(file);
 
             file.Close();
-
+            Utils::syncPersistFile (CEC_SETTING_ENABLED_FILE);
             return;
         }
 
@@ -1497,6 +1497,7 @@ namespace WPEFramework
             cecSetting.IElement::ToFile(file);
 
             file.Close();
+            Utils::syncPersistFile (CEC_SETTING_ENABLED_FILE);
 
             return;
         }
@@ -1518,6 +1519,7 @@ namespace WPEFramework
             cecSetting.IElement::ToFile(file);
 
             file.Close();
+            Utils::syncPersistFile (CEC_SETTING_ENABLED_FILE);
 
             return;
         }

--- a/HdmiCec_2/HdmiCec_2.cpp
+++ b/HdmiCec_2/HdmiCec_2.cpp
@@ -889,7 +889,7 @@ namespace WPEFramework
             cecSetting.IElement::ToFile(file);
 
             file.Close();
-
+            Utils::syncPersistFile (CEC_SETTING_ENABLED_FILE);
             return;
         }
 
@@ -910,6 +910,7 @@ namespace WPEFramework
             cecSetting.IElement::ToFile(file);
 
             file.Close();
+            Utils::syncPersistFile (CEC_SETTING_ENABLED_FILE);
 
             return;
         }
@@ -931,6 +932,7 @@ namespace WPEFramework
             cecSetting.IElement::ToFile(file);
 
             file.Close();
+            Utils::syncPersistFile (CEC_SETTING_ENABLED_FILE);
 
             return;
         }
@@ -952,6 +954,7 @@ namespace WPEFramework
             cecSetting.IElement::ToFile(file);
 
             file.Close();
+            Utils::syncPersistFile (CEC_SETTING_ENABLED_FILE);
 
             return;
         }

--- a/helpers/utils.cpp
+++ b/helpers/utils.cpp
@@ -381,3 +381,14 @@ bool Utils::isValidInt(char* x)
     return Checked;
 }
 
+void Utils::syncPersistFile (char* strFileToFlush) {
+    FILE * fp = NULL;
+    fp = fopen(strFileToFlush, "r");
+    if (fp == NULL) {
+        printf("fopen NULL\n");
+        return;
+    }
+    fflush(fp);
+    fsync(fileno(fp));
+    fclose(fp);
+}

--- a/helpers/utils.h
+++ b/helpers/utils.h
@@ -348,6 +348,7 @@ namespace Utils
 
     bool getRFCConfig(char* paramName, RFC_ParamData_t& paramOutput);
     bool isValidInt(char* x);
+    void syncPersistFile (char* strFileToFlush);
 
     //class for std::thread RAII
     class ThreadRAII 


### PR DESCRIPTION
Reason for change:
HDMI-CEC_state_does_not_persist
Test Procedure: None
Risks: Low

Change-Id: I8374c97ed6a3ca901686d83a5e1115f8259a3baa
Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>