### PR TITLE
RDK-35079: AC4 Settings Configuration

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -209,6 +209,15 @@ namespace WPEFramework {
             registerMethod("resetSurroundVirtualizer", &DisplaySettings::resetSurroundVirtualizer, this);
             registerMethod("resetVolumeLeveller", &DisplaySettings::resetVolumeLeveller, this);
 
+            registerMethod("setAssociatedAudioMixing", &DisplaySettings::setAssociatedAudioMixing, this);
+            registerMethod("getAssociatedAudioMixing", &DisplaySettings::getAssociatedAudioMixing, this);
+            registerMethod("setFaderControl", &DisplaySettings::setFaderControl, this);
+            registerMethod("getFaderControl", &DisplaySettings::getFaderControl, this);
+            registerMethod("setPrimaryLanguage", &DisplaySettings::setPrimaryLanguage, this);
+            registerMethod("getPrimaryLanguage", &DisplaySettings::getPrimaryLanguage, this);
+            registerMethod("setSecondaryLanguage", &DisplaySettings::setSecondaryLanguage, this);
+            registerMethod("getSecondaryLanguage", &DisplaySettings::getSecondaryLanguage, this);
+
             registerMethod("getAudioDelay", &DisplaySettings::getAudioDelay, this);
             registerMethod("setAudioDelay", &DisplaySettings::setAudioDelay, this);
             registerMethod("getAudioDelayOffset", &DisplaySettings::getAudioDelayOffset, this);
@@ -486,6 +495,10 @@ namespace WPEFramework {
 		IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_VIDEO_FORMAT_UPDATE, formatUpdateEventHandler) );
                 IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_PWRMGR_NAME, IARM_BUS_PWRMGR_EVENT_MODECHANGED, powerEventHandler) );
                 IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_AUDIO_PORT_STATE, audioPortStateEventHandler) );
+                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_AUDIO_ASSOCIATED_AUDIO_MIXING_CHANGED, dsSettingsChangeEventHandler) );
+                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_AUDIO_FADER_CONTROL_CHANGED, dsSettingsChangeEventHandler) );
+                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_AUDIO_PRIMARY_LANGUAGE_CHANGED, dsSettingsChangeEventHandler) );
+                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_AUDIO_SECONDARY_LANGUAGE_CHANGED, dsSettingsChangeEventHandler) );
  
                 res = IARM_Bus_Call(IARM_BUS_PWRMGR_NAME, IARM_BUS_PWRMGR_API_GetPowerState, (void *)&param, sizeof(param));
                 if (res == IARM_RESULT_SUCCESS)
@@ -914,7 +927,62 @@ namespace WPEFramework {
                   break;
            }  
         }  
- 
+
+        void DisplaySettings::dsSettingsChangeEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
+        {
+
+            LOGINFO("%s \n", __FUNCTION__);
+            switch (eventId) {
+                case IARM_BUS_DSMGR_EVENT_AUDIO_ASSOCIATED_AUDIO_MIXING_CHANGED:
+                  {
+                    bool mixing = false;
+                    IARM_Bus_DSMgr_EventData_t *eventData = (IARM_Bus_DSMgr_EventData_t *)data;
+                    mixing = eventData->data.AssociatedAudioMixingInfo.mixing;
+                    LOGINFO("Received IARM_BUS_DSMGR_EVENT_AUDIO_ASSOCIATED_AUDIO_MIXING_CHANGED. Associated Audio Mixing: %d \n", mixing);
+                    if(DisplaySettings::_instance) {
+                        DisplaySettings::_instance->notifyAssociatedAudioMixingChange(mixing);
+                    }
+                  }
+                  break;
+                case IARM_BUS_DSMGR_EVENT_AUDIO_FADER_CONTROL_CHANGED:
+                  {
+                    int mixerbalance = 0;
+                    IARM_Bus_DSMgr_EventData_t *eventData = (IARM_Bus_DSMgr_EventData_t *)data;
+                    mixerbalance = eventData->data.FaderControlInfo.mixerbalance;
+                    LOGINFO("Received IARM_BUS_DSMGR_EVENT_AUDIO_FADER_CONTROL_CHANGED. Fader Control: %d \n", mixerbalance);
+                    if(DisplaySettings::_instance) {
+                        DisplaySettings::_instance->notifyFaderControlChange(mixerbalance);
+                    }
+                  }
+                  break;
+                case IARM_BUS_DSMGR_EVENT_AUDIO_PRIMARY_LANGUAGE_CHANGED:
+                  {
+                    std::string pLang = "DEF";
+                    IARM_Bus_DSMgr_EventData_t *eventData = (IARM_Bus_DSMgr_EventData_t *)data;
+                    pLang = eventData->data.PrimaryLanguageInfo.primaryLanguage;
+                    LOGINFO("Received IARM_BUS_DSMGR_EVENT_AUDIO_PRIMARY_LANGUAGE_CHANGED. Primary Language: %s \n", pLang);
+                    if(DisplaySettings::_instance) {
+                        DisplaySettings::_instance->notifyPrimaryLanguageChange(pLang);
+                    }
+                  }
+                  break;
+                case IARM_BUS_DSMGR_EVENT_AUDIO_SECONDARY_LANGUAGE_CHANGED:
+                  {
+                    std::string sLang = "DEF";
+                    IARM_Bus_DSMgr_EventData_t *eventData = (IARM_Bus_DSMgr_EventData_t *)data;
+                    sLang = eventData->data.SecondaryLanguageInfo.secondaryLanguage;
+                    LOGINFO("Received IARM_BUS_DSMGR_EVENT_AUDIO_SECONDARY_LANGUAGE_CHANGED. Secondary Language: %s \n", sLang);
+                    if(DisplaySettings::_instance) {
+                        DisplaySettings::_instance->notifySecondaryLanguageChange(sLang);
+                    }
+                  }
+                  break;
+                default:
+                    LOGERR("Invalid event ID\n");
+                    break;
+           }
+        }
+
         void setResponseArray(JsonObject& response, const char* key, const vector<string>& items)
         {
             JsonArray arr;
@@ -2098,6 +2166,34 @@ namespace WPEFramework {
             sendNotify("videoFormatChanged", params);
         }
 
+        void DisplaySettings::notifyAssociatedAudioMixingChange(bool mixing)
+        {
+             JsonObject params;
+             params["mixing"] = mixing;
+             sendNotify("associatedAudioMixingChanged", params);
+        }
+
+        void DisplaySettings::notifyFaderControlChange(bool mixerbalance)
+        {
+             JsonObject params;
+             params["mixerBalance"] = mixerbalance;
+             sendNotify("faderControlChanged", params);
+        }
+
+        void DisplaySettings::notifyPrimaryLanguageChange(std::string pLang)
+        {
+             JsonObject params;
+             params["primaryLanguage"] = pLang;
+             sendNotify("primaryLanguageChanged", params);
+        }
+
+        void DisplaySettings::notifySecondaryLanguageChange(std::string sLang)
+        {
+             JsonObject params;
+             params["secondaryLanguage"] = sLang;
+             sendNotify("secondaryLanguageChanged", params);
+        }
+
         uint32_t DisplaySettings::getBassEnhancer(const JsonObject& parameters, JsonObject& response)
         {
                 LOGINFOMETHOD();
@@ -3087,6 +3183,251 @@ namespace WPEFramework {
             }
             setResponseArray(response, "supportedMS12AudioProfiles", supportedProfiles);
             returnResponse(true);
+        }
+
+
+        uint32_t DisplaySettings::setAssociatedAudioMixing(const JsonObject& parameters, JsonObject& response)
+        {
+                LOGINFOMETHOD();
+                returnIfParamNotFound(parameters, "mixing");
+                string sMixing = parameters["mixing"].String();
+                bool mixing = false;
+                try {
+                        mixing = parameters["mixing"].Boolean();
+                }catch (const device::Exception& err) {
+                        LOG_DEVICE_EXCEPTION1(sMixing);
+                        returnResponse(false);
+                }
+                bool success = true;
+                string audioPort = parameters.HasLabel("audioPort") ? parameters["audioPort"].String() : "HDMI0";
+                try
+                {
+                    if (device::Host::getInstance().isHDMIOutPortPresent())
+                    {
+                        device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
+                        aPort.setAssociatedAudioMixing(mixing);
+                    }
+                    else {
+                        device::Host::getInstance().setAssociatedAudioMixing(mixing);
+                    }
+                }
+                catch (const device::Exception& err)
+                {
+                        LOG_DEVICE_EXCEPTION2(audioPort, sMixing);
+                        success = false;
+                }
+                returnResponse(success)
+        }
+
+
+
+        uint32_t DisplaySettings::getAssociatedAudioMixing(const JsonObject& parameters, JsonObject& response)
+        {
+                LOGINFOMETHOD();
+                bool success = true;
+                bool mixing = false;
+                string audioPort = parameters.HasLabel("audioPort") ? parameters["audioPort"].String() : "HDMI0";
+                try
+                {
+                    if (device::Host::getInstance().isHDMIOutPortPresent())
+                    {
+                        device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
+                        mixing = aPort.getAssociatedAudioMixing();
+                    }
+                    else {
+                        mixing = device::Host::getInstance().getAssociatedAudioMixing();
+                    }
+                    response["mixing"] = mixing;
+                }
+                catch (const device::Exception& err)
+                {
+                    LOG_DEVICE_EXCEPTION1(audioPort);
+                    success = false;
+                }
+                returnResponse(success);
+        }
+
+        uint32_t DisplaySettings::setFaderControl(const JsonObject& parameters, JsonObject& response)
+        {
+                LOGINFOMETHOD();
+                returnIfParamNotFound(parameters, "mixerBalance");
+                string sMixerBalance = parameters["mixerBalance"].String();
+                int mixerBalance = 0;
+                bool isIntiger = Utils::isValidInt ((char*)sMixerBalance.c_str(), true);
+                if (false == isIntiger) {
+                    LOGWARN("mixerBalance should be an integer");
+                    returnResponse(false);
+                }
+                try {
+                        mixerBalance = stoi(sMixerBalance);
+                }catch (const device::Exception& err) {
+                        LOG_DEVICE_EXCEPTION1(sMixerBalance);
+                        returnResponse(false);
+                }
+                bool success = true;
+                string audioPort = parameters.HasLabel("audioPort") ? parameters["audioPort"].String() : "HDMI0";
+                try
+                {
+                    if (device::Host::getInstance().isHDMIOutPortPresent())
+                    {
+                        device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
+                        aPort.setFaderControl(mixerBalance);
+                    }
+                    else {
+                        device::Host::getInstance().setFaderControl(mixerBalance);
+                    }
+                }
+                catch (const device::Exception& err)
+                {
+                        LOG_DEVICE_EXCEPTION2(audioPort, sMixerBalance);
+                        success = false;
+                }
+                returnResponse(success);
+        }
+
+
+        uint32_t DisplaySettings::getFaderControl(const JsonObject& parameters, JsonObject& response)
+        {
+                LOGINFOMETHOD();
+                bool success = true;
+                string audioPort = parameters.HasLabel("audioPort") ? parameters["audioPort"].String() : "HDMI0";
+                int mixerBalance = 0;
+                try
+                {
+                    if (device::Host::getInstance().isHDMIOutPortPresent())
+                    {
+                        device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
+                        mixerBalance = aPort.getFaderControl();
+                    }
+                    else {
+                        mixerBalance = device::Host::getInstance().getFaderControl();
+                    }
+                    response["mixerBalance"] = mixerBalance;
+                }
+                catch (const device::Exception& err)
+                {
+                        LOG_DEVICE_EXCEPTION1(audioPort);
+                        success = false;
+                }
+                returnResponse(success);
+        }
+
+        uint32_t DisplaySettings::setPrimaryLanguage (const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+
+            bool success = true;
+
+            returnIfParamNotFound(parameters, "lang");
+            string primaryLanguage = parameters["lang"].String();
+
+            string audioPort = parameters.HasLabel("audioPort") ? parameters["audioPort"].String() : "HDMI0";
+            try
+            {
+                if (device::Host::getInstance().isHDMIOutPortPresent())
+                {
+                    device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
+                    aPort.setPrimaryLanguage(primaryLanguage);
+		}
+                else {
+                    device::Host::getInstance().setPrimaryLanguage(primaryLanguage);
+                }
+            }
+            catch (const device::Exception& err)
+            {
+                LOG_DEVICE_EXCEPTION2(audioPort, primaryLanguage);
+                success = false;
+            }
+
+            returnResponse(success);
+        }
+
+
+        uint32_t DisplaySettings::getPrimaryLanguage (const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool success = true;
+
+            string primaryLanguage;
+            string audioPort = parameters.HasLabel("audioPort") ? parameters["audioPort"].String() : "HDMI0";
+            try
+            {
+                if (device::Host::getInstance().isHDMIOutPortPresent())
+                {
+                    device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
+                    primaryLanguage = aPort.getPrimaryLanguage();
+                }
+                else {
+                    primaryLanguage = device::Host::getInstance().getPrimaryLanguage();
+                }
+                response["lang"] = primaryLanguage;
+            }
+            catch(const device::Exception& err)
+            {
+                LOG_DEVICE_EXCEPTION1(audioPort);
+                response["lang"] = "None";
+                success = false;
+            }
+            returnResponse(success);
+        }
+
+        uint32_t DisplaySettings::setSecondaryLanguage (const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+
+            bool success = true;
+
+            returnIfParamNotFound(parameters, "lang");
+            string secondaryLanguage = parameters["lang"].String();
+
+            string audioPort = parameters.HasLabel("audioPort") ? parameters["audioPort"].String() : "HDMI0";
+            try
+            {
+                if (device::Host::getInstance().isHDMIOutPortPresent())
+                {
+                    device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
+                    aPort.setSecondaryLanguage(secondaryLanguage);
+                }
+                else {
+                    device::Host::getInstance().setSecondaryLanguage(secondaryLanguage);
+                }
+            }
+            catch (const device::Exception& err)
+            {
+                LOG_DEVICE_EXCEPTION2(audioPort, secondaryLanguage);
+                success = false;
+            }
+
+            returnResponse(success);
+        }
+
+
+        uint32_t DisplaySettings::getSecondaryLanguage (const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool success = true;
+
+            string secondaryLanguage;
+            string audioPort = parameters.HasLabel("audioPort") ? parameters["audioPort"].String() : "HDMI0";
+            try
+            {
+                if (device::Host::getInstance().isHDMIOutPortPresent())
+                {
+                    device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
+                    secondaryLanguage = aPort.getSecondaryLanguage();
+                }
+                else {
+                    secondaryLanguage = device::Host::getInstance().getSecondaryLanguage();
+                }
+                response["lang"] = secondaryLanguage;
+            }
+            catch(const device::Exception& err)
+            {
+                LOG_DEVICE_EXCEPTION1(audioPort);
+                response["lang"] = "None";
+                success = false;
+            }
+            returnResponse(success);
         }
 
 

--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -128,6 +128,15 @@ namespace WPEFramework {
             uint32_t getSettopAudioCapabilities(const JsonObject& parameters, JsonObject& response);
             uint32_t getEnableAudioPort(const JsonObject& parameters, JsonObject& response);
 
+	    uint32_t setAssociatedAudioMixing(const JsonObject& parameters, JsonObject& response);
+            uint32_t getAssociatedAudioMixing(const JsonObject& parameters, JsonObject& response);
+            uint32_t setFaderControl(const JsonObject& parameters, JsonObject& response);
+            uint32_t getFaderControl(const JsonObject& parameters, JsonObject& response);
+            uint32_t setPrimaryLanguage(const JsonObject& parameters, JsonObject& response);
+            uint32_t getPrimaryLanguage(const JsonObject& parameters, JsonObject& response);
+            uint32_t setSecondaryLanguage(const JsonObject& parameters, JsonObject& response);
+            uint32_t getSecondaryLanguage(const JsonObject& parameters, JsonObject& response);
+
 	    uint32_t getAudioFormat(const JsonObject& parameters, JsonObject& response);
 	    uint32_t getVolumeLeveller2(const JsonObject& parameters, JsonObject& response);
 	    uint32_t setVolumeLeveller2(const JsonObject& parameters, JsonObject& response);
@@ -152,6 +161,10 @@ namespace WPEFramework {
             void connectedVideoDisplaysUpdated(int hdmiHotPlugEvent);
             void connectedAudioPortUpdated (int iAudioPortType, bool isPortConnected);
 	    void notifyAudioFormatChange(dsAudioFormat_t audioFormat);
+            void notifyAssociatedAudioMixingChange(bool mixing);
+            void notifyFaderControlChange(bool mixerbalance);
+            void notifyPrimaryLanguageChange(std::string pLang);
+            void notifySecondaryLanguageChange(std::string sLang);
 	    void notifyVideoFormatChange(dsHDRStandard_t videoFormat);
 	    void onARCInitiationEventHandler(const JsonObject& parameters);
             void onARCTerminationEventHandler(const JsonObject& parameters);
@@ -176,6 +189,7 @@ namespace WPEFramework {
 	    static void formatUpdateEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
             static void powerEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
             static void audioPortStateEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
+            static void dsSettingsChangeEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
             void getConnectedVideoDisplaysHelper(std::vector<string>& connectedDisplays);
 	    void audioFormatToString(dsAudioFormat_t audioFormat, JsonObject &response);
             const char *getVideoFormatTypeToString(dsHDRStandard_t format);

--- a/helpers/utils.cpp
+++ b/helpers/utils.cpp
@@ -357,10 +357,15 @@ Utils::ThreadRAII::~ThreadRAII()
     }
 }
 
-bool Utils::isValidInt(char* x)
+bool Utils::isValidInt(char* x, bool negativeIntAllowed /*= false*/)
 {
     bool Checked = true;
     int i = 0;
+
+    if(negativeIntAllowed && (x[0] == '-')) {
+        i = 1;
+    }
+
     do
     {
         //valid digit?

--- a/helpers/utils.h
+++ b/helpers/utils.h
@@ -371,7 +371,7 @@ namespace Utils
     bool isPluginActivated(const char* callSign);
 
     bool getRFCConfig(char* paramName, RFC_ParamData_t& paramOutput);
-    bool isValidInt(char* x);
+    bool isValidInt(char* x, bool negativeIntAllowed = false);
     void syncPersistFile (const string file);
     void persistJsonSettings(const string file, const string strKey, const JsonValue& jsValue);
 


### PR DESCRIPTION
Reason for change: Added Displaysettings thunder APIs & events
for associated audio mixing, fader control, primary
and secondary language selection
Added negative int check support in rdkservices helper
utils
Test Procedure: Validate using thunder APIs
Risks: None

Signed-off-by: Deekshit Devadas deekshit.devadasy@sky.uk