### PR TITLE
RDKTV-11877: sync timeZoneDST and TZ

### DIFF
--- a/LocationSync/LocationSync.cpp
+++ b/LocationSync/LocationSync.cpp
@@ -28,7 +28,7 @@ namespace Plugin {
     static Core::ProxyPoolType<Web::JSONBodyType<LocationSync::Data>> jsonResponseFactory(4);
 
     namespace {
-        string readTextFile(const string &filename) {
+        string ReadTextFile(const string &filename) {
             string result;
 
             Core::File file(filename);
@@ -72,7 +72,7 @@ namespace Plugin {
         string version = service->Version();
 
         if (config.TimeZoneOverrideFile.IsSet() == true) {
-            auto timeZone = readTextFile(config.TimeZoneOverrideFile.Value());
+            auto timeZone = ReadTextFile(config.TimeZoneOverrideFile.Value());
   
             if (timeZone.empty() == false) {
                 Core::SystemInfo::SetEnvironment(_T("TZ"), timeZone);

--- a/LocationSync/LocationSync.h
+++ b/LocationSync/LocationSync.h
@@ -151,10 +151,12 @@ namespace Plugin {
                 : Interval(30)
                 , Retries(8)
                 , Source()
+                , TimeZoneOverrideFile()
             {
                 Add(_T("interval"), &Interval);
                 Add(_T("retries"), &Retries);
                 Add(_T("source"), &Source);
+                Add(_T("timeZoneOverrideFile"), &TimeZoneOverrideFile);
             }
             ~Config()
             {
@@ -164,6 +166,7 @@ namespace Plugin {
             Core::JSON::DecUInt16 Interval;
             Core::JSON::DecUInt8 Retries;
             Core::JSON::String Source;
+            Core::JSON::String TimeZoneOverrideFile;
         };
 
     private:

--- a/LocationSync/LocationSyncPlugin.json
+++ b/LocationSync/LocationSyncPlugin.json
@@ -29,6 +29,10 @@
                         "type": "string",
                         "size": 16,
                         "description": "URI of the Location Server (default:\"http://jsonip.metrological.com/?maf=true\")."
+                    },
+                    "timeZoneOverrideFile": {
+                        "type": "string",
+                        "description": "Location of a file with override time zone value."
                     }
                 }
             }

--- a/LocationSync/doc/LocationSyncPlugin.md
+++ b/LocationSync/doc/LocationSyncPlugin.md
@@ -80,6 +80,7 @@ The table below lists configuration options of the plugin.
 | configuration?.interval | number | <sup>*(optional)*</sup> Maximum time duration between each request to the Location Server (default: 10) |
 | configuration?.retries | number | <sup>*(optional)*</sup> Maximum number of request reties to the Location Server (default:20) |
 | configuration?.source | string | <sup>*(optional)*</sup> URI of the Location Server (default:"http://jsonip.metrological.com/?maf=true") |
+| configuration?.timeZoneOverrideFile | string | <sup>*(optional)*</sup> Location of a file with override time zone value |
 
 <a name="head.Methods"></a>
 # Methods

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -2082,9 +2082,6 @@ namespace WPEFramework {
 				if (timeZone.empty() || (timeZone == "null")) {
 					LOGERR("Empty timeZone received.");
 				} else {
-
-                    Core::SystemInfo::SetEnvironment(_T("TZ"), timeZone);
-
 					if (!dirExists(dir)) {
 						std::string command = "mkdir -p " + dir + " \0";
 						Utils::cRunScript(command.c_str());
@@ -2101,6 +2098,9 @@ namespace WPEFramework {
 						fsync(fileno(f));
 						fclose(f);
 						resp = true;
+
+                        Core::SystemInfo::SetEnvironment(_T("TZ"), timeZone);
+
 					} else {
 						LOGERR("Unable to open %s file.\n", TZ_FILE);
 						populateResponseWithError(SysSrv_FileAccessFailed, response);

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -2072,6 +2072,7 @@ namespace WPEFramework {
         uint32_t SystemServices::setTimeZoneDST(const JsonObject& parameters,
                 JsonObject& response)
 	{
+        LOGINFOMETHOD();
 		bool resp = false;
 		if (parameters.HasLabel("timeZone")) {
 			std::string dir = dirnameOf(TZ_FILE);
@@ -2081,6 +2082,9 @@ namespace WPEFramework {
 				if (timeZone.empty() || (timeZone == "null")) {
 					LOGERR("Empty timeZone received.");
 				} else {
+
+                    Core::SystemInfo::SetEnvironment(_T("TZ"), timeZone);
+
 					if (!dirExists(dir)) {
 						std::string command = "mkdir -p " + dir + " \0";
 						Utils::cRunScript(command.c_str());


### PR DESCRIPTION
Reason for change: TZ should be
timeZoneDST (if exists), otherwise real time zone.
setTimeZoneDST should set TZ.
Test Procedure: Refer to the ticket.
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>