### PR TITLE
Added missing method

### DIFF
--- a/DisplaySettings/DisplaySettings.json
+++ b/DisplaySettings/DisplaySettings.json
@@ -1954,6 +1954,47 @@
                 "$ref": "#/definitions/result"
             }
         },
+        "setMS12ProfileSettingsOverride":{
+            "summary": "Overrides individual MS12 audio settings in order to optimize the customer experience (for example, enabling dialog enhancement in sports mode)",
+            "params": {
+                "type":"object",
+                "properties": {
+                    "audioPort": {
+                        "$ref": "#/definitions/audioPort1"
+                    },
+                    "operation": {
+                        "summary": "The audio profile state",
+                        "type": "string",
+                        "example": ""
+                    },
+                    "profileName": {
+                        "summary": "An MS12 audio profile name from `getSupportedMS12AudioProfile`",
+                         "type": "string",
+                        "example": "Sports"
+                    },
+                    "ms12SettingsName": {
+                        "summary": "An ms12 setting name",
+                        "type": "string",
+                        "example": "Dialog Enhance"
+                    },
+                    "ms12SettingsValue": {
+                        "summary": "The value to set",
+                        "type": "string",
+                        "example": "On"
+                    }
+                },
+                "required": [
+                    "audioPort",
+                    "operation",
+                    "profileName",
+                    "ms12SettingsName",
+                    "ms12SettingsValue"
+                ]
+            },
+            "result": {
+                "$ref": "#/definitions/result"
+            }
+        },
         "setMuted":{
             "summary": "Mutes or unmutes audio on a specific port.\n \n### Event \n\n No Events.",
             "params": {

--- a/DisplaySettings/doc/DisplaySettingsPlugin.md
+++ b/DisplaySettings/doc/DisplaySettingsPlugin.md
@@ -150,6 +150,7 @@ DisplaySettings interface methods:
 | [setMISteering](#method.setMISteering) | Enables or Disables Media Intelligent Steering |
 | [setMS12AudioCompression](#method.setMS12AudioCompression) | Sets the audio dynamic range compression level (port HDMI0) |
 | [setMS12AudioProfile](#method.setMS12AudioProfile) | Sets the selected MS12 audio profile |
+| [setMS12ProfileSettingsOverride](#method.setMS12ProfileSettingsOverride) | Overrides individual MS12 audio settings in order to optimize the customer experience (for example, enabling dialog enhancement in sports mode) |
 | [setMuted](#method.setMuted) | Mutes or unmutes audio on a specific port |
 | [setScartParameter](#method.setScartParameter) | Sets SCART parameters |
 | [setSoundMode](#method.setSoundMode) | Sets the current sound mode for the corresponding video display |
@@ -3497,6 +3498,60 @@ Sets the selected MS12 audio profile.
     "params": {
         "audioPort": "SPEAKER0",
         "ms12AudioProfile": "Game"
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "success": true
+    }
+}
+```
+
+<a name="method.setMS12ProfileSettingsOverride"></a>
+## *setMS12ProfileSettingsOverride [<sup>method</sup>](#head.Methods)*
+
+Overrides individual MS12 audio settings in order to optimize the customer experience (for example, enabling dialog enhancement in sports mode).
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.audioPort | string | Audio port name (`HDMI0`, `SPEAKER0`, `SPDIF0`, and so on). The default port is `HDMI0` if no port is specified |
+| params.operation | string | The audio profile state |
+| params.profileName | string | An MS12 audio profile name from `getSupportedMS12AudioProfile` |
+| params.ms12SettingsName | string | An ms12 setting name |
+| params.ms12SettingsValue | string | The value to set |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.success | boolean | Whether the request succeeded |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.DisplaySettings.1.setMS12ProfileSettingsOverride",
+    "params": {
+        "audioPort": "SPEAKER0",
+        "operation": "...",
+        "profileName": "Sports",
+        "ms12SettingsName": "Dialog Enhance",
+        "ms12SettingsValue": "On"
     }
 }
 ```


### PR DESCRIPTION
The setMS12ProfileSettingsOverride method was introduced as part of RDK-32486 and must be part of the documentation in main. Cherry-picked this change from sprint/2201.