### PR TITLE
LLAMA-3913: Changing HDMI_ARC0 sound mode via setSoundMode

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -1339,7 +1339,7 @@ namespace WPEFramework {
                             modeString.append(mode.toString());
                         }
                     }
-                    if((aPort.getType().getId() == device::AudioOutputPortType::kHDMI)){
+                    else if((aPort.getType().getId() == device::AudioOutputPortType::kHDMI)){
                         mode = aPort.getStereoMode();
                         if (aPort.getStereoAuto() || mode == device::AudioStereoMode::kSurround)
                         {


### PR DESCRIPTION
    from PASSTHRU to STEREO sets to value to STEREOPASSTHRU

Reason for change:
SetSoundMode is not setting the mode properly
Test Procedure: Curl CMDS
Risks: Low

Signed-off-by: shafi.ahmed@sky.uk <shafi.ahmed@sky.uk>