### PR TITLE
RDKTV-14004: Switching From Apple tv to firetv epg getting restarted

### DIFF
--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -1169,8 +1169,6 @@ namespace WPEFramework
 
 				LOGINFO("Addr = %s, length = %d", id.c_str(), id.length());
 
-				sendPowerOFFCommand(phy_addr);
-				sendPowerONCommand(phy_addr);
 				setStreamPath(phy_addr);
 				returnResponse(true);
             }


### PR DESCRIPTION
Reason for change: No need to explicitly bring source
out of standby in setActivePath CEC APi
Test Procedure: Refer Ticket
Risks: Low

Signed-off-by: Deekshit Devadas deekshit.devadasy@sky.uk