### PR TITLE
RDK-33276: Map pre-auth flags to respective WPA2/WPA3 security modes

### DIFF
--- a/WifiManager/Wifi.json
+++ b/WifiManager/Wifi.json
@@ -308,7 +308,19 @@
                                 "type": "integer",
                                 "example": 10
                             },
-                            "NET_WIFI_SECURITY_WPA3_SAE": {
+                            "NET_WIFI_SECURITY_WPA_WPA2_PSK": {
+                                "type": "integer",
+                                "example": 11
+                            },
+                            "NET_WIFI_SECURITY_WPA_WPA2_ENTERPRISE": {
+                                "type": "integer",
+                                "example": 12
+                            },
+			    "NET_WIFI_SECURITY_WPA3_PSK_AES": {
+                                "type": "integer",
+                                "example": 13
+                            },
+			    "NET_WIFI_SECURITY_WPA3_SAE": {
                                 "type": "integer",
                                 "example": 14
                             }

--- a/WifiManager/doc/WifiPlugin.md
+++ b/WifiManager/doc/WifiPlugin.md
@@ -496,6 +496,9 @@ This method takes no parameters.
 | result.security_modes?.NET_WIFI_SECURITY_WPA_ENTERPRISE_AES | integer | <sup>*(optional)*</sup>  |
 | result.security_modes?.NET_WIFI_SECURITY_WPA2_ENTERPRISE_TKIP | integer | <sup>*(optional)*</sup>  |
 | result.security_modes?.NET_WIFI_SECURITY_WPA2_ENTERPRISE_AES | integer | <sup>*(optional)*</sup>  |
+| result.security_modes?.NET_WIFI_SECURITY_WPA_WPA2_PSK | integer | <sup>*(optional)*</sup>  |
+| result.security_modes?.NET_WIFI_SECURITY_WPA_WPA2_ENTERPRISE | integer | <sup>*(optional)*</sup>  |
+| result.security_modes?.NET_WIFI_SECURITY_WPA3_PSK_AES | integer | <sup>*(optional)*</sup>  |
 | result.security_modes?.NET_WIFI_SECURITY_WPA3_SAE | integer | <sup>*(optional)*</sup>  |
 | result.success | boolean | Whether the request succeeded |
 
@@ -530,6 +533,9 @@ This method takes no parameters.
             "NET_WIFI_SECURITY_WPA_ENTERPRISE_AES": 8,
             "NET_WIFI_SECURITY_WPA2_ENTERPRISE_TKIP": 9,
             "NET_WIFI_SECURITY_WPA2_ENTERPRISE_AES": 10,
+            "NET_WIFI_SECURITY_WPA_WPA2_PSK": 11,
+            "NET_WIFI_SECURITY_WPA_WPA2_ENTERPRISE": 12,
+            "NET_WIFI_SECURITY_WPA3_PSK_AES": 13,
             "NET_WIFI_SECURITY_WPA3_SAE": 14
         },
         "success": true


### PR DESCRIPTION
Reason for change: Updated the WPA2/WPA3  Security modes for rdkservices
documentation
Test Procedure: Please refer the ticket
Risks: Low