### PR TITLE
RDK-33290: Move westeros sockets to sub-dir based on plugin classname

### DIFF
--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -2755,6 +2755,10 @@ namespace WPEFramework {
                 const string callsign = parameters["callsign"].String();
                 const string callsignWithVersion = callsign + ".1";
                 string type;
+                if (parameters.HasLabel("type"))
+                {
+                    type = parameters["type"].String();
+                }
                 string version = "0.0";
                 string uri;
                 int32_t x = 0;
@@ -2766,7 +2770,25 @@ namespace WPEFramework {
                 bool focused = true;
                 string configuration;
                 string behind;
-                string displayName = "wst-" + callsign;
+
+                // Ensure cloned plugin displays are in a sub-dir based on
+                // plugin classname
+                string displayName;
+                if (type.empty())
+                {
+                    displayName = "wst-" + callsign;
+                }
+                else
+                {
+                    string xdgDir;
+                    Core::SystemInfo::GetEnvironment(_T("XDG_RUNTIME_DIR"), xdgDir);
+                    string displaySubdir = xdgDir + "/" + type;
+                    Core::Directory(displaySubdir.c_str()).CreatePath();
+
+                    // don't add XDG_RUNTIME_DIR to display name
+                    displayName = type + "/" + "wst-" + callsign;
+                }
+
                 if (gRdkShellSurfaceModeEnabled)
                 {
                     displayName = "rdkshell_display";


### PR DESCRIPTION
Update RDKShell to store display sockets in sub-dirs based on the plugin classname. Required to support secure access to display sockets when running Thunder plugins in container.

Example: When launching HtmlApp-0 and HtmlApp-1, RDKShell should create the following sockets:

- /run/HtmlApp/HtmlApp-0
- /run/HtmlApp/HtmlApp-1