### PR TITLE
XIONE-7443 : WPEFramework Crashing Reboot

### DIFF
--- a/HdmiCec_2/HdmiCec_2.cpp
+++ b/HdmiCec_2/HdmiCec_2.cpp
@@ -476,6 +476,12 @@ namespace WPEFramework
        void HdmiCec_2::Deinitialize(PluginHost::IShell* /* service */)
        {
            LOGWARN("Deinitialize CEC_2");
+           if(true == getEnabled())
+           {
+               LOGINFO("%s %d. Calling setEnabled false during CEC_2 deinit", __func__, __LINE__);
+               setEnabled(false);
+               LOGINFO("%s %d. After setEnabled false during CEC_2 deinit", __func__, __LINE__);
+           }
            HdmiCec_2::_instance = nullptr;
            smConnection = NULL;
            DeinitializeIARM();


### PR DESCRIPTION
Reason for change:
WPEFramework Crashing Reboot. HdmiCec2 plugin crash.
Test Procedure: None
Risks: Low

Change-Id: I95b90b721bff5f1b4982cdf06c3197bba2f0c1b6
Signed-off-by: Anooj Cheriyan <Anooj_Cheriyan@comcast.com>