### PR TITLE
DELIA-53384: WPS_PIN should allow exactly 8 digits

### DIFF
--- a/WifiManager/impl/WifiManagerWPS.cpp
+++ b/WifiManager/impl/WifiManagerWPS.cpp
@@ -74,9 +74,9 @@ namespace WPEFramework
                 }
                 std::string wps_pin;
                 getStringParameter("wps_pin", wps_pin);
-		if(wps_pin == "")
+		if (wps_pin.length() != 8)
                 {
-                    LOGERR("parameter 'wps_pin' is empty");
+                    LOGERR("parameter 'wps_pin' should be 8 digits");
                     returnResponse(false);
                 }
                 snprintf(wps_parameters.pin, sizeof(wps_parameters.pin), "%s", wps_pin.c_str());


### PR DESCRIPTION
Reason for change: Error should be reported for wps_pin if it is other than 8 digits
Test Procedure: Build the image and test org.rdk.Wifi.2.initiateWPSPairing
Risks: Low
Signed-off-by: Nivetha J <Nivetha_JosephJohnBritto@comcast.com>