### PR TITLE
RDKTV-11801: Avoid unecessary Dummy ARC messages sent on coming out o…

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -63,7 +63,7 @@ using namespace std;
 #define HDMICECSINK_ARC_TERMINATION_EVENT "arcTerminationEvent"
 #define HDMICECSINK_SHORT_AUDIO_DESCRIPTOR_EVENT "shortAudiodesciptorEvent"
 #define HDMICECSINK_SYSTEM_AUDIO_MODE_EVENT "setSystemAudioModeEvent"
-#define HDMICECSINK_AUDIO_DEVICE_STATUS_EVENT "reportAudioDeviceStatus"
+#define HDMICECSINK_AUDIO_DEVICE_CONNECTED_STATUS_EVENT "reportAudioDeviceConnectedStatus"
 #define HDMICECSINK_CEC_ENABLED_EVENT "reportCecEnabledEvent"
 #define SERVER_DETAILS  "127.0.0.1:9998"
 #define WARMING_UP_TIME_IN_SECONDS 5
@@ -316,7 +316,7 @@ namespace WPEFramework {
 				LOG_DEVICE_EXCEPTION1(string("HDMI_ARC0"));
 			}
 			try {
-		    		m_hdmiCecAudioDeviceDetected = getHdmiCecSinkAudioDeviceStatus();
+		    		m_hdmiCecAudioDeviceDetected = getHdmiCecSinkAudioDeviceConnectedStatus();
 			}
 			catch (const device::Exception& err){
 				LOG_DEVICE_EXCEPTION1(string("HDMI_ARC0"));
@@ -326,7 +326,7 @@ namespace WPEFramework {
 
 			if(isPluginActivated) {
 			    if(!m_subscribed) {
-			        if((subscribeForHdmiCecSinkEvent(HDMICECSINK_ARC_INITIATION_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_ARC_TERMINATION_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_SHORT_AUDIO_DESCRIPTOR_EVENT)== Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_SYSTEM_AUDIO_MODE_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_AUDIO_DEVICE_STATUS_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_CEC_ENABLED_EVENT) == Core::ERROR_NONE)) {
+			        if((subscribeForHdmiCecSinkEvent(HDMICECSINK_ARC_INITIATION_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_ARC_TERMINATION_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_SHORT_AUDIO_DESCRIPTOR_EVENT)== Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_SYSTEM_AUDIO_MODE_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_AUDIO_DEVICE_CONNECTED_STATUS_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_CEC_ENABLED_EVENT) == Core::ERROR_NONE)) {
                                     m_subscribed = true;
                                     LOGINFO("%s: HdmiCecSink event subscription completed.\n",__FUNCTION__);
 			        }
@@ -3458,7 +3458,7 @@ namespace WPEFramework {
             return cecEnable;
         }
 
-	bool DisplaySettings::getHdmiCecSinkAudioDeviceStatus ()
+	bool DisplaySettings::getHdmiCecSinkAudioDeviceConnectedStatus ()
         {
             bool success = true;
             bool hdmiAudioDeviceDetected = false;
@@ -3472,7 +3472,7 @@ namespace WPEFramework {
                     JsonObject hdmiCecSinkResult;
                     JsonObject param;
 
-                    hdmiCecSinkPlugin->Invoke<JsonObject, JsonObject>(2000, "getAudioDeviceStatus", param, hdmiCecSinkResult);
+                    hdmiCecSinkPlugin->Invoke<JsonObject, JsonObject>(2000, "getAudioDeviceConnectedStatus", param, hdmiCecSinkResult);
 
                     hdmiAudioDeviceDetected = hdmiCecSinkResult["connected"].Boolean();
                     LOGINFO("getAudioDeviceConnectedStatus [%d]\n",hdmiAudioDeviceDetected);
@@ -3901,9 +3901,9 @@ namespace WPEFramework {
                 } else if(strcmp(eventName, HDMICECSINK_SYSTEM_AUDIO_MODE_EVENT) == 0) {
                     err =m_client->Subscribe<JsonObject>(1000, eventName
                             , &DisplaySettings::onSystemAudioModeEventHandler, this);
-                } else if(strcmp(eventName, HDMICECSINK_AUDIO_DEVICE_STATUS_EVENT) == 0) {
+                } else if(strcmp(eventName, HDMICECSINK_AUDIO_DEVICE_CONNECTED_STATUS_EVENT) == 0) {
                     err =m_client->Subscribe<JsonObject>(1000, eventName
-                            , &DisplaySettings::onAudioDeviceStatusEventHandler, this);
+                            , &DisplaySettings::onAudioDeviceConnectedStatusEventHandler, this);
                 } else if(strcmp(eventName, HDMICECSINK_CEC_ENABLED_EVENT) == 0) {
                     err =m_client->Subscribe<JsonObject>(1000, eventName
                             , &DisplaySettings::onCecEnabledEventHandler, this);
@@ -4140,7 +4140,7 @@ namespace WPEFramework {
         }
 
 	/* Event handler when Audio Device is Added/Removed     */
-	void DisplaySettings::onAudioDeviceStatusEventHandler(const JsonObject& parameters)
+	void DisplaySettings::onAudioDeviceConnectedStatusEventHandler(const JsonObject& parameters)
 	{
             int types = dsAUDIOARCSUPPORT_NONE;
 	    string value;
@@ -4232,7 +4232,7 @@ namespace WPEFramework {
             bool pluginActivated = Utils::isPluginActivated(HDMICECSINK_CALLSIGN);
             LOGWARN ("DisplaySettings::onTimer pluginActivated:%d line:%d", pluginActivated, __LINE__);
             if(!m_subscribed) {
-                if (pluginActivated && (subscribeForHdmiCecSinkEvent(HDMICECSINK_ARC_INITIATION_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_ARC_TERMINATION_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_SHORT_AUDIO_DESCRIPTOR_EVENT)== Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_SYSTEM_AUDIO_MODE_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_AUDIO_DEVICE_STATUS_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_CEC_ENABLED_EVENT) == Core::ERROR_NONE))
+                if (pluginActivated && (subscribeForHdmiCecSinkEvent(HDMICECSINK_ARC_INITIATION_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_ARC_TERMINATION_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_SHORT_AUDIO_DESCRIPTOR_EVENT)== Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_SYSTEM_AUDIO_MODE_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_AUDIO_DEVICE_CONNECTED_STATUS_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_CEC_ENABLED_EVENT) == Core::ERROR_NONE))
                 {
                     m_subscribed = true;
                     if (m_timer.isActive()) {

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -63,7 +63,7 @@ using namespace std;
 #define HDMICECSINK_ARC_TERMINATION_EVENT "arcTerminationEvent"
 #define HDMICECSINK_SHORT_AUDIO_DESCRIPTOR_EVENT "shortAudiodesciptorEvent"
 #define HDMICECSINK_SYSTEM_AUDIO_MODE_EVENT "setSystemAudioModeEvent"
-#define HDMICECSINK_AUDIO_DEVICE_ADDED_EVENT "reportAudioDeviceAdded"
+#define HDMICECSINK_AUDIO_DEVICE_STATUS_EVENT "reportAudioDeviceStatus"
 #define HDMICECSINK_CEC_ENABLED_EVENT "reportCecEnabledEvent"
 #define SERVER_DETAILS  "127.0.0.1:9998"
 #define WARMING_UP_TIME_IN_SECONDS 5
@@ -233,6 +233,7 @@ namespace WPEFramework {
 	    m_subscribed = false; //HdmiCecSink event subscription
 	    m_hdmiInAudioDeviceConnected = false;
         m_arcAudioEnabled = false;
+	    m_hdmiCecAudioDeviceDetected = false;
 	    m_currentArcRoutingState = ARC_STATE_ARC_TERMINATED;
 	    m_cecArcRoutingThreadRun = false;
 	    isCecArcRoutingThreadEnabled = true;
@@ -314,12 +315,18 @@ namespace WPEFramework {
 			catch (const device::Exception& err){
 				LOG_DEVICE_EXCEPTION1(string("HDMI_ARC0"));
 			}
+			try {
+		    		m_hdmiCecAudioDeviceDetected = getHdmiCecSinkAudioDeviceStatus();
+			}
+			catch (const device::Exception& err){
+				LOG_DEVICE_EXCEPTION1(string("HDMI_ARC0"));
+			}
 
 			bool isPluginActivated = Utils::isPluginActivated(HDMICECSINK_CALLSIGN);
 
 			if(isPluginActivated) {
 			    if(!m_subscribed) {
-			        if((subscribeForHdmiCecSinkEvent(HDMICECSINK_ARC_INITIATION_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_ARC_TERMINATION_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_SHORT_AUDIO_DESCRIPTOR_EVENT)== Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_SYSTEM_AUDIO_MODE_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_AUDIO_DEVICE_ADDED_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_CEC_ENABLED_EVENT) == Core::ERROR_NONE)) {
+			        if((subscribeForHdmiCecSinkEvent(HDMICECSINK_ARC_INITIATION_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_ARC_TERMINATION_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_SHORT_AUDIO_DESCRIPTOR_EVENT)== Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_SYSTEM_AUDIO_MODE_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_AUDIO_DEVICE_STATUS_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_CEC_ENABLED_EVENT) == Core::ERROR_NONE)) {
                                     m_subscribed = true;
                                     LOGINFO("%s: HdmiCecSink event subscription completed.\n",__FUNCTION__);
 			        }
@@ -339,6 +346,9 @@ namespace WPEFramework {
                                     LOGINFO("%s: Audio Port : [HDMI_ARC0] initialized successfully, enable: %d\n", __FUNCTION__, arcEnable);
                                 }
 
+				LOGINFO("m_hdmiCecAudioDeviceDetected status [%d] ... \n", m_hdmiCecAudioDeviceDetected);
+			     if (m_hdmiCecAudioDeviceDetected)
+			     {
                                 //Connected Audio Ports status update is necessary on bootup / power state transitions
 				sendHdmiCecSinkAudioDevicePowerOn();
 				LOGINFO("%s: Audio Port : [HDMI_ARC0] sendHdmiCecSinkAudioDevicePowerOn !!! \n", __FUNCTION__);
@@ -369,6 +379,7 @@ namespace WPEFramework {
                                 catch (const device::Exception& err){
                                     LOG_DEVICE_EXCEPTION1(string("HDMI_ARC0"));
                                 }
+			     } /*m_hdmiCecAudioDeviceDetected */
                             }
 			}
 			else {
@@ -3447,6 +3458,38 @@ namespace WPEFramework {
             return cecEnable;
         }
 
+	bool DisplaySettings::getHdmiCecSinkAudioDeviceStatus ()
+        {
+            bool success = true;
+            bool hdmiAudioDeviceDetected = false;
+
+            if (Utils::isPluginActivated(HDMICECSINK_CALLSIGN)) {
+                auto hdmiCecSinkPlugin = getHdmiCecSinkPlugin();
+                if (!hdmiCecSinkPlugin) {
+                    LOGERR("HdmiCecSink Initialisation failed\n");
+                }
+                else {
+                    JsonObject hdmiCecSinkResult;
+                    JsonObject param;
+
+                    hdmiCecSinkPlugin->Invoke<JsonObject, JsonObject>(2000, "getAudioDeviceStatus", param, hdmiCecSinkResult);
+
+                    hdmiAudioDeviceDetected = hdmiCecSinkResult["connected"].Boolean();
+                    LOGINFO("getAudioDeviceConnectedStatus [%d]\n",hdmiAudioDeviceDetected);
+
+                    if (!hdmiCecSinkResult["success"].Boolean()) {
+                        success = false;
+                        LOGERR("HdmiCecSink Plugin returned error\n");
+                    }
+                }
+            }
+            else {
+                success = false;
+                LOGERR("HdmiCecSink plugin not ready\n");
+            }
+            return hdmiAudioDeviceDetected;
+        }
+
         bool DisplaySettings::sendHdmiCecSinkAudioDevicePowerOn ()
         {
             bool success = true;
@@ -3858,9 +3901,9 @@ namespace WPEFramework {
                 } else if(strcmp(eventName, HDMICECSINK_SYSTEM_AUDIO_MODE_EVENT) == 0) {
                     err =m_client->Subscribe<JsonObject>(1000, eventName
                             , &DisplaySettings::onSystemAudioModeEventHandler, this);
-                } else if(strcmp(eventName, HDMICECSINK_AUDIO_DEVICE_ADDED_EVENT) == 0) {
+                } else if(strcmp(eventName, HDMICECSINK_AUDIO_DEVICE_STATUS_EVENT) == 0) {
                     err =m_client->Subscribe<JsonObject>(1000, eventName
-                            , &DisplaySettings::onAudioDeviceAddedEventHandler, this);
+                            , &DisplaySettings::onAudioDeviceStatusEventHandler, this);
                 } else if(strcmp(eventName, HDMICECSINK_CEC_ENABLED_EVENT) == 0) {
                     err =m_client->Subscribe<JsonObject>(1000, eventName
                             , &DisplaySettings::onCecEnabledEventHandler, this);
@@ -4096,44 +4139,60 @@ namespace WPEFramework {
             }
         }
 
-	/* Event handler when Audio Device is Added     */
-	void DisplaySettings::onAudioDeviceAddedEventHandler(const JsonObject& parameters)
+	/* Event handler when Audio Device is Added/Removed     */
+	void DisplaySettings::onAudioDeviceStatusEventHandler(const JsonObject& parameters)
 	{
             int types = dsAUDIOARCSUPPORT_NONE;
-	  try
-	  {
-	    device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort("HDMI_ARC0");
-	    aPort.getSupportedARCTypes(&types);
+	    string value;
 
-            LOGINFO("[ Audio Device Added Event], AudioSupport_type [%d], m_hdmiInAudioDeviceConnected [%d], m_currentArcRoutingState [%d], m_cecArcRoutingThreadRun [%d] \n", types, m_hdmiInAudioDeviceConnected, m_currentArcRoutingState, m_cecArcRoutingThreadRun);
-	    if(types & dsAUDIOARCSUPPORT_eARC) {
-		if(m_hdmiInAudioDeviceConnected == false)
+	    if (parameters.HasLabel("audioDeviceConnected"))
+		value = parameters["audioDeviceConnected"].String();
+	    
+	    if(!value.compare("true")) {
+	        m_hdmiCecAudioDeviceDetected = true;
+        } else{
+	        m_hdmiCecAudioDeviceDetected = false;
+        }
+	    LOGINFO("updated m_hdmiCecAudioDeviceDetected status [%d] ... \n", m_hdmiCecAudioDeviceDetected);
+
+		if (m_hdmiCecAudioDeviceDetected)
 		{
-			m_hdmiInAudioDeviceConnected = true;
-			LOGINFO("eARC_mode: Notify Audio Port \n");
-			connectedAudioPortUpdated(dsAUDIOPORT_TYPE_HDMI_ARC, true);
+		    try
+		    {
+		    	device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort("HDMI_ARC0");
+		    	aPort.getSupportedARCTypes(&types);
+	        
+		    		LOGINFO("[ Audio Device Added ], AudioSupport_type [%d], m_hdmiInAudioDeviceConnected [%d], m_currentArcRoutingState [%d], m_cecArcRoutingThreadRun [%d] \n", types, m_hdmiInAudioDeviceConnected, m_currentArcRoutingState, m_cecArcRoutingThreadRun);
+		    	if(types & dsAUDIOARCSUPPORT_eARC) {
+		    	if(m_hdmiInAudioDeviceConnected == false)
+		    	{
+		    		m_hdmiInAudioDeviceConnected = true;
+		    		LOGINFO("eARC_mode: Notify Audio Port \n");
+		    		connectedAudioPortUpdated(dsAUDIOPORT_TYPE_HDMI_ARC, true);
+		    	}
+		    	}else if(types & dsAUDIOARCSUPPORT_ARC) {
+		    			LOGINFO("ARC_mode: settings... \n");
+	        
+		    	std::lock_guard<std::mutex> lock(m_arcRoutingStateMutex);
+	        
+		    		if((m_currentArcRoutingState == ARC_STATE_ARC_TERMINATED) && (isCecEnabled == true)) {
+		    		LOGINFO("ARC_mode: Send dummy ARC initiation request... \n");
+		    		m_currentArcRoutingState = ARC_STATE_REQUEST_ARC_INITIATION;
+		    					m_cecArcRoutingThreadRun = true;
+		    		LOGINFO("ARC_mode: Notify Arc routing with m_currentArcRoutingStat [%d] \n", DisplaySettings::_instance->m_currentArcRoutingState );
+		    					arcRoutingCV.notify_one();
+		    	}
+		    	}else {
+		    					LOGINFO("Connected Device doesn't have ARC/eARC capability... \n");
+		    		}
+		    }
+		    catch (const device::Exception& err){
+		    LOG_DEVICE_EXCEPTION1(string("HDMI_ARC0"));
+		    }
+		}else{
+				LOGINFO("Audio Device is removed \n");
 		}
-	    }else if(types & dsAUDIOARCSUPPORT_ARC) {
-                LOGINFO("ARC_mode: settings... \n");
-
-		std::lock_guard<std::mutex> lock(m_arcRoutingStateMutex);
-
-	        if((m_currentArcRoutingState == ARC_STATE_ARC_TERMINATED) && (isCecEnabled == true)) {
-			LOGINFO("ARC_mode: Send dummy ARC initiation request... \n");
-			m_currentArcRoutingState = ARC_STATE_REQUEST_ARC_INITIATION;
-                        m_cecArcRoutingThreadRun = true;
-			LOGINFO("ARC_mode: Notify Arc routing with m_currentArcRoutingStat [%d] \n", DisplaySettings::_instance->m_currentArcRoutingState );
-                        arcRoutingCV.notify_one();
-		}
-	    }else {
-                         LOGINFO("Connected Device doesn't have ARC/eARC capability... \n");
-            }
-	}
-	catch (const device::Exception& err){
-		LOG_DEVICE_EXCEPTION1(string("HDMI_ARC0"));
-	}
-
-      }
+    }
 
 	/* DisplaaySettings gets notified whenever CEC is made Enable or Disable  */
 	void DisplaySettings::onCecEnabledEventHandler(const JsonObject& parameters)
@@ -4173,7 +4232,7 @@ namespace WPEFramework {
             bool pluginActivated = Utils::isPluginActivated(HDMICECSINK_CALLSIGN);
             LOGWARN ("DisplaySettings::onTimer pluginActivated:%d line:%d", pluginActivated, __LINE__);
             if(!m_subscribed) {
-                if (pluginActivated && (subscribeForHdmiCecSinkEvent(HDMICECSINK_ARC_INITIATION_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_ARC_TERMINATION_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_SHORT_AUDIO_DESCRIPTOR_EVENT)== Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_SYSTEM_AUDIO_MODE_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_AUDIO_DEVICE_ADDED_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_CEC_ENABLED_EVENT) == Core::ERROR_NONE))
+                if (pluginActivated && (subscribeForHdmiCecSinkEvent(HDMICECSINK_ARC_INITIATION_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_ARC_TERMINATION_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_SHORT_AUDIO_DESCRIPTOR_EVENT)== Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_SYSTEM_AUDIO_MODE_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_AUDIO_DEVICE_STATUS_EVENT) == Core::ERROR_NONE) && (subscribeForHdmiCecSinkEvent(HDMICECSINK_CEC_ENABLED_EVENT) == Core::ERROR_NONE))
                 {
                     m_subscribed = true;
                     if (m_timer.isActive()) {

--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -156,7 +156,7 @@ namespace WPEFramework {
             void onARCTerminationEventHandler(const JsonObject& parameters);
 	    void onShortAudioDescriptorEventHandler(const JsonObject& parameters);
 	    void onSystemAudioModeEventHandler(const JsonObject& parameters);
-	    void onAudioDeviceStatusEventHandler(const JsonObject& parameters);
+	    void onAudioDeviceConnectedStatusEventHandler(const JsonObject& parameters);
 	    void onCecEnabledEventHandler(const JsonObject& parameters);
             //End events
         public:
@@ -191,7 +191,7 @@ namespace WPEFramework {
 	    bool requestShortAudioDescriptor();
 	    bool sendHdmiCecSinkAudioDevicePowerOn();
 	    bool getHdmiCecSinkCecEnableStatus();
-	    bool getHdmiCecSinkAudioDeviceStatus();
+	    bool getHdmiCecSinkAudioDeviceConnectedStatus();
 	    static void  cecArcRoutingThread();
 	    void onTimer();
 

--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -156,7 +156,7 @@ namespace WPEFramework {
             void onARCTerminationEventHandler(const JsonObject& parameters);
 	    void onShortAudioDescriptorEventHandler(const JsonObject& parameters);
 	    void onSystemAudioModeEventHandler(const JsonObject& parameters);
-	    void onAudioDeviceAddedEventHandler(const JsonObject& parameters);
+	    void onAudioDeviceStatusEventHandler(const JsonObject& parameters);
 	    void onCecEnabledEventHandler(const JsonObject& parameters);
             //End events
         public:
@@ -191,6 +191,7 @@ namespace WPEFramework {
 	    bool requestShortAudioDescriptor();
 	    bool sendHdmiCecSinkAudioDevicePowerOn();
 	    bool getHdmiCecSinkCecEnableStatus();
+	    bool getHdmiCecSinkAudioDeviceStatus();
 	    static void  cecArcRoutingThread();
 	    void onTimer();
 
@@ -203,6 +204,7 @@ namespace WPEFramework {
 	    std::condition_variable arcRoutingCV;
 	    bool m_hdmiInAudioDeviceConnected;
         bool m_arcAudioEnabled;
+	    bool m_hdmiCecAudioDeviceDetected;
 	    JsonObject m_audioOutputPortConfig;
             JsonObject getAudioOutputPortConfig() { return m_audioOutputPortConfig; }
             static IARM_Bus_PWRMgr_PowerState_t m_powerState;

--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -60,7 +60,7 @@
 #define HDMICECSINK_METHOD_SEND_AUDIO_DEVICE_POWER_ON "sendAudioDevicePowerOnMessage"
 #define HDMICECSINK_METHOD_SEND_KEY_PRESS                          "sendKeyPressEvent"
 #define HDMICECSINK_METHOD_SEND_GIVE_AUDIO_STATUS          "sendGetAudioStatusMessage"
-#define HDMICECSINK_METHOD_GET_AUDIO_DEVICE_STATUS   "getAudioDeviceStatus"
+#define HDMICECSINK_METHOD_GET_AUDIO_DEVICE_CONNECTED_STATUS   "getAudioDeviceConnectedStatus"
 
 #define TEST_ADD 0
 #define HDMICECSINK_REQUEST_MAX_RETRY 				3
@@ -118,7 +118,7 @@ static char *eventString[] = {
         "standbyMessageReceived",
         "setSystemAudioModeEvent",
         "reportAudioStatusEvent",
-	"reportAudioDeviceStatus",
+	"reportAudioDeviceConnectedStatus",
 	"reportCecEnabledEvent"
 };
 	
@@ -525,7 +525,7 @@ namespace WPEFramework
 		   registerMethod(HDMICECSINK_METHOD_SEND_AUDIO_DEVICE_POWER_ON, &HdmiCecSink::sendAudioDevicePowerOnMsgWrapper, this);
 		   registerMethod(HDMICECSINK_METHOD_SEND_KEY_PRESS,&HdmiCecSink::sendRemoteKeyPressWrapper,this);
 		   registerMethod(HDMICECSINK_METHOD_SEND_GIVE_AUDIO_STATUS,&HdmiCecSink::sendGiveAudioStatusWrapper,this);
-		   registerMethod(HDMICECSINK_METHOD_GET_AUDIO_DEVICE_STATUS,&HdmiCecSink::getAudioDeviceStatusWrapper,this);
+		   registerMethod(HDMICECSINK_METHOD_GET_AUDIO_DEVICE_CONNECTED_STATUS,&HdmiCecSink::getAudioDeviceConnectedStatusWrapper,this);
            logicalAddressDeviceType = "None";
            logicalAddress = 0xFF;
            m_sendKeyEventThreadExit = false;
@@ -1030,7 +1030,7 @@ namespace WPEFramework
             returnResponse(true);
        }
 
-       uint32_t HdmiCecSink::getAudioDeviceStatusWrapper(const JsonObject& parameters, JsonObject& response)
+       uint32_t HdmiCecSink::getAudioDeviceConnectedStatusWrapper(const JsonObject& parameters, JsonObject& response)
        {
             response["connected"] = getAudioDeviceConnectedStatus();
             returnResponse(true);

--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -60,6 +60,7 @@
 #define HDMICECSINK_METHOD_SEND_AUDIO_DEVICE_POWER_ON "sendAudioDevicePowerOnMessage"
 #define HDMICECSINK_METHOD_SEND_KEY_PRESS                          "sendKeyPressEvent"
 #define HDMICECSINK_METHOD_SEND_GIVE_AUDIO_STATUS          "sendGetAudioStatusMessage"
+#define HDMICECSINK_METHOD_GET_AUDIO_DEVICE_STATUS   "getAudioDeviceStatus"
 
 #define TEST_ADD 0
 #define HDMICECSINK_REQUEST_MAX_RETRY 				3
@@ -97,7 +98,7 @@ enum {
         HDMICECSINK_EVENT_STANDBY_MSG_EVENT,
 	HDMICECSINK_EVENT_SYSTEM_AUDIO_MODE,
 	HDMICECSINK_EVENT_REPORT_AUDIO_STATUS,
-	HDMICECSINK_EVENT_AUDIO_DEVICE_ADDED,
+	HDMICECSINK_EVENT_AUDIO_DEVICE_CONNECTED_STATUS,
 	HDMICECSINK_EVENT_CEC_ENABLED,
 };
 
@@ -117,7 +118,7 @@ static char *eventString[] = {
         "standbyMessageReceived",
         "setSystemAudioModeEvent",
         "reportAudioStatusEvent",
-	"reportAudioDeviceAdded",
+	"reportAudioDeviceStatus",
 	"reportCecEnabledEvent"
 };
 	
@@ -496,6 +497,7 @@ namespace WPEFramework
 		   m_logicalAddressAllocated = LogicalAddress::UNREGISTERED;
 		   m_currentActiveSource = -1;
 		   m_isHdmiInConnected = false;
+		   hdmiCecAudioDeviceConnected = false;
 		   m_pollNextState = POLL_THREAD_STATE_NONE;
 		   m_pollThreadState = POLL_THREAD_STATE_NONE;
 		   dsHdmiInGetNumberOfInputsParam_t hdmiInput;
@@ -523,6 +525,7 @@ namespace WPEFramework
 		   registerMethod(HDMICECSINK_METHOD_SEND_AUDIO_DEVICE_POWER_ON, &HdmiCecSink::sendAudioDevicePowerOnMsgWrapper, this);
 		   registerMethod(HDMICECSINK_METHOD_SEND_KEY_PRESS,&HdmiCecSink::sendRemoteKeyPressWrapper,this);
 		   registerMethod(HDMICECSINK_METHOD_SEND_GIVE_AUDIO_STATUS,&HdmiCecSink::sendGiveAudioStatusWrapper,this);
+		   registerMethod(HDMICECSINK_METHOD_GET_AUDIO_DEVICE_STATUS,&HdmiCecSink::getAudioDeviceStatusWrapper,this);
            logicalAddressDeviceType = "None";
            logicalAddress = 0xFF;
            m_sendKeyEventThreadExit = false;
@@ -1024,6 +1027,12 @@ namespace WPEFramework
        uint32_t HdmiCecSink::getEnabledWrapper(const JsonObject& parameters, JsonObject& response)
        {
             response["enabled"] = getEnabled();
+            returnResponse(true);
+       }
+
+       uint32_t HdmiCecSink::getAudioDeviceStatusWrapper(const JsonObject& parameters, JsonObject& response)
+       {
+            response["connected"] = getAudioDeviceConnectedStatus();
             returnResponse(true);
        }
 
@@ -2065,7 +2074,9 @@ namespace WPEFramework
 				{
 					LOGINFO(" logicalAddress =%d , Audio device detected, Notify Device Settings", logicalAddress );
 					params["status"] = string("success");
-					sendNotify(eventString[HDMICECSINK_EVENT_AUDIO_DEVICE_ADDED], params)
+					params["audioDeviceConnected"] = string("true");
+					hdmiCecAudioDeviceConnected = true;
+					sendNotify(eventString[HDMICECSINK_EVENT_AUDIO_DEVICE_CONNECTED_STATUS], params)
 				}
 
 				sendNotify(eventString[HDMICECSINK_EVENT_DEVICE_ADDED], JsonObject())
@@ -2073,6 +2084,8 @@ namespace WPEFramework
 		}
 
 		void HdmiCecSink::removeDevice(const int logicalAddress) {
+			JsonObject params;
+
 			if(!HdmiCecSink::_instance)
 				return;
 			
@@ -2092,6 +2105,16 @@ namespace WPEFramework
                                                 hdmiInputs[i].update(LogicalAddress(LogicalAddress::UNREGISTERED));
 					}
 				}
+
+                                if(logicalAddress == 0x5)
+                                {
+                                        LOGINFO(" logicalAddress =%d , Audio device removed, Notify Device Settings", logicalAddress );
+                                        params["status"] = string("success");
+                                        params["audioDeviceConnected"] = string("false");
+					hdmiCecAudioDeviceConnected = false;
+                                        sendNotify(eventString[HDMICECSINK_EVENT_AUDIO_DEVICE_CONNECTED_STATUS], params)
+                                }
+
 				_instance->deviceList[logicalAddress].clear();
 				sendNotify(eventString[HDMICECSINK_EVENT_DEVICE_REMOVED], JsonObject());
 			}
@@ -2725,6 +2748,15 @@ namespace WPEFramework
             
             LOGINFO("getEnabled :%d ",cecEnableStatus);
             if(true == cecEnableStatus)
+                return true;
+            else
+                return false;
+        }
+
+        bool HdmiCecSink::getAudioDeviceConnectedStatus()
+        {
+            LOGINFO("getAudioDeviceConnectedStatus :%d ", hdmiCecAudioDeviceConnected);
+            if(true == hdmiCecAudioDeviceConnected)
                 return true;
             else
                 return false;

--- a/HdmiCecSink/HdmiCecSink.h
+++ b/HdmiCecSink/HdmiCecSink.h
@@ -567,11 +567,13 @@ private:
 			uint32_t sendAudioDevicePowerOnMsgWrapper(const JsonObject& parameters, JsonObject& response);
                         uint32_t sendRemoteKeyPressWrapper(const JsonObject& parameters, JsonObject& response);
 	                uint32_t sendGiveAudioStatusWrapper(const JsonObject& parameters, JsonObject& response);
+			uint32_t getAudioDeviceStatusWrapper(const JsonObject& parameters, JsonObject& response);
                         //End methods
             std::string logicalAddressDeviceType;
             bool cecSettingEnabled;
             bool cecOTPSettingEnabled;
             bool cecEnableStatus;
+	    bool hdmiCecAudioDeviceConnected;
 			bool m_isHdmiInConnected;
 			int  m_numofHdmiInput;
 			uint8_t m_deviceType;
@@ -629,6 +631,7 @@ private:
             void persistVendorId(unsigned int vendorID);
             void setEnabled(bool enabled);
             bool getEnabled();
+	    bool getAudioDeviceConnectedStatus();
             void CECEnable(void);
             void CECDisable(void);
             void getPhysicalAddress();

--- a/HdmiCecSink/HdmiCecSink.h
+++ b/HdmiCecSink/HdmiCecSink.h
@@ -567,7 +567,7 @@ private:
 			uint32_t sendAudioDevicePowerOnMsgWrapper(const JsonObject& parameters, JsonObject& response);
                         uint32_t sendRemoteKeyPressWrapper(const JsonObject& parameters, JsonObject& response);
 	                uint32_t sendGiveAudioStatusWrapper(const JsonObject& parameters, JsonObject& response);
-			uint32_t getAudioDeviceStatusWrapper(const JsonObject& parameters, JsonObject& response);
+			uint32_t getAudioDeviceConnectedStatusWrapper(const JsonObject& parameters, JsonObject& response);
                         //End methods
             std::string logicalAddressDeviceType;
             bool cecSettingEnabled;


### PR DESCRIPTION
…f Standby

Reason for change: Changes made for the scenario When Device coming out of Standby,
avoid cec messages like "system audio mode" and "request arc initiation"
based on Audio device connected status.
Test Procedure: Refer ticket.
Risks: Low
Signed-off-by: bp-ynagas047 <yeshwanth.nagaswamy@sky.uk>