### PR TITLE
DELIA-53546: Connect() call prints redundant logs

### DIFF
--- a/Network/Network.cpp
+++ b/Network/Network.cpp
@@ -745,6 +745,15 @@ namespace WPEFramework
                 getStringParameter("interface", interface);
                 getStringParameter("ipversion", ipversion);
             }
+	    for(uint8_t ver = 1; ver <= m_currVersion; ver++)
+            {
+                auto handler = m_versionHandlers.find(ver);
+                if(handler != m_versionHandlers.end())
+                {
+                    LOGINFO("%s :: Enabled = %d  --> %d   %d",__FUNCTION__,handler,m_currVersion,ver);
+                }
+            }
+
             IARM_BUS_NetSrvMgr_Iface_Settings_t iarmData = { 0 };
             strncpy(iarmData.interface, interface.c_str(), 16);
             strncpy(iarmData.ipversion, ipversion.c_str(), 16);

--- a/Network/Network.h
+++ b/Network/Network.h
@@ -25,6 +25,7 @@
 #include "Module.h"
 #include "NetUtils.h"
 #include "utils.h"
+#include "AbstractPlugin.h"
 #include "upnpdiscoverymanager.h"
 
 

--- a/WifiManager/WifiManager.cpp
+++ b/WifiManager/WifiManager.cpp
@@ -178,19 +178,6 @@ namespace WPEFramework
 
         uint32_t WifiManager::connect(const JsonObject &parameters, JsonObject &response)
         {
-            JsonObject params = parameters;
-
-            if (params.HasLabel("passphrase"))
-            {
-                params["passphrase"] = "<passphrase>";
-
-                std::string json;
-                params.ToString(json);
-                LOGINFO( "params=%s", json.c_str() );
-            }
-            else
-                LOGINFOMETHOD();
-
             uint32_t result = wifiConnect.connect(parameters, response);
 
             LOGTRACEMETHODFIN();


### PR DESCRIPTION
Reason for change: removed the redutant parameter checking and logs
Test Procedure: validate with Connect Curl request
Risks: Medium

(cherry picked from commit 7f6b6b353c79ee02923c1313ddd1dfdec519c5ea)

Update WifiManager.cpp

(cherry picked from commit dad6a97f01876e148d0d1a94b67a3be00ffb60ee)