### PR TITLE
DELIA-51515:readEDID is returning incorrect base64 string

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -1499,15 +1499,7 @@ namespace WPEFramework {
                     if(edidVec.size() > (size_t)numeric_limits<uint16_t>::max())
                         LOGERR("Size too large to use ToString base64 wpe api");
                     string edidbase64;
-                    // Align input string size to multiple of 3
-                    int paddingSize = 0;
-                    for (; paddingSize < (3-size%3);paddingSize++)
-                    {
-                        edidVec.push_back(0x00);
-                    }
-                    size += paddingSize;
-
-                    Core::ToString((uint8_t*)&edidVec[0], size, false, edidbase64);
+                    Core::ToString((uint8_t*)&edidVec[0], size, true, edidbase64);
                     response["EDID"] = edidbase64;
 
                 }
@@ -1548,16 +1540,7 @@ namespace WPEFramework {
             if(edidVec.size() > (size_t)numeric_limits<uint16_t>::max())
                 LOGINFO("size too large to use ToString base64 wpe api");
 
-            // Align input string size to multiple of 3
-            int paddingSize = 0;
-            for (; paddingSize < (3-size%3);paddingSize++)
-            {
-                edidVec.push_back(0x00);
-            }
-            size += paddingSize;
-
-
-            Core::ToString((uint8_t*)&edidVec[0], size, false, base64String);
+            Core::ToString((uint8_t*)&edidVec[0], size, true, base64String);
             response["EDID"] = base64String;
             returnResponse(true);
         }

--- a/HdmiInput/HdmiInput.cpp
+++ b/HdmiInput/HdmiInput.cpp
@@ -344,15 +344,8 @@ namespace WPEFramework
                     LOGERR("Size too large to use ToString base64 wpe api");
                     return edidbase64;
                 }
-                // Align input string size to multiple of 3
-                int paddingSize = 0;
-                for (; paddingSize < (3-size%3);paddingSize++)
-                {
-                    edidVec.push_back(0x00);
-                }
-                size += paddingSize;
 
-                Core::ToString((uint8_t*)&edidVec[0], size, false, edidbase64);
+                Core::ToString((uint8_t*)&edidVec[0], size, true, edidbase64);
 
             }
             catch (const device::Exception& err)


### PR DESCRIPTION
Reason for change: fix incorrect padding
Test Procedure: Refer JIRA.
Risks: Low

Signed-off-by: apatel859 <amit_patel5@comcast.com>