### PR TITLE
RDK-34042: SystemServices API Event implementation.

### DIFF
--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -3458,6 +3458,8 @@ namespace WPEFramework {
         void _systemStateChanged(const char *owner, IARM_EventId_t eventId,
                 void *data, size_t len)
         {
+            int seconds = 600; /* 10 Minutes to Reboot */
+
             LOGINFO("len = %d\n", len);
             /* Only handle state events */
             if (eventId != IARM_BUS_SYSMGR_EVENT_SYSTEMSTATE) return;
@@ -3470,8 +3472,14 @@ namespace WPEFramework {
                 case IARM_BUS_SYSMGR_SYSSTATE_FIRMWARE_UPDATE_STATE:
                     {
                         LOGWARN("IARMEvt: IARM_BUS_SYSMGR_SYSSTATE_FIRMWARE_UPDATE_STATE = '%d'\n", state);
-                        if (SystemServices::_instance) {
-                            SystemServices::_instance->onFirmwareUpdateStateChange(state);
+                        if (SystemServices::_instance)
+                        {
+                            if (IARM_BUS_SYSMGR_FIRMWARE_UPDATE_STATE_CRITICAL_REBOOT == state) {
+                                LOGWARN(" Critical reboot is required. \n ");
+                                SystemServices::_instance->onFirmwarePendingReboot(seconds);
+                            } else {
+                                SystemServices::_instance->onFirmwareUpdateStateChange(state);
+                            }
                         } else {
                             LOGERR("SystemServices::_instance is NULL.\n");
                         }


### PR DESCRIPTION
Reason for change: Added event to notify critical reboot is required
Test Procedure: Refer ticket
Risks: None
Signed-off-by: Punam Kumbhar<punam_kumbhar@comcast.com>