### PR TITLE
SERXIONE-244: dial support for YouTube kids

### DIFF
--- a/XCast/XCast.cpp
+++ b/XCast/XCast.cpp
@@ -441,13 +441,22 @@ void XCast::getUrlFromAppLaunchParams (const char *app_name, const char *payload
             sprintf( url, "https://www.youtube.com/tv");
         }
     }
-    else if((strcmp(app_name,"YouTubeTV") == 0) || (strcmp(app_name,"YouTubeKids") == 0)){
+    else if(strcmp(app_name,"YouTubeTV") == 0) {
         if ((payload != NULL) && (additional_data_url != NULL)){
             sprintf( url, "https://www.youtube.com/tv/upg?%s&additionalDataUrl=%s", payload, additional_data_url);
         }else if (payload != NULL){
             sprintf( url, "https://www.youtube.com/tv/upg?%s", payload);
         }else{
             sprintf( url, "https://www.youtube.com/tv/upg?");
+        }
+    }
+    else if(strcmp(app_name,"YouTubeKids") == 0) {
+        if ((payload != NULL) && (additional_data_url != NULL)){
+            sprintf( url, "https://www.youtube.com/tv_kids?%s&additionalDataUrl=%s", payload, additional_data_url);
+        }else if (payload != NULL){
+            sprintf( url, "https://www.youtube.com/tv_kids?%s", payload);
+        }else{
+            sprintf( url, "https://www.youtube.com/tv_kids?");
         }
     }
     else if(strcmp(app_name,"Netflix") == 0) {


### PR DESCRIPTION
Reason for change:  corrected YT kids url
Test Procedure: refer jira.
Risks: Low

Signed-off-by: apatel859 <amit_patel5@comcast.com>