### PR TITLE
RDK-34677: Thunder implementation for getMfgSerialNumber

### DIFF
--- a/SystemServices/System.json
+++ b/SystemServices/System.json
@@ -484,6 +484,26 @@
                 ]
             }
         },
+        "getMfgSerialNumber": {
+            "summary": "Gets the Manufacturing Serial Number",
+            "result": {
+                "type": "object",
+                "properties": {
+                    "mfgSerialNumber": {
+                        "summary": "Manufacturing Serial Number",
+                        "type": "string",
+                        "example": "F00020CE000003"
+                    },
+                    "success":{
+                        "$ref": "#/definitions/success"
+                    }
+                },
+                "required": [
+                    "mfgSerialNumber",
+                    "success"
+                ]
+            }
+        },
         "getDownloadedFirmwareInfo":{
             "summary": "Returns information about firmware downloads",
             "result": {

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -315,6 +315,9 @@ namespace WPEFramework {
             registerMethod("sampleSystemServiceAPI", &SystemServices::sampleAPI, this);
 #endif /* DEBUG */
             registerMethod("getDeviceInfo", &SystemServices::getDeviceInfo, this);
+#ifdef ENABLE_DEVICE_MANUFACTURER_INFO
+            registerMethod("getMfgSerialNumber", &SystemServices::getMfgSerialNumber, this);
+#endif
             registerMethod("reboot", &SystemServices::requestSystemReboot, this);
             registerMethod("enableMoca", &SystemServices::requestEnableMoca, this);
             registerMethod("queryMocaStatus", &SystemServices::queryMocaStatus,
@@ -913,6 +916,33 @@ namespace WPEFramework {
         }
 
 #ifdef ENABLE_DEVICE_MANUFACTURER_INFO
+        /***
+         * @brief : To retrieve Manufacturing Serial Number.
+         * @param1[in] : {"params":{}}
+         * @param2[out] : {"result":{"mfgSerialNumber":"<string>","success":<bool>}}
+         */
+        uint32_t SystemServices::getMfgSerialNumber(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGWARN("SystemService getMfgSerialNumber query");
+
+            IARM_Bus_MFRLib_GetSerializedData_Param_t param;
+            param.bufLen = 0;
+            param.type = mfrSERIALIZED_TYPE_MANUFACTURING_SERIALNUMBER;
+            IARM_Result_t result = IARM_Bus_Call(IARM_BUS_MFRLIB_NAME, IARM_BUS_MFRLIB_API_GetSerializedData, &param, sizeof(param));
+            param.buffer[param.bufLen] = '\0';
+
+            bool status = false;
+            if (result == IARM_RESULT_SUCCESS) {
+                response["mfgSerialNumber"] = string(param.buffer);
+                status = true;
+                LOGWARN("SystemService getMfgSerialNumber Manufacturing Serial Number: %s", param.buffer);
+            } else {
+                LOGERR("SystemService getMfgSerialNumber Manufacturing Serial Number: NULL");
+            }
+
+            returnResponse(status);;
+        }
+
         bool SystemServices::getManufacturerData(const string& parameter, JsonObject& response)
         {
             LOGWARN("SystemService getDeviceInfo query %s", parameter.c_str());

--- a/SystemServices/SystemServices.h
+++ b/SystemServices/SystemServices.h
@@ -126,6 +126,7 @@ namespace WPEFramework {
                 static void stopModeTimer();
                 static void updateDuration();
 #ifdef ENABLE_DEVICE_MANUFACTURER_INFO
+                uint32_t getMfgSerialNumber(const JsonObject& parameters, JsonObject& response);
                 bool getManufacturerData(const string& parameter, JsonObject& response);
 #endif
             public:

--- a/SystemServices/doc/SystemPlugin.md
+++ b/SystemServices/doc/SystemPlugin.md
@@ -102,6 +102,7 @@ SystemServices interface methods:
 | [getCachedValue](#method.getCachedValue) | Gets the value of a key in the cache |
 | [getCoreTemperature](#method.getCoreTemperature) | Returns the core temperature of the device |
 | [getDeviceInfo](#method.getDeviceInfo) | Collects device details available from `/etc/device |
+| [getMfgSerialNumber](#method.getMfgSerialNumber) | Gets the Manufacturing Serial Number |
 | [getDownloadedFirmwareInfo](#method.getDownloadedFirmwareInfo) | Returns information about firmware downloads |
 | [getFirmwareDownloadPercent](#method.getFirmwareDownloadPercent) | Gets the current download percentage |
 | [getFirmwareUpdateInfo](#method.getFirmwareUpdateInfo) | Returns information about a firmware update and includes whether or not an update is mandatory |
@@ -564,6 +565,48 @@ Collects device details available from `/etc/device.properties`. Sample keys inc
     "id": 42,
     "result": {
         "estb_mac": "20:F1:9E:EE:62:08",
+        "success": true
+    }
+}
+```
+
+<a name="method.getMfgSerialNumber"></a>
+## *getMfgSerialNumber [<sup>method</sup>](#head.Methods)*
+
+Gets the Manufacturing Serial Number.
+
+### Parameters
+
+This method takes no parameters.
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.mfgSerialNumber | string | Manufacturing Serial Number |
+| result.success | boolean | Whether the request succeeded |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.System.1.getMfgSerialNumber"
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "mfgSerialNumber": "F00020CE000003",
         "success": true
     }
 }


### PR DESCRIPTION
Reason for change: added new API getMfgSerialNumber
Test Procedure: Verified get curl command
curl command: curl -H "Authorization: Bearer $TOKEN_tmp" -d '{"jsonrpc":"2.0","id":"3","method": "org.rdk.System.1.getMfgSerialNumber","params":{}}' http://127.0.0.1:9998/jsonrpc
expected result: {"jsonrpc":"2.0","id":3,"result":{"mfgSerialNumber":"F000209C000177B10","success":true}}
Risks: Low