### PR TITLE
RDKTV-10083: Maintenance stuck at MAINTENANCE_ERROR

### DIFF
--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -264,7 +264,13 @@ namespace WPEFramework {
 #if defined (SKY_BUILD)
             bool internetConnectStatus = true;
 #else
-            bool internetConnectStatus = isDeviceOnline();
+            bool internetConnectStatus = false;
+            for(int retries = 0; retries < 3; retries++) {
+                internetConnectStatus =  isDeviceOnline();
+                if(internetConnectStatus == true) {
+                    break;
+                }
+            }	    
 #endif
 
             MaintenanceManager::_instance->onMaintenanceStatusChange(MAINTENANCE_STARTED);


### PR DESCRIPTION
Reason for change: Retry isDeviceOnline
Test Procedure: See ticket.
Risks: Low

Signed-off-by: Mark Vandenbriele <mark.vandenbriele@consult.red>