### PR TITLE
RDKTV-13125: WPEFramework timeout during shutdown

### DIFF
--- a/MaintenanceManager/MaintenanceManager.h
+++ b/MaintenanceManager/MaintenanceManager.h
@@ -153,6 +153,7 @@ namespace WPEFramework {
                 bool checkNetwork();
                 bool getActivatedStatus(bool &skipFirmwareCheck);
                 const string checkActivatedStatus(void);
+                bool isMaintenanceStarted(void);
                 pid_t getTaskPID(const char*);
 
                 string getLastRebootReason();


### PR DESCRIPTION
Reason for change:Due to maintenance running the task seems to be
blocked.
Test Procedure:Refer Ticket.
Risks: Low

(cherry picked from commit b8154719a21bcd3f4a64766edd93eaf4b65d81f3)