### PR TITLE
RDKTV-11982 : enableLogsFlushing and getLogsFlushingEnabled fails

### DIFF
--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -28,6 +28,7 @@
 #include <unistd.h>
 #include <rdkshell/compositorcontroller.h>
 #include <rdkshell/application.h>
+#include <rdkshell/logger.h>
 #include <interfaces/IMemory.h>
 #include <interfaces/IBrowser.h>
 #include <rdkshell/logger.h>
@@ -114,7 +115,8 @@ const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_GET_LAST_WAKEUP_KEY
 const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_HIDE_ALL_CLIENTS = "hideAllClients";
 const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_GET_SCREENSHOT = "getScreenshot";
 const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_ENABLE_EASTER_EGGS = "enableEasterEggs";
-
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_ENABLE_LOGS_FLUSHING = "enableLogsFlushing";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_GET_LOGS_FLUSHING_ENABLED = "getLogsFlushingEnabled";
 
 const string WPEFramework::Plugin::RDKShell::RDKSHELL_EVENT_ON_USER_INACTIVITY = "onUserInactivity";
 const string WPEFramework::Plugin::RDKShell::RDKSHELL_EVENT_ON_APP_LAUNCHED = "onApplicationLaunched";
@@ -780,7 +782,9 @@ namespace WPEFramework {
             registerMethod(RDKSHELL_METHOD_GET_SCREENSHOT, &RDKShell::getScreenshotWrapper, this);
             registerMethod(RDKSHELL_METHOD_ENABLE_EASTER_EGGS, &RDKShell::enableEasterEggsWrapper, this);
 
-            m_timer.connect(std::bind(&RDKShell::onTimer, this));
+            registerMethod(RDKSHELL_METHOD_ENABLE_LOGS_FLUSHING, &RDKShell::enableLogsFlushingWrapper, this);
+            registerMethod(RDKSHELL_METHOD_GET_LOGS_FLUSHING_ENABLED, &RDKShell::getLogsFlushingEnabledWrapper, this);
+	    m_timer.connect(std::bind(&RDKShell::onTimer, this));
         }
 
         RDKShell::~RDKShell()
@@ -4992,6 +4996,37 @@ namespace WPEFramework {
             gRdkShellMutex.unlock();
             returnResponse(result);
         }
+
+        uint32_t RDKShell::enableLogsFlushingWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool result = true;
+
+            if (!parameters.HasLabel("enable"))
+            {
+                response["message"] = "please specify enable parameter";
+                result = false;
+            }
+            else
+            {
+                bool enable = parameters["enable"].Boolean();
+                enableLogsFlushing(enable);
+                result = true;
+            }
+
+            returnResponse(result);
+        }
+
+        uint32_t RDKShell::getLogsFlushingEnabledWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+           LOGINFOMETHOD();
+
+            bool enabled = false;
+            getLogsFlushingEnabled(enabled);
+            response["enabled"] = enabled;
+
+            returnResponse(true);
+        }
         // Registered methods end
 
         // Events begin
@@ -6113,6 +6148,21 @@ namespace WPEFramework {
 
             return status;
         }
+        
+	void RDKShell::enableLogsFlushing(const bool enable)
+        {
+            gRdkShellMutex.lock();
+            Logger::enableFlushing(enable);
+            gRdkShellMutex.unlock();
+        }
+
+        void RDKShell::getLogsFlushingEnabled(bool &enabled)
+        {
+            gRdkShellMutex.lock();
+            enabled = Logger::isFlushingEnabled();
+            gRdkShellMutex.unlock();
+        }
+
         // Internal methods end
     } // namespace Plugin
 } // namespace WPEFramework

--- a/RDKShell/RDKShell.h
+++ b/RDKShell/RDKShell.h
@@ -123,6 +123,8 @@ namespace WPEFramework {
             static const string RDKSHELL_METHOD_HIDE_ALL_CLIENTS;
             static const string RDKSHELL_METHOD_GET_SCREENSHOT;
             static const string RDKSHELL_METHOD_ENABLE_EASTER_EGGS;
+            static const string RDKSHELL_METHOD_ENABLE_LOGS_FLUSHING;
+            static const string RDKSHELL_METHOD_GET_LOGS_FLUSHING_ENABLED;
 
             // events
             static const string RDKSHELL_EVENT_ON_USER_INACTIVITY;
@@ -223,6 +225,8 @@ namespace WPEFramework {
             uint32_t hideAllClientsWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t getScreenshotWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t enableEasterEggsWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t enableLogsFlushingWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t getLogsFlushingEnabledWrapper(const JsonObject& parameters, JsonObject& response);
 
         private/*internal methods*/:
             RDKShell(const RDKShell&) = delete;
@@ -288,6 +292,8 @@ namespace WPEFramework {
 
             void addFactoryModeEasterEggs();
             void removeFactoryModeEasterEggs();
+            void enableLogsFlushing(const bool enable);
+            void getLogsFlushingEnabled(bool &enabled);
 
             static std::shared_ptr<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement> > getThunderControllerClient(std::string callsign="", std::string localidentifier="");
             static std::shared_ptr<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement> > getPackagerPlugin();


### PR DESCRIPTION
Reason for change: defining enableLogsFlushing and getLogsFlushingEnabled.
Test Procedure: sanity test
Risks: None
Signed-off-by: Neeraj_Sahu@comcast.com