### PR TITLE
DELIA-50624 : GetActiveInput Invalid Ret True

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -1577,6 +1577,8 @@ namespace WPEFramework {
             catch(const device::Exception& err)
             {
                 LOG_DEVICE_EXCEPTION1(videoDisplay);
+                response["activeInput"] = JsonValue(false);
+                returnResponse(false);
             }
             response["activeInput"] = JsonValue(active);
             returnResponse(true);


### PR DESCRIPTION
Reason for change:
GetActiveInput Invalid Ret True
Test Procedure: None
Risks: Low

Change-Id: I28b22248c7ea2002976e57011dd6794889f2db09
Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>