### PR TITLE
RDKTV-9417 : HDMI-CEC state does not persist

### DIFF
--- a/HdmiCec/HdmiCec.cpp
+++ b/HdmiCec/HdmiCec.cpp
@@ -97,7 +97,7 @@ namespace WPEFramework
             else
             {
                 setEnabled(false);
-                persistSettings(false);
+                Utils::persistJsonSettings (CEC_SETTING_ENABLED_FILE, CEC_SETTING_ENABLED, JsonValue(false));
             }
         }
 
@@ -307,32 +307,13 @@ namespace WPEFramework
             return cecSettingEnabled;
         }
 
-        void HdmiCec::persistSettings(bool enableStatus)
-        {
-            Core::File file;
-            file = CEC_SETTING_ENABLED_FILE;
-
-            file.Open(false);
-            if (!file.IsOpen())
-                file.Create();
-
-            JsonObject cecSetting;
-            cecSetting[CEC_SETTING_ENABLED] = enableStatus;
-
-            cecSetting.IElement::ToFile(file);
-
-            file.Close();
-
-            return;
-        }
-
         void HdmiCec::setEnabled(bool enabled)
         {
            LOGWARN("Entered setEnabled ");
 
            if (cecSettingEnabled != enabled)
            {
-               persistSettings(enabled);
+               Utils::persistJsonSettings (CEC_SETTING_ENABLED_FILE, CEC_SETTING_ENABLED, JsonValue(enabled));
            }
            if(true == enabled)
            {

--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -1087,7 +1087,7 @@ namespace WPEFramework
                 std::string osd = parameters["name"].String();
                 LOGINFO("setOSDNameWrapper osdName: %s",osd.c_str());
                 osdName = osd.c_str();
-                persistOSDName(osd.c_str());
+                Utils::persistJsonSettings (CEC_SETTING_ENABLED_FILE, CEC_SETTING_OSD_NAME, JsonValue(osd.c_str()));
             }
             else
             {
@@ -1270,7 +1270,7 @@ namespace WPEFramework
                 appVendorId = {(uint8_t)(vendorID >> 16 & 0xff),(uint8_t)(vendorID>> 8 & 0xff),(uint8_t) (vendorID & 0xff)};
                 LOGINFO("appVendorId : %s  vendorID :%x \n",appVendorId.toString().c_str(), vendorID );
 
-                persistVendorId(vendorID);
+                Utils::persistJsonSettings (CEC_SETTING_ENABLED_FILE, CEC_SETTING_VENDOR_ID, JsonValue(vendorID));
             }
             else
             {
@@ -1449,76 +1449,13 @@ namespace WPEFramework
             return cecSettingEnabled;
         }
 
-        void HdmiCecSink::persistSettings(bool enableStatus)
-        {
-            Core::File file;
-            file = CEC_SETTING_ENABLED_FILE;
-
-            file.Open(false);
-            if (!file.IsOpen())
-                file.Create();
-
-            JsonObject cecSetting;
-            cecSetting.IElement::FromFile(file);
-            file.Destroy();
-            file.Create();
-            cecSetting[CEC_SETTING_ENABLED] = enableStatus;
-            cecSetting.IElement::ToFile(file);
-
-            file.Close();
-
-            return;
-        }
-
-        void HdmiCecSink::persistOSDName(const char *name)
-        {
-            Core::File file;
-            file = CEC_SETTING_ENABLED_FILE;
-
-            file.Open(false);
-            if (!file.IsOpen())
-                file.Create();
-
-            JsonObject cecSetting;
-            cecSetting.IElement::FromFile(file);
-            file.Destroy();
-            file.Create();
-            cecSetting[CEC_SETTING_OSD_NAME] = name;
-            cecSetting.IElement::ToFile(file);
-
-            file.Close();
-
-            return;
-        }
-
-        void HdmiCecSink::persistVendorId(unsigned int vendorId)
-        {
-            Core::File file;
-            file = CEC_SETTING_ENABLED_FILE;
-
-            file.Open(false);
-            if (!file.IsOpen())
-                file.Create();
-
-            JsonObject cecSetting;
-            cecSetting.IElement::FromFile(file);
-            file.Destroy();
-            file.Create();
-            cecSetting[CEC_SETTING_VENDOR_ID] = vendorId;
-            cecSetting.IElement::ToFile(file);
-
-            file.Close();
-
-            return;
-        }
-
         void HdmiCecSink::setEnabled(bool enabled)
         {
            LOGINFO("Entered setEnabled: %d  cecSettingEnabled :%d ",enabled, cecSettingEnabled);
 
            if (cecSettingEnabled != enabled)
            {
-               persistSettings(enabled);
+               Utils::persistJsonSettings (CEC_SETTING_ENABLED_FILE, CEC_SETTING_ENABLED, JsonValue(enabled));
                cecSettingEnabled = enabled;
            }
            if(true == enabled)

--- a/HdmiCec_2/HdmiCec_2.cpp
+++ b/HdmiCec_2/HdmiCec_2.cpp
@@ -646,7 +646,7 @@ namespace WPEFramework
                 std::string osd = parameters["name"].String();
                 LOGINFO("setOSDNameWrapper osdName: %s",osd.c_str());
                 osdName = osd.c_str();
-                persistOSDName(osd.c_str());
+                Utils::persistJsonSettings (CEC_SETTING_ENABLED_FILE, CEC_SETTING_OSD_NAME, JsonValue(osd.c_str()));
             }
             else
             {
@@ -684,7 +684,7 @@ namespace WPEFramework
                 appVendorId = {(uint8_t)(vendorID >> 16 & 0xff),(uint8_t)(vendorID>> 8 & 0xff),(uint8_t) (vendorID & 0xff)};
                 LOGINFO("appVendorId : %s  vendorID :%x \n",appVendorId.toString().c_str(), vendorID );
 
-                persistVendorId(vendorID);
+                Utils::persistJsonSettings (CEC_SETTING_ENABLED_FILE, CEC_SETTING_VENDOR_ID, JsonValue(vendorID));
             }
             else
             {
@@ -814,97 +814,13 @@ namespace WPEFramework
             return cecSettingEnabled;
         }
 
-        void HdmiCec_2::persistSettings(bool enableStatus)
-        {
-            Core::File file;
-            file = CEC_SETTING_ENABLED_FILE;
-
-            file.Open(false);
-            if (!file.IsOpen())
-                file.Create();
-
-            JsonObject cecSetting;
-            cecSetting.IElement::FromFile(file);
-            file.Destroy();
-            file.Create();
-            cecSetting[CEC_SETTING_ENABLED] = enableStatus;
-            cecSetting.IElement::ToFile(file);
-
-            file.Close();
-
-            return;
-        }
-
-        void HdmiCec_2::persistOTPSettings(bool enableStatus)
-        {
-            Core::File file;
-            file = CEC_SETTING_ENABLED_FILE;
-
-            file.Open(false);
-            if (!file.IsOpen())
-                file.Create();
-
-            JsonObject cecSetting;
-            cecSetting.IElement::FromFile(file);
-            file.Destroy();
-            file.Create();
-            cecSetting[CEC_SETTING_OTP_ENABLED] = enableStatus;
-            cecSetting.IElement::ToFile(file);
-
-            file.Close();
-
-            return;
-        }
-
-        void HdmiCec_2::persistOSDName(const char *name)
-        {
-            Core::File file;
-            file = CEC_SETTING_ENABLED_FILE;
-
-            file.Open(false);
-            if (!file.IsOpen())
-                file.Create();
-
-            JsonObject cecSetting;
-            cecSetting.IElement::FromFile(file);
-            file.Destroy();
-            file.Create();
-            cecSetting[CEC_SETTING_OSD_NAME] = name;
-            cecSetting.IElement::ToFile(file);
-
-            file.Close();
-
-            return;
-        }
-
-        void HdmiCec_2::persistVendorId(unsigned int vendorId)
-        {
-            Core::File file;
-            file = CEC_SETTING_ENABLED_FILE;
-
-            file.Open(false);
-            if (!file.IsOpen())
-                file.Create();
-
-            JsonObject cecSetting;
-            cecSetting.IElement::FromFile(file);
-            file.Destroy();
-            file.Create();
-            cecSetting[CEC_SETTING_VENDOR_ID] = vendorId;
-            cecSetting.IElement::ToFile(file);
-
-            file.Close();
-
-            return;
-        }
-
         void HdmiCec_2::setEnabled(bool enabled)
         {
            LOGINFO("Entered setEnabled ");
 
            if (cecSettingEnabled != enabled)
            {
-               persistSettings(enabled);
+               Utils::persistJsonSettings (CEC_SETTING_ENABLED_FILE, CEC_SETTING_ENABLED, JsonValue(enabled));
                cecSettingEnabled = enabled;
            }
            if(true == enabled)
@@ -923,7 +839,7 @@ namespace WPEFramework
            if (cecOTPSettingEnabled != enabled)
            {
                LOGINFO("persist setOTPEnabled ");
-               persistOTPSettings(enabled);
+               Utils::persistJsonSettings (CEC_SETTING_ENABLED_FILE, CEC_SETTING_OTP_ENABLED, JsonValue(enabled));
                cecOTPSettingEnabled = enabled;
            }
            return;

--- a/helpers/frontpanel.cpp
+++ b/helpers/frontpanel.cpp
@@ -607,6 +607,7 @@ namespace WPEFramework
             m_preferencesHash.IElement::ToFile(file);
 
             file.Close();
+            Utils::syncPersistFile (FP_SETTINGS_FILE_JSON);
         }
 
         void CFrontPanel::loadPreferences()

--- a/helpers/utils.cpp
+++ b/helpers/utils.cpp
@@ -381,3 +381,39 @@ bool Utils::isValidInt(char* x)
     return Checked;
 }
 
+void Utils::syncPersistFile (const string file) {
+    FILE * fp = NULL;
+    fp = fopen(file.c_str(), "r");
+    if (fp == NULL) {
+        printf("fopen NULL\n");
+        return;
+    }
+    fflush(fp);
+    fsync(fileno(fp));
+    fclose(fp);
+}
+
+void Utils::persistJsonSettings(const string strFile, const string strKey, const JsonValue& jsValue)
+{
+    Core::File file;
+    file = strFile.c_str();
+
+    file.Open(false);
+    if (!file.IsOpen())
+        file.Create();
+
+    JsonObject cecSetting;
+    cecSetting.IElement::FromFile(file);
+    file.Destroy();
+    file.Create();
+    cecSetting[strKey.c_str()] = jsValue;
+    cecSetting.IElement::ToFile(file);
+
+    file.Close();
+
+    //Sync the settings
+    Utils::syncPersistFile (strFile);
+
+    return;
+}
+

--- a/helpers/utils.h
+++ b/helpers/utils.h
@@ -350,6 +350,8 @@ namespace Utils
 
     bool getRFCConfig(char* paramName, RFC_ParamData_t& paramOutput);
     bool isValidInt(char* x);
+    void syncPersistFile (const string file);
+    void persistJsonSettings(const string file, const string strKey, const JsonValue& jsValue);
 
     //class for std::thread RAII
     class ThreadRAII 


### PR DESCRIPTION
Reason for change:
HDMI-CEC_state_does_not_persist
Test Procedure: None
Risks: Low

Change-Id: I89a8bfe8cba6e796fd54b7579a48f967a9facea0
Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>