### PR TITLE
DELIA-40282 : Cec_devlist return NULL when daemon not running

### DIFF
--- a/HdmiCec/HdmiCec.cpp
+++ b/HdmiCec/HdmiCec.cpp
@@ -785,6 +785,13 @@ namespace WPEFramework
 					_instance->smConnection, _instance->logicalAddress);
 			return isConnected;
 		}
+		RFC_ParamData_t param;
+		bool ret = Utils::getRFCConfig("Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.HDMICECDaemon.Enable", param);
+		if (!(true == ret && param.type == WDMP_BOOLEAN && (strncasecmp(param.value,"true",4) == 0))){
+			//cec daemon is not enabled
+			LOGERR("HDMICECDaemon is not enabled. Not able to detected cec devices");
+			return isConnected;
+		}
 
 		LOGWARN("PING for  0x%x \r\n",idev);
 		try {

--- a/HdmiCec_2/HdmiCec_2.cpp
+++ b/HdmiCec_2/HdmiCec_2.cpp
@@ -1263,6 +1263,13 @@ namespace WPEFramework
 					_instance->smConnection, logicalAddress.toInt());
 			return isConnected;
 		}
+		RFC_ParamData_t param;
+		bool ret = Utils::getRFCConfig("Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.HDMICECDaemon.Enable", param);
+		if (!(true == ret && param.type == WDMP_BOOLEAN && (strncasecmp(param.value,"true",4) == 0))){
+			//cec daemon is not enabled
+			LOGERR("HDMICECDaemon is not enabled. Not able to detected cec devices");
+			return isConnected;
+		}
 
 		LOGWARN("PING for  0x%x \r\n",idev);
 		try {


### PR DESCRIPTION
Reason for change: DELIA-53130
Cec_devlist return NULL when daemon not running
Test Procedure: None
Risks: Low

Change-Id: If7d8f62d27323158b3cc1f24ee02698c3cef9d8b
Signed-off-by: Anooj Cheriyan <Anooj_Cheriyan@comcast.com>