### PR TITLE
RDKTV-9258: Set property tts-mode for TTS audio

### DIFF
--- a/TextToSpeech/impl/TTSSpeaker.cpp
+++ b/TextToSpeech/impl/TTSSpeaker.cpp
@@ -539,7 +539,7 @@ void TTSSpeaker::createPipeline() {
         if(m_pcmAudioEnabled) {
             //Raw PCM audio does not work with souphhtpsrc on Amlogic alsaasink
             m_source = gst_element_factory_make("httpsrc", NULL);
-            g_object_set(G_OBJECT(m_audioSink), "direct-mode", FALSE, NULL);
+            g_object_set(G_OBJECT(m_audioSink), "tts-mode", TRUE, NULL);
         }
         else {
             m_source = gst_element_factory_make("souphttpsrc", NULL);
@@ -854,8 +854,8 @@ void TTSSpeaker::speakText(TTSConfiguration config, SpeechData &data) {
         g_object_set(G_OBJECT(m_audioVolume), "volume", (double) (data.client->configuration()->volume() / MAX_VOLUME), NULL);
         gst_element_set_state(m_pipeline, GST_STATE_PLAYING);
 #if defined(PLATFORM_AMLOGIC)
-	//-12db is almost 25%
-	setMixGain(MIXGAIN_PRIM,-12);
+        //-12db is almost 25%
+        setMixGain(MIXGAIN_PRIM,-12);
 #endif
         TTSLOG_VERBOSE("Speaking.... ( %d, \"%s\")", data.id, data.text.c_str());
 


### PR DESCRIPTION
Reason for change: Amlogic supports tts-mode for
TTS audio
Test Procedure:
1. Turn on voice guidance and navigate through tiles.
while voice guidance is narrating a longer sentence,
execute the following
gst-launch-1.0 httpsrc location="http://localhost:50050/
nuanceEve/tts?voice=ava&language=en-US&rate=50&text=How_are_you"
! audio/x-raw, rate=22050, channels=1, format=S16LE,
layout=interleaved ! audioconvert ! audioresample !
amlhalasink direct-mode=false
Audio from both sources should be heard without any
glitches.
2. No regression for voice guidance

Risks: Low

Signed-off-by: Simi Mathew <simim@tataelxsi.co.in>
