### PR TITLE
RDKTV-10975: Return updated Downloaded FW Version

### DIFF
--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -1870,26 +1870,32 @@ namespace WPEFramework {
                             }
                         }
                     }
-                    found = line.find("DnldVersn|");
-                    if (std::string::npos != found) {
-                        while ((pos = line.find(delimiter)) != std::string::npos) {
-                            token = line.substr(0, pos);
-                            line.erase(0, pos + delimiter.length());
+                    // return DnldVersn based on IARM Firmware Update State
+                    // If Firmware Update State is Downloading or above then 
+                    // return DnldVersion from FWDNLDSTATUS_FILE_NAME else return empty
+                    if(m_FwUpdateState_LatestEvent >=2)
+                    {
+                        found = line.find("DnldVersn|");
+                        if (std::string::npos != found) {
+                            while ((pos = line.find(delimiter)) != std::string::npos) {
+                                token = line.substr(0, pos);
+                                line.erase(0, pos + delimiter.length());
+                            }
+                            line = std::regex_replace(line, std::regex("^ +| +$"), "$1");
+                            if (line.length() > 1) {
+                                downloadedFWVersion = line.c_str();
+                            }
                         }
-                        line = std::regex_replace(line, std::regex("^ +| +$"), "$1");
-                        if (line.length() > 1) {
-                            downloadedFWVersion = line.c_str();
-                        }
-                    }
-                    found = line.find("DnldURL|");
-                    if (std::string::npos != found) {
-                        while ((pos = line.find(delimiter)) != std::string::npos) {
-                            token = line.substr(0, pos);
-                            line.erase(0, pos + delimiter.length());
-                        }
-                        line = std::regex_replace(line, std::regex("^ +| +$"), "$1");
-                        if (line.length() > 1) {
-                            downloadedFWLocation = line.c_str();
+                        found = line.find("DnldURL|");
+                        if (std::string::npos != found) {
+                            while ((pos = line.find(delimiter)) != std::string::npos) {
+                                token = line.substr(0, pos);
+                                line.erase(0, pos + delimiter.length());
+                            }
+                            line = std::regex_replace(line, std::regex("^ +| +$"), "$1");
+                            if (line.length() > 1) {
+                                downloadedFWLocation = line.c_str();
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Return Downloaded Firmware Version based on IARM Firmware Update State instead of always reading from /opt/fwdnldstatus.txt.
If Firmware Update State is Downloading or above then return DnldVersion from /opt/fwdnldstatus.txt else return empty