### PR TITLE
RDK-35079: AC4 Settings Configuration

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -932,6 +932,10 @@ namespace WPEFramework {
         {
 
             LOGINFO("%s \n", __FUNCTION__);
+            if (data == NULL) {
+                LOGERR("data is NULL, return !!!\n");
+                return;
+            }
             switch (eventId) {
                 case IARM_BUS_DSMGR_EVENT_AUDIO_ASSOCIATED_AUDIO_MIXING_CHANGED:
                   {
@@ -957,9 +961,8 @@ namespace WPEFramework {
                   break;
                 case IARM_BUS_DSMGR_EVENT_AUDIO_PRIMARY_LANGUAGE_CHANGED:
                   {
-                    std::string pLang = "DEF";
                     IARM_Bus_DSMgr_EventData_t *eventData = (IARM_Bus_DSMgr_EventData_t *)data;
-                    pLang = eventData->data.AudioLanguageInfo.audioLanguage;
+                    std::string pLang = eventData->data.AudioLanguageInfo.audioLanguage;
                     LOGINFO("Received IARM_BUS_DSMGR_EVENT_AUDIO_PRIMARY_LANGUAGE_CHANGED. Primary Language: %s \n", pLang);
                     if(DisplaySettings::_instance) {
                         DisplaySettings::_instance->notifyPrimaryLanguageChange(pLang);
@@ -968,9 +971,8 @@ namespace WPEFramework {
                   break;
                 case IARM_BUS_DSMGR_EVENT_AUDIO_SECONDARY_LANGUAGE_CHANGED:
                   {
-                    std::string sLang = "DEF";
                     IARM_Bus_DSMgr_EventData_t *eventData = (IARM_Bus_DSMgr_EventData_t *)data;
-                    sLang = eventData->data.AudioLanguageInfo.audioLanguage;
+                    std::string sLang = eventData->data.AudioLanguageInfo.audioLanguage;
                     LOGINFO("Received IARM_BUS_DSMGR_EVENT_AUDIO_SECONDARY_LANGUAGE_CHANGED. Secondary Language: %s \n", sLang);
                     if(DisplaySettings::_instance) {
                         DisplaySettings::_instance->notifySecondaryLanguageChange(sLang);
@@ -978,7 +980,7 @@ namespace WPEFramework {
                   }
                   break;
                 default:
-                    LOGERR("Invalid event ID\n");
+                    LOGERR("Unhandled Event... \n");
                     break;
            }
         }
@@ -2441,20 +2443,20 @@ namespace WPEFramework {
                 returnIfParamNotFound(parameters, "level");
                 string sVolumeLeveller = parameters["level"].String();
                 dsVolumeLeveller_t VolumeLeveller;
-                bool isIntiger = Utils::isValidInt ((char*)sVolumeLeveller.c_str());
+                bool isIntiger = Utils::isValidUnsignedInt ((char*)sVolumeLeveller.c_str());
                 if (false == isIntiger) {
-                    LOGWARN("level should be an integer");
+                    LOGWARN("level should be an unsigned integer");
                     returnResponse(false);
                 }
 
                 try {
-                        VolumeLeveller.level = stoi(sVolumeLeveller);
-			if(VolumeLeveller.level == 0) {
-				VolumeLeveller.mode = 0; //Off
-			}
-			else {
-				VolumeLeveller.mode = 1; //On
-			}
+                    VolumeLeveller.level = stoi(sVolumeLeveller);
+                    if(VolumeLeveller.level == 0) {
+                        VolumeLeveller.mode = 0; //Off
+                    }
+                    else {
+                        VolumeLeveller.mode = 1; //On
+                    }
                 }catch (const device::Exception& err) {
                         LOG_DEVICE_EXCEPTION1(sVolumeLeveller);
                         returnResponse(false);
@@ -2481,8 +2483,8 @@ namespace WPEFramework {
 		string sMode = parameters["mode"].String();
                 string sLevel = parameters["level"].String();
                 dsVolumeLeveller_t volumeLeveller;
-                if ((Utils::isValidInt ((char*)sMode.c_str()) == false) || (Utils::isValidInt ((char*)sMode.c_str()) == false)) {
-                    LOGWARN("mode and level should be an integer");
+                if ((Utils::isValidUnsignedInt ((char*)sMode.c_str()) == false) || (Utils::isValidUnsignedInt ((char*)sMode.c_str()) == false)) {
+                    LOGWARN("mode and level should be an unsigned integer");
                     returnResponse(false);
                 }
 
@@ -2557,9 +2559,9 @@ namespace WPEFramework {
                 returnIfParamNotFound(parameters, "bassBoost");
                 string sBassBoost = parameters["bassBoost"].String();
                 int bassBoost = 0;
-                bool isIntiger = Utils::isValidInt ((char*)sBassBoost.c_str());
+                bool isIntiger = Utils::isValidUnsignedInt ((char*)sBassBoost.c_str());
                 if (false == isIntiger) {
-                    LOGWARN("bassBoost should be an integer");
+                    LOGWARN("bassBoost should be an unsigned integer");
                     returnResponse(false);
                 }
                 try {
@@ -2589,9 +2591,9 @@ namespace WPEFramework {
                returnIfParamNotFound(parameters, "boost");
                string sSurroundVirtualizer = parameters["boost"].String();
                dsSurroundVirtualizer_t surroundVirtualizer;
-               bool isIntiger = Utils::isValidInt ((char*)sSurroundVirtualizer.c_str());
+               bool isIntiger = Utils::isValidUnsignedInt ((char*)sSurroundVirtualizer.c_str());
                if (false == isIntiger) {
-                   LOGWARN("boost should be an integer");
+                   LOGWARN("boost should be an unsigned integer");
                    returnResponse(false);
                }
 
@@ -2630,8 +2632,8 @@ namespace WPEFramework {
                 string sBoost = parameters["boost"].String();
                 dsSurroundVirtualizer_t surroundVirtualizer;
 
-                if ((Utils::isValidInt ((char*)sMode.c_str()) == false) || (Utils::isValidInt ((char*)sBoost.c_str()) == false)) {
-                    LOGWARN("mode and boost value should be an integer");
+                if ((Utils::isValidUnsignedInt ((char*)sMode.c_str()) == false) || (Utils::isValidUnsignedInt ((char*)sBoost.c_str()) == false)) {
+                    LOGWARN("mode and boost value should be an unsigned integer");
                     returnResponse(false);
                 }
 
@@ -2791,9 +2793,9 @@ namespace WPEFramework {
                 returnIfParamNotFound(parameters, "DRCMode");
                 string sDRCMode = parameters["DRCMode"].String();
                 int DRCMode = 0;
-                bool isIntiger = Utils::isValidInt ((char*)sDRCMode.c_str());
+                bool isIntiger = Utils::isValidUnsignedInt ((char*)sDRCMode.c_str());
                 if (false == isIntiger) {
-                    LOGWARN("DRCMode should be an integer");
+                    LOGWARN("DRCMode should be an unsigned integer");
                     returnResponse(false);
                 }
                 try {
@@ -3253,7 +3255,7 @@ namespace WPEFramework {
                 returnIfParamNotFound(parameters, "mixerBalance");
                 string sMixerBalance = parameters["mixerBalance"].String();
                 int mixerBalance = 0;
-                bool isIntiger = Utils::isValidInt ((char*)sMixerBalance.c_str(), true);
+                bool isIntiger = Utils::isValidInt ((char*)sMixerBalance.c_str());
                 if (false == isIntiger) {
                     LOGWARN("mixerBalance should be an integer");
                     returnResponse(false);

--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -128,6 +128,15 @@ namespace WPEFramework {
             uint32_t getSettopAudioCapabilities(const JsonObject& parameters, JsonObject& response);
             uint32_t getEnableAudioPort(const JsonObject& parameters, JsonObject& response);
 
+	    uint32_t setAssociatedAudioMixing(const JsonObject& parameters, JsonObject& response);
+            uint32_t getAssociatedAudioMixing(const JsonObject& parameters, JsonObject& response);
+            uint32_t setFaderControl(const JsonObject& parameters, JsonObject& response);
+            uint32_t getFaderControl(const JsonObject& parameters, JsonObject& response);
+            uint32_t setPrimaryLanguage(const JsonObject& parameters, JsonObject& response);
+            uint32_t getPrimaryLanguage(const JsonObject& parameters, JsonObject& response);
+            uint32_t setSecondaryLanguage(const JsonObject& parameters, JsonObject& response);
+            uint32_t getSecondaryLanguage(const JsonObject& parameters, JsonObject& response);
+
 	    uint32_t getAudioFormat(const JsonObject& parameters, JsonObject& response);
 	    uint32_t getVolumeLeveller2(const JsonObject& parameters, JsonObject& response);
 	    uint32_t setVolumeLeveller2(const JsonObject& parameters, JsonObject& response);
@@ -152,6 +161,10 @@ namespace WPEFramework {
             void connectedVideoDisplaysUpdated(int hdmiHotPlugEvent);
             void connectedAudioPortUpdated (int iAudioPortType, bool isPortConnected);
 	    void notifyAudioFormatChange(dsAudioFormat_t audioFormat);
+            void notifyAssociatedAudioMixingChange(bool mixing);
+            void notifyFaderControlChange(bool mixerbalance);
+            void notifyPrimaryLanguageChange(std::string pLang);
+            void notifySecondaryLanguageChange(std::string sLang);
 	    void notifyVideoFormatChange(dsHDRStandard_t videoFormat);
 	    void onARCInitiationEventHandler(const JsonObject& parameters);
             void onARCTerminationEventHandler(const JsonObject& parameters);
@@ -176,6 +189,7 @@ namespace WPEFramework {
 	    static void formatUpdateEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
             static void powerEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
             static void audioPortStateEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
+            static void dsSettingsChangeEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
             void getConnectedVideoDisplaysHelper(std::vector<string>& connectedDisplays);
 	    void audioFormatToString(dsAudioFormat_t audioFormat, JsonObject &response);
             const char *getVideoFormatTypeToString(dsHDRStandard_t format);

--- a/helpers/utils.cpp
+++ b/helpers/utils.cpp
@@ -357,10 +357,15 @@ Utils::ThreadRAII::~ThreadRAII()
     }
 }
 
-bool Utils::isValidInt(char* x)
+bool Utils::isValidInt(char* x, bool negativeIntAllowed /*= false*/)
 {
     bool Checked = true;
     int i = 0;
+
+    if(negativeIntAllowed && (x[0] == '-')) {
+        i = 1;
+    }
+
     do
     {
         //valid digit?

--- a/helpers/utils.cpp
+++ b/helpers/utils.cpp
@@ -357,14 +357,39 @@ Utils::ThreadRAII::~ThreadRAII()
     }
 }
 
-bool Utils::isValidInt(char* x, bool negativeIntAllowed /*= false*/)
+bool Utils::isValidInt(char* x)
 {
     bool Checked = true;
     int i = 0;
 
-    if(negativeIntAllowed && (x[0] == '-')) {
+    if(x[0] == '-') {
         i = 1;
     }
+
+    do
+    {
+        //valid digit?
+        if (isdigit(x[i]))
+        {
+            //to the next character
+            i++;
+            Checked = true;
+        }
+        else
+        {
+            //to the next character
+            i++;
+            Checked = false;
+            break;
+        }
+    } while (x[i] != '\0');
+    return Checked;
+}
+
+bool Utils::isValidUnsignedInt(char* x)
+{
+    bool Checked = true;
+    int i = 0;
 
     do
     {

--- a/helpers/utils.h
+++ b/helpers/utils.h
@@ -371,7 +371,8 @@ namespace Utils
     bool isPluginActivated(const char* callSign);
 
     bool getRFCConfig(char* paramName, RFC_ParamData_t& paramOutput);
-    bool isValidInt(char* x, bool negativeIntAllowed = false);
+    bool isValidInt(char* x);
+    bool isValidUnsignedInt(char* x);
     void syncPersistFile (const string file);
     void persistJsonSettings(const string file, const string strKey, const JsonValue& jsValue);
 

--- a/helpers/utils.h
+++ b/helpers/utils.h
@@ -371,7 +371,7 @@ namespace Utils
     bool isPluginActivated(const char* callSign);
 
     bool getRFCConfig(char* paramName, RFC_ParamData_t& paramOutput);
-    bool isValidInt(char* x);
+    bool isValidInt(char* x, bool negativeIntAllowed = false);
     void syncPersistFile (const string file);
     void persistJsonSettings(const string file, const string strKey, const JsonValue& jsValue);
 


### PR DESCRIPTION
Reason for change: Added Displaysettings thunder APIs & events
for associated audio mixing, fader control, primary
and secondary language selection
Added negative int check support in rdkservices helper
utils
Test Procedure: Validate using thunder APIs
Risks: None

Signed-off-by: Deekshit Devadas deekshit.devadasy@sky.uk