### PR TITLE
RDKTV-9927 The device did not go to deepsleep after 15 minutes

### DIFF
--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -258,7 +258,7 @@ namespace WPEFramework {
 
             LOGINFO("Reboot_Pending :%s",g_is_reboot_pending.c_str());
 
-#if defined (SKY_BUILD) || defined (BUILD_LLAMA)
+#if defined (SKY_BUILD)
             bool internetConnectStatus = true;
 #else
             bool internetConnectStatus = isDeviceOnline();


### PR DESCRIPTION
Reason for change: The device did not go to deepsleep after 15 minutes
Test Procedure: build procedure
Risks: Low

Signed-off-by: Michael Anand Michael_AmalAnand@comcast.com