### PR TITLE
DELIA-52731: fix curl crash

### DIFF
--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -1672,7 +1672,6 @@ namespace WPEFramework {
                 curlResponse = data;
                 free(data);
                 curl_easy_cleanup(curl);
-                curl_global_cleanup();
             }
             if (CURLE_OK == res) {
                 /* Eg: {"paramList":[{"name":"Device.DeviceInfo.SerialNumber",


### PR DESCRIPTION
Reason for change: curl_global_cleanup
should only be called once.
Test Procedure: Invoke many concurrent
curl-s, see no crash.
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>