### PR TITLE
RDKTV-8896: [User mode][ARC] The ARC is no sound after open HDMI-CEC …

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -63,6 +63,8 @@ using namespace std;
 #define HDMICECSINK_ARC_TERMINATION_EVENT "arcTerminationEvent"
 #define HDMICECSINK_SHORT_AUDIO_DESCRIPTOR_EVENT "shortAudiodesciptorEvent"
 #define HDMICECSINK_SYSTEM_AUDIO_MODE_EVENT "setSystemAudioModeEvent"
+#define HDMICECSINK_AUDIO_DEVICE_ADDED_EVENT "reportAudioDeviceAdded"
+#define HDMICECSINK_CEC_ENABLED_EVENT "reportCecEnabledEvent"
 #define SERVER_DETAILS  "127.0.0.1:9998"
 #define WARMING_UP_TIME_IN_SECONDS 5
 #define HDMICECSINK_PLUGIN_ACTIVATION_TIME 2
@@ -72,6 +74,7 @@ using namespace std;
 #define ZOOM_SETTINGS_DIRECTORY "/opt/persistent/rdkservices"
 
 static bool isCecArcRoutingThreadEnabled = false;
+static bool isCecEnabled = false;
 
 #ifdef USE_IARM
 namespace
@@ -303,11 +306,18 @@ namespace WPEFramework {
                             m_timer.stop();
                         }
 
+			try {
+		    		isCecEnabled = getHdmiCecSinkCecEnableStatus();
+			}
+			catch (const device::Exception& err){
+				LOG_DEVICE_EXCEPTION1(string("HDMI_ARC0"));
+			}
+
 			bool isPluginActivated = Utils::isPluginActivated(HDMICECSINK_CALLSIGN);
 
 			if(isPluginActivated) {
 			    if(!m_subscribed) {
-			        if((subscribeForHdmiCecSinkEvent(HDMICECSINK_ARC_INITIATION_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_ARC_TERMINATION_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_SHORT_AUDIO_DESCRIPTOR_EVENT)== Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_SYSTEM_AUDIO_MODE_EVENT) == Core::ERROR_NONE)) {
+			        if((subscribeForHdmiCecSinkEvent(HDMICECSINK_ARC_INITIATION_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_ARC_TERMINATION_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_SHORT_AUDIO_DESCRIPTOR_EVENT)== Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_SYSTEM_AUDIO_MODE_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_AUDIO_DEVICE_ADDED_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_CEC_ENABLED_EVENT) == Core::ERROR_NONE)) {
                                     m_subscribed = true;
                                     LOGINFO("%s: HdmiCecSink event subscription completed.\n",__FUNCTION__);
 			        }
@@ -342,7 +352,7 @@ namespace WPEFramework {
                                         //Dummy ARC intiation request
                                        {
                                         std::lock_guard<std::mutex> lock(m_arcRoutingStateMutex);
-                                        if(m_currentArcRoutingState == ARC_STATE_ARC_TERMINATED) {
+                                        if((m_currentArcRoutingState == ARC_STATE_ARC_TERMINATED) && (isCecEnabled == true)) {
                                             LOGINFO("%s: Send dummy ARC initiation request... \n", __FUNCTION__);
                                             m_currentArcRoutingState = ARC_STATE_REQUEST_ARC_INITIATION;
                                             m_cecArcRoutingThreadRun = true;
@@ -3325,6 +3335,38 @@ namespace WPEFramework {
 
             return success;
 	}
+	
+	bool DisplaySettings::getHdmiCecSinkCecEnableStatus ()
+        {
+            bool success = true;
+	    bool cecEnable = false;
+
+            if (Utils::isPluginActivated(HDMICECSINK_CALLSIGN)) {
+                auto hdmiCecSinkPlugin = getHdmiCecSinkPlugin();
+                if (!hdmiCecSinkPlugin) {
+                    LOGERR("HdmiCecSink Initialisation failed\n");
+                }
+                else {
+                    JsonObject hdmiCecSinkResult;
+                    JsonObject param;
+
+                    hdmiCecSinkPlugin->Invoke<JsonObject, JsonObject>(2000, "getEnabled", param, hdmiCecSinkResult);
+
+		    cecEnable = hdmiCecSinkResult["enabled"].Boolean();
+		    LOGINFO("get-cecEnabled [%d]\n",cecEnable);
+
+                    if (!hdmiCecSinkResult["success"].Boolean()) {
+                        success = false;
+                        LOGERR("HdmiCecSink Plugin returned error\n");
+                    }
+                }
+            }
+            else {
+                success = false;
+                LOGERR("HdmiCecSink plugin not ready\n");
+            }
+            return cecEnable;
+        }
 
         bool DisplaySettings::sendHdmiCecSinkAudioDevicePowerOn ()
         {
@@ -3495,7 +3537,7 @@ namespace WPEFramework {
                                 LOGINFO("%s: setUpHdmiCecSinkArcRouting true. Audio routing after CEC ARC handshake \n",__FUNCTION__);
                                 {
                                     std::lock_guard<std::mutex> lock(m_arcRoutingStateMutex);
-                                    if(m_currentArcRoutingState == ARC_STATE_ARC_TERMINATED) {
+                                    if((m_currentArcRoutingState == ARC_STATE_ARC_TERMINATED) && (isCecEnabled == true)) {
                                         m_currentArcRoutingState = ARC_STATE_REQUEST_ARC_INITIATION;
                                         m_cecArcRoutingThreadRun = true;
                                         arcRoutingCV.notify_one();
@@ -3737,8 +3779,13 @@ namespace WPEFramework {
                 } else if(strcmp(eventName, HDMICECSINK_SYSTEM_AUDIO_MODE_EVENT) == 0) {
                     err =m_client->Subscribe<JsonObject>(1000, eventName
                             , &DisplaySettings::onSystemAudioModeEventHandler, this);
-                }
-                else {
+                } else if(strcmp(eventName, HDMICECSINK_AUDIO_DEVICE_ADDED_EVENT) == 0) {
+                    err =m_client->Subscribe<JsonObject>(1000, eventName
+                            , &DisplaySettings::onAudioDeviceAddedEventHandler, this);
+                } else if(strcmp(eventName, HDMICECSINK_CEC_ENABLED_EVENT) == 0) {
+                    err =m_client->Subscribe<JsonObject>(1000, eventName
+                            , &DisplaySettings::onCecEnabledEventHandler, this);
+		} else {
                      err = Core::ERROR_UNAVAILABLE;
                      LOGERR("Unsupported Event: %s ", eventName);
                 }
@@ -3908,7 +3955,7 @@ namespace WPEFramework {
 //                    connectedAudioPortUpdated(dsAUDIOPORT_TYPE_HDMI_ARC, true);
                     LOGINFO("%s :  audioMode ON !!!\n", __FUNCTION__);
                     std::lock_guard<std::mutex> lock(m_arcRoutingStateMutex);
-                    if((m_currentArcRoutingState == ARC_STATE_ARC_TERMINATED) && (m_hdmiInAudioDeviceConnected == false)) {
+                    if((m_currentArcRoutingState == ARC_STATE_ARC_TERMINATED) && (m_hdmiInAudioDeviceConnected == false) && (isCecEnabled == true)) {
 			LOGINFO("%s :  m_hdmiInAudioDeviceConnected = false. ARC state is terminated.  Trigger ARC Initiation request !!!\n", __FUNCTION__); 
     		        m_currentArcRoutingState = ARC_STATE_REQUEST_ARC_INITIATION;
 			m_cecArcRoutingThreadRun = true;
@@ -3947,6 +3994,63 @@ namespace WPEFramework {
             }
         }
 
+	/* Event handler when Audio Device is Added     */
+	void DisplaySettings::onAudioDeviceAddedEventHandler(const JsonObject& parameters)
+	{
+            int types = dsAUDIOARCSUPPORT_NONE;
+	  try
+	  {
+	    device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort("HDMI_ARC0");
+	    aPort.getSupportedARCTypes(&types);
+
+            LOGINFO("[ Audio Device Added Event], AudioSupport_type [%d], m_hdmiInAudioDeviceConnected [%d], m_currentArcRoutingState [%d], m_cecArcRoutingThreadRun [%d] \n", types, m_hdmiInAudioDeviceConnected, m_currentArcRoutingState, m_cecArcRoutingThreadRun);
+	    if(types & dsAUDIOARCSUPPORT_eARC) {
+		if(m_hdmiInAudioDeviceConnected == false)
+		{
+			m_hdmiInAudioDeviceConnected = true;
+			LOGINFO("eARC_mode: Notify Audio Port \n");
+			connectedAudioPortUpdated(dsAUDIOPORT_TYPE_HDMI_ARC, true);
+		}
+	    }else if(types & dsAUDIOARCSUPPORT_ARC) {
+                LOGINFO("ARC_mode: settings... \n");
+
+		std::lock_guard<std::mutex> lock(m_arcRoutingStateMutex);
+
+	        if((m_currentArcRoutingState == ARC_STATE_ARC_TERMINATED) && (isCecEnabled == true)) {
+			LOGINFO("ARC_mode: Send dummy ARC initiation request... \n");
+			m_currentArcRoutingState = ARC_STATE_REQUEST_ARC_INITIATION;
+                        m_cecArcRoutingThreadRun = true;
+			LOGINFO("ARC_mode: Notify Arc routing with m_currentArcRoutingStat [%d] \n", DisplaySettings::_instance->m_currentArcRoutingState );
+                        arcRoutingCV.notify_one();
+		}
+	    }else {
+                         LOGINFO("Connected Device doesn't have ARC/eARC capability... \n");
+            }
+	}
+	catch (const device::Exception& err){
+		LOG_DEVICE_EXCEPTION1(string("HDMI_ARC0"));
+	}
+
+      }
+
+	/* DisplaaySettings gets notified whenever CEC is made Enable or Disable  */
+	void DisplaySettings::onCecEnabledEventHandler(const JsonObject& parameters)
+	{
+             string value;
+
+             LOGINFO(" CEC Enable-Disable Event... \n");
+	     if (parameters.HasLabel("cecEnable"))
+                 value = parameters["cecEnable"].String();
+
+	     if(!value.compare("true")) {
+		isCecEnabled = true;
+	      } else{
+		isCecEnabled = false;
+	      }
+
+              LOGINFO("updated isCecEnabled [%d] ... \n", isCecEnabled);
+	}
+
         // 6.
         void DisplaySettings::onTimer()
         {
@@ -3967,7 +4071,7 @@ namespace WPEFramework {
             bool pluginActivated = Utils::isPluginActivated(HDMICECSINK_CALLSIGN);
             LOGWARN ("DisplaySettings::onTimer pluginActivated:%d line:%d", pluginActivated, __LINE__);
             if(!m_subscribed) {
-                if (pluginActivated && (subscribeForHdmiCecSinkEvent(HDMICECSINK_ARC_INITIATION_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_ARC_TERMINATION_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_SHORT_AUDIO_DESCRIPTOR_EVENT)== Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_SYSTEM_AUDIO_MODE_EVENT) == Core::ERROR_NONE))
+                if (pluginActivated && (subscribeForHdmiCecSinkEvent(HDMICECSINK_ARC_INITIATION_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_ARC_TERMINATION_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_SHORT_AUDIO_DESCRIPTOR_EVENT)== Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_SYSTEM_AUDIO_MODE_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_AUDIO_DEVICE_ADDED_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_CEC_ENABLED_EVENT) == Core::ERROR_NONE))
                 {
                     m_subscribed = true;
                     if (m_timer.isActive()) {
@@ -4032,7 +4136,7 @@ namespace WPEFramework {
                         //Dummy ARC intiation request
                       {
                         std::lock_guard<std::mutex> lock(m_arcRoutingStateMutex);
-                        if(m_currentArcRoutingState == ARC_STATE_ARC_TERMINATED) {
+                        if((m_currentArcRoutingState == ARC_STATE_ARC_TERMINATED) && (isCecEnabled == true)) {
                             LOGINFO("%s: Send dummy ARC initiation request... \n", __FUNCTION__);
                             m_currentArcRoutingState = ARC_STATE_REQUEST_ARC_INITIATION;
                             m_cecArcRoutingThreadRun = true;

--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -155,6 +155,8 @@ namespace WPEFramework {
             void onARCTerminationEventHandler(const JsonObject& parameters);
 	    void onShortAudioDescriptorEventHandler(const JsonObject& parameters);
 	    void onSystemAudioModeEventHandler(const JsonObject& parameters);
+	    void onAudioDeviceAddedEventHandler(const JsonObject& parameters);
+	    void onCecEnabledEventHandler(const JsonObject& parameters);
             //End events
         public:
             DisplaySettings();
@@ -186,6 +188,7 @@ namespace WPEFramework {
 	    bool setUpHdmiCecSinkArcRouting (bool arcEnable);
 	    bool requestShortAudioDescriptor();
 	    bool sendHdmiCecSinkAudioDevicePowerOn();
+	    bool getHdmiCecSinkCecEnableStatus();
 	    static void  cecArcRoutingThread();
 	    void onTimer();
 

--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -97,6 +97,8 @@ enum {
         HDMICECSINK_EVENT_STANDBY_MSG_EVENT,
 	HDMICECSINK_EVENT_SYSTEM_AUDIO_MODE,
 	HDMICECSINK_EVENT_REPORT_AUDIO_STATUS,
+	HDMICECSINK_EVENT_AUDIO_DEVICE_ADDED,
+	HDMICECSINK_EVENT_CEC_ENABLED,
 };
 
 static char *eventString[] = {
@@ -114,7 +116,9 @@ static char *eventString[] = {
         "shortAudiodesciptorEvent",
         "standbyMessageReceived",
         "setSystemAudioModeEvent",
-        "reportAudioStatusEvent"
+        "reportAudioStatusEvent",
+	"reportAudioDeviceAdded",
+	"reportCecEnabledEvent"
 };
 	
 
@@ -1798,7 +1802,7 @@ namespace WPEFramework
         {
         	int i;
 
-			if(!HdmiCecSink::_instance)
+		if(!HdmiCecSink::_instance)
                 return;
                 if(!(_instance->smConnection))
                     return;
@@ -2040,6 +2044,7 @@ namespace WPEFramework
 		}
 
 		void HdmiCecSink::addDevice(const int logicalAddress) {
+			JsonObject params;
 
 			if(!HdmiCecSink::_instance)
 				return;
@@ -2055,6 +2060,14 @@ namespace WPEFramework
 				HdmiCecSink::_instance->deviceList[logicalAddress].m_logicalAddress = LogicalAddress(logicalAddress);
 				HdmiCecSink::_instance->m_numberOfDevices++;
 				HdmiCecSink::_instance->m_pollNextState = POLL_THREAD_STATE_INFO;
+
+				if(logicalAddress == 0x5)
+				{
+					LOGINFO(" logicalAddress =%d , Audio device detected, Notify Device Settings", logicalAddress );
+					params["status"] = string("success");
+					sendNotify(eventString[HDMICECSINK_EVENT_AUDIO_DEVICE_ADDED], params)
+				}
+
 				sendNotify(eventString[HDMICECSINK_EVENT_DEVICE_ADDED], JsonObject())
 			 }
 		}
@@ -2551,6 +2564,7 @@ namespace WPEFramework
         void HdmiCecSink::CECEnable(void)
         {
             std::lock_guard<std::mutex> lock(m_enableMutex);
+	    JsonObject params;
             LOGINFO("Entered CECEnable");
             if (cecEnableStatus)
             {
@@ -2596,12 +2610,16 @@ namespace WPEFramework
             }
             cecEnableStatus = true;
 
+	    params["cecEnable"] = string("true");
+            sendNotify(eventString[HDMICECSINK_EVENT_CEC_ENABLED], params);
+ 
             return;
         }
 
         void HdmiCecSink::CECDisable(void)
         {
             std::lock_guard<std::mutex> lock(m_enableMutex);
+	    JsonObject params;
             LOGINFO("Entered CECDisable ");
             if(!cecEnableStatus)
             {
@@ -2652,6 +2670,15 @@ namespace WPEFramework
             
 	    m_logicalAddressAllocated = LogicalAddress::UNREGISTERED;
             m_currentArcRoutingState = ARC_STATE_ARC_TERMINATED;
+
+	    for(int i=0; i< 16; i++)
+            {
+		 if (_instance->deviceList[i].m_isDevicePresent)
+	         {
+	 		_instance->deviceList[i].clear();
+	         }
+            }
+
             if(1 == libcecInitStatus)
             {
                 try
@@ -2666,6 +2693,10 @@ namespace WPEFramework
 
             libcecInitStatus--;
             LOGWARN("CEC Disabled %d",libcecInitStatus); 
+
+	   params["cecEnable"] = string("false");
+           sendNotify(eventString[HDMICECSINK_EVENT_CEC_ENABLED], params);
+
             return;
         }
 


### PR DESCRIPTION
…option.

RDKTV-8896: [User mode][ARC] The ARC is no sound after open HDMI-CEC option.

Reason for change: When HDMI-CEC is enabled Arc initiation will not happen for ARC device.
    Modifications made to HdmiCecSink to notify the Device settings on Audio Device added Event and cecEnable status.
	Modified to clear device list elements during CecDisable.
    Display settings will then request for ARC initiation based on cecEnable status.
Test Procedure:
    1. Enter a live TV channel
    2. HDMI2 is connected Yamaha V781 AVR and The AVR is power on
    3. Enter settings-Antenna and inputs, set the HDMI-CEC to ON
Risks: Low
Signed-off-by: bp-ynagas047 <yeshwanth.nagaswamy@sky.uk>