### PR TITLE
RDKTV-10041: HDMI Compatibility Mode API is not behaving as expected …

### DIFF
--- a/HdmiInput/HdmiInput.cpp
+++ b/HdmiInput/HdmiInput.cpp
@@ -756,9 +756,9 @@ namespace WPEFramework
 
             LOGINFOMETHOD();
             returnIfParamNotFound(parameters, "portId");
-            returnIfParamNotFound(parameters, "version");
+            returnIfParamNotFound(parameters, "edidVersion");
             string sPortId = parameters["portId"].String();
-            string sVersion = parameters["version"].String();
+            string sVersion = parameters["edidVersion"].String();
             try {
                 portId = stoi(sPortId);
             }catch (const device::Exception& err) {

--- a/HdmiInput/HdmiInput.json
+++ b/HdmiInput/HdmiInput.json
@@ -249,7 +249,7 @@
                     "portId":{
                         "$ref": "#/definitions/portId"
                     },
-                    "version":{
+                    "edidVersion":{
                         "summary": "The EDID version",
                         "type": "string",
                         "example": "HDMI2.0"
@@ -257,7 +257,7 @@
                 },
                 "required": [
                     "portId",
-                    "version"
+                    "edidVersion"
                 ]
             },
             "result": {

--- a/HdmiInput/doc/HdmiInputPlugin.md
+++ b/HdmiInput/doc/HdmiInputPlugin.md
@@ -438,7 +438,7 @@ This method takes no parameters.
 | :-------- | :-------- | :-------- |
 | params | object |  |
 | params.portId | string | An ID of an HDMI Input port as returned by the `getHdmiInputDevices` method |
-| params.version | string | The EDID version |
+| params.edidVersion | string | The EDID version |
 
 ### Result
 
@@ -458,7 +458,7 @@ This method takes no parameters.
     "method": "org.rdk.HdmiInput.1.setEdidVersion",
     "params": {
         "portId": "0",
-        "version": "HDMI2.0"
+        "edidVersion": "HDMI2.0"
     }
 }
 ```


### PR DESCRIPTION
RDKTV-10041: HDMI Compatibility Mode API is not behaving as expected 
on setEdid API Method calls

Reason for change: ThunderJS uses string version to identify the version of plugin. Which causing
setEdidVersion api is getting failed during integration.
Hence modifying the param name of setEdidVersion from version to edidVersion.
Test Procedure: Verified get/set curl commands
Risks: Low