### PR TITLE
DELIA-53546: Connect() call prints reductant logs

### DIFF
--- a/WifiManager/WifiManager.cpp
+++ b/WifiManager/WifiManager.cpp
@@ -178,8 +178,6 @@ namespace WPEFramework
 
         uint32_t WifiManager::connect(const JsonObject &parameters, JsonObject &response)
         {
-            LOGINFOMETHOD();
-
             uint32_t result = wifiConnect.connect(parameters, response);
 
             LOGTRACEMETHODFIN();

--- a/WifiManager/WifiManager.cpp
+++ b/WifiManager/WifiManager.cpp
@@ -178,18 +178,7 @@ namespace WPEFramework
 
         uint32_t WifiManager::connect(const JsonObject &parameters, JsonObject &response)
         {
-            JsonObject params = parameters;
-
-            if (params.HasLabel("passphrase"))
-            {
-                params["passphrase"] = "<passphrase>";
-
-                std::string json;
-                params.ToString(json);
-                LOGINFO( "params=%s", json.c_str() );
-            }
-            else
-                LOGINFOMETHOD();
+            LOGINFOMETHOD();
 
             uint32_t result = wifiConnect.connect(parameters, response);
 


### PR DESCRIPTION
Reason for change: removed the reductant parameter checking and logs
Test Procedure: validate with Connect Curl request
Risks: Medium