### PR TITLE
RDK-32486: Audio Mode Settings Override (Amlogic)

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -216,6 +216,7 @@ namespace WPEFramework {
             registerMethod("setScartParameter", &DisplaySettings::setScartParameter, this);
             registerMethod("getSettopMS12Capabilities", &DisplaySettings::getSettopMS12Capabilities, this);
             registerMethod("getSettopAudioCapabilities", &DisplaySettings::getSettopAudioCapabilities, this);
+            registerMethod("setMS12ProfileSettingsOverride", &DisplaySettings::setMS12ProfileSettingsOverride,this);
 
 	    registerMethod("getVolumeLeveller", &DisplaySettings::getVolumeLeveller2, this, {2});
 	    registerMethod("setVolumeLeveller", &DisplaySettings::setVolumeLeveller2, this, {2});
@@ -2874,6 +2875,38 @@ namespace WPEFramework {
             returnResponse(success);
         }
 
+
+        uint32_t DisplaySettings::setMS12ProfileSettingsOverride(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool success = true;
+
+            returnIfParamNotFound(parameters, "operation");
+            string audioProfileState = parameters["operation"].String();
+
+            returnIfParamNotFound(parameters, "profileName");
+            string audioProfileName = parameters["profileName"].String();
+
+            returnIfParamNotFound(parameters, "ms12SettingsName");
+            string audioProfileSettingsName = parameters["ms12SettingsName"].String();
+
+            returnIfParamNotFound(parameters, "ms12SettingsValue");
+            string audioProfileSettingValue = parameters["ms12SettingsValue"].String();
+
+
+            string audioPort = parameters.HasLabel("audioPort") ? parameters["audioPort"].String() : "HDMI0";
+            try
+            {
+                device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
+                aPort.setMS12AudioProfileSetttingsOverride(audioProfileState,audioProfileName,audioProfileSettingsName, audioProfileSettingValue);
+            }
+            catch (const device::Exception& err)
+            {
+                success = false;
+            }
+
+            returnResponse(success);
+        }
 
         uint32_t DisplaySettings::getSupportedMS12AudioProfiles(const JsonObject& parameters, JsonObject& response)
         {   //sample response: {"success":true,"supportedMS12AudioProfiles":["Off","Music","Movie","Game","Voice","Night","User"]}

--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -136,7 +136,8 @@ namespace WPEFramework {
             uint32_t resetBassEnhancer(const JsonObject& parameters, JsonObject& response);
             uint32_t resetSurroundVirtualizer(const JsonObject& parameters, JsonObject& response);
             uint32_t resetVolumeLeveller(const JsonObject& parameters, JsonObject& response);
-             
+            uint32_t setMS12ProfileSettingsOverride(const JsonObject& parameters, JsonObject& response);        
+     
             void InitAudioPorts();
             void AudioPortsReInitialize();
             //End methods


### PR DESCRIPTION
Reason for change: Audio Mode Settings Override (Amlogic)
Test Procedure: Curl Cmd
Risks: Low

Signed-off-by: bp-sahmed600 <shafi.ahmed@sky.uk>