### PR TITLE
LLAMA-4597:Bring back the Network Check

### DIFF
--- a/MaintenanceManager/MaintenanceManager.h
+++ b/MaintenanceManager/MaintenanceManager.h
@@ -69,6 +69,7 @@ typedef enum{
 #define ALL_TASKS_SUCCESS              0xFF
 #define MAINTENANCE_TASK_SKIPPED       0x200
 
+#define MAX_NETWORK_RETRIES             4
 
 #define DCM_SUCCESS                     0
 #define DCM_COMPLETE                    1
@@ -139,6 +140,7 @@ namespace WPEFramework {
                 void maintenanceManagerOnBootup();
                 bool checkAutoRebootFlag();
                 bool checkAbortFlag();
+                bool checkNetwork();
                 pid_t getTaskPID(const char*);
 
                 string getLastRebootReason();


### PR DESCRIPTION
Reason for change:Periodic maintenance lasts 1'32''
when eth0 interface established, but router has not internet connection.
Add 4 retries with 30 sec sleep.
Ref:XIONE-5622.
Test Procedure:Refer Ticket.
Risk: Medium

(cherry picked from commit 50d4d7b31fbb86f3d5ba8704932b827453ea8b01)