### PR TITLE
RDK-29350 : Implemented ScreenCapture for amlogic

### DIFF
--- a/ScreenCapture/CMakeLists.txt
+++ b/ScreenCapture/CMakeLists.txt
@@ -43,7 +43,7 @@ endif()
 
 target_include_directories(${MODULE_NAME} PRIVATE ../helpers ${IARMBUS_INCLUDE_DIRS} )
 
-target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins -lpng -lcurl trower-base64 ${VNC_FRAMEBUFFER_LIBRARIES})
+target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins ${NAMESPACE}SecurityUtil -lpng -lcurl trower-base64 ${VNC_FRAMEBUFFER_LIBRARIES})
 
 install(TARGETS ${MODULE_NAME}
         DESTINATION lib/${STORAGE_DIRECTORY}/plugins)


### PR DESCRIPTION
Reason for change: Fix GetSecurityToken error
Implements: screen capture for Amlogic
Test Procedure: described in the ticket
Risks: None

Signed-off-by: Mark Vandenbriele <mark.vandenbriele@consult.red>