### PR TITLE
DELIA-51606: Set default voice for voice guidance language (#1723)

### DIFF
--- a/TextToSpeech/impl/TTSManager.cpp
+++ b/TextToSpeech/impl/TTSManager.cpp
@@ -99,7 +99,15 @@ TTS_Error TTSManager::setConfiguration(Configuration &configuration) {
     m_defaultConfiguration.setEndPoint(configuration.ttsEndPoint);
     m_defaultConfiguration.setSecureEndPoint(configuration.ttsEndPointSecured);
     updated |= m_defaultConfiguration.setLanguage(configuration.language);
-    updated |= m_defaultConfiguration.setVoice(configuration.voice);
+    /* Set default voice for the language only when voice is empty*/
+    if(!configuration.language.empty() && configuration.voice.empty()) {
+        std::vector<std::string> voices;
+        listVoices(configuration.language, voices);
+        updated |= m_defaultConfiguration.setVoice(voices.front());
+    }
+    else
+        updated |= m_defaultConfiguration.setVoice(configuration.voice);
+
     updated |= m_defaultConfiguration.setVolume(configuration.volume);
     updated |= m_defaultConfiguration.setRate(configuration.rate);
 


### PR DESCRIPTION
Reason for change: Set a default voice when the voice guidance
language is updated if the application does not set it along with
the voice.
Test Procedure:
1. Change the voice guidance language in the
accessibility setting. Navigate to web apps and verify voice guidance
works.
2. No voice guidance regression
3. Verify persistence of the voice guidance settings
Risks: Low

Signed-off-by: Simi Mathew <simim@tataelxsi.co.in>