### PR TITLE
RDKTV-9387: fix exit codes

### DIFF
--- a/UsbAccess/UsbAccess.cpp
+++ b/UsbAccess/UsbAccess.cpp
@@ -62,10 +62,9 @@ namespace Plugin {
         }
 
         int runScript(const char *command) {
-            int result = -1;
-            FILE *pipe = nullptr;
-            if ((pipe = popen(command, "r"))) {
-                result = pclose(pipe);
+            int result = system(command);
+            if (result != -1 && WIFEXITED(result)) {
+                result = WEXITSTATUS(result);
             }
             return result;
         }


### PR DESCRIPTION
Reason for change: Exit codes invalid if script has output.
Test Procedure: USB disk space is 100% full,
invoke ArchiveLogs.
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>