### PR TITLE
DELIA-52305: Fix possible buffer overflow in getFileContentToCharBuffer

### DIFF
--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -207,7 +207,7 @@ namespace WPEFramework {
             string reason="";
 
             if (Utils::fileExists(SYSTEM_SERVICE_PREVIOUS_REBOOT_INFO_FILE)) {
-                retAPIStatus = getFileContentToCharBuffer(SYSTEM_SERVICE_PREVIOUS_REBOOT_INFO_FILE, rebootInfo );
+                retAPIStatus = getFileContentToCharBuffer(SYSTEM_SERVICE_PREVIOUS_REBOOT_INFO_FILE, rebootInfo, sizeof(rebootInfo));
             }
 
             if (retAPIStatus && strlen(rebootInfo)) {

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -145,11 +145,11 @@ bool isGzEnabledHelper(bool& enabled)
 {
     bool retVal = false;
 
-    char lines[32] = {'\0'};
+    char buffer[32] = {'\0'};
     string gzStatus = "";
-    retVal = getFileContentToCharBuffer(GZ_STATUS.c_str(), lines);
-    if (retVal) {
-        gzStatus = strtok(lines," ");
+    retVal = getFileContentToCharBuffer(GZ_STATUS.c_str(), buffer, sizeof(buffer));
+    if (retVal && strlen(buffer)) {
+        gzStatus = strtok(buffer," ");
         if ("true" == gzStatus) {
             enabled = true;
         } else {
@@ -2578,7 +2578,7 @@ namespace WPEFramework {
 
             if (Utils::fileExists(SYSTEM_SERVICE_PREVIOUS_REBOOT_INFO_FILE)) {
                 retAPIStatus = getFileContentToCharBuffer(
-                        SYSTEM_SERVICE_PREVIOUS_REBOOT_INFO_FILE, rebootInfo);
+                        SYSTEM_SERVICE_PREVIOUS_REBOOT_INFO_FILE, rebootInfo, sizeof(rebootInfo));
                 if (retAPIStatus && strlen(rebootInfo)) {
                     string dataBuf(rebootInfo);
                     JsonObject rebootInfoJson;
@@ -2597,7 +2597,7 @@ namespace WPEFramework {
 
             if (Utils::fileExists(SYSTEM_SERVICE_HARD_POWER_INFO_FILE)) {
                 retAPIStatus = getFileContentToCharBuffer(
-                        SYSTEM_SERVICE_HARD_POWER_INFO_FILE, hardPowerInfo);
+                        SYSTEM_SERVICE_HARD_POWER_INFO_FILE, hardPowerInfo, sizeof(hardPowerInfo));
                 if (retAPIStatus && strlen(hardPowerInfo)) {
                     string dataBuf(hardPowerInfo);
                     JsonObject hardPowerInfoJson;
@@ -2640,7 +2640,7 @@ namespace WPEFramework {
 
             if (Utils::fileExists(SYSTEM_SERVICE_PREVIOUS_REBOOT_INFO_FILE)) {
                 retAPIStatus = getFileContentToCharBuffer(
-                        SYSTEM_SERVICE_PREVIOUS_REBOOT_INFO_FILE, rebootInfo);
+                        SYSTEM_SERVICE_PREVIOUS_REBOOT_INFO_FILE, rebootInfo, sizeof(rebootInfo));
                 if (retAPIStatus && strlen(rebootInfo)) {
                     string dataBuf(rebootInfo);
                     JsonObject rebootInfoJson;
@@ -3662,12 +3662,12 @@ namespace WPEFramework {
 		bool optout = false;
 		bool result = true;
                 bool retVal = false;
-                char lines[32] = {'\0'};
+                char buffer[32] = {'\0'};
                 string optStatus = "";
 
-                retVal = getFileContentToCharBuffer(OPTOUT_TELEMETRY_STATUS, lines);
-                if (retVal) {
-                    optStatus = strtok(lines," ");
+                retVal = getFileContentToCharBuffer(OPTOUT_TELEMETRY_STATUS, buffer, sizeof(buffer));
+                if (retVal && strlen(buffer)) {
+                    optStatus = strtok(buffer," ");
                     if ("true" == optStatus) {
                        optout = true;
                     } else {

--- a/helpers/SystemServicesHelper.cpp
+++ b/helpers/SystemServicesHelper.cpp
@@ -287,12 +287,12 @@ bool getFileContent(std::string fileName, std::vector<std::string> & vecOfStrs)
  * @brief	: Used to read file contents into a C char array/buffer
  * @param1[in]	: Complete file name with path
  * @param2[in]	: Destination C char buffer to be filled with file contents
+ * @param3[in]	: Buffer size
  * @return	: <bool>; TRUE if operation success; else FALSE.
  */
-bool getFileContentToCharBuffer(std::string fileName, char* pBuffer)
+bool getFileContentToCharBuffer(std::string fileName, char* pBuffer, const size_t bufferSize)
 {
     bool retStat = false;
-    long numbytes = 0;
     std::string str;
     std::ifstream inFile(fileName.c_str());
 
@@ -300,16 +300,24 @@ bool getFileContentToCharBuffer(std::string fileName, char* pBuffer)
         return retStat;
     }
 
-    numbytes = inFile.tellg();
-    fprintf(stdout, "getFileContentToCharBuffer : numbytes = %ld\n", numbytes);
+    inFile.seekg(0, std::ios::end);
+    size_t fileSize = inFile.tellg();
 
-    std::strcpy(pBuffer, str.c_str());
+    fprintf(stdout, "getFileContentToCharBuffer : fileSize = %ld\n", fileSize);
+
+    if (fileSize > bufferSize - 1) {
+        return retStat;
+    }
+
+    inFile.seekg(0);
+
     while (std::getline(inFile, str)) {
         std::strcat(pBuffer, str.c_str());
         if (!inFile.eof()) {
             std::strcat(pBuffer, "\n");
         }
     }
+
     retStat = true;
     inFile.close();
 

--- a/helpers/SystemServicesHelper.h
+++ b/helpers/SystemServicesHelper.h
@@ -194,9 +194,10 @@ bool getFileContent(std::string fileName, std::vector<std::string> & vecOfStrs);
  * @brief  : Used to read file contents into a C char array/buffer
  * @param1[in] : Complete file name with path
  * @param2[in] : Destination C char buffer to be filled with file contents
+ * @param3[in] : Buffer size
  * @return : <bool>; TRUE if operation success; else FALSE.
  */
-bool getFileContentToCharBuffer(std::string fileName, char *pBuffer);
+bool getFileContentToCharBuffer(std::string fileName, char *pBuffer, const size_t bufferSize);
 
 /***
  * @brief	: Used to search for files in the given directory


### PR DESCRIPTION
Reason for change: Prevent buffer overflow in function getFileContentToCharBuffer
by checking if buffer has enough size to fit file content. Add check for empty file in
isGzEnabledHelper and isOptOutTelemetry to prevent segmentation fault.
Test Procedure: Test APIs which are using function getFileContentToCharBuffer
Risks: None