### PR TITLE
RDKTV-14225: fix regression in PersistentStore

### DIFF
--- a/PersistentStore/PersistentStore.h
+++ b/PersistentStore/PersistentStore.h
@@ -23,6 +23,7 @@ namespace WPEFramework {
             // Build QueryInterface implementation, specifying all possible interfaces to be returned.
             BEGIN_INTERFACE_MAP(PersistentStore)
             INTERFACE_ENTRY(PluginHost::IPlugin)
+            INTERFACE_ENTRY(PluginHost::IDispatcher)
             END_INTERFACE_MAP
 
         public:


### PR DESCRIPTION
Reason for change: IDispatcher interface of
PluginHost::JSONRPC is missing in PersistentStore
interface map, the plugin can't be (de)activated.
Test Procedure: Test org.rdk.PersistentStore via curl.
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>