### PR TITLE
RDKTV-10679: Add auto mode for SPDIF connection [NTS:AUDIO-023-TC2]

### DIFF
--- a/PlayerInfo/DeviceSettings/PlatformImplementation.cpp
+++ b/PlayerInfo/DeviceSettings/PlatformImplementation.cpp
@@ -375,7 +375,9 @@ public:
                 else if(soundmode == device::AudioStereoMode::kPassThru) mode = PASSTHRU;
                 else mode = UNKNOWN;
 
-                if(aPort.getType().getId() == device::AudioOutputPortType::kARC && aPort.getStereoAuto())
+                /* Auto mode applicable for HDMI Arc and SPDIF */
+                if((aPort.getType().getId() == device::AudioOutputPortType::kARC || aPort.getType().getId() == device::AudioOutputPortType::kSPDIF)
+                        && aPort.getStereoAuto())
                 {
                     mode = SOUNDMODE_AUTO;
                 }


### PR DESCRIPTION
Reason for change: Adding AUTO mode for SPDIF.
Test Procedure: check ticket
Risks:low
Signed-off-by: Vinod Jacob <vinod_jacob@comcast.com>