### PR TITLE
Extend OCIContainer to support crypted containers.

### DIFF
--- a/OCIContainer/CMakeLists.txt
+++ b/OCIContainer/CMakeLists.txt
@@ -39,7 +39,6 @@ find_package_handle_standard_args(
 target_include_directories(${MODULE_NAME}
         PRIVATE
         ../helpers
-
         )
 
 target_link_libraries(${MODULE_NAME}
@@ -55,6 +54,20 @@ target_link_libraries(${MODULE_NAME}
         ${NAMESPACE}Plugins::${NAMESPACE}Plugins
         ${SYSTEMD_LIBRARIES}
 )
+
+
+find_library(OMIPROXY omiclientlib)
+if(OMIPROXY)
+
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I=/usr/include/glib-2.0 -I=/usr/lib/glib-2.0/include")
+  target_link_libraries (${MODULE_NAME} PRIVATE omiclientlib)
+
+else()
+
+  target_include_directories(${MODULE_NAME} PRIVATE stubs)
+
+endif (OMIPROXY)
+
 # ${NAMESPACE}Protocols::${NAMESPACE}Protocols
 install(TARGETS ${MODULE_NAME}
         DESTINATION lib/${STORAGE_DIRECTORY}/plugins)

--- a/OCIContainer/OCIContainer.h
+++ b/OCIContainer/OCIContainer.h
@@ -8,6 +8,7 @@
 
 #include <vector>
 #include <map>
+#include <i_omi_proxy.hpp>
 
 namespace WPEFramework
 {
@@ -39,6 +40,7 @@ public:
     uint32_t getContainerState(const JsonObject &parameters, JsonObject &response);
     uint32_t getContainerInfo(const JsonObject &parameters, JsonObject &response);
     uint32_t startContainer(const JsonObject &parameters, JsonObject &response);
+    uint32_t startContainerFromCryptedBundle(const JsonObject &parameters, JsonObject &response);
     uint32_t startContainerFromDobbySpec(const JsonObject &parameters, JsonObject &response);
     uint32_t stopContainer(const JsonObject &parameters, JsonObject &response);
     uint32_t pauseContainer(const JsonObject &parameters, JsonObject &response);
@@ -49,6 +51,7 @@ public:
     //Begin events
     void onContainerStarted(int32_t descriptor, const std::string& name);
     void onContainerStopped(int32_t descriptor, const std::string& name);
+    void onVerityFailed(const std::string& name);
     //End events
 
     //Build QueryInterface implementation, specifying all possible interfaces to be returned.
@@ -66,10 +69,13 @@ public:
 
 private:
     int mEventListenerId; // Dobby event listener ID
+    long unsigned mOmiListenerId;
     std::shared_ptr<IDobbyProxy> mDobbyProxy; // DobbyProxy instance
     std::shared_ptr<AI_IPC::IIpcService> mIpcService; // Ipc Service instance
     const int GetContainerDescriptorFromId(const std::string& containerId);
     static const void stateListener(int32_t descriptor, const std::string& name, IDobbyProxyEvents::ContainerState state, const void* _this);
+    static const void omiErrorListener(const std::string& id, omi::IOmiProxy::ErrorType err, const void* _this);
+    std::shared_ptr<omi::IOmiProxy> mOmiProxy;
 };
 } // namespace Plugin
 } // namespace WPEFramework

--- a/OCIContainer/OCIContainer.json
+++ b/OCIContainer/OCIContainer.json
@@ -373,6 +373,63 @@
                 ]
             }
         },
+        "startContainerFromCryptedBundle":{
+            "summary": "Starts a new container from an existing encrypted OCI bundle",
+            "params": {
+                "type": "object",
+                "properties": {
+                    "containerId": {
+                        "$ref": "#/definitions/containerId"
+                    },
+                    "rootFSPath": {
+                        "summary": "Path to the enrypted OCI bundle containing the rootfs to use to create the container",
+                        "type": "string",
+                        "example": "/containers/rootfs/myBundle"
+                    },
+                    "configFilePath": {
+                        "summary": "Path to the enrypted OCI bundle containing the config file to use to create the container",
+                        "type": "string",
+                        "example": "/containers/var/myBundle"
+                    },
+                    "command": {
+                        "$ref": "#/definitions/command"
+                    },
+                    "westerosSocket":{
+                        "summary": "Path to a Westeros socket to mount inside the container",
+                        "type": "string",
+                        "example": "/usr/mySocket"
+                    },
+                    "envvar": {
+                        "summary": "A list of environment variables to add to the container",
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "example": "FOO=BAR"
+                        }
+                    }
+                },
+                "required": [
+                    "containerId",
+                    "rootFSPath",
+                    "configFilePath"
+                ]
+            },
+            "result": {
+                "type": "object",
+                "properties": {
+                    "descriptor": {
+                        "$ref": "#/definitions/Descriptor"
+                    },
+                    "success":{
+                        "$ref": "#/definitions/success"
+                    }
+                },
+                "required": [
+                    "descriptor",
+                    "success"
+                ]
+            }
+        },
         "startContainerFromDobbySpec":{
             "summary": "Starts a new container from a legacy Dobby JSON specification",
             "params": {

--- a/OCIContainer/README.md
+++ b/OCIContainer/README.md
@@ -126,6 +126,32 @@ Starts a new container from an existing OCI bundle.
 }
 ```
 
+## startContainerFromCryptedBundle
+
+Starts a new container from an existing encrypted OCI bundle.
+
+### Params
+| Name           | Type   | Description                                                                                |
+| -------------- | ------ | ------------------------------------------------------------------------------------------ |
+| containerId    | string | ID for the new container                                                                   |
+| rootFSPath     | string | Path to the OCI bundle containing the rootfs to use to create the container                |
+| configFilePath | string | Path to the OCI bundle containing the config file to use to create the container           |
+| command        | string | Custom command to run inside the container, overriding the command in the container config |
+| westerosSocket | string | Path to a westeros socket to mount inside the container                                    |
+---
+
+### Response
+```json
+{
+   "jsonrpc":"2.0",
+   "id":3,
+   "result":{
+      "descriptor":257,
+      "success":true
+   }
+}
+```
+
 ## startContainerFromDobbySpec
 
 Starts a new container from a legacy Dobby json specification

--- a/OCIContainer/doc/OCIContainerPlugin.md
+++ b/OCIContainer/doc/OCIContainerPlugin.md
@@ -91,6 +91,7 @@ OCIContainer interface methods:
 | [pauseContainer](#method.pauseContainer) | Pauses a currently running container |
 | [resumeContainer](#method.resumeContainer) | Resumes a previously paused container |
 | [startContainer](#method.startContainer) | Starts a new container from an existing OCI bundle |
+| [startContainerFromCryptedBundle](#method.startContainerFromCryptedBundle) | Starts a new container from an existing encrypted OCI bundle |
 | [startContainerFromDobbySpec](#method.startContainerFromDobbySpec) | Starts a new container from a legacy Dobby JSON specification |
 | [stopContainer](#method.stopContainer) | Stops a currently running container |
 
@@ -466,6 +467,61 @@ Starts a new container from an existing OCI bundle.
         "envvar": [
             "FOO=BAR"
         ]
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": {
+        "descriptor": 91,
+        "success": true
+    }
+}
+```
+<a name="method.startContainerFromCryptedBundle"></a>
+## *startContainerFromCryptedBundle <sup>method</sup>*
+
+Starts a new container from an existing encrypted OCI bundle.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.containerId | string | The ID of a container as returned by `listContainers` |
+| params.rootFSPath | string | Path to the OCI bundle containing the rootfs to use to create the container |
+| params.configFilePath | string | Path to the OCI bundle containing the config to use to create the container |
+| params?.command | string | <sup>*(optional)*</sup> Command to execute |
+| params?.westerosSocket | string | <sup>*(optional)*</sup> Path to a Westeros socket to mount inside the container |
+| params?.envvar | array | <sup>*(optional)*</sup> A list of environment variables to add to the container |
+| params?.envvar[#] | string | <sup>*(optional)*</sup>  |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.descriptor | integer | The container descriptor |
+| result.success | boolean | Whether the request succeeded |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "org.rdk.OCIContainer.1.startContainerFromCryptedBundle",
+    "params": {
+        "containerId": "com.bskyb.epgui",
+        "rootFSPath": "/containers/myBundle",
+        "configFilePath": "/containers/var/myBundle"
     }
 }
 ```

--- a/OCIContainer/stubs/i_omi_proxy.hpp
+++ b/OCIContainer/stubs/i_omi_proxy.hpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2021, LIBERTY GLOBAL all rights reserved.
+ */
+
+#ifndef I_OMI_PROXY_HPP_
+#define I_OMI_PROXY_HPP_
+
+#include <string>
+#include <functional>
+
+namespace omi
+{
+
+/**
+ *  @interface IOmiProxy
+ *  @brief Wrapper around an omi_dbus_api that provides simpler method
+ *  calls and give possibility to register/unregister for incoming signals.
+ */
+class IOmiProxy
+{
+public:
+    enum class ErrorType { verityFailed };
+
+    typedef std::function<void(const std::string&, ErrorType, const void*)> OmiErrorListener;
+
+    // Mount crypted bundle
+    // id               [IN]  - Container ID in reverse domain name notation
+    // rootfs_file_path [IN]  - Absolute pathname for filesystem image
+    // config_json_path [IN]  - Absolute pathname for config.json.jwt
+    // bundlePath       [OUT] - Absolute pathname for decrypted config.json payload
+    // Returns TRUE on success, FALSE on error
+    virtual bool mountCryptedBundle(const std::string& id,
+                                    const std::string& rootfs_file_path,
+                                    const std::string& config_json_path,
+                                    std::string& bundlePath /*out parameter*/) = 0;
+
+    // Unmount crypted bundle
+    // id               [IN]  - Container ID in reverse domain name notation
+    // Returns TRUE on success, FALSE on error
+    virtual bool umountCryptedBundle(const std::string& id) = 0;
+
+    // Register listener
+    // listener         [IN]  - OMI error listener which will be called on error event occurrence
+    // Returns listener ID (0<) or 0 on error
+    virtual long unsigned registerListener(const OmiErrorListener &listener, const void* cbParams) = 0;
+
+    // Unregister listener
+    // tag           [IN]  - ID which defines listener to be unregistered
+    virtual void unregisterListener(long unsigned tag) = 0;
+
+};
+} // namespace omi
+#endif // #ifndef I_OMI_PROXY_HPP_

--- a/OCIContainer/stubs/i_omi_proxy.hpp
+++ b/OCIContainer/stubs/i_omi_proxy.hpp
@@ -1,5 +1,20 @@
 /*
- * Copyright (c) 2021, LIBERTY GLOBAL all rights reserved.
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2021 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef I_OMI_PROXY_HPP_

--- a/OCIContainer/stubs/omi_proxy.hpp
+++ b/OCIContainer/stubs/omi_proxy.hpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021, LIBERTY GLOBAL all rights reserved.
+ */
+
+#ifndef OMI_PROXY_HPP_
+#define OMI_PROXY_HPP_
+
+#include <i_omi_proxy.hpp>
+
+namespace omi
+{
+
+class OmiProxy : public IOmiProxy
+{
+public:
+    OmiProxy() = default;
+    virtual ~OmiProxy() = default;
+
+    virtual bool mountCryptedBundle(const std::string& id,
+                                       const std::string& rootfs_file_path,
+                                       const std::string& config_json_path,
+                                       std::string& bundlePath) { return true; }
+
+    virtual bool umountCryptedBundle(const std::string& id) { return true; }
+
+    virtual long unsigned registerListener(const OmiErrorListener &listener, const void* cbParams) { return 0; }
+
+    virtual void unregisterListener(long unsigned tag) {}
+};
+
+} // namespace omi
+
+#endif // OMI_PROXY_HPP_

--- a/OCIContainer/stubs/omi_proxy.hpp
+++ b/OCIContainer/stubs/omi_proxy.hpp
@@ -1,5 +1,20 @@
 /*
- * Copyright (c) 2021, LIBERTY GLOBAL all rights reserved.
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2021 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef OMI_PROXY_HPP_


### PR DESCRIPTION
Gives possibility to link omi component which decrypts, mounts and unmounts encrypted bundle according to ocicontainer requests. If omi library has not been found local stub files are being used (no impact on existing functionality).