### PR TITLE
RDKTV-13966: Correction setCoreTempThresholds API

### DIFF
--- a/SystemServices/doc/SystemPlugin.md
+++ b/SystemServices/doc/SystemPlugin.md
@@ -2504,7 +2504,7 @@ Sets the temperature threshold values. Not supported on all devices.
     "id": 1234567890,
     "method": "org.rdk.System.1.setTemperatureThresholds",
     "params": {
-        "Thresholds": {
+        "thresholds": {
             "WARN": "100.000000",
             "MAX": "110.000000"
         }


### PR DESCRIPTION
Reason for change: setCoreTempThresholds API documentation correction

Test Procedure: Create a thunder command based on the documentation
and execute the command

Risks: Low

Signed-off-by: sputhi200 <Sujeesh_Puthiya@comcast.com>