### PR TITLE
RDKTV-9927 The device did not go to deepsleep after 15 minutes

### DIFF
--- a/amlogic.cmake
+++ b/amlogic.cmake
@@ -86,6 +86,10 @@ if (AMLOGIC_E2)
     add_definitions (-DAMLOGIC_E2)
 endif()
 
+if (SKY_BUILD)
+    message("Building for SKY variant")
+    add_definitions (-DSKY_BUILD)
+
 if (BUILD_LLAMA)
     message("Building for LLAMA")
     add_definitions (-DBUILD_LLAMA)


### PR DESCRIPTION
Reason for change: add SKY_BUILD in amlogic make
Test Procedure: build procedure
Risks: Low

Signed-off-by: Michael Anand Michael_AmalAnand@comcast.com