### PR TITLE
RDKTV-3757: Quickly Toggling HDMI-CEC ON/OFF Causes Crash.

### DIFF
--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -2529,6 +2529,7 @@ namespace WPEFramework
 
         void HdmiCecSink::CECEnable(void)
         {
+            std::lock_guard<std::mutex> lock(m_enableMutex);
             LOGINFO("Entered CECEnable");
             if (cecEnableStatus)
             {
@@ -2565,7 +2566,6 @@ namespace WPEFramework
             }
             msgProcessor = new HdmiCecSinkProcessor(*smConnection);
             msgFrameListener = new HdmiCecSinkFrameListener(*msgProcessor);
-            cecEnableStatus = true;
             if(smConnection)
             {
            		LOGWARN("Start Thread %p", smConnection );
@@ -2573,12 +2573,13 @@ namespace WPEFramework
                             m_pollThreadExit = false;
 				m_pollThread = std::thread(threadRun);
             }
- 
+            cecEnableStatus = true;
             return;
         }
 
         void HdmiCecSink::CECDisable(void)
         {
+            std::lock_guard<std::mutex> lock(m_enableMutex);
             LOGINFO("Entered CECDisable ");
             if(!cecEnableStatus)
             {

--- a/HdmiCecSink/HdmiCecSink.h
+++ b/HdmiCecSink/HdmiCecSink.h
@@ -576,6 +576,7 @@ private:
 			bool m_pollThreadExit;
 			uint32_t m_sleepTime;
             std::mutex m_pollMutex;
+            std::mutex m_enableMutex;
             /* ARC related */
             std::thread m_arcRoutingThread;
 	    uint32_t m_currentArcRoutingState;


### PR DESCRIPTION
Reason for change: CECEnable call was made even before the CECDisable would
delete already existing CECEnable thread. Added Mutex to make sure CECEnable is processed
only after CECDisable has completed and finished and vice-versa.
Test Procedure:
1. Open Settings and navigate to 'Antenna and inputs' settings
2. Quickly toggle 'Enable HDMI-CEC' on and off

Risks: Low
Signed-off-by: yeshwanth.nagaswamy@sky.uk