### PR TITLE
DELIA-53637: Check if interface and gateway IP are in the same network

### DIFF
--- a/Network/Network.cpp
+++ b/Network/Network.cpp
@@ -19,10 +19,13 @@
 
 #include "Network.h"
 #include <net/if.h>
+#include <arpa/inet.h>
+#include "utils.h"
 
 using namespace std;
 
 #define DEFAULT_PING_PACKETS 15
+#define CIDR_NETMASK_IP_LEN 32
 
 /* Netsrvmgr Based Macros & Structures */
 #define IARM_BUS_NM_SRV_MGR_NAME "NET_SRV_MGR"
@@ -242,6 +245,56 @@ namespace WPEFramework
         {
              return(string());
         }
+
+        bool Network::isValidCIDRv4(string buf)
+        {
+            string CIDR_PREFIXES[CIDR_NETMASK_IP_LEN] = {
+                                                     "128.0.0.0",
+                                                     "192.0.0.0",
+                                                     "224.0.0.0",
+                                                     "240.0.0.0",
+                                                     "248.0.0.0",
+                                                     "252.0.0.0",
+                                                     "254.0.0.0",
+                                                     "255.0.0.0",
+                                                     "255.128.0.0",
+                                                     "255.192.0.0",
+                                                     "255.224.0.0",
+                                                     "255.240.0.0",
+                                                     "255.248.0.0",
+                                                     "255.252.0.0",
+                                                     "255.254.0.0",
+                                                     "255.255.0.0",
+                                                     "255.255.128.0",
+                                                     "255.255.192.0",
+                                                     "255.255.224.0",
+                                                     "255.255.240.0",
+                                                     "255.255.248.0",
+                                                     "255.255.252.0",
+                                                     "255.255.254.0",
+                                                     "255.255.255.0",
+                                                     "255.255.255.128",
+                                                     "255.255.255.192",
+                                                     "255.255.255.224",
+                                                     "255.255.255.240",
+                                                     "255.255.255.248",
+                                                     "255.255.255.252",
+                                                     "255.255.255.254",
+                                                     "255.255.255.255",
+                                                   };
+            int i = 0;
+            bool retval = false;
+            while(i < CIDR_NETMASK_IP_LEN)
+            {
+                if((buf.compare(CIDR_PREFIXES[i])) == 0)
+	        {
+                    retval = true;
+                    break;
+                }
+                i++;
+            }
+            return retval;
+	}
 
         // Wrapper methods
         uint32_t Network::getQuirks(const JsonObject& parameters, JsonObject& response)
@@ -534,6 +587,8 @@ namespace WPEFramework
         uint32_t Network::setIPSettings(const JsonObject& parameters, JsonObject& response)
         {
             bool result = false;
+            struct in_addr ip_address, gateway_address, mask;
+            struct in_addr broadcast_addr1, broadcast_addr2;
 
             if ((parameters.HasLabel("interface")) && (parameters.HasLabel("ipversion")) && (parameters.HasLabel("autoconfig")) &&
                 (parameters.HasLabel("ipaddr")) && (parameters.HasLabel("netmask")) && (parameters.HasLabel("gateway")) &&
@@ -566,8 +621,69 @@ namespace WPEFramework
                 strncpy(iarmData.gateway, gateway.c_str(), 16);
                 strncpy(iarmData.primarydns, primarydns.c_str(), 16);
                 strncpy(iarmData.secondarydns, secondarydns.c_str(), 16);
-                iarmData.isSupported = true;
+                iarmData.isSupported = false;
 
+                RFC_ParamData_t param;
+                if (Utils::getRFCConfig("Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.Network.ManualIPSettings.Enable", param))
+                {
+                    if (param.type == WDMP_BOOLEAN && (strncasecmp(param.value,"true",4) == 0))
+                    {
+                        iarmData.isSupported  = true;
+                    }
+                }
+                if (false == iarmData.isSupported)
+                {
+                    LOGWARN("Manual IP Settings not Enabled..\n");
+                    response["supported"] = iarmData.isSupported;
+                    result = false;
+                    returnResponse(result)
+                }
+                bool mask_validation;
+                mask_validation = isValidCIDRv4(netmask.c_str());
+                if (false == mask_validation)
+                {
+                    LOGWARN("Netmask is not valid ..\n");
+                    response["supported"] = iarmData.isSupported;
+                    result = false;
+                    returnResponse(result)
+                }
+
+                if (inet_pton(AF_INET, ipaddr.c_str(), &ip_address) == 1 &&
+                    inet_pton(AF_INET, netmask.c_str(), &mask) == 1 &&
+                    inet_pton(AF_INET, gateway.c_str(), &gateway_address) == 1)
+                {
+                    broadcast_addr1.s_addr = ip_address.s_addr | ~mask.s_addr;
+                    broadcast_addr2.s_addr = gateway_address.s_addr | ~mask.s_addr;
+
+                    if (ip_address.s_addr == gateway_address.s_addr)
+                    {
+                        LOGWARN("Interface and Gateway IP are same , return false \n");
+                        response["supported"] = iarmData.isSupported;
+                        result = false;
+                        returnResponse(result)
+                    }
+                    if (broadcast_addr1.s_addr != broadcast_addr2.s_addr)
+                    {
+                        LOGWARN("Interface and Gateway IP is not in same broadcast domain, return false \n");
+                        response["supported"] = iarmData.isSupported;
+                        result = false;
+                        returnResponse(result)
+                    }
+                    if (ip_address.s_addr == broadcast_addr1.s_addr)
+                    {
+                        LOGWARN("Interface and Broadcast IP is same, return false \n");
+                        response["supported"] = iarmData.isSupported;
+                        result = false;
+                        returnResponse(result)
+                    }
+                    if (gateway_address.s_addr == broadcast_addr2.s_addr)
+                    {
+                        LOGWARN("Gateway and Broadcast IP is same, return false \n");
+                        response["supported"] = iarmData.isSupported;
+                        result = false;
+                        returnResponse(result)
+                    }
+                }
                 if (IARM_RESULT_SUCCESS ==
                     IARM_Bus_Call(IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_NETSRVMGR_API_setIPSettings, (void *) &iarmData,
                                   sizeof(iarmData)))

--- a/Network/Network.h
+++ b/Network/Network.h
@@ -83,6 +83,8 @@ namespace WPEFramework {
             static void eventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
             void iarmEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
 
+	    // Netmask Validation
+            bool isValidCIDRv4(std::string interface);
             // Internal methods
             bool _getDefaultInterface(std::string& interface, std::string& gateway);
 


### PR DESCRIPTION
Reason for change: Added condition to validate the correctness of
the IP(Interface-IP/Netmask/Gateway) & also to check if they are
in same network.
Test Procedure: Verify by giving correct/wrong IPs
Risks: Medium
Signed-off-by: Arun Vijay asathy881@cable.comcast.com