### PR TITLE
RDKTV-9927 The device did not go to deepsleep after 15 minutes

### DIFF
--- a/amlogic.cmake
+++ b/amlogic.cmake
@@ -89,6 +89,7 @@ endif()
 if (SKY_BUILD)
     message("Building for SKY variant")
     add_definitions (-DSKY_BUILD)
+endif()
 
 if (BUILD_LLAMA)
     message("Building for LLAMA")


### PR DESCRIPTION
Reason for change: add SKY_BUILD in amlogic make
Test Procedure: build procedure
Risks: Low

Signed-off-by: Michael Anand Michael_AmalAnand@comcast.com