### PR TITLE
RDK-32366 : Display Resolution Irrespective of EDID

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -1163,11 +1163,15 @@ namespace WPEFramework {
             bool persist = hasPersist ? parameters["persist"].Boolean() : true;
             if (!hasPersist) LOGINFO("persist: true");
 
+            bool isIgnoreEdidArg = parameters.HasLabel("ignoreEdid");
+            bool isIgnoreEdid = isIgnoreEdidArg ? parameters["ignoreEdid"].Boolean() : false;
+            if (!isIgnoreEdidArg) LOGINFO("isIgnoreEdid: false"); else LOGINFO("isIgnoreEdid: %d", isIgnoreEdid);
+
             bool success = true;
             try
             {
                 device::VideoOutputPort &vPort = device::Host::getInstance().getVideoOutputPort(videoDisplay);
-                vPort.setResolution(resolution, persist);
+                vPort.setResolution(resolution, persist, isIgnoreEdid);
             }
             catch (const device::Exception& err)
             {


### PR DESCRIPTION
Reason for change:
Display Resolution Irrespective of EDID
Test Procedure: None
Risks: Low

Change-Id: Ifd2c4b054157810d5c69672d5bc73e248c821d06
Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>