### PR TITLE
DELIA-53757: SIGABRT in getvideodevices

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -1048,6 +1048,12 @@ namespace WPEFramework {
             vector<string> supportedSettopResolutions;
             try
             {
+                if (device::Host::getInstance().getVideoDevices().size() < 1)
+                {
+                    LOGINFO("DSMGR_NOT_RUNNING");
+                    returnResponse(false);
+                }
+
                 device::VideoDevice &device = device::Host::getInstance().getVideoDevices().at(0);
                 list<string> resolutions;
                 device.getSettopSupportedResolutions(resolutions);
@@ -1166,8 +1172,16 @@ namespace WPEFramework {
         {   //sample servicemanager response:
             LOGINFOMETHOD();
             string zoomSetting = "unknown";
+
+            bool success = true;
             try
             {
+                if (device::Host::getInstance().getVideoDevices().size() < 1)
+                {
+                    LOGINFO("DSMGR_NOT_RUNNING");
+                    returnResponse(false);
+                }
+
                 // TODO: why is this always the first one in the list
                 device::VideoDevice &decoder = device::Host::getInstance().getVideoDevices().at(0);
                 zoomSetting = decoder.getDFC().getName();
@@ -1175,12 +1189,13 @@ namespace WPEFramework {
             catch(const device::Exception& err)
             {
                 LOG_DEVICE_EXCEPTION0();
+                success = false;
             }
 #ifdef USE_IARM
             zoomSetting = iarm2svc(zoomSetting);
 #endif
             response["zoomSetting"] = zoomSetting;
-            returnResponse(true);
+            returnResponse(success);
         }
 
         uint32_t DisplaySettings::setZoomSetting(const JsonObject& parameters, JsonObject& response)
@@ -1196,6 +1211,12 @@ namespace WPEFramework {
 #ifdef USE_IARM
                 zoomSetting = svc2iarm(zoomSetting);
 #endif
+                if (device::Host::getInstance().getVideoDevices().size() < 1)
+                {
+                    LOGINFO("DSMGR_NOT_RUNNING");
+                    returnResponse(false);
+                }
+
                 // TODO: why is this always the first one in the list?
                 device::VideoDevice &decoder = device::Host::getInstance().getVideoDevices().at(0);
                 decoder.setDFC(zoomSetting);
@@ -1734,6 +1755,12 @@ namespace WPEFramework {
 
             try
             {
+                if (device::Host::getInstance().getVideoDevices().size() < 1)
+                {
+                    LOGINFO("DSMGR_NOT_RUNNING");
+                    returnResponse(false);
+                }
+
                 device::VideoDevice &device = device::Host::getInstance().getVideoDevices().at(0);
                 device.getHDRCapabilities(&capabilities);
             }
@@ -4741,6 +4768,12 @@ namespace WPEFramework {
 
             try
             {
+                if (device::Host::getInstance().getVideoDevices().size() < 1)
+                {
+                    LOGINFO("DSMGR_NOT_RUNNING");
+                    return videoFormats;
+                }
+
                 device::VideoDevice &device = device::Host::getInstance().getVideoDevices().at(0);
                 device.getHDRCapabilities(&capabilities);
             }


### PR DESCRIPTION
Reason for change:  validating getvideodevices size
Test Procedure: reload multiple times
Risks: Medium
Signed-off-by: Kumar Santhanam <Kumar_Santhanam@comcast.com>
(cherry picked from commit cc8b4c01cdcb560394c77aa38b3cbbcb3c75eb94)