### PR TITLE
RDKTV-10229: After AC power, the voice guidance speech rate does not persist

### DIFF
--- a/TextToSpeech/TextToSpeechImplementation.cpp
+++ b/TextToSpeech/TextToSpeechImplementation.cpp
@@ -537,6 +537,7 @@ namespace Plugin {
         config["voice"] = ttsConfig.voice();
         config["language"] = ttsConfig.language();
         config.IElement::ToFile(file);
+        fsync((int)file);
         file.Close();
         return true;
     }


### PR DESCRIPTION
file sync after file  write
Core::File( Thunder)  does not support fsync. 