### PR TITLE
RDKTV-8152:[AUTO][Release] WPEFramework crash with callstack RDKShell…

### DIFF
--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -1264,6 +1264,13 @@ namespace WPEFramework {
             sRunning = false;
             gRdkShellMutex.unlock();
             shellThread.join();
+	    std::vector<std::string> clientList;
+            CompositorController::getClients(clientList);
+            std::vector<std::string>::iterator ptr;
+            for(ptr=clientList.begin();ptr!=clientList.end();ptr++)
+            {
+               RdkShell::CompositorController::removeListener((*ptr),mEventListener);
+            }
             mCurrentService = nullptr;
             service->Unregister(mClientsMonitor);
             mClientsMonitor->Release();


### PR DESCRIPTION
…::notify

From: kchinn681 <kathiravan_chinnadurai@comcast.com>
Date: Tue Jan  4 16:17:50  2022
Subject: WPEFramework crash with callstack RDKShell::notify
Reason for change: fix for RDKshell nottify while rdkshell doing dtor
Test Procedure: launch any rdk shell app ,kill rdkshell and exit launched app
Risks: Low
Signed-off-by: kathiravan chinnadurai <kathiravan_chinnadurai@comcast.com>
Source: COMCAST
License: GPLV2
Upstream-Status: Pending