### PR TITLE
RDK-33276:  Map pre-auth flags to respective WPA2/WPA3 security modes

### DIFF
--- a/WifiManager/WifiManagerDefines.h
+++ b/WifiManager/WifiManagerDefines.h
@@ -37,10 +37,9 @@ namespace WPEFramework {
             WPA2_ENTERPRISE_AES,
             WPA_WPA2_PSK,
             WPA_WPA2_ENTERPRISE,
-            WPA2_PSK_AES_PREAUTH,
-            WPA2_PSK_TKIP_PREAUTH,
-            WPA2_PSK_AES_TKIP_PREAUTH,
-            NOT_SUPPORTED
+            WPA3_PSK_AES,
+            WPA3_SAE,
+            NOT_SUPPORTED=99
         };
 
         /**

--- a/WifiManager/impl/WifiManagerState.cpp
+++ b/WifiManager/impl/WifiManagerState.cpp
@@ -123,7 +123,11 @@ uint32_t WifiManagerState::getSupportedSecurityModes(const JsonObject &parameter
     security_modes["NET_WIFI_SECURITY_WPA_ENTERPRISE_AES"]   = (int)NET_WIFI_SECURITY_WPA_ENTERPRISE_AES;
     security_modes["NET_WIFI_SECURITY_WPA2_ENTERPRISE_TKIP"] = (int)NET_WIFI_SECURITY_WPA2_ENTERPRISE_TKIP;
     security_modes["NET_WIFI_SECURITY_WPA2_ENTERPRISE_AES"]  = (int)NET_WIFI_SECURITY_WPA2_ENTERPRISE_AES;
+    security_modes["NET_WIFI_SECURITY_WPA_WPA2_PSK"]         = (int)NET_WIFI_SECURITY_WPA_WPA2_PSK;
+    security_modes["NET_WIFI_SECURITY_WPA_WPA2_ENTERPRISE"]  = (int)NET_WIFI_SECURITY_WPA_WPA2_ENTERPRISE;
+    security_modes["NET_WIFI_SECURITY_WPA3_PSK_AES"]         = (int)NET_WIFI_SECURITY_WPA3_PSK_AES;
     security_modes["NET_WIFI_SECURITY_WPA3_SAE"]             = (int)NET_WIFI_SECURITY_WPA3_SAE;
+    security_modes["NET_WIFI_SECURITY_NOT_SUPPORTED"]        = (int)NET_WIFI_SECURITY_NOT_SUPPORTED;
 
     response["security_modes"] = security_modes;
 


### PR DESCRIPTION
Reason for change: Updated the Security modes and support preauth for wpa/wpa2/wpa3
Test Procedure: Please refer the ticket
Risks: Low