### PR TITLE
AMLOGIC-2825: Don't request SAD over CEC for eARC device

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -710,15 +710,18 @@ namespace WPEFramework {
                                     else{
                                         device::AudioStereoMode mode = device::AudioStereoMode::kStereo;  //default to stereo
                                         mode = aPort.getStereoMode(); //get Last User set stereo mode and set
-					if(mode == device::AudioStereoMode::kPassThru){
+					if((types & dsAUDIOARCSUPPORT_ARC) && (mode == device::AudioStereoMode::kPassThru)){
                                             if (!DisplaySettings::_instance->requestShortAudioDescriptor()) {
                                                 LOGERR("dsHdmiEventHandler (ARC Passthru mode): requestShortAudioDescriptor failed !!!\n");;
                                             }
                                             else {
                                                 LOGINFO("dsHdmiEventHandler (ARC Passthru mode): requestShortAudioDescriptor successful\n");
                                             }
+					    aPort.setStereoMode(mode.toString(), true);
                                         }
-                                        aPort.setStereoMode(mode.toString(), true);
+					else if(types & dsAUDIOARCSUPPORT_eARC) {
+                                            aPort.setStereoMode(mode.toString(), true);
+                                        }
                                     }
 
                                     if(types & dsAUDIOARCSUPPORT_eARC) {


### PR DESCRIPTION
Reason for change: No need to request SAD over CEC for
eARC device as we get it from eARC CDS
Test Procedure: Check dynamic EDID update for
eARC Passthru mode
Risks: None

Signed-off-by: Deekshit Devadas <deekshit.devadasy@sky.uk>