### PR TITLE
SecurityAgent: Syncup with Metro plugin changes

### DIFF
--- a/SecurityAgent/AccessControlList.h
+++ b/SecurityAgent/AccessControlList.h
@@ -221,7 +221,8 @@ namespace Plugin {
                     Add(_T("role"), &Role);
                 }
                 Group(const Group& copy)
-                    : URL()
+                    : Core::JSON::Container()
+                    , URL()
                     , Role()
                 {
                     Add(_T("url"), &URL);

--- a/SecurityAgent/CMakeLists.txt
+++ b/SecurityAgent/CMakeLists.txt
@@ -15,8 +15,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+project(SecurityAgent)
+
+cmake_minimum_required(VERSION 3.3)
+
+find_package(WPEFramework)
 set(PLUGIN_NAME SecurityAgent)
-set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
+set(MODULE_NAME ${NAMESPACE}${PROJECT_NAME})
+
+set(PLUGIN_SECURITYAGENT_AUTOSTART "true" CACHE STRING "Automatically start SecurityAgent plugin")
 
 find_package(${NAMESPACE}Plugins REQUIRED)
 find_package(CompileSettingsDebug CONFIG REQUIRED)

--- a/SecurityAgent/Module.h
+++ b/SecurityAgent/Module.h
@@ -21,7 +21,7 @@
 #define TIMESYNC_MODULE_H
 
 #ifndef MODULE_NAME
-#define MODULE_NAME Plugin_TimeSync
+#define MODULE_NAME Plugin_SecurityAgent
 #endif
 
 #include <plugins/plugins.h>

--- a/SecurityAgent/SecurityAgent.config
+++ b/SecurityAgent/SecurityAgent.config
@@ -1,6 +1,6 @@
 set(autostart ${PLUGIN_SECURITYAGENT_AUTOSTART})
 
 map()
-    map(acl acl.json)
+    kv(acl acl.json)
 end()
 ans(configuration)

--- a/SecurityAgent/SecurityAgent.config
+++ b/SecurityAgent/SecurityAgent.config
@@ -1,4 +1,4 @@
-set (autostart true)
+set(autostart ${PLUGIN_SECURITYAGENT_AUTOSTART})
 
 map()
     map(acl acl.json)

--- a/SecurityAgent/SecurityAgent.cpp
+++ b/SecurityAgent/SecurityAgent.cpp
@@ -78,7 +78,7 @@ namespace Plugin {
         string version = service->Version();
 
         _skipURL = static_cast<uint8_t>(service->WebPrefix().length());
-        Core::File aclFile(service->PersistentPath() + config.ACL.Value(), true);
+        Core::File aclFile(service->PersistentPath() + config.ACL.Value());
 
         PluginHost::ISubSystem* subSystem = service->SubSystems();
 
@@ -139,6 +139,8 @@ namespace Plugin {
         PluginHost::ISubSystem* subSystem = service->SubSystems();
 
         ASSERT(subSystem != nullptr);
+
+        _dispatcher.reset(nullptr);
 
         if (subSystem != nullptr) {
             subSystem->Set(PluginHost::ISubSystem::NOT_SECURITY, nullptr);

--- a/SecurityAgent/SecurityContext.cpp
+++ b/SecurityAgent/SecurityContext.cpp
@@ -68,13 +68,13 @@ namespace Plugin {
     }
 
     //! Allow a websocket upgrade to be checked if it is allowed to be opened.
-    bool SecurityContext::Allowed(const string& path) const /* override */
+    bool SecurityContext::Allowed(const string&) const /* override */
     {
         return (true);
     }
 
     //! Allow a request to be checked before it is offered for processing.
-    bool SecurityContext::Allowed(const Web::Request& request) const /* override */ 
+    bool SecurityContext::Allowed(const Web::Request&) const /* override */
     {
         bool allowed = (_accessControlList != nullptr);
 


### PR DESCRIPTION
1. Minor alignment and coding standard changes
2. Module name corrected
3. Clear (delete) the dispatcher at shutdown.