### PR TITLE
XIONE-7443 : HDMI-CEC state does not persist

### DIFF
--- a/HdmiCec_2/HdmiCec_2.cpp
+++ b/HdmiCec_2/HdmiCec_2.cpp
@@ -476,6 +476,10 @@ namespace WPEFramework
        void HdmiCec_2::Deinitialize(PluginHost::IShell* /* service */)
        {
            LOGWARN("Deinitialize CEC_2");
+           if(true == getEnabled())
+           {
+               setEnabled(false);
+           }
            HdmiCec_2::_instance = nullptr;
            smConnection = NULL;
            DeinitializeIARM();


### PR DESCRIPTION
Reason for change:
Disbaling CEC before, CEC plugin deinitialization.
Since CEC threads are not required after this point.
Test Procedure: None
Risks: Low

Change-Id: I6949c0fe662b8b08a49519b50492ea135f52a7c9
Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>
(cherry picked from commit 2bb314344806ce6e8de3d4ac0b2f17d109e632c9)