### PR TITLE
Onem 22659 firebolt deinitialization flow sprint 2201

### DIFF
--- a/FireboltMediaPlayer/FireboltMediaPlayer.cpp
+++ b/FireboltMediaPlayer/FireboltMediaPlayer.cpp
@@ -31,17 +31,6 @@ namespace WPEFramework {
          */
         FireboltMediaPlayer::MediaStreamProxy::~MediaStreamProxy()
         {
-            while(_implementation) {
-                auto result = _implementation->Release();
-
-                // If the release wasn't successful then we should stop calling it
-                if (result != Core::ERROR_NONE) {
-                    // Expecting to get destruction succeeded eventually but might encounter an error, e.g out-of-process has been killed
-                    if (result != Core::ERROR_DESTRUCTION_SUCCEEDED)
-                        LOGERR("_implementation->Release() unexpectedly returned %d", result);
-                    _implementation = nullptr;
-                }
-            }
         }
 
         /**
@@ -52,16 +41,13 @@ namespace WPEFramework {
          */
         uint32_t FireboltMediaPlayer::MediaStreamProxy::Release()
         {
-            auto result = _implementation->Release();
-
-            // If the release wasn't successful then this instance should be destroyed
-            if (result != Core::ERROR_NONE) {
-                // Expecting to get destruction succeeded eventually but might encounter an error, e.g out-of-process has been killed
-                if (result != Core::ERROR_DESTRUCTION_SUCCEEDED)
-                    LOGERR("_implementation->Release() unexpectedly returned %d", result);
-                _implementation = nullptr;
-                delete this;
-            }
+            auto result = _implementation->Unregister(&_mediaPlayerSink);
+            if (result != Core::ERROR_DESTRUCTION_SUCCEEDED)
+                LOGERR("Unregister failed: %d", result);
+            result = _implementation->Release();
+            if (result != Core::ERROR_DESTRUCTION_SUCCEEDED)
+                LOGERR("Release failed: %d", result);
+            _implementation = nullptr;
             return result;
         }
 
@@ -115,32 +101,20 @@ namespace WPEFramework {
             //release all Streams
             for(auto stream : _mediaStreams)
             {
+                stream.second->Release();
                 delete stream.second;
             }
             _mediaStreams.clear();
 
             service->Unregister(&_notification);
 
+            RPC::IRemoteConnection* connection(_service->RemoteConnection(_aampMediaPlayerConnectionId));
             auto const result = _aampMediaPlayer->Release();
-            if (result == Core::ERROR_NONE) {
-
-                ASSERT(_aampMediaPlayerConnectionId != 0);
-
-                LOGERR("OutOfProcess AAMP Player is not properly destructed. PID: %d", _aampMediaPlayerConnectionId);
-
-                RPC::IRemoteConnection* connection(_service->RemoteConnection(_aampMediaPlayerConnectionId));
-
-                // The connection can disappear in the meantime...
-                if (connection != nullptr) {
-
-                    // But if it did not dissapear in the meantime, forcefully terminate it. Shoot to kill :-)
+            ASSERT(result == Core::ERROR_DESTRUCTION_SUCCEEDED);
+            if (connection != nullptr) {
                     connection->Terminate();
                     connection->Release();
-                }
             }
-            else if (result != Core::ERROR_DESTRUCTION_SUCCEEDED) 
-                LOGERR("_aampMediaPlayer->Release() unexpectedly returned %d", result);
-
             _aampMediaPlayer = nullptr;
             _service = nullptr;
         }
@@ -218,7 +192,8 @@ namespace WPEFramework {
             }
             else
             {
-                _mediaStreams[id]->AddRef();
+                // we have already such stream created (no need to AddRef one more time)
+                returnResponse(true);
             }
 
             returnResponse(true);
@@ -236,6 +211,7 @@ namespace WPEFramework {
             {
                 if(_mediaStreams[id]->Release() == Core::ERROR_DESTRUCTION_SUCCEEDED)
                 {
+                    delete _mediaStreams[id];
                     _mediaStreams.erase(id);
                 }
                 returnResponse(true);

--- a/FireboltMediaPlayer/FireboltMediaPlayer.h
+++ b/FireboltMediaPlayer/FireboltMediaPlayer.h
@@ -131,10 +131,6 @@ namespace WPEFramework {
                     return (_implementation);
                 }
 
-                void AddRef()
-                {
-                    _implementation->AddRef();
-                }
                 uint32_t Release();
 
                 void OnEvent(const string &eventName, const string &parametersJson)

--- a/FireboltMediaPlayer/impl/AampMediaPlayer/AampMediaStream.cpp
+++ b/FireboltMediaPlayer/impl/AampMediaPlayer/AampMediaStream.cpp
@@ -488,7 +488,7 @@ namespace WPEFramework {
 
         AampMediaStream::AampMediaStream()
         : _adminLock()
-	, _notificationRelease() //Lock
+        , _notificationRelease() //Lock
         , _notification(nullptr)
         , _aampPlayer(nullptr)
         , _aampEventListener(nullptr)
@@ -523,12 +523,12 @@ namespace WPEFramework {
                 return;
             }
 
-	    _notificationRelease.Lock();
+             _notificationRelease.Lock();
             if (_notification != nullptr) {
                 _notification->Release();
                 _notification = nullptr;
             }
-	    _notificationRelease.Unlock();
+            _notificationRelease.Unlock();
             _adminLock.Unlock();
             _aampPlayer->Stop();
             Block();
@@ -664,14 +664,14 @@ namespace WPEFramework {
         {
             LOGINFO();
             _adminLock.Lock();
-	    
-	    _notificationRelease.Lock();
+
+            _notificationRelease.Lock();
             if (_notification != nullptr) {
                 _notification->Release();
             }
-	    _notificationRelease.Unlock();
-	    
-	    if (notification != nullptr) {
+            _notificationRelease.Unlock();
+
+            if (notification != nullptr) {
                 notification->AddRef();
             }
             _notification = notification;
@@ -686,11 +686,9 @@ namespace WPEFramework {
 
             if (_notification != nullptr
                     && _notification == notification) {
-	        _notificationRelease.Lock();
-	        _notification->Release();
-		_notificationRelease.Unlock();
-		
-		notification->Release();
+                _notificationRelease.Lock();
+                _notification->Release();
+                _notificationRelease.Unlock();
                 _notification = nullptr;
             }
             _adminLock.Unlock();
@@ -707,14 +705,14 @@ namespace WPEFramework {
                 _adminLock.Unlock();
                 return;
             }
-	    // deep copy
-	    string eventForNotification = eventName.c_str();
-	    string parametersForNotification = parameters.c_str();
-	    _adminLock.Unlock();
-	    
-	    _notificationRelease.Lock();
-	    _notification->Event(eventForNotification, parametersForNotification);
-	    _notificationRelease.Unlock();
+            // deep copy
+            string eventForNotification = eventName.c_str();
+            string parametersForNotification = parameters.c_str();
+            _adminLock.Unlock();
+
+            _notificationRelease.Lock();
+            _notification->Event(eventForNotification, parametersForNotification);
+            _notificationRelease.Unlock();
         }
 
         // Thread overrides

--- a/FireboltMediaPlayer/impl/AampMediaPlayer/AampMediaStream.cpp
+++ b/FireboltMediaPlayer/impl/AampMediaPlayer/AampMediaStream.cpp
@@ -488,6 +488,7 @@ namespace WPEFramework {
 
         AampMediaStream::AampMediaStream()
         : _adminLock()
+	, _notificationRelease() //Lock
         , _notification(nullptr)
         , _aampPlayer(nullptr)
         , _aampEventListener(nullptr)
@@ -522,11 +523,12 @@ namespace WPEFramework {
                 return;
             }
 
+	    _notificationRelease.Lock();
             if (_notification != nullptr) {
                 _notification->Release();
                 _notification = nullptr;
             }
-
+	    _notificationRelease.Unlock();
             _adminLock.Unlock();
             _aampPlayer->Stop();
             Block();
@@ -662,11 +664,14 @@ namespace WPEFramework {
         {
             LOGINFO();
             _adminLock.Lock();
-
+	    
+	    _notificationRelease.Lock();
             if (_notification != nullptr) {
                 _notification->Release();
             }
-            if (notification != nullptr) {
+	    _notificationRelease.Unlock();
+	    
+	    if (notification != nullptr) {
                 notification->AddRef();
             }
             _notification = notification;
@@ -681,8 +686,11 @@ namespace WPEFramework {
 
             if (_notification != nullptr
                     && _notification == notification) {
-                _notification->Release();
-                notification->Release();
+	        _notificationRelease.Lock();
+	        _notification->Release();
+		_notificationRelease.Unlock();
+		
+		notification->Release();
                 _notification = nullptr;
             }
             _adminLock.Unlock();
@@ -699,8 +707,14 @@ namespace WPEFramework {
                 _adminLock.Unlock();
                 return;
             }
-            _notification->Event(eventName, parameters);
-            _adminLock.Unlock();
+	    // deep copy
+	    string eventForNotification = eventName.c_str();
+	    string parametersForNotification = parameters.c_str();
+	    _adminLock.Unlock();
+	    
+	    _notificationRelease.Lock();
+	    _notification->Event(eventForNotification, parametersForNotification);
+	    _notificationRelease.Unlock();
         }
 
         // Thread overrides

--- a/FireboltMediaPlayer/impl/AampMediaPlayer/AampMediaStream.h
+++ b/FireboltMediaPlayer/impl/AampMediaPlayer/AampMediaStream.h
@@ -59,7 +59,7 @@ namespace WPEFramework {
             // Thread Interface
             uint32_t Worker() override;
 
-            mutable Core::CriticalSection _adminLock;
+            mutable Core::CriticalSection _adminLock, _notificationRelease;
             Exchange::IMediaPlayer::IMediaStream::INotification *_notification;
             PlayerInstanceAAMP *_aampPlayer;
             AampEventListener *_aampEventListener;


### PR DESCRIPTION
[ONEM-20942] notification locking separated from main lock

[ONEM-22659] Firebolt Media Player deinitialization flow and bugfixes
(1) New deinitialization flow - similar to the one that was proposed for OCDM
(2) Bugfixes - issues on plugin deinitialization/create stream/release stream
* FireboltMediaPlayer::MediaStreamProxy::Release() invokes Unregister and then relase
* explict Release for MediaStream in FireboltMediaPlayer::Deinitialize
* FireboltMediaPlayer::create do not AddRef if create is invoked second time for the equal stream id
* delete mediaStream object after Release in FireboltMediaPlayer::release
* double Release() removed in AampMediaStream::Unregister 

and ONEM-20942 previous cherry-pick reformating
