### PR TITLE
RDK-34139: Unit Testing Framework for RDKServices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -315,6 +315,10 @@ if(PLUGIN_WEBBRIDGE)
     add_subdirectory(WebBridge)
 endif()
 
+if(RDK_SERVICES_TEST)
+    add_subdirectory(RdkServicesTest)
+endif()
+
 if(WPEFRAMEWORK_CREATE_IPKG_TARGETS)
     set(CPACK_GENERATOR "DEB")
     set(CPACK_DEB_COMPONENT_INSTALL ON)

--- a/LoggingPreferences/LoggingPreferencesTest.cpp
+++ b/LoggingPreferences/LoggingPreferencesTest.cpp
@@ -1,0 +1,89 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2020 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+#include "gtest/gtest.h"
+
+#include "definitions.h"
+
+namespace RdkServicesTest {
+namespace Tests {
+
+class LoggingPreferencesTest : public ::testing::Test {
+protected:
+  LoggingPreferencesTest()
+      : link("org.rdk.LoggingPreferences.1"),
+        event(false, true),
+        eventHandler([&](const JsonObject &parameters) -> void {
+          eventParams = parameters;
+
+          event.SetEvent();
+        }) {}
+
+  Fixtures::Link link;
+  JsonObject result;
+
+  WPEFramework::Core::Event event;
+  std::function<void(const JsonObject &)> eventHandler;
+  JsonObject eventParams;
+};
+
+TEST_F(LoggingPreferencesTest, activate) {
+  EXPECT_ERROR_NONE(link.activate());
+}
+
+TEST_F(LoggingPreferencesTest, isKeystrokeMaskEnabled_default) {
+  EXPECT_SUCCESS(result, link.invoke("isKeystrokeMaskEnabled", "{}", result));
+
+  EXPECT_FALSE(result.Get("keystrokeMaskEnabled").Boolean());
+}
+
+TEST_F(LoggingPreferencesTest, setKeystrokeMaskEnabled_true) {
+  EXPECT_ERROR_NONE(link->Subscribe<JsonObject>(1000, "onKeystrokeMaskEnabledChange", eventHandler));
+
+  EXPECT_SUCCESS(result, link.invoke("setKeystrokeMaskEnabled", "{\"keystrokeMaskEnabled\":true}", result));
+
+  EXPECT_ERROR_NONE(event.Lock(1000));
+
+  EXPECT_TRUE(eventParams.Get("keystrokeMaskEnabled").Boolean());
+}
+
+TEST_F(LoggingPreferencesTest, isKeystrokeMaskEnabled_true) {
+  EXPECT_SUCCESS(result, link.invoke("isKeystrokeMaskEnabled", "{}", result));
+  
+  EXPECT_TRUE(result.Get("keystrokeMaskEnabled").Boolean());
+}
+
+TEST_F(LoggingPreferencesTest, setKeystrokeMaskEnabled_false) {
+  EXPECT_ERROR_NONE(link->Subscribe<JsonObject>(1000, "onKeystrokeMaskEnabledChange", eventHandler));
+
+  EXPECT_SUCCESS(result, link.invoke("setKeystrokeMaskEnabled", "{\"keystrokeMaskEnabled\":false}", result));
+
+  EXPECT_ERROR_NONE(event.Lock(1000));
+
+  EXPECT_FALSE(eventParams.Get("keystrokeMaskEnabled").Boolean());
+}
+
+TEST_F(LoggingPreferencesTest, isKeystrokeMaskEnabled_false) {
+  EXPECT_SUCCESS(result, link.invoke("isKeystrokeMaskEnabled", "{}", result));
+  
+  EXPECT_FALSE(result.Get("keystrokeMaskEnabled").Boolean());
+}
+
+} // namespace Tests
+} // namespace RdkServicesTest

--- a/PersistentStore/PersistentStoreTest.cpp
+++ b/PersistentStore/PersistentStoreTest.cpp
@@ -1,0 +1,81 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2020 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+#include "gtest/gtest.h"
+
+#include "definitions.h"
+
+namespace RdkServicesTest {
+namespace Tests {
+
+class PersistentStoreTest : public ::testing::Test {
+protected:
+  PersistentStoreTest()
+      : link("org.rdk.PersistentStore.1") {}
+
+  Fixtures::Link link;
+  JsonObject result;
+};
+
+TEST_F(PersistentStoreTest, activate) {
+  EXPECT_ERROR_NONE(link.activate());
+}
+
+TEST_F(PersistentStoreTest, setValue) {
+  EXPECT_SUCCESS(result, link.invoke("setValue", "{\"namespace\":\"test\",\"key\":\"a\",\"value\":\"1\"}", result));
+}
+
+TEST_F(PersistentStoreTest, getValue) {
+  EXPECT_SUCCESS(result, link.invoke("getValue", "{\"namespace\":\"test\",\"key\":\"a\"}", result));
+
+  EXPECT_EQ(string("1"), result.Get("value").String());
+}
+
+TEST_F(PersistentStoreTest, getNamespaces) {
+  EXPECT_SUCCESS(result, link.invoke("getNamespaces", "{}", result));
+
+  EXPECT_TRUE(result.Get("namespaces").IsSet());
+}
+
+TEST_F(PersistentStoreTest, getStorageSize) {
+  EXPECT_SUCCESS(result, link.invoke("getStorageSize", "{}", result));
+
+  EXPECT_EQ(2, result.Get("namespaceSizes").Object().Get("test").Number());
+}
+
+TEST_F(PersistentStoreTest, getKeys) {
+  EXPECT_SUCCESS(result, link.invoke("getKeys", "{\"namespace\":\"test\"}", result));
+
+  EXPECT_EQ(1, result.Get("keys").Array().Length());
+}
+
+TEST_F(PersistentStoreTest, deleteKey) {
+  EXPECT_SUCCESS(result, link.invoke("deleteKey", "{\"namespace\":\"test\",\"key\":\"a\"}", result));
+}
+
+TEST_F(PersistentStoreTest, deleteNamespace) {
+  EXPECT_SUCCESS(result, link.invoke("deleteNamespace", "{\"namespace\":\"test\"}", result));
+}
+
+TEST_F(PersistentStoreTest, flushCache) {
+  EXPECT_SUCCESS(result, link.invoke("flushCache", "{}", result, 5000));
+}
+
+} // namespace Tests
+} // namespace RdkServicesTest

--- a/RdkServicesTest/CMakeLists.txt
+++ b/RdkServicesTest/CMakeLists.txt
@@ -1,0 +1,55 @@
+# If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2020 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.8)
+project(RdkServicesTest)
+
+set(CMAKE_CXX_STANDARD 11)
+
+find_package(${NAMESPACE}Protocols REQUIRED)
+find_package(${NAMESPACE}SecurityUtil REQUIRED)
+
+find_package(GTest REQUIRED)
+
+file(GLOB TEST_FILES
+        ../PersistentStore/PersistentStoreTest.cpp
+        ../SecurityAgent/SecurityAgentTest.cpp
+        ../LoggingPreferences/LoggingPreferencesTest.cpp
+        )
+
+add_executable(${PROJECT_NAME}
+        ${TEST_FILES}
+        Module.cpp
+        Source/Link.cpp
+        Source/Web.cpp
+        Source/Token.cpp
+        )
+
+target_link_libraries(${PROJECT_NAME}
+        GTest::GTest GTest::Main
+        ${NAMESPACE}Protocols::${NAMESPACE}Protocols
+        ${NAMESPACE}SecurityUtil::${NAMESPACE}SecurityUtil
+        )
+
+target_include_directories(${PROJECT_NAME}
+        PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<INSTALL_INTERFACE:include>
+        Source
+        )
+
+install(TARGETS ${PROJECT_NAME} DESTINATION bin)

--- a/RdkServicesTest/Module.cpp
+++ b/RdkServicesTest/Module.cpp
@@ -1,0 +1,22 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2020 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+#include "Module.h"
+
+MODULE_NAME_DECLARATION(BUILD_REFERENCE)

--- a/RdkServicesTest/Module.h
+++ b/RdkServicesTest/Module.h
@@ -1,0 +1,28 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2020 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+#pragma once
+
+#ifndef MODULE_NAME
+#define MODULE_NAME RdkServicesTest
+#endif
+
+#include <core/core.h>
+#include <websocket/websocket.h>
+#include <securityagent/SecurityTokenUtil.h>

--- a/RdkServicesTest/Source/Link.cpp
+++ b/RdkServicesTest/Source/Link.cpp
@@ -1,0 +1,56 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2020 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+#include "Link.h"
+
+#include "Token.h"
+
+namespace RdkServicesTest {
+namespace Fixtures {
+
+auto LinkMap::get(
+    const string &callsign) -> JsonRpcLinkProxy {
+
+  auto retval = links.emplace(
+      std::piecewise_construct,
+      std::make_tuple(callsign),
+      std::make_tuple());
+
+  if (retval.second == true) {
+    static auto token = securityToken();
+    auto query = ("token=" + token);
+
+    retval.first->second =
+        JsonRpcLinkProxy::Create(callsign, nullptr, false, query);
+  }
+
+  return retval.first->second;
+}
+
+Link::Link(const string &callsign) : _callsign(callsign) {}
+
+auto Link::activate(
+    const uint32_t waitTime) -> uint32_t {
+
+  return map.get("")->Invoke<JsonObject, void>(
+      waitTime, "activate", JsonObject("{\"callsign\":\"" + _callsign + "\"}"));
+}
+
+} // namespace Fixtures
+} // namespace RdkServicesTest

--- a/RdkServicesTest/Source/Link.h
+++ b/RdkServicesTest/Source/Link.h
@@ -1,0 +1,73 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2020 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+#pragma once
+
+#include "Module.h"
+
+namespace RdkServicesTest {
+namespace Fixtures {
+
+typedef WPEFramework::JSONRPC::LinkType <WPEFramework::Core::JSON::IElement> JsonRpcLink;
+
+typedef WPEFramework::Core::ProxyType <JsonRpcLink> JsonRpcLinkProxy;
+
+class LinkMap {
+public:
+  LinkMap() = default;
+
+  LinkMap(const LinkMap &) = delete;
+
+  LinkMap &operator=(const LinkMap &) = delete;
+
+public:
+  auto get(const string &callsign) -> JsonRpcLinkProxy;
+
+private:
+  std::map <string, JsonRpcLinkProxy> links;
+};
+
+class Link {
+public:
+  Link(const string &callsign);
+
+  template<typename PARAMETERS, typename RESPONSE>
+  auto invoke(
+      const string &method,
+      const PARAMETERS &parameters,
+      RESPONSE &inbound,
+      const uint32_t waitTime = 1000) -> uint32_t {
+
+    return map.get(_callsign)->Invoke(
+        waitTime, method, JsonObject(parameters), inbound);
+  }
+
+  auto activate(const uint32_t waitTime = 1000) -> uint32_t;
+
+  auto operator->() -> JsonRpcLink* {
+    return map.get(_callsign).operator->();
+  }
+
+private:
+  string _callsign;
+  LinkMap map;
+};
+
+} // namespace Fixtures
+} // namespace RdkServicesTest

--- a/RdkServicesTest/Source/Token.cpp
+++ b/RdkServicesTest/Source/Token.cpp
@@ -1,0 +1,35 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2020 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+#include "Token.h"
+
+namespace RdkServicesTest {
+
+auto securityToken() -> string {
+  string token;
+
+  unsigned char buffer[1024] = {0};
+  if (GetSecurityToken(1024, buffer) > 0) {
+    token = (const char *) buffer;
+  }
+
+  return token;
+}
+
+} // namespace RdkServicesTest

--- a/RdkServicesTest/Source/Token.h
+++ b/RdkServicesTest/Source/Token.h
@@ -1,0 +1,28 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2020 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+#pragma once
+
+#include "Module.h"
+
+namespace RdkServicesTest {
+
+auto securityToken() -> string;
+
+} // namespace RdkServicesTest

--- a/RdkServicesTest/Source/Web.cpp
+++ b/RdkServicesTest/Source/Web.cpp
@@ -1,0 +1,104 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2020 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+#include "Web.h"
+
+#include "Token.h"
+
+namespace RdkServicesTest {
+namespace Fixtures {
+
+Web::Web(const string &callsign)
+    : WebLink(1 /*queueSize*/, false,
+              WPEFramework::Core::NodeId(), WPEFramework::Core::NodeId(), 256, 1024),
+      _callsign(callsign),
+      _event(false, true) {}
+
+Web::~Web() {
+  Close(WPEFramework::Core::infinite);
+}
+
+auto Web::submit(
+    WPEFramework::Web::Request::type type,
+    const string &url,
+    uint32_t connectTimeout,
+    uint32_t timeout) -> uint32_t {
+
+  uint32_t result;
+
+  static auto host = thunderAccess();
+
+  static auto token = securityToken();
+
+  auto request = RequestProxy::Create();
+
+  request->Host = host;
+  request->Verb = type;
+  request->Path = ("/Service/" + _callsign + "/" + url);
+
+  request->WebToken =
+      WPEFramework::Web::Authorization(WPEFramework::Web::Authorization::BEARER, token);
+
+  WPEFramework::Core::NodeId remote(
+      host.c_str(), WPEFramework::Core::NodeId::TYPE_IPV4);
+
+  _lock.Lock();
+
+  _event.ResetEvent();
+
+  Link().LocalNode(remote.AnyInterface());
+  Link().RemoteNode(remote);
+
+  result = Open(connectTimeout);
+
+  if (result == WPEFramework::Core::ERROR_NONE) {
+    Submit(request);
+
+    result = _event.Lock(timeout);
+
+    if (result == WPEFramework::Core::ERROR_NONE) {
+      if (_errorCode != WPEFramework::Web::STATUS_OK /*200*/) {
+        result = WPEFramework::Core::ERROR_BAD_REQUEST;
+      }
+    }
+  } else {
+    Close(WPEFramework::Core::infinite);
+  }
+
+  _lock.Unlock();
+
+  return result;
+}
+
+auto Web::Received(ResponseProxy &element) -> void {
+  _errorCode = element->ErrorCode;
+
+  _event.SetEvent();
+}
+
+auto Web::thunderAccess() -> string {
+  string result;
+
+  WPEFramework::Core::SystemInfo::GetEnvironment(_T("THUNDER_ACCESS"), result);
+
+  return result;
+}
+
+} // namespace Fixtures
+} // namespace RdkServicesTest

--- a/RdkServicesTest/Source/Web.h
+++ b/RdkServicesTest/Source/Web.h
@@ -1,0 +1,79 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2020 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+#pragma once
+
+#include "Module.h"
+
+namespace RdkServicesTest {
+namespace Fixtures {
+
+typedef WPEFramework::Web::WebLinkType<
+    WPEFramework::Core::SocketStream,
+    WPEFramework::Web::Response,
+    WPEFramework::Web::Request,
+    WPEFramework::Core::ProxyPoolType < WPEFramework::Web::Response>> WebLink;
+
+typedef WPEFramework::Core::ProxyType <
+    WPEFramework::Web::Request> RequestProxy;
+
+typedef WPEFramework::Core::ProxyType <
+    WPEFramework::Web::Response> ResponseProxy;
+
+class Web : public WebLink {
+public:
+  Web(const string &callsign);
+
+  ~Web();
+
+  template<typename... Args>
+  auto get(Args... args) -> uint32_t {
+    return submit(WPEFramework::Web::Request::HTTP_GET, args...);
+  }
+
+  template<typename... Args>
+  auto post(Args... args) -> uint32_t {
+    return submit(WPEFramework::Web::Request::HTTP_POST, args...);
+  }
+
+  auto submit(
+      WPEFramework::Web::Request::type type,
+      const string &url,
+      uint32_t connectTimeout = 1000,
+      uint32_t timeout = 1000) -> uint32_t;
+
+private:
+  // WebLinkType methods
+  virtual void LinkBody(ResponseProxy &element) override {}
+  virtual void Send(const RequestProxy &element) override {}
+  virtual void StateChange() override {}
+  virtual void Received(ResponseProxy &element) override;
+
+private:
+  static auto thunderAccess() -> string;
+
+private:
+  string _callsign;
+  WPEFramework::Core::Event _event;
+  uint16_t _errorCode;
+  WPEFramework::Core::CriticalSection _lock;
+};
+
+} // namespace Fixtures
+} // namespace RdkServicesTest

--- a/RdkServicesTest/Source/definitions.h
+++ b/RdkServicesTest/Source/definitions.h
@@ -1,0 +1,26 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2020 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+#pragma once
+
+#include "Token.h"
+#include "Link.h"
+#include "Web.h"
+
+#include "expect.h"

--- a/RdkServicesTest/Source/expect.h
+++ b/RdkServicesTest/Source/expect.h
@@ -1,0 +1,27 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2020 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+#pragma once
+
+#define EXPECT_ERROR_NONE(...) \
+    EXPECT_EQ(WPEFramework::Core::ERROR_NONE, __VA_ARGS__);
+
+#define EXPECT_SUCCESS(result, ...) \
+    EXPECT_EQ(WPEFramework::Core::ERROR_NONE, __VA_ARGS__); \
+    EXPECT_TRUE((result).Get("success").Boolean());

--- a/SecurityAgent/SecurityAgentTest.cpp
+++ b/SecurityAgent/SecurityAgentTest.cpp
@@ -1,0 +1,53 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2020 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+#include "gtest/gtest.h"
+
+#include "definitions.h"
+
+namespace RdkServicesTest {
+namespace Tests {
+
+class SecurityAgentTest : public ::testing::Test {
+protected:
+  SecurityAgentTest()
+      : link("SecurityAgent.1"),
+        web("SecurityAgent") {}
+
+  Fixtures::Link link;
+  Fixtures::Web web;
+  JsonObject result;
+};
+
+TEST_F(SecurityAgentTest, activate) {
+  EXPECT_ERROR_NONE(link.activate());
+}
+
+TEST_F(SecurityAgentTest, validate) {
+  EXPECT_ERROR_NONE(link.invoke("validate", "{\"token\":\"" + securityToken() + "\"}", result));
+
+  EXPECT_TRUE(result.Get("valid").Boolean());
+}
+
+TEST_F(SecurityAgentTest, validateWeb) {
+  EXPECT_ERROR_NONE(web.get("Valid"));
+}
+
+} // namespace Tests
+} // namespace RdkServicesTest


### PR DESCRIPTION
Reason for change: Build RdkServicesTest target
with sample tests and link gtest.
Test Procedure: Execute RdkServicesTest.
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>