### PR TITLE
DELIA-53637: Check if interface and gateway IP are in the same network

### DIFF
--- a/Network/Network.cpp
+++ b/Network/Network.cpp
@@ -668,6 +668,7 @@ namespace WPEFramework
                 if (false == iarmData.isSupported)
                 {
                     LOGWARN("Manual IP Settings not Enabled..\n");
+                    response["supported"] = iarmData.isSupported;
                     result = false;
                     returnResponse(result)
                 }
@@ -676,6 +677,7 @@ namespace WPEFramework
                 if (false == mask_validation)
                 {
                     LOGWARN("Netmask is not valid ..\n");
+                    response["supported"] = iarmData.isSupported;
                     result = false;
                     returnResponse(result)
                 }
@@ -690,24 +692,28 @@ namespace WPEFramework
                     if (ip_address.s_addr == gateway_address.s_addr)
                     {
                         LOGWARN("Interface and Gateway IP are same , return false \n");
+                        response["supported"] = iarmData.isSupported;
                         result = false;
                         returnResponse(result)
                     }
                     if (broadcast_addr1.s_addr != broadcast_addr2.s_addr)
                     {
                         LOGWARN("Interface and Gateway IP is not in same broadcast domain, return false \n");
+                        response["supported"] = iarmData.isSupported;
                         result = false;
                         returnResponse(result)
                     }
                     if (ip_address.s_addr == broadcast_addr1.s_addr)
                     {
                         LOGWARN("Interface and Broadcast IP is same, return false \n");
+                        response["supported"] = iarmData.isSupported;
                         result = false;
                         returnResponse(result)
                     }
                     if (gateway_address.s_addr == broadcast_addr2.s_addr)
                     {
                         LOGWARN("Gateway and Broadcast IP is same, return false \n");
+                        response["supported"] = iarmData.isSupported;
                         result = false;
                         returnResponse(result)
                     }


### PR DESCRIPTION
Reason for change: Added condition to validate the correctness of
the IP(Interface-IP/Netmask/Gateway) & also to check if they are
in same network.
Test Procedure: Verify by giving correct/wrong IPs
Risks: Medium
Signed-off-by: Arun Vijay asathy881@cable.comcast.com