### PR TITLE
RDK-30268: Provide Required HDMI Source Properties to Netflix App

### DIFF
--- a/DisplayInfo/DeviceSettings/Broadcom/SoC_abstraction.cpp
+++ b/DisplayInfo/DeviceSettings/Broadcom/SoC_abstraction.cpp
@@ -46,7 +46,7 @@ using namespace WPEFramework;
  */
 void sanitizeLine(string& line)
 {
-    for(int i = 0; i < line.size(); i++)
+    for(unsigned int i = 0; i < line.size(); i++)
     {
         while(line[i] == ' ' && line[i+1] == ' ')
         {
@@ -157,7 +157,7 @@ uint64_t SoC_GetTotalGpuRam()
     }
     catch(...)
     {
-        LOGERR("Unable to process Total Gpu ram", value.c_str());
+        LOGERR("Unable to process Total Gpu ram");
     }
     return ret;
 }
@@ -174,7 +174,7 @@ uint64_t SoC_GetFreeGpuRam()
     }
     catch(...)
     {
-        LOGERR("Unable to process Free Gpu ram", value.c_str());
+        LOGERR("Unable to process Free Gpu ram");
     }
 
     ret = (100 - usedPercentage) * 0.01 * SoC_GetTotalGpuRam();

--- a/DisplayInfo/DeviceSettings/PlatformImplementation.cpp
+++ b/DisplayInfo/DeviceSettings/PlatformImplementation.cpp
@@ -32,6 +32,7 @@
 #include "audioOutputPortType.hpp"
 #include "audioOutputPortConfig.hpp"
 #include "manager.hpp"
+#include "edid-parser.hpp"
 #include "utils.h"
 
 #include "libIBus.h"
@@ -47,9 +48,11 @@ namespace Plugin {
 class DisplayInfoImplementation :
     public Exchange::IGraphicsProperties,
     public Exchange::IConnectionProperties,
-    public Exchange::IHDRProperties  {
+    public Exchange::IHDRProperties,
+    public Exchange::IDisplayProperties  {
 private:
     using HdrteratorImplementation = RPC::IteratorType<Exchange::IHDRProperties::IHDRIterator>;
+    using ColorimetryIteratorImplementation = RPC::IteratorType<Exchange::IDisplayProperties::IColorimetryIterator>;
 public:
     DisplayInfoImplementation()
     {
@@ -64,7 +67,6 @@ public:
             //TODO: this is probably per process so we either need to be running in our own process or be carefull no other plugin is calling it
             device::Manager::Initialize();
             TRACE(Trace::Information, (_T("device::Manager::Initialize success")));
-            UpdateFrameRate(_frameRate);
         }
         catch(...)
         {
@@ -132,7 +134,7 @@ public:
 
     static void ResolutionChange(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
     {
-        IConnectionProperties::INotification::Source eventtype;
+        IConnectionProperties::INotification::Source eventtype = IConnectionProperties::INotification::Source::PRE_RESOLUTION_CHANGE;
         if (strcmp(owner, IARM_BUS_DSMGR_NAME) == 0)
         {
             switch (eventId) {
@@ -155,10 +157,6 @@ public:
         _adminLock.Lock();
 
         std::list<IConnectionProperties::INotification*>::const_iterator index = _observers.begin();
-        if(eventtype == IConnectionProperties::INotification::Source::POST_RESOLUTION_CHANGE) {
-            UpdateFrameRate(_frameRate);
-        }
-
         while(index != _observers.end()) {
             (*index)->Updated(eventtype);
             index++;
@@ -213,9 +211,34 @@ public:
     }
     uint32_t VerticalFreq(uint32_t& value) const override
     {
-        value = _frameRate;
-        return (Core::ERROR_NONE);
-    }
+        vector<uint8_t> edidVec;
+        uint32_t ret = GetEdidBytes(edidVec);
+        if (ret == Core::ERROR_NONE)
+        {
+            uint32_t edidLen = edidVec.size();
+            unsigned char* edidbytes = new unsigned char [edidLen];
+            std::copy(edidVec.begin(), edidVec.end(), edidbytes);
+            if (edid_parser::EDID_Verify(edidbytes, edidLen) == edid_parser::EDID_STATUS_OK)
+            {
+                edid_parser::edid_data_t data_ptr;
+                edid_parser::EDID_Parse(edidbytes, edidLen, &data_ptr);
+                value = data_ptr.res.refresh;
+                TRACE(Trace::Information, (_T("Vertical frequency = %d"), value));
+            }
+            else
+            {
+                TRACE(Trace::Information, (_T("EDID Verification failed")));
+                ret = Core::ERROR_GENERAL;
+            }
+            delete edidbytes;
+        }
+        else
+        {
+            TRACE(Trace::Information, (_T("HDMI not connected")));
+            ret = Core::ERROR_GENERAL;
+        }
+        return ret;
+   }
 
     uint32_t HDCPProtection(HDCPProtectionType& value) const override //get
     {
@@ -266,7 +289,6 @@ public:
                 if(!vPort.SetHdmiPreference(hdcpversion))
                 {
                     TRACE(Trace::Information, (_T("HDCPProtection: SetHdmiPreference failed")));
-                    LOGERR("SetHdmiPreference failed");
                 }
             }
             catch(const device::Exception& err)
@@ -283,32 +305,24 @@ public:
 
     uint32_t WidthInCentimeters(uint8_t& width /* @out */) const override
     {
-        try
+        int ret = Core::ERROR_NONE;
+        vector<uint8_t> edidVec;
+        ret = GetEdidBytes(edidVec);
+        if (Core::ERROR_NONE == ret)
         {
             std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
-            ::device::VideoOutputPort vPort = ::device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str());
-            if (vPort.isDisplayConnected())
+            if(edidVec.size() > EDID_MAX_VERTICAL_SIZE)
             {
-                std::vector<uint8_t> edidVec;
-
-                vPort.getDisplay().getEDIDBytes(edidVec);
-
-                if(edidVec.size() > EDID_MAX_VERTICAL_SIZE)
-                {
-                    width = edidVec[EDID_MAX_HORIZONTAL_SIZE];
-                    TRACE(Trace::Information, (_T("Width in cm = %d"), width));
-                }
-                else
-                {
-                    LOGWARN("Failed to get Display Size!\n");
-                }
+                width = edidVec[EDID_MAX_HORIZONTAL_SIZE];
+                TRACE(Trace::Information, (_T("Width in cm = %d"), width));
+            }
+            else
+            {
+                TRACE(Trace::Information, (_T("Failed to get Display Size!")));
+                ret = Core::ERROR_GENERAL;
             }
         }
-        catch (const device::Exception& err)
-        {
-           TRACE(Trace::Error, (_T("Exception during DeviceSetting library call. code = %d message = %s"), err.getCode(), err.what()));
-        }
-        return (Core::ERROR_NONE);
+        return ret;
     }
 
     uint32_t HeightInCentimeters(uint8_t& height /* @out */) const override
@@ -330,7 +344,7 @@ public:
                 }
                 else
                 {
-                    LOGWARN("Failed to get Display Size!\n");
+                    TRACE(Trace::Information, (_T("Failed to get Display Size!")));
                 }
             }
         }
@@ -344,6 +358,7 @@ public:
     uint32_t EDID (uint16_t& length /* @inout */, uint8_t data[] /* @out @length:length */) const override
     {
         vector<uint8_t> edidVec({'u','n','k','n','o','w','n' });
+        int ret = Core::ERROR_NONE;
         try
         {
             vector<uint8_t> edidVec2;
@@ -356,12 +371,14 @@ public:
             }
             else
             {
-                LOGWARN("failure: HDMI0 not connected!");
+                TRACE(Trace::Information, (_T("failure: HDMI not connected!")));
+                ret = Core::ERROR_GENERAL;
             }
         }
         catch (const device::Exception& err)
         {
             LOG_DEVICE_EXCEPTION0();
+            ret = Core::ERROR_GENERAL;
         }
         //convert to base64
         uint16_t size = min(edidVec.size(), (size_t)numeric_limits<uint16_t>::max());
@@ -373,7 +390,7 @@ public:
             data[i] = edidVec[i];
         }
         length = i;
-        return (Core::ERROR_NONE);
+        return ret;
 
     }
 
@@ -400,6 +417,239 @@ public:
         return (Core::ERROR_NONE);
     }
 
+    uint32_t ColorSpace(ColourSpaceType& cs /* @out */) const override
+    {
+        int ret = Core::ERROR_NONE;
+        try
+        {
+            std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+            device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str());
+            if (vPort.isDisplayConnected())
+            {
+                int _cs = vPort.getColorSpace();
+                TRACE(Trace::Information, (_T("colour space = %d"), _cs ));
+                switch(_cs)
+                {
+                    case dsDISPLAY_COLORSPACE_RGB:
+                        cs = FORMAT_RGB_444; break;
+                    case dsDISPLAY_COLORSPACE_YCbCr444:
+                        cs = FORMAT_YCBCR_444; break;
+                    case dsDISPLAY_COLORSPACE_YCbCr422:
+                        cs = FORMAT_YCBCR_422; break;
+                    case dsDISPLAY_COLORSPACE_YCbCr420:
+                        cs = FORMAT_YCBCR_420; break;
+                    case dsDISPLAY_COLORSPACE_AUTO:
+                        cs = FORMAT_OTHER;break;
+                    case dsDISPLAY_COLORSPACE_UNKNOWN:
+                    default:
+                        cs = FORMAT_UNKNOWN;
+                }
+            }
+            else
+            {
+                TRACE(Trace::Error, (_T("HDMI not connected!")));
+                ret = Core::ERROR_GENERAL;
+            }
+        }
+        catch (const device::Exception& err)
+        {
+            TRACE(Trace::Error, (_T("caught an exception: %d, %s"),err.getCode(), err.what()));
+            ret = Core::ERROR_GENERAL;
+        }
+        return ret;
+    }
+
+    uint32_t FrameRate(FrameRateType& rate /* @out */) const override
+    {
+        rate = FRAMERATE_UNKNOWN;
+        uint32_t ret =  (Core::ERROR_NONE);
+        try
+        {
+            std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+            device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str());
+            device::VideoResolution resolution = vPort.getResolution();
+            device::PixelResolution pr = resolution.getPixelResolution();
+            device::FrameRate fr = resolution.getFrameRate();
+            if (fr == device::FrameRate::k24 ) {
+                rate = FRAMERATE_24;
+            } else if(fr == device::FrameRate::k25) {
+                rate = FRAMERATE_25;
+            } else if(fr == device::FrameRate::k30) {
+                rate = FRAMERATE_30;
+            } else if(fr == device::FrameRate::k60) {
+                rate = FRAMERATE_60;
+            } else if(fr == device::FrameRate::k23dot98) {
+                rate = FRAMERATE_23_976;
+            } else if(fr == device::FrameRate::k29dot97) {
+                rate = FRAMERATE_29_97;
+            } else if(fr == device::FrameRate::k50) {
+                rate = FRAMERATE_50;
+            } else if(fr == device::FrameRate::k59dot94) {
+                rate = FRAMERATE_59_94;
+            } else {
+                rate = FRAMERATE_UNKNOWN;
+            }
+        }
+        catch (const device::Exception& err)
+        {
+           TRACE(Trace::Error, (_T("Exception during DeviceSetting library call. code = %d message = %s"), err.getCode(), err.what()));
+           ret = Core::ERROR_GENERAL;
+        }
+        return ret;
+    }
+
+    uint32_t ColourDepth(ColourDepthType& colour /* @out */) const override
+    {
+        int ret = Core::ERROR_NONE;
+        try
+        {
+            std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+            device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str());
+            if (vPort.isDisplayConnected())
+            {
+                int _colour = vPort.getColorDepth();
+                TRACE(Trace::Information, (_T("colour depth = %d"),_colour));
+                switch(_colour)
+                {
+                    case 8:
+                        colour = COLORDEPTH_8_BIT;  break;
+                    case 10:
+                        colour = COLORDEPTH_10_BIT; break;
+                    case 12:
+                        colour = COLORDEPTH_12_BIT; break;
+                    case 0:
+                    default:
+                        colour = COLORDEPTH_UNKNOWN;
+                }
+            }
+            else
+            {
+                TRACE(Trace::Error, (_T("HDMI not connected!")));
+                ret = Core::ERROR_GENERAL;
+            }
+        }
+        catch (const device::Exception& err)
+        {
+            TRACE(Trace::Error, (_T("caught an exception: %d, %s"),err.getCode(), err.what()));
+            ret = Core::ERROR_GENERAL;
+        }
+        return ret;
+    }
+
+    uint32_t QuantizationRange(QuantizationRangeType& qr /* @out */) const override
+    {
+        int ret = Core::ERROR_NONE;
+        try
+        {
+            std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+            device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str());
+            if (vPort.isDisplayConnected())
+            {
+                int _qr = vPort.getQuantizationRange();
+                TRACE(Trace::Information, (_T("quantization range = %d"),_qr));
+                switch (_qr)
+                {
+                    case dsDISPLAY_QUANTIZATIONRANGE_LIMITED:
+                        qr = QUANTIZATIONRANGE_LIMITED; break;
+                    case dsDISPLAY_QUANTIZATIONRANGE_FULL:
+                        qr = QUANTIZATIONRANGE_FULL; break;
+                    case dsDISPLAY_QUANTIZATIONRANGE_UNKNOWN:
+                    default:
+                        qr = QUANTIZATIONRANGE_UNKNOWN;
+                }
+            }
+            else
+            {
+                TRACE(Trace::Error, (_T("HDMI not connected!")));
+                ret = Core::ERROR_GENERAL;
+            }
+        }
+        catch (const device::Exception& err)
+        {
+            TRACE(Trace::Error, (_T("caught an exception: %d, %s"),err.getCode(), err.what()));
+            ret = Core::ERROR_GENERAL;
+        }
+        return ret;
+    }
+
+    uint32_t Colorimetry(IColorimetryIterator*& colorimetry /* @out */) const override
+    {
+        std::list<Exchange::IDisplayProperties::ColorimetryType> colorimetryCaps;
+        vector<uint8_t> edidVec;
+        uint32_t ret = GetEdidBytes(edidVec);
+        if (ret == Core::ERROR_NONE)
+        {
+            uint32_t edidLen = edidVec.size();
+            unsigned char* edidbytes = new unsigned char [edidLen];
+            std::copy(edidVec.begin(), edidVec.end(), edidbytes);
+            if (edid_parser::EDID_Verify(edidbytes, edidLen) == edid_parser::EDID_STATUS_OK)
+            {
+                edid_parser::edid_data_t data_ptr;
+                edid_parser::EDID_Parse(edidbytes, edidLen, &data_ptr);
+                uint32_t colorimetry_info = data_ptr.colorimetry_info;
+                TRACE(Trace::Information, (_T("colorimetry = %d"),colorimetry_info));
+                if (!colorimetry_info) colorimetryCaps.push_back(COLORIMETRY_UNKNOWN);
+                if (colorimetry_info & edid_parser::COLORIMETRY_INFO_XVYCC601) colorimetryCaps.push_back(COLORIMETRY_XVYCC601);
+                if (colorimetry_info & edid_parser::COLORIMETRY_INFO_XVYCC709) colorimetryCaps.push_back(COLORIMETRY_XVYCC709);
+                if (colorimetry_info & edid_parser::COLORIMETRY_INFO_SYCC601) colorimetryCaps.push_back(COLORIMETRY_SYCC601);
+                if (colorimetry_info & edid_parser::COLORIMETRY_INFO_ADOBEYCC601) colorimetryCaps.push_back(COLORIMETRY_OPYCC601);
+                if (colorimetry_info & edid_parser::COLORIMETRY_INFO_ADOBERGB) colorimetryCaps.push_back(COLORIMETRY_OPRGB);
+                if (colorimetry_info & edid_parser::COLORIMETRY_INFO_BT2020CL || colorimetry_info & edid_parser::COLORIMETRY_INFO_BT2020NCL) colorimetryCaps.push_back(COLORIMETRY_BT2020YCCBCBRC);
+                if (colorimetry_info & edid_parser::COLORIMETRY_INFO_BT2020RGB) colorimetryCaps.push_back(COLORIMETRY_BT2020RGB_YCBCR);
+                if (colorimetry_info & edid_parser::COLORIMETRY_INFO_DCI_P3) colorimetryCaps.push_back(COLORIMETRY_OTHER);
+            }
+            else
+            {
+                TRACE(Trace::Error, (_T("EDID Verification failed")));
+                ret = Core::ERROR_GENERAL;
+            }
+            delete edidbytes;
+        }
+        else
+        {
+            TRACE(Trace::Error, (_T("HDMI not connected!")));
+            ret = Core::ERROR_GENERAL;
+        }
+        colorimetry = Core::Service<ColorimetryIteratorImplementation>::Create<Exchange::IDisplayProperties::IColorimetryIterator>(colorimetryCaps);
+        return (colorimetry != nullptr && ret == Core::ERROR_NONE ? Core::ERROR_NONE : Core::ERROR_GENERAL);
+    }
+
+    uint32_t EOTF(EotfType& eotf /* @out */) const override
+    {
+        int ret = Core::ERROR_NONE;
+        try
+        {
+            std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+            device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str());
+            if (vPort.isDisplayConnected())
+            {
+                int _eotf = vPort.getVideoEOTF();
+                TRACE(Trace::Information, (_T("videoEOTF = %d"),_eotf));
+                switch (_eotf)
+                {
+                    /* bt1886 = sdr; smpte2084 = hdr10; bt2100 = HLG*/
+                    case dsHDRSTANDARD_HDR10:
+                        eotf = EOTF_SMPTE_ST_2084; break;
+                    case dsHDRSTANDARD_HLG:
+                        eotf = EOTF_BT2100; break;
+                    default:
+                        eotf = EOTF_UNKNOWN;
+                }
+            }
+            else
+            {
+                TRACE(Trace::Error, (_T("HDMI not connected!")));
+                ret = Core::ERROR_GENERAL;
+            }
+        }
+        catch (const device::Exception& err)
+        {
+            TRACE(Trace::Error, (_T("caught an exception: %d, %s"),err.getCode(), err.what()));
+            ret = Core::ERROR_GENERAL;
+        }
+        return ret;
+    }
+
     // @property
     // @brief HDR formats supported by TV
     // @return HDRType: array of HDR formats
@@ -416,7 +666,7 @@ public:
                 vPort.getTVHDRCapabilities(&capabilities);
             }
             else {
-                TRACE(Trace::Error, (_T("getTVHDRCapabilities failure: HDMI0 not connected!")));
+                TRACE(Trace::Error, (_T("getTVHDRCapabilities failure: HDMI not connected!")));
             }
         }
         catch(const device::Exception& err)
@@ -478,7 +728,7 @@ public:
             }
             else
             {
-                TRACE(Trace::Information, (_T("IsOutputHDR failure: HDMI0 not connected!")));
+                TRACE(Trace::Information, (_T("IsOutputHDR failure: HDMI not connected!")));
             }
         }
         catch(const device::Exception& err)
@@ -496,54 +746,41 @@ public:
         INTERFACE_ENTRY(Exchange::IGraphicsProperties)
         INTERFACE_ENTRY(Exchange::IConnectionProperties)
         INTERFACE_ENTRY(Exchange::IHDRProperties)
+        INTERFACE_ENTRY(Exchange::IDisplayProperties)
     END_INTERFACE_MAP
 
 private:
-    uint32_t UpdateFrameRate(uint32_t &rate)
+    std::list<IConnectionProperties::INotification*> _observers;
+    mutable Core::CriticalSection _adminLock;
+
+private:
+    uint32_t GetEdidBytes(vector<uint8_t> &edid) const
     {
-        rate = 0;
-        uint32_t ret =  (Core::ERROR_NONE);
+        uint32_t ret = Core::ERROR_NONE;
         try
         {
             std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
             device::VideoOutputPort vPort = device::Host::getInstance().getVideoOutputPort(strVideoPort.c_str());
-            device::VideoResolution resolution = vPort.getResolution();
-            device::PixelResolution pr = resolution.getPixelResolution();
-            device::FrameRate fr = resolution.getFrameRate();
-            if (fr == device::FrameRate::k24 ) {
-                rate = 24;
-            } else if(fr == device::FrameRate::k25) {
-                rate = 25;
-            } else if(fr == device::FrameRate::k30) {
-                rate = 30;
-            } else if(fr == device::FrameRate::k60) {
-                rate = 60;
-            } else if(fr == device::FrameRate::k23dot98) {
-                rate = 23;
-            } else if(fr == device::FrameRate::k29dot97) {
-                rate = 29;
-            } else if(fr == device::FrameRate::k50) {
-                rate = 50;
-            } else if(fr == device::FrameRate::k59dot94) {
-                rate = 59;
-            } else {
+            if (vPort.isDisplayConnected())
+            {
+                vPort.getDisplay().getEDIDBytes(edid);
+            }
+            else
+            {
+                TRACE(Trace::Error, (_T("HDMI not connected!")));
                 ret = Core::ERROR_GENERAL;
             }
 
         }
         catch (const device::Exception& err)
         {
-           TRACE(Trace::Error, (_T("Exception during DeviceSetting library call. code = %d message = %s"), err.getCode(), err.what()));
-           ret = Core::ERROR_GENERAL;
+            TRACE(Trace::Error, (_T("caught an exception: %d, %s"),err.getCode(), err.what()));
+            ret = Core::ERROR_GENERAL;
         }
 
         return ret;
     }
 
-private:
-    std::list<IConnectionProperties::INotification*> _observers;
-    mutable Core::CriticalSection _adminLock;
-    uint32_t _frameRate;
 
 public:
     static DisplayInfoImplementation* _instance;

--- a/DisplayInfo/DisplayInfo.cpp
+++ b/DisplayInfo/DisplayInfo.cpp
@@ -58,6 +58,19 @@ namespace Plugin {
                     Exchange::JGraphicsProperties::Register(*this, _graphicsProperties);
                     Exchange::JConnectionProperties::Register(*this, _connectionProperties);
                     Exchange::JHDRProperties::Register(*this, _hdrProperties);
+
+                    // The code execution should proceed regardless of the _displayProperties
+                    // value, as it is not a essential.
+                    // The relevant JSONRPC endpoints will return ERROR_UNAVAILABLE,
+                    // if it hasn't been initialized.
+                    _displayProperties = _connectionProperties->QueryInterface<Exchange::IDisplayProperties>();
+                    if (_displayProperties == nullptr) {
+                        SYSLOG(Logging::Startup, (_T("Display Properties service is unavailable.")));
+                    }
+                    else
+                    {
+                        Exchange::JDisplayProperties::Register(*this, _displayProperties);
+                    }
                 }
             }
         }
@@ -73,6 +86,7 @@ namespace Plugin {
     {
         ASSERT(_connectionProperties != nullptr);
 
+        Exchange::JGraphicsProperties::Unregister(*this);
         Exchange::JHDRProperties::Unregister(*this);
         Exchange::JConnectionProperties::Unregister(*this);
 
@@ -94,6 +108,14 @@ namespace Plugin {
             _hdrProperties->Release();
             _hdrProperties = nullptr;
         }
+
+        if (_displayProperties != nullptr)
+        {
+            _displayProperties->Release();
+            Exchange::JDisplayProperties::Unregister(*this);
+            _displayProperties = nullptr;
+        }
+
         _connectionId = 0;
     }
 

--- a/DisplayInfo/DisplayInfo.h
+++ b/DisplayInfo/DisplayInfo.h
@@ -24,6 +24,7 @@
 #include <interfaces/json/JGraphicsProperties.h>
 #include <interfaces/json/JConnectionProperties.h>
 #include <interfaces/json/JHDRProperties.h>
+#include <interfaces/json/JDisplayProperties.h>
 
 namespace WPEFramework {
 namespace Plugin {
@@ -85,6 +86,7 @@ namespace Plugin {
             , _graphicsProperties(nullptr)
             , _connectionProperties(nullptr)
             , _hdrProperties(nullptr)
+            , _displayProperties(nullptr)
             , _notification(this)
         {
         }
@@ -99,6 +101,7 @@ namespace Plugin {
         INTERFACE_AGGREGATE(Exchange::IGraphicsProperties, _graphicsProperties)
         INTERFACE_AGGREGATE(Exchange::IConnectionProperties, _connectionProperties)
         INTERFACE_AGGREGATE(Exchange::IHDRProperties, _hdrProperties)
+        INTERFACE_AGGREGATE(Exchange::IDisplayProperties, _displayProperties)
         INTERFACE_ENTRY(PluginHost::IDispatcher)
         END_INTERFACE_MAP
 
@@ -124,6 +127,7 @@ namespace Plugin {
         Exchange::IGraphicsProperties* _graphicsProperties;
         Exchange::IConnectionProperties* _connectionProperties;
         Exchange::IHDRProperties* _hdrProperties;
+        Exchange::IDisplayProperties* _displayProperties;
         Core::Sink<Notification> _notification;
     };
 


### PR DESCRIPTION
Reason for change: Adding HDMI source
properties to IConnectionProperties interface
Added properties

1.Colour space
2.Frame Rate
3.Colour depth
4.Quantization Range
5.Colorimetry
6.EOTF
Test Procedure: Check compilation of rdkservices
Risks: Low
Signed-off-by: Akhil Baby Sarada akhil_sarada@comcast.com