### PR TITLE
LLAMA-4563: Enable Network availability Check.

### DIFF
--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -222,11 +222,9 @@ namespace WPEFramework {
 
             LOGINFO("Reboot_Pending :%s",g_is_reboot_pending.c_str());
 
-#if defined (SKY_BUILD)
-            bool internetConnectStatus = true;
-#else
-            bool internetConnectStatus = isDeviceOnline();
-#endif
+            bool internetConnectStatus = false;
+
+            internetConnectStatus = isDeviceOnline();
 
             MaintenanceManager::_instance->onMaintenanceStatusChange(MAINTENANCE_STARTED);
             /*  In an unsolicited maintenance we make sure only after


### PR DESCRIPTION
Reason for change: Enable network availability check for LLAMA
platform.
Test Procedure: Refer ticket
Risk: Medium