### PR TITLE
RDKTV-11877: setTimeZoneDST should set TZ env

### DIFF
--- a/LocationSync/LocationSync.cpp
+++ b/LocationSync/LocationSync.cpp
@@ -149,7 +149,7 @@ namespace Plugin {
             subSystem->Release();
 
             if ((_sink.Location() != nullptr) && (_sink.Location()->TimeZone().empty() == false)) {
-                Core::SystemInfo::SetEnvironment(_T("TZ"), _sink.Location()->TimeZone());
+                Core::SystemInfo::SetEnvironment(_T("TZ"), _sink.Location()->TimeZone(), false);
                 event_locationchange();
             }
         }

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -2072,6 +2072,7 @@ namespace WPEFramework {
         uint32_t SystemServices::setTimeZoneDST(const JsonObject& parameters,
                 JsonObject& response)
 	{
+    LOGINFOMETHOD();
 		bool resp = false;
 		if (parameters.HasLabel("timeZone")) {
 			std::string dir = dirnameOf(TZ_FILE);
@@ -2081,6 +2082,9 @@ namespace WPEFramework {
 				if (timeZone.empty() || (timeZone == "null")) {
 					LOGERR("Empty timeZone received.");
 				} else {
+
+          Core::SystemInfo::SetEnvironment(_T("TZ"), timeZone);
+
 					if (!dirExists(dir)) {
 						std::string command = "mkdir -p " + dir + " \0";
 						Utils::cRunScript(command.c_str());


### PR DESCRIPTION
Reason for change: setTimeZoneDST doesn't change TZ env.
Test Procedure: Refer to the ticket.
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>