### PR TITLE
RDKTV-10041: HDMI Compatibility Mode API is not behaving as expected …

### DIFF
--- a/HdmiInput/HdmiInput.cpp
+++ b/HdmiInput/HdmiInput.cpp
@@ -749,9 +749,9 @@ namespace WPEFramework
 
             LOGINFOMETHOD();
             returnIfParamNotFound(parameters, "portId");
-            returnIfParamNotFound(parameters, "version");
+            returnIfParamNotFound(parameters, "edidVersion");
             string sPortId = parameters["portId"].String();
-            string sVersion = parameters["version"].String();
+            string sVersion = parameters["edidVersion"].String();
             try {
                 portId = stoi(sPortId);
             }catch (const device::Exception& err) {


### PR DESCRIPTION
RDKTV-10041: HDMI Compatibility Mode API is not behaving as expected on setEdid API Method calls

Reason for change: ThunderJS uses string version to identify the version of plugin. Which causing
setEdidVersion api is getting failed during integration.
Hence modifying the param name of setEdidVersion from version to edidVersion.
Test Procedure: Verified get/set curl commands
Risks: Low