### PR TITLE
DELIA-50538 : Fix clearKeyActionMapping API in ramTestClient.

### DIFF
--- a/RemoteActionMapping/test/ramTestClient.cpp
+++ b/RemoteActionMapping/test/ramTestClient.cpp
@@ -760,7 +760,7 @@ int main(int argc, char** argv)
                                 {
                                     array.Add(JsonValue(KEDKeyNames[i]));               // Clear mappings for all keys
                                 }
-                                params["keyNames"] = JsonValue(array);
+                                params["keyNames"] = array;
 
                                 ret = remoteObject->Invoke<JsonObject, JsonObject>(1000,
                                                     _T("clearKeyActionMapping"), params, result);


### PR DESCRIPTION
Reason for change: clearKeyActionMapping API in ramTestClient is failing.
Test Procedure: Verify support for XRA.
Risks: None.
Signed-off-by: jschmidt <Jeff_Schmidt@cable.comcast>