### PR TITLE
RDKTV-11039:FWDOWNLOAD continues after stop event

### DIFF
--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -472,7 +472,8 @@ namespace WPEFramework {
                     /* Store it in a Global structure */
                     g_epoch_time=l_time;
                 }
-                else if ( IARM_BUS_MAINTENANCEMGR_EVENT_UPDATE == eventId ) {
+                else if ( (IARM_BUS_MAINTENANCEMGR_EVENT_UPDATE == eventId ) &&
+                        ( MAINTENANCE_STARTED == m_notify_status) ) { /* receive notification only during maintenence */
                     module_status = module_event_data->data.maintenance_module_status.status;
                     LOGINFO("MaintMGR Status %d \n",module_status);
                     string status_string=moduleStatusToString(module_status);
@@ -481,6 +482,7 @@ namespace WPEFramework {
                         case MAINT_RFC_COMPLETE :
                             if(task_status_RFC->second != true) {
                                  LOGINFO("Ignoring Event RFC_COMPLETE");
+                                 return;
                             }
                             else {
                                  SET_STATUS(g_task_status,RFC_SUCCESS);
@@ -492,6 +494,7 @@ namespace WPEFramework {
                         case MAINT_DCM_COMPLETE :
                             if(task_status_DCM->second != true) {
                                  LOGINFO("Ignoring Event DCM_COMPLETE");
+                                 return;
                             }
                             else {
                                 SET_STATUS(g_task_status,DCM_SUCCESS);
@@ -503,6 +506,7 @@ namespace WPEFramework {
                         case MAINT_FWDOWNLOAD_COMPLETE :
                             if(task_status_FWDLD->second != true) {
                                  LOGINFO("Ignoring Event MAINT_FWDOWNLOAD_COMPLETE");
+                                 return;
                             }
                             else {
                                 SET_STATUS(g_task_status,DIFD_SUCCESS);
@@ -514,6 +518,7 @@ namespace WPEFramework {
                        case MAINT_LOGUPLOAD_COMPLETE :
                             if(task_status_LOGUPLD->second != true) {
                                  LOGINFO("Ignoring Event MAINT_LOGUPLOAD_COMPLETE");
+                                 return;
                             }
                             else {
                                 SET_STATUS(g_task_status,LOGUPLOAD_SUCCESS);
@@ -535,6 +540,7 @@ namespace WPEFramework {
                         case MAINT_DCM_ERROR:
                             if(task_status_DCM->second != true) {
                                  LOGINFO("Ignoring Event DCM_ERROR");
+                                 return;
                             }
                             else {
                                 SET_STATUS(g_task_status,DCM_COMPLETE);
@@ -546,6 +552,7 @@ namespace WPEFramework {
                         case MAINT_RFC_ERROR:
                             if(task_status_RFC->second != true) {
                                  LOGINFO("Ignoring Event RFC_ERROR");
+                                 return;
                             }
                             else {
                                  SET_STATUS(g_task_status,RFC_COMPLETE);
@@ -558,6 +565,7 @@ namespace WPEFramework {
                         case MAINT_LOGUPLOAD_ERROR:
                             if(task_status_LOGUPLD->second != true) {
                                   LOGINFO("Ignoring Event MAINT_LOGUPLOAD_ERROR");
+                                  return;
                             }
                             else {
                                 SET_STATUS(g_task_status,LOGUPLOAD_COMPLETE);
@@ -569,6 +577,7 @@ namespace WPEFramework {
                        case MAINT_FWDOWNLOAD_ERROR:
                             if(task_status_FWDLD->second != true) {
                                  LOGINFO("Ignoring Event MAINT_FWDOWNLOAD_ERROR");
+                                 return;
                             }
                             else {
                                 SET_STATUS(g_task_status,DIFD_COMPLETE);
@@ -600,7 +609,8 @@ namespace WPEFramework {
                     }
                 }
                 else{
-                    LOGINFO("Unknown Maintenance Status!!");
+                    LOGINFO("Ignoring/Unknown Maintenance Status!!");
+                    return;
                 }
 
                 LOGINFO(" BITFIELD Status : %x",g_task_status);


### PR DESCRIPTION
Reason for change: Duplicate event posted triggering
overall maintenance status events and receive events only when
maintenance is in progress. 
Test Procedure: Build and Verify
Risks: Medium