### PR TITLE
RDKTV-4203  Changes for invalid Client for opacity,scale and generate…

### DIFF
--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -5294,8 +5294,22 @@ namespace WPEFramework {
                 {
                   keyClient = keyInputInfo.HasLabel("callsign")? keyInputInfo["callsign"].String(): "";
                 }
-                gRdkShellMutex.lock();
-                ret = CompositorController::generateKey(keyClient, keyCode, flags, virtualKey);
+                lockRdkShellMutex();
+		bool targetFound = false;
+                if (keyClient != "")
+                {
+                  std::vector<std::string> clientList;
+                  CompositorController::getClients(clientList);
+                  transform(keyClient.begin(), keyClient.end(), keyClient.begin(), ::tolower);
+                  if (std::find(clientList.begin(), clientList.end(), keyClient) != clientList.end())
+                  {
+                    targetFound = true;
+                  }
+                }
+                if (targetFound || keyClient == "")
+                {
+                  ret = CompositorController::generateKey(keyClient, keyCode, flags, virtualKey);
+                }
                 gRdkShellMutex.unlock();
             }
             return ret;
@@ -5499,7 +5513,19 @@ namespace WPEFramework {
         {
             bool ret = false;
             lockRdkShellMutex();
-            ret = CompositorController::setOpacity(client, opacity);
+            std::vector<std::string> clientList;
+            CompositorController::getClients(clientList);
+            bool targetFound = false;
+            std::string newClient(client);
+            std::transform(newClient.begin(), newClient.end(), newClient.begin(), ::tolower);
+            if (std::find(clientList.begin(), clientList.end(), newClient) != clientList.end())
+            {
+              targetFound = true;
+            }
+            if (targetFound)
+            {
+              ret = CompositorController::setOpacity(newClient, opacity);
+            }
             gRdkShellMutex.unlock();
             return ret;
         }
@@ -5517,7 +5543,19 @@ namespace WPEFramework {
         {
             bool ret = false;
             lockRdkShellMutex();
-            ret = CompositorController::setScale(client, scaleX, scaleY);
+            std::vector<std::string> clientList;
+            CompositorController::getClients(clientList);
+            std::string newClient(client);
+            bool targetFound = false;
+            transform(newClient.begin(), newClient.end(), newClient.begin(), ::tolower);
+            if (std::find(clientList.begin(), clientList.end(), newClient) != clientList.end())
+            {
+              targetFound = true;
+            }
+            if (targetFound)
+            {
+              ret = CompositorController::setScale(newClient, scaleX, scaleY);
+            }
             gRdkShellMutex.unlock();
             return ret;
         }


### PR DESCRIPTION
…Key (#1163)

RDKTV-6185 changes to take care of case insenstivity for client name (#1189)

OTTX-16270,RDKTV-4203 generateKey should not check if client is valid… (#1236)

* OTTX-16270,RDKTV-4203 generateKey should not check if client is valid. If no client name is passed the keys should be sent to the app in focus

* Update RDKShell.cpp

Co-authored-by: Binu Inbaraj <Binu_Inbaraj@cable.comcast.com>

RDKTV-6185 build fix (#1192)