### PR TITLE
RDKTV-14205: HDMI-CEC value does not persist after reboot

### DIFF
--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -808,17 +808,22 @@ namespace WPEFramework
 
        void HdmiCecSink::onCECDaemonInit()
        {
-            if(true == getEnabled())
-            {
-		LOGINFO("CEC getEnabled() already TRUE. Disable and enable CEC again\n ");
-                setEnabled(false);
-                setEnabled(true);
-            }
-            else
-            {
-		LOGINFO("CEC getEnabled() FALSE. Enable CEC\n ");
-                setEnabled(true);
-            }
+           if(cecSettingEnabled) {
+                if(true == getEnabled())
+                {
+		    LOGINFO("CEC getEnabled() already TRUE. Disable and enable CEC again\n ");
+                    setEnabled(false);
+                    setEnabled(true);
+                }
+                else
+                {
+		    LOGINFO("CEC getEnabled() FALSE. Enable CEC\n ");
+                    setEnabled(true);
+                }
+           }
+           else {
+               LOGINFO("cecSettingEnabled FALSE. Do Nothing....\n ");
+           }
        }
 
        void HdmiCecSink::cecStatusUpdated(void *evtStatus)


### PR DESCRIPTION
Reason for change: CEC setting getting reset from
onCECDaemonInit. Added cec setting check.
Test Procedure: Verify CEC UI settings are
persisted
Risks: None

Signed-off-by: Deekshit Devadas <deekshit.devadasy@sky.uk>