### PR TITLE
DELIA-53637: Check if interface and gateway IP are in the same network

### DIFF
--- a/Network/Network.h
+++ b/Network/Network.h
@@ -83,6 +83,8 @@ namespace WPEFramework {
             static void eventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
             void iarmEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
 
+	    // Netmask Validation
+            bool isValidCIDRv4(std::string interface);
             // Internal methods
             bool _getDefaultInterface(std::string& interface, std::string& gateway);
 


### PR DESCRIPTION
Reason for change: Added condition to validate the correctness of
the IP(Interface-IP/Netmask/Gateway) & also to check if they are
in same network.
Test Procedure: Verify by giving correct/wrong IPs
Risks: Medium
Signed-off-by: Arun Vijay asathy881@cable.comcast.com
(cherry picked from commit 7166dd0b04a6cf8519bb68016e384276d7861951)

DELIA-53637: Switching between AutoConfig and Manual IP

The IP details should not be cared when switching to AutoConfig from Manual IP mode.

(cherry picked from commit 45da3751492469003d2653519b4bd325775053d9)