### PR TITLE
StateObserver: fix memory leaks

### DIFF
--- a/StateObserver/StateObserver.cpp
+++ b/StateObserver/StateObserver.cpp
@@ -235,6 +235,7 @@ namespace WPEFramework {
 			if( items == NULL)
 			{
 				LOGWARN("not able to fetch property names from request \n");
+				cJSON_Delete(root);
 				returnResponse(ret);
 			}
 			int arrsize=cJSON_GetArraySize(items);
@@ -254,6 +255,7 @@ namespace WPEFramework {
 				getVal(pname,response);
 			}
 			LOGTRACEMETHODFIN();
+			cJSON_Delete(root);
 			returnResponse(ret);
 		}
 
@@ -609,6 +611,7 @@ namespace WPEFramework {
 			if( items == NULL)
 			{
 				LOGWARN("not able to fetch property names from request \n");
+				cJSON_Delete(root);
 				returnResponse(ret);
 			}
 			int arrsize=cJSON_GetArraySize(items);
@@ -636,6 +639,7 @@ namespace WPEFramework {
 				getVal(pname,response);
 			}
 			LOGTRACEMETHODFIN();
+			cJSON_Delete(root);
 			returnResponse(ret);
 		}
 
@@ -669,6 +673,7 @@ namespace WPEFramework {
 			if( items == NULL)
 			{
 				LOGWARN("not able to fetch property names from request \n");
+				cJSON_Delete(root);
 				returnResponse(ret);
 			}
 			int arrsize=cJSON_GetArraySize(items);
@@ -696,6 +701,7 @@ namespace WPEFramework {
 				}
 			}
 			LOGTRACEMETHODFIN();
+			cJSON_Delete(root);
 			returnResponse(ret);
 		}
 


### PR DESCRIPTION
Every cJSON_Parse() should have matching cJSON_Delete().

Signed-off-by: Michał Łyszczek <michal.lyszczek@consult.red>