### PR TITLE
[WebKitBrowser] bridge object improvement

### DIFF
--- a/WebKitBrowser/CMakeLists.txt
+++ b/WebKitBrowser/CMakeLists.txt
@@ -223,11 +223,6 @@ if(PLUGIN_WEBKITBROWSER_UX)
     write_config( UX )
 endif()
 
-# Resident App configuration
-if(PLUGIN_WEBKITBROWSER_RESIDENT_APP)
-    write_config( ResidentApp )
-endif()
-
 # Search&Discovery configuration
 if(PLUGIN_WEBKITBROWSER_SEARCH_AND_DISCOVERY_APP)
     write_config( SearchAndDiscoveryApp )
@@ -241,4 +236,9 @@ endif()
 # Lightning App configuration
 if(PLUGIN_WEBKITBROWSER_LIGHTNING_APP)
     write_config( LightningApp )
+endif()
+
+# Resident App configuration
+if(PLUGIN_WEBKITBROWSER_RESIDENT_APP)
+    write_config( ResidentApp )
 endif()

--- a/WebKitBrowser/Extension/BridgeObject.cpp
+++ b/WebKitBrowser/Extension/BridgeObject.cpp
@@ -30,7 +30,7 @@ window.ServiceManager = {
   version: 2.1,
   getServiceForJavaScript: function(name,readyCb) {
     if (name === 'com.comcast.BridgeObject_1')
-      readyCb({ JSMessageChanged: (msg) => window.ServiceManager.BridgeQuery(btoa(msg)) })
+      readyCb(window.ServiceManager.createBridgeObject())
     else
       console.error('Requested service not supported')
   }
@@ -38,13 +38,17 @@ window.ServiceManager = {
 )jssrc";
 
 const char kBadgerReplySrc[] = R"jssrc(
-  var obj = JSON.parse(atob(payload))
+(function(payload) {
+  var obj = JSON.parse(payload)
   window.$badger.callback(obj.pid, obj.success, obj.json)
+})
 )jssrc";
 
 const char kBadgerEventSrc[] = R"jssrc(
-  var obj = JSON.parse(atob(payload))
+(function(payload) {
+  var obj = JSON.parse(payload)
   window.$badger.event(obj.handlerId, obj.json)
+})
 )jssrc";
 
 static void CallBridge(WebKitWebPage* page, const char* scriptSrc, WebKitUserMessage* message)
@@ -58,25 +62,52 @@ static void CallBridge(WebKitWebPage* page, const char* scriptSrc, WebKitUserMes
     }
     g_variant_get(payload, "&s", &payloadPtr);
 
+    gsize decodedLen = 0;
+    gchar *decoded = reinterpret_cast<gchar*>(g_base64_decode(payloadPtr, &decodedLen));
+    if (g_utf8_validate(decoded, decodedLen, nullptr) == FALSE) {
+        TRACE_GLOBAL(Trace::Error, (_T("Decoded message is not a valid UTF8 string!")));
+        gchar *tmp = decoded;
+        decoded = g_utf8_make_valid(tmp, decodedLen);
+        g_free(tmp);
+        decodedLen = strlen(decoded);
+    }
+
     WebKitFrame* frame = webkit_web_page_get_main_frame(page);
     JSCContext* jsContext = webkit_frame_get_js_context(frame);
 
-    JSCValue *payloadVal = jsc_value_new_string(jsContext, payloadPtr);
-    jsc_context_set_value(jsContext, "payload", payloadVal);
-    g_object_unref(payloadVal);
+    GBytes *payloadBytes = g_bytes_new_take(decoded, decodedLen);
+    JSCValue *payloadVal = jsc_value_new_string_from_bytes(jsContext, payloadBytes);
+    g_bytes_unref(payloadBytes);
 
     JSCValue* script = jsc_context_evaluate(jsContext, scriptSrc, -1);
-    g_object_unref(script);
+    JSCValue* ignore = jsc_value_function_call(script, JSC_TYPE_VALUE, payloadVal, G_TYPE_NONE);
 
+    g_object_unref(ignore);
+    g_object_unref(script);
+    g_object_unref(payloadVal);
     g_object_unref(jsContext);
 }
 
 static void OnBridgeQuery(const char* arg, gpointer userData)
 {
     WebKitWebPage* page = reinterpret_cast<WebKitWebPage*>(userData);
+    gchar *b64string = g_base64_encode(reinterpret_cast<const guchar*>(arg), strlen(arg));
     webkit_web_page_send_message_to_view(page,
             webkit_user_message_new(Tags::BridgeObjectQuery,
-                    g_variant_new("s", arg)), nullptr, nullptr, nullptr);
+                    g_variant_new_take_string(b64string)), nullptr, nullptr, nullptr);
+}
+
+static JSCValue* OnCreateBridgeObject(gpointer userData)
+{
+    JSCContext *jsContext = jsc_context_get_current();
+    JSCValue* jsObject = jsc_value_new_object(jsContext, nullptr, nullptr);
+    JSCValue* jsFunction = jsc_value_new_function(jsContext, nullptr,
+              reinterpret_cast<GCallback>(OnBridgeQuery), userData,
+              nullptr, G_TYPE_NONE, 1, G_TYPE_STRING);
+    jsc_value_object_set_property(jsObject, "JSMessageChanged", jsFunction);
+    g_object_unref(jsFunction);
+
+    return jsObject;
 }
 
 void InjectJS(WebKitScriptWorld* world, WebKitWebPage* page, WebKitFrame* frame)
@@ -91,9 +122,9 @@ void InjectJS(WebKitScriptWorld* world, WebKitWebPage* page, WebKitFrame* frame)
 
     JSCValue* jsObject = jsc_context_get_value(jsContext, "ServiceManager");
     JSCValue* jsFunction = jsc_value_new_function(jsContext, nullptr,
-            reinterpret_cast<GCallback>(OnBridgeQuery), (gpointer) page,
-            nullptr, G_TYPE_NONE, 1, G_TYPE_STRING);
-    jsc_value_object_set_property(jsObject, "BridgeQuery", jsFunction);
+            reinterpret_cast<GCallback>(OnCreateBridgeObject), (gpointer) page,
+            nullptr, JSC_TYPE_VALUE,  0, G_TYPE_NONE);
+    jsc_value_object_set_property(jsObject, "createBridgeObject", jsFunction);
     g_object_unref(jsFunction);
     g_object_unref(jsObject);
 

--- a/WebKitBrowser/InjectedBundle/BridgeObject.cpp
+++ b/WebKitBrowser/InjectedBundle/BridgeObject.cpp
@@ -21,10 +21,10 @@
 
 #include "Utils.h"
 
+#include <glib.h>
+
 // Global handle to this bundle.
 extern WKBundleRef g_Bundle;
-
-extern "C" WK_EXPORT JSStringRef WKStringCopyJSString(WKStringRef string);
 
 namespace WPEFramework {
 namespace JavaScript {
@@ -35,7 +35,7 @@ window.ServiceManager = {
   version: 2.1,
   getServiceForJavaScript: function(name,readyCb) {
     if (name === 'com.comcast.BridgeObject_1')
-      readyCb({ JSMessageChanged: (msg) => window.ServiceManager.BridgeQuery(btoa(msg)) })
+      readyCb(window.ServiceManager.createBridgeObject())
     else
       console.error('Requested service not supported')
   }
@@ -43,12 +43,12 @@ window.ServiceManager = {
 )jssrc";
 
 const char kBadgerReplySrc[] = R"jssrc(
-  var obj = JSON.parse(atob(payload))
+  var obj = JSON.parse(payload)
   window.$badger.callback(obj.pid, obj.success, obj.json)
 )jssrc";
 
 const char kBadgerEventSrc[] = R"jssrc(
-  var obj = JSON.parse(atob(payload))
+  var obj = JSON.parse(payload)
   window.$badger.event(obj.handlerId, obj.json)
 )jssrc";
 
@@ -60,6 +60,56 @@ static string JSStringToString(JSStringRef str)
   std::unique_ptr<char[]> buffer(new char[len]);
   len = JSStringGetUTF8CString(str, buffer.get(), len);
   return Core::ToString(buffer.get(), len);
+}
+
+static WKStringRef JSStringToB64WKString(JSStringRef str)
+{
+  if (str) {
+    size_t len = JSStringGetMaximumUTF8CStringSize(str);
+    std::unique_ptr<char[]> buffer(new char[len]);
+    len = JSStringGetUTF8CString(str, buffer.get(), len);
+    if (len > 0) {
+      gchar *b64string = g_base64_encode(reinterpret_cast<const guchar*>(buffer.get()), len - 1); // -1 to exclude encoding of trailing '\0'
+      auto *ret = WKStringCreateWithUTF8CString(b64string);
+      g_free(b64string);
+      return ret;
+    } else {
+      TRACE_GLOBAL(Trace::Error, (_T("Failed to convert JS to UTF8 'C' string!")));
+    }
+  }
+  return WKStringCreateWithUTF8CString(nullptr);
+}
+
+static JSStringRef B64WKStringToJSString(WKStringRef str)
+{
+  if (str) {
+    size_t len = WKStringGetMaximumUTF8CStringSize(str);
+    std::unique_ptr<char[]> buffer(new char[len]);
+    len = WKStringGetUTF8CString(str, buffer.get(), len);
+    if (len > 0) {
+      gsize decodedLen = 0;
+      gchar *decoded = reinterpret_cast<gchar*>(g_base64_decode(buffer.get(), &decodedLen));
+
+      if (g_utf8_validate(decoded, decodedLen, nullptr) == FALSE) {
+        TRACE_GLOBAL(Trace::Error, (_T("Decoded message is not a valid UTF8 string!")));
+        gchar *tmp = decoded;
+        decoded = g_utf8_make_valid(tmp, decodedLen);
+        g_free(tmp);
+      }
+      else if (decoded[decodedLen] != '\0') {
+        gchar *tmp = decoded;
+        decoded = g_strndup (tmp, decodedLen);
+        g_free(tmp);
+      }
+
+      auto *ret = JSStringCreateWithUTF8CString(decoded);
+      g_free(decoded);
+      return ret;
+    } else {
+      TRACE_GLOBAL(Trace::Error, (_T("Failed to convert WK to UTF8 'C' string!")));
+    }
+  }
+  return JSStringCreateWithUTF8CString(nullptr);
 }
 
 static void LogException(JSContextRef ctx, JSValueRef exception)
@@ -78,7 +128,7 @@ static JSValueRef OnBridgeQuery(
     if (argumentCount > 0 && JSValueIsString(context, arguments[0])) {
         WKStringRef messageName = WKStringCreateWithUTF8CString(Tags::BridgeObjectQuery);
         JSStringRef jsString = JSValueToStringCopy(context, arguments[0], nullptr);
-        WKStringRef messageBody = WKStringCreateWithJSString(jsString);
+        WKStringRef messageBody = JSStringToB64WKString(jsString);
         JSStringRelease(jsString);
 
         WKBundlePostSynchronousMessage(g_Bundle, messageName, messageBody, nullptr);
@@ -86,6 +136,20 @@ static JSValueRef OnBridgeQuery(
         WKRelease(messageName);
     }
     return JSValueMakeNull(context);
+}
+
+static JSValueRef OnCreateBridgeObject(
+    JSContextRef context, JSObjectRef,
+    JSObjectRef, size_t argumentCount,
+    const JSValueRef arguments[], JSValueRef* exception)
+{
+    JSObjectRef bridgeObject = JSObjectMake(context, nullptr, nullptr);
+    JSStringRef bridgeQueryStr = JSStringCreateWithUTF8CString("JSMessageChanged");
+    JSValueRef  bridgeQueryFun = JSObjectMakeFunctionWithCallback(context, bridgeQueryStr, OnBridgeQuery);
+    JSObjectSetProperty(context, bridgeObject, bridgeQueryStr, bridgeQueryFun,
+         kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete | kJSPropertyAttributeDontEnum, exception);
+    JSStringRelease(bridgeQueryStr);
+    return bridgeObject;
 }
 
 static void CallBridge(WKBundlePageRef page, const char* scriptSrc, WKTypeRef payload)
@@ -108,7 +172,7 @@ static void CallBridge(WKBundlePageRef page, const char* scriptSrc, WKTypeRef pa
         return;
     }
 
-    JSStringRef messageStr = WKStringCopyJSString(static_cast<WKStringRef>(payload));
+    JSStringRef messageStr = B64WKStringToJSString(static_cast<WKStringRef>(payload));
     JSValueRef argValue = JSValueMakeString(context, messageStr);
     JSObjectCallAsFunction(context, fun, nullptr, 1, &argValue, &exception);
     JSStringRelease(messageStr);
@@ -143,11 +207,11 @@ void InjectJS(WKBundleFrameRef frame)
         return;
     }
 
-    JSStringRef bridgeQueryStr = JSStringCreateWithUTF8CString("BridgeQuery");
-    JSValueRef  bridgeQueryFun = JSObjectMakeFunctionWithCallback(context, bridgeQueryStr, OnBridgeQuery);
-    JSObjectSetProperty(context, smObject, bridgeQueryStr, bridgeQueryFun,
+    JSStringRef createBridgeObjectStr = JSStringCreateWithUTF8CString("createBridgeObject");
+    JSValueRef  createBridgeObjectFun = JSObjectMakeFunctionWithCallback(context, createBridgeObjectStr, OnCreateBridgeObject);
+    JSObjectSetProperty(context, smObject, createBridgeObjectStr, createBridgeObjectFun,
         kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete | kJSPropertyAttributeDontEnum, &exception);
-    JSStringRelease(bridgeQueryStr);
+    JSStringRelease(createBridgeObjectStr);
     if (exception) {
         LogException(context, exception);
         return;


### PR DESCRIPTION
- remove usage of btoa/atob, instead use glib for base64 encoding/decoding
- don't expose BridgeQuery
- [glib extension]: avoid polution of global object
- [CMakeLists.txt] reorder config generation to avoid 'resumed' setup in other callsigns