### PR TITLE
AMLOGIC-2825: Don't request SAD over CEC for eARC device

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -708,15 +708,18 @@ namespace WPEFramework {
                                     else{
                                         device::AudioStereoMode mode = device::AudioStereoMode::kStereo;  //default to stereo
                                         mode = aPort.getStereoMode(); //get Last User set stereo mode and set
-					if(mode == device::AudioStereoMode::kPassThru){
+					if((types & dsAUDIOARCSUPPORT_ARC) && (mode == device::AudioStereoMode::kPassThru)){
                                             if (!DisplaySettings::_instance->requestShortAudioDescriptor()) {
                                                 LOGERR("dsHdmiEventHandler (ARC Passthru mode): requestShortAudioDescriptor failed !!!\n");;
                                             }
                                             else {
                                                 LOGINFO("dsHdmiEventHandler (ARC Passthru mode): requestShortAudioDescriptor successful\n");
                                             }
+					    aPort.setStereoMode(mode.toString(), true);
                                         }
-                                        aPort.setStereoMode(mode.toString(), true);
+					else if(types & dsAUDIOARCSUPPORT_eARC) {
+                                            aPort.setStereoMode(mode.toString(), true);
+                                        }
                                     }
 
                                     if(types & dsAUDIOARCSUPPORT_eARC) {
@@ -3417,7 +3420,7 @@ namespace WPEFramework {
                         else{
                             device::AudioStereoMode mode = device::AudioStereoMode::kStereo;  //default to stereo
                             mode = aPort.getStereoMode(); //get Last User set stereo mode and set
-                            if(mode == device::AudioStereoMode::kPassThru){
+                            if((mode == device::AudioStereoMode::kPassThru) && (types & dsAUDIOARCSUPPORT_ARC)){
                                 if (!DisplaySettings::_instance->requestShortAudioDescriptor()) {
                                     LOGERR("DisplaySettings::setEnableAudioPort (ARC-Passthru): requestShortAudioDescriptor failed !!!\n");;
                                 }
@@ -3427,7 +3430,7 @@ namespace WPEFramework {
                             }
                             aPort.setStereoMode(mode.toString(), true);
                         }
-                    }		    
+                    }
 
                     if(types & dsAUDIOARCSUPPORT_eARC) {
                         if(pEnable) {


### PR DESCRIPTION
Reason for change: No need to request SAD over CEC for
eARC device as we get it from eARC CDS
Test Procedure: Check dynamic EDID update for
eARC Passthru mode
Risks: None

Signed-off-by: Deekshit Devadas <deekshit.devadasy@sky.uk>

AMLOGIC-2825: Don't request SAD over CEC for eARC device

Reason for change: No need to request SAD over CEC for
eARC device as we get it from eARC CDS
Test Procedure: Check dynamic EDID update for
eARC Passthru mode
Risks: None

Signed-off-by: Deekshit Devadas deekshit.devadasy@sky.uk