### PR TITLE
DELIA-51606: Set default voice for voice guidance language

### DIFF
--- a/TextToSpeech/impl/TTSManager.cpp
+++ b/TextToSpeech/impl/TTSManager.cpp
@@ -99,7 +99,15 @@ TTS_Error TTSManager::setConfiguration(Configuration &configuration) {
     m_defaultConfiguration.setEndPoint(configuration.ttsEndPoint);
     m_defaultConfiguration.setSecureEndPoint(configuration.ttsEndPointSecured);
     updated |= m_defaultConfiguration.setLanguage(configuration.language);
-    updated |= m_defaultConfiguration.setVoice(configuration.voice);
+    /* Set default voice for the language only if XRE does not set the voice */
+    std::string defaultVoice = configuration.voice;
+    if(configuration.voice.empty())
+    {
+        std::vector<std::string> voices;
+        listVoices(configuration.language, voices);
+        defaultVoice = voices.front();
+    }
+    updated |= m_defaultConfiguration.setVoice(defaultVoice);
     updated |= m_defaultConfiguration.setVolume(configuration.volume);
     updated |= m_defaultConfiguration.setRate(configuration.rate);
 

--- a/TextToSpeech/impl/TTSSpeaker.cpp
+++ b/TextToSpeech/impl/TTSSpeaker.cpp
@@ -539,7 +539,7 @@ void TTSSpeaker::createPipeline() {
         if(m_pcmAudioEnabled) {
             //Raw PCM audio does not work with souphhtpsrc on Amlogic alsaasink
             m_source = gst_element_factory_make("httpsrc", NULL);
-            g_object_set(G_OBJECT(m_audioSink), "direct-mode", FALSE, NULL);
+            g_object_set(G_OBJECT(m_audioSink), "tts-mode", TRUE, NULL);
         }
         else {
             m_source = gst_element_factory_make("souphttpsrc", NULL);
@@ -854,8 +854,8 @@ void TTSSpeaker::speakText(TTSConfiguration config, SpeechData &data) {
         g_object_set(G_OBJECT(m_audioVolume), "volume", (double) (data.client->configuration()->volume() / MAX_VOLUME), NULL);
         gst_element_set_state(m_pipeline, GST_STATE_PLAYING);
 #if defined(PLATFORM_AMLOGIC)
-	//-12db is almost 25%
-	setMixGain(MIXGAIN_PRIM,-12);
+        //-12db is almost 25%
+        setMixGain(MIXGAIN_PRIM,-12);
 #endif
         TTSLOG_VERBOSE("Speaking.... ( %d, \"%s\")", data.id, data.text.c_str());
 


### PR DESCRIPTION
Reason for change: Set a default voice when the voice guidance
language is updated if the application does not set it along with
the voice.
Test Procedure:
1. Change the voice guidance language in the
accessibility setting. Navigate to web apps and verify voice guidance
works.
2. No voice guidance regression
3. Verify persistence of the voice guidance settings
Risks: Low

Signed-off-by: Simi Mathew <simim@tataelxsi.co.in>