### PR TITLE
XIONE-7388: Enable LogUpload before deepsleep

### DIFF
--- a/realtek.cmake
+++ b/realtek.cmake
@@ -107,6 +107,11 @@ if (BUILD_XI1)
         message("Building for US variant")
     endif()
 
+    if (LOGUPLOAD_BEFORE_DEEPSLEEP)
+        message("Enabling LOGUPLOAD_BEFORE_DEEPSLEEP")
+        add_definitions (-DLOGUPLOAD_BEFORE_DEEPSLEEP)
+    endif()
+
     add_definitions (-DENABLE_DEEP_SLEEP)
     add_definitions (-DUSE_XI1_MORE_DEFINITIONS)
     add_definitions (-DUSE_UIMAF)


### PR DESCRIPTION
Reason for change: Enable Logupload before deep sleep.
for XIONE-UK platforms.
Test Procedure: Refer ticket.
Risk: Low.

(cherry picked from commit fa0b8aa1d6e2856ae4fb30473425d57f5bf0765f)