### PR TITLE
DELIA-52305: Remove function getFileContentToCharBuffer from SystemSe…

### DIFF
--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -200,18 +200,16 @@ namespace WPEFramework {
 
 
         string MaintenanceManager::getLastRebootReason(){
-
-            char rebootInfo[1024] = {'\0'};
             bool retAPIStatus = false;
             string reboot_reason="";
             string reason="";
+            string rebootInfo;
 
             if (Utils::fileExists(SYSTEM_SERVICE_PREVIOUS_REBOOT_INFO_FILE)) {
-                retAPIStatus = getFileContentToCharBuffer(SYSTEM_SERVICE_PREVIOUS_REBOOT_INFO_FILE, rebootInfo );
+                retAPIStatus = getFileContent(SYSTEM_SERVICE_PREVIOUS_REBOOT_INFO_FILE, rebootInfo);
             }
 
-            if (retAPIStatus && strlen(rebootInfo)) {
-                string dataBuf(rebootInfo);
+            if (retAPIStatus && rebootInfo.length()) {
                 JsonObject rebootInfoJson;
                 rebootInfoJson.FromString(rebootInfo);
                 reason = rebootInfoJson["reason"].String();

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -144,13 +144,11 @@ bool setGzEnabled(bool enabled)
 bool isGzEnabledHelper(bool& enabled)
 {
     bool retVal = false;
+    string gzEnabled;
 
-    char lines[32] = {'\0'};
-    string gzStatus = "";
-    retVal = getFileContentToCharBuffer(GZ_STATUS.c_str(), lines);
-    if (retVal) {
-        gzStatus = strtok(lines," ");
-        if ("true" == gzStatus) {
+    retVal = getFileContent(GZ_STATUS.c_str(), gzEnabled);
+    if (retVal && gzEnabled.length()) {
+        if (gzEnabled.find("true") != string::npos) {
             enabled = true;
         } else {
             enabled = false;
@@ -2572,16 +2570,15 @@ namespace WPEFramework {
             uint8_t parseStatus = 0;
             JsonObject respData;
             string timestamp, source, reason, customReason, lastHardPowerReset;
-            char rebootInfo[1024] = {'\0'};
-            char hardPowerInfo[1024] = {'\0'};
+            string rebootInfo;
+            string hardPowerInfo;
 
             if (Utils::fileExists(SYSTEM_SERVICE_PREVIOUS_REBOOT_INFO_FILE)) {
-                retAPIStatus = getFileContentToCharBuffer(
+                retAPIStatus = getFileContent(
                         SYSTEM_SERVICE_PREVIOUS_REBOOT_INFO_FILE, rebootInfo);
-                if (retAPIStatus && strlen(rebootInfo)) {
-                    string dataBuf(rebootInfo);
+                if (retAPIStatus && rebootInfo.length()) {
                     JsonObject rebootInfoJson;
-                    rebootInfoJson.FromString(dataBuf);
+                    rebootInfoJson.FromString(rebootInfo);
                     timestamp = rebootInfoJson["timestamp"].String();
                     source = rebootInfoJson["source"].String();
                     reason = rebootInfoJson["reason"].String();
@@ -2595,10 +2592,9 @@ namespace WPEFramework {
             }
 
             if (Utils::fileExists(SYSTEM_SERVICE_HARD_POWER_INFO_FILE)) {
-                retAPIStatus = getFileContentToCharBuffer(
+                retAPIStatus = getFileContent(
                         SYSTEM_SERVICE_HARD_POWER_INFO_FILE, hardPowerInfo);
-                if (retAPIStatus && strlen(hardPowerInfo)) {
-                    string dataBuf(hardPowerInfo);
+                if (retAPIStatus && hardPowerInfo.length()) {
                     JsonObject hardPowerInfoJson;
                     hardPowerInfoJson.FromString(hardPowerInfo);
                     lastHardPowerReset = hardPowerInfoJson["lastHardPowerReset"].String();
@@ -2635,13 +2631,12 @@ namespace WPEFramework {
             bool retAPIStatus = false;
             uint8_t parseStatus = 0;
             string reason;
-            char rebootInfo[1024] = {'\0'};
+            string rebootInfo;
 
             if (Utils::fileExists(SYSTEM_SERVICE_PREVIOUS_REBOOT_INFO_FILE)) {
-                retAPIStatus = getFileContentToCharBuffer(
+                retAPIStatus = getFileContent(
                         SYSTEM_SERVICE_PREVIOUS_REBOOT_INFO_FILE, rebootInfo);
-                if (retAPIStatus && strlen(rebootInfo)) {
-                    string dataBuf(rebootInfo);
+                if (retAPIStatus && rebootInfo.length()) {
                     JsonObject rebootInfoJson;
                     rebootInfoJson.FromString(rebootInfo);
                     reason = rebootInfoJson["reason"].String();
@@ -3008,12 +3003,12 @@ namespace WPEFramework {
         uint32_t SystemServices::isGZEnabled(const JsonObject& parameters,
                 JsonObject& response)
         {
-		bool enabled = false;
-		bool result = true;
+            bool enabled = false;
 
-		isGzEnabledHelper(enabled);
-		response["enabled"] = enabled;
-		returnResponse(result);
+            isGzEnabledHelper(enabled);
+            response["enabled"] = enabled;
+
+            returnResponse(true);
         } //end of isGZEnbaled
 
         /***
@@ -3658,24 +3653,21 @@ namespace WPEFramework {
         uint32_t SystemServices::isOptOutTelemetry(const JsonObject& parameters,
                 JsonObject& response)
         {
-		bool optout = false;
-		bool result = true;
-                bool retVal = false;
-                char lines[32] = {'\0'};
-                string optStatus = "";
+            bool optout = false;
+            string optOutStatus;
 
-                retVal = getFileContentToCharBuffer(OPTOUT_TELEMETRY_STATUS, lines);
-                if (retVal) {
-                    optStatus = strtok(lines," ");
-                    if ("true" == optStatus) {
-                       optout = true;
-                    } else {
-                       optout = false;
-                    }
+            bool retVal = getFileContent(OPTOUT_TELEMETRY_STATUS, optOutStatus);
+            if (retVal && optOutStatus.length()) {
+                if (optOutStatus.find("true") != string::npos) {
+                    optout = true;
+                } else {
+                    optout = false;
                 }
-                LOGINFO("Current TelemetryOptOut flag is %d\n", optout);
-		response["Opt-Out"] = optout;
-		returnResponse(result);
+            }
+
+            LOGINFO("Current TelemetryOptOut flag is %d\n", optout);
+            response["Opt-Out"] = optout;
+            returnResponse(true);
         } //end of isOptOutTelemetry
 
         uint32_t SystemServices::getStoreDemoLink(const JsonObject& parameters, JsonObject& response)

--- a/helpers/SystemServicesHelper.cpp
+++ b/helpers/SystemServicesHelper.cpp
@@ -240,7 +240,7 @@ void setJSONResponseArray(JsonObject& response, const char* key,
 }
 
 /***
- * @brief	: Used to read file contents into a vector
+ * @brief	: Used to read file contents into a string
  * @param1[in]	: Complete file name with path
  * @param2[out]	: Destination string object filled with file contents
  * @return	: <bool>; TRUE if operation success; else FALSE.
@@ -281,39 +281,6 @@ bool getFileContent(std::string fileName, std::vector<std::string> & vecOfStrs)
     }
     inFile.close();
     return retStatus;
-}
-
-/***
- * @brief	: Used to read file contents into a C char array/buffer
- * @param1[in]	: Complete file name with path
- * @param2[in]	: Destination C char buffer to be filled with file contents
- * @return	: <bool>; TRUE if operation success; else FALSE.
- */
-bool getFileContentToCharBuffer(std::string fileName, char* pBuffer)
-{
-    bool retStat = false;
-    long numbytes = 0;
-    std::string str;
-    std::ifstream inFile(fileName.c_str());
-
-    if (!inFile.is_open()) {
-        return retStat;
-    }
-
-    numbytes = inFile.tellg();
-    fprintf(stdout, "getFileContentToCharBuffer : numbytes = %ld\n", numbytes);
-
-    std::strcpy(pBuffer, str.c_str());
-    while (std::getline(inFile, str)) {
-        std::strcat(pBuffer, str.c_str());
-        if (!inFile.eof()) {
-            std::strcat(pBuffer, "\n");
-        }
-    }
-    retStat = true;
-    inFile.close();
-
-    return retStat;
 }
 
 /***

--- a/helpers/SystemServicesHelper.h
+++ b/helpers/SystemServicesHelper.h
@@ -175,7 +175,7 @@ void setJSONResponseArray(JsonObject& response, const char* key,
         const vector<string>& items);
 
 /***
- * @brief	: Used to read file contents into a vector
+ * @brief	: Used to read file contents into a string
  * @param1[in]	: Complete file name with path
  * @param2[out]	: Destination string object filled with file contents
  * @return	: <bool>; TRUE if operation success; else FALSE.
@@ -189,14 +189,6 @@ bool getFileContent(std::string fileName, std::string& fileContent);
  * @return : <bool>; TRUE if operation success; else FALSE.
  */
 bool getFileContent(std::string fileName, std::vector<std::string> & vecOfStrs);
-
-/***
- * @brief  : Used to read file contents into a C char array/buffer
- * @param1[in] : Complete file name with path
- * @param2[in] : Destination C char buffer to be filled with file contents
- * @return : <bool>; TRUE if operation success; else FALSE.
- */
-bool getFileContentToCharBuffer(std::string fileName, char *pBuffer);
 
 /***
  * @brief	: Used to search for files in the given directory


### PR DESCRIPTION
…rvicesHelper

Reason for change: Function getFileContentToCharBuffer could cause a buffer overflow
if size of the file content was bigger then destination buffer size. Function is removed
completely and replaced by more secure getFileContent.
Test Procedure: Test APIs which were using function getFileContentToCharBuffer
Risks: None