### PR TITLE
RDKTV-9417 : HDMI-CEC state does not persist

### DIFF
--- a/HdmiCec/HdmiCec.cpp
+++ b/HdmiCec/HdmiCec.cpp
@@ -97,7 +97,7 @@ namespace WPEFramework
             else
             {
                 setEnabled(false);
-                persistSettings(false);
+                Utils::persistJsonSettings (CEC_SETTING_ENABLED_FILE, CEC_SETTING_ENABLED, JsonValue(false));
             }
         }
 
@@ -307,32 +307,13 @@ namespace WPEFramework
             return cecSettingEnabled;
         }
 
-        void HdmiCec::persistSettings(bool enableStatus)
-        {
-            Core::File file;
-            file = CEC_SETTING_ENABLED_FILE;
-
-            file.Open(false);
-            if (!file.IsOpen())
-                file.Create();
-
-            JsonObject cecSetting;
-            cecSetting[CEC_SETTING_ENABLED] = enableStatus;
-
-            cecSetting.IElement::ToFile(file);
-
-            file.Close();
-
-            return;
-        }
-
         void HdmiCec::setEnabled(bool enabled)
         {
            LOGWARN("Entered setEnabled ");
 
            if (cecSettingEnabled != enabled)
            {
-               persistSettings(enabled);
+               Utils::persistJsonSettings (CEC_SETTING_ENABLED_FILE, CEC_SETTING_ENABLED, JsonValue(enabled));
            }
            if(true == enabled)
            {

--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -1097,7 +1097,7 @@ namespace WPEFramework
                 std::string osd = parameters["name"].String();
                 LOGINFO("setOSDNameWrapper osdName: %s",osd.c_str());
                 osdName = osd.c_str();
-                persistOSDName(osd.c_str());
+                Utils::persistJsonSettings (CEC_SETTING_ENABLED_FILE, CEC_SETTING_OSD_NAME, JsonValue(osd.c_str()));
             }
             else
             {
@@ -1280,7 +1280,7 @@ namespace WPEFramework
                 appVendorId = {(uint8_t)(vendorID >> 16 & 0xff),(uint8_t)(vendorID>> 8 & 0xff),(uint8_t) (vendorID & 0xff)};
                 LOGINFO("appVendorId : %s  vendorID :%x \n",appVendorId.toString().c_str(), vendorID );
 
-                persistVendorId(vendorID);
+                Utils::persistJsonSettings (CEC_SETTING_ENABLED_FILE, CEC_SETTING_VENDOR_ID, JsonValue(vendorID));
             }
             else
             {
@@ -1459,76 +1459,13 @@ namespace WPEFramework
             return cecSettingEnabled;
         }
 
-        void HdmiCecSink::persistSettings(bool enableStatus)
-        {
-            Core::File file;
-            file = CEC_SETTING_ENABLED_FILE;
-
-            file.Open(false);
-            if (!file.IsOpen())
-                file.Create();
-
-            JsonObject cecSetting;
-            cecSetting.IElement::FromFile(file);
-            file.Destroy();
-            file.Create();
-            cecSetting[CEC_SETTING_ENABLED] = enableStatus;
-            cecSetting.IElement::ToFile(file);
-
-            file.Close();
-
-            return;
-        }
-
-        void HdmiCecSink::persistOSDName(const char *name)
-        {
-            Core::File file;
-            file = CEC_SETTING_ENABLED_FILE;
-
-            file.Open(false);
-            if (!file.IsOpen())
-                file.Create();
-
-            JsonObject cecSetting;
-            cecSetting.IElement::FromFile(file);
-            file.Destroy();
-            file.Create();
-            cecSetting[CEC_SETTING_OSD_NAME] = name;
-            cecSetting.IElement::ToFile(file);
-
-            file.Close();
-
-            return;
-        }
-
-        void HdmiCecSink::persistVendorId(unsigned int vendorId)
-        {
-            Core::File file;
-            file = CEC_SETTING_ENABLED_FILE;
-
-            file.Open(false);
-            if (!file.IsOpen())
-                file.Create();
-
-            JsonObject cecSetting;
-            cecSetting.IElement::FromFile(file);
-            file.Destroy();
-            file.Create();
-            cecSetting[CEC_SETTING_VENDOR_ID] = vendorId;
-            cecSetting.IElement::ToFile(file);
-
-            file.Close();
-
-            return;
-        }
-
         void HdmiCecSink::setEnabled(bool enabled)
         {
            LOGINFO("Entered setEnabled: %d  cecSettingEnabled :%d ",enabled, cecSettingEnabled);
 
            if (cecSettingEnabled != enabled)
            {
-               persistSettings(enabled);
+               Utils::persistJsonSettings (CEC_SETTING_ENABLED_FILE, CEC_SETTING_ENABLED, JsonValue(enabled));
                cecSettingEnabled = enabled;
            }
            if(true == enabled)

--- a/HdmiCec_2/HdmiCec_2.cpp
+++ b/HdmiCec_2/HdmiCec_2.cpp
@@ -704,7 +704,7 @@ namespace WPEFramework
                 std::string osd = parameters["name"].String();
                 LOGINFO("setOSDNameWrapper osdName: %s",osd.c_str());
                 osdName = osd.c_str();
-                persistOSDName(osd.c_str());
+                Utils::persistJsonSettings (CEC_SETTING_ENABLED_FILE, CEC_SETTING_OSD_NAME, JsonValue(osd.c_str()));
             }
             else
             {
@@ -742,7 +742,7 @@ namespace WPEFramework
                 appVendorId = {(uint8_t)(vendorID >> 16 & 0xff),(uint8_t)(vendorID>> 8 & 0xff),(uint8_t) (vendorID & 0xff)};
                 LOGINFO("appVendorId : %s  vendorID :%x \n",appVendorId.toString().c_str(), vendorID );
 
-                persistVendorId(vendorID);
+                Utils::persistJsonSettings (CEC_SETTING_ENABLED_FILE, CEC_SETTING_VENDOR_ID, JsonValue(vendorID));
             }
             else
             {
@@ -872,97 +872,13 @@ namespace WPEFramework
             return cecSettingEnabled;
         }
 
-        void HdmiCec_2::persistSettings(bool enableStatus)
-        {
-            Core::File file;
-            file = CEC_SETTING_ENABLED_FILE;
-
-            file.Open(false);
-            if (!file.IsOpen())
-                file.Create();
-
-            JsonObject cecSetting;
-            cecSetting.IElement::FromFile(file);
-            file.Destroy();
-            file.Create();
-            cecSetting[CEC_SETTING_ENABLED] = enableStatus;
-            cecSetting.IElement::ToFile(file);
-
-            file.Close();
-
-            return;
-        }
-
-        void HdmiCec_2::persistOTPSettings(bool enableStatus)
-        {
-            Core::File file;
-            file = CEC_SETTING_ENABLED_FILE;
-
-            file.Open(false);
-            if (!file.IsOpen())
-                file.Create();
-
-            JsonObject cecSetting;
-            cecSetting.IElement::FromFile(file);
-            file.Destroy();
-            file.Create();
-            cecSetting[CEC_SETTING_OTP_ENABLED] = enableStatus;
-            cecSetting.IElement::ToFile(file);
-
-            file.Close();
-
-            return;
-        }
-
-        void HdmiCec_2::persistOSDName(const char *name)
-        {
-            Core::File file;
-            file = CEC_SETTING_ENABLED_FILE;
-
-            file.Open(false);
-            if (!file.IsOpen())
-                file.Create();
-
-            JsonObject cecSetting;
-            cecSetting.IElement::FromFile(file);
-            file.Destroy();
-            file.Create();
-            cecSetting[CEC_SETTING_OSD_NAME] = name;
-            cecSetting.IElement::ToFile(file);
-
-            file.Close();
-
-            return;
-        }
-
-        void HdmiCec_2::persistVendorId(unsigned int vendorId)
-        {
-            Core::File file;
-            file = CEC_SETTING_ENABLED_FILE;
-
-            file.Open(false);
-            if (!file.IsOpen())
-                file.Create();
-
-            JsonObject cecSetting;
-            cecSetting.IElement::FromFile(file);
-            file.Destroy();
-            file.Create();
-            cecSetting[CEC_SETTING_VENDOR_ID] = vendorId;
-            cecSetting.IElement::ToFile(file);
-
-            file.Close();
-
-            return;
-        }
-
         void HdmiCec_2::setEnabled(bool enabled)
         {
            LOGINFO("Entered setEnabled ");
 
            if (cecSettingEnabled != enabled)
            {
-               persistSettings(enabled);
+               Utils::persistJsonSettings (CEC_SETTING_ENABLED_FILE, CEC_SETTING_ENABLED, JsonValue(enabled));
                cecSettingEnabled = enabled;
            }
            if(true == enabled)
@@ -981,7 +897,7 @@ namespace WPEFramework
            if (cecOTPSettingEnabled != enabled)
            {
                LOGINFO("persist setOTPEnabled ");
-               persistOTPSettings(enabled);
+               Utils::persistJsonSettings (CEC_SETTING_ENABLED_FILE, CEC_SETTING_OTP_ENABLED, JsonValue(enabled));
                cecOTPSettingEnabled = enabled;
            }
            return;

--- a/helpers/utils.cpp
+++ b/helpers/utils.cpp
@@ -381,3 +381,35 @@ bool Utils::isValidInt(char* x)
     return Checked;
 }
 
+void Utils::persistJsonSettings(string strFileName, string strKey, JsonValue jsValue)
+{
+    Core::File file;
+    file = strFileName.c_str();
+
+    file.Open(false);
+    if (!file.IsOpen())
+        file.Create();
+
+    JsonObject cecSetting;
+    cecSetting.IElement::FromFile(file);
+    file.Destroy();
+    file.Create();
+    cecSetting[strKey.c_str()] = jsValue;
+    cecSetting.IElement::ToFile(file);
+
+    file.Close();
+
+    //Sync the settings
+    FILE * fp = NULL;
+    fp = fopen(strFileName.c_str(), "r");
+    if (fp == NULL) {
+        printf("fopen NULL\n");
+        return;
+    }
+    fflush(fp);
+    fsync(fileno(fp));
+    fclose(fp);
+
+    return;
+}
+

--- a/helpers/utils.h
+++ b/helpers/utils.h
@@ -348,6 +348,7 @@ namespace Utils
 
     bool getRFCConfig(char* paramName, RFC_ParamData_t& paramOutput);
     bool isValidInt(char* x);
+    void persistJsonSettings(string strFileName, string strKey, JsonValue jsValue);
 
     //class for std::thread RAII
     class ThreadRAII 


### PR DESCRIPTION
Reason for change:
HDMI-CEC_state_does_not_persist
Test Procedure: None
Risks: Low

Change-Id: I88fd8e399165ef4375fe9dc0bfbe205992f1a55a
Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>