### PR TITLE
RDKTV-13091: Update CECEnable logic

### DIFF
--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -581,8 +581,20 @@ namespace WPEFramework
 			LOGINFO("Check the HDMI State \n");
 
 			CheckHdmiInState();
-			    
-            if (cecSettingEnabled)
+
+            int cecMgrIsAvailableParam;
+            err = IARM_Bus_Call(IARM_BUS_CECMGR_NAME,
+                            IARM_BUS_CECMGR_API_isAvailable,
+                            (void *)&cecMgrIsAvailableParam,
+                            sizeof(cecMgrIsAvailableParam));
+
+	    if(err == IARM_RESULT_SUCCESS) {
+                LOGINFO("RDK CECDaemon up and running. IARM Call: IARM_BUS_CECMGR_API_isAvailable successful... \n");
+            }
+	    else {
+                LOGINFO("RDK CECDaemon not up yet. IARM Call: IARM_BUS_CECMGR_API_isAvailable failed !!! \n");
+            }
+            if (cecSettingEnabled && (err == IARM_RESULT_SUCCESS))
             {
                try
                {
@@ -679,6 +691,7 @@ namespace WPEFramework
                 {
                     case IARM_BUS_CECMGR_EVENT_DAEMON_INITIALIZED:
                     {
+			LOGINFO("Received IARM_BUS_CECMGR_EVENT_DAEMON_INITIALIZED event \r\n");
                         HdmiCecSink::_instance->onCECDaemonInit();
                     }
                     break;
@@ -797,12 +810,14 @@ namespace WPEFramework
        {
             if(true == getEnabled())
             {
+		LOGINFO("CEC getEnabled() already TRUE. Disable and enable CEC again\n ");
                 setEnabled(false);
                 setEnabled(true);
             }
             else
             {
-                /*Do nothing as CEC is not already enabled*/
+		LOGINFO("CEC getEnabled() FALSE. Enable CEC\n ");
+                setEnabled(true);
             }
        }
 
@@ -2564,7 +2579,7 @@ namespace WPEFramework
                     catch(Exception &e)
                     {
                         LOGWARN("Poll caught %s \r\n",e.what());
-                        usleep(500000);
+                        usleep(250000);
                     }
                 }
                 if (gotLogicalAddress)


### PR DESCRIPTION
Reason for change: CECEnable must be done only if
RDK cec daemon is up & running.  If not then action
must be taken on CECDaemonInit event from RDK.
Test Procedure: Refer Ticket
Risks: None

Signed-off-by: Deekshit Devadas <deekshit.devadasy@sky.uk>