### PR TITLE
RDK-34750: add getPublicIP method to Network plugin

### DIFF
--- a/Network/Network.cpp
+++ b/Network/Network.cpp
@@ -33,6 +33,7 @@ using namespace std;
 #define INTERFACE_LIST 50
 #define MAX_IP_ADDRESS_LEN 46
 #define MAX_IP_FAMILY_SIZE 10
+#define MAX_HOST_NAME_LEN 128
 #define MAX_ENDPOINTS 5
 #define MAX_ENDPOINT_SIZE 260 // 253 + 1 + 5 + 1 (domain name max length + ':' + port number max chars + '\0')
 #define IARM_BUS_NETSRVMGR_API_getActiveInterface "getActiveInterface"
@@ -49,6 +50,7 @@ using namespace std;
 #define IARM_BUS_NETSRVMGR_API_isConnectedToInternet "isConnectedToInternet"
 #define IARM_BUS_NETSRVMGR_API_setConnectivityTestEndpoints "setConnectivityTestEndpoints"
 #define IARM_BUS_NETSRVMGR_API_isAvailable "isAvailable"
+#define IARM_BUS_NETSRVMGR_API_getPublicIP "getPublicIP"
 
 typedef enum _NetworkManager_EventId_t {
     IARM_BUS_NETWORK_MANAGER_EVENT_SET_INTERFACE_ENABLED=50,
@@ -128,6 +130,17 @@ typedef struct {
     char newInterface[16];
 } IARM_BUS_NetSrvMgr_Iface_EventDefaultInterface_t;
 
+typedef struct
+{
+    char server[MAX_HOST_NAME_LEN];
+    uint16_t port;
+    bool ipv6;
+    char interface[16];
+    uint16_t bind_timeout;
+    uint16_t cache_timeout;
+    bool sync;
+    char public_ip[MAX_IP_ADDRESS_LEN];
+} IARM_BUS_NetSrvMgr_Iface_StunRequest_t;
 
 namespace WPEFramework
 {
@@ -166,6 +179,8 @@ namespace WPEFramework
             Register("getSTBIPFamily", &Network::getSTBIPFamily, this);
             Register("isConnectedToInternet", &Network::isConnectedToInternet, this);
             Register("setConnectivityTestEndpoints", &Network::setConnectivityTestEndpoints, this);
+
+            Register("getPublicIP", &Network::getPublicIP, this);
 
             m_netUtils.InitialiseNetUtils();
         }
@@ -226,8 +241,6 @@ namespace WPEFramework
             Unregister("getDefaultInterface");
             Unregister("setDefaultInterface");
             Unregister("getStbIp");
-            Unregister("setApiVersionNumber");
-            Unregister("getApiVersionNumber");
             Unregister("trace");
             Unregister("traceNamedEndpoint");
             Unregister("getNamedEndpoints");
@@ -237,6 +250,7 @@ namespace WPEFramework
             Unregister("getIPSettings");
             Unregister("isConnectedToInternet");
             Unregister("setConnectivityTestEndpoints");
+            Unregister("getPublicIP");
 
             Network::_instance = nullptr;
         }
@@ -365,11 +379,11 @@ namespace WPEFramework
 
                 getStringParameter("interface", interface)
 
-	        if (!(strcmp (interface.c_str(), "ETHERNET") == 0 || strcmp (interface.c_str(), "WIFI") == 0))
-		{
-	            LOGERR ("Call for %s failed due to invalid interface [%s]", IARM_BUS_NETSRVMGR_API_setDefaultInterface, interface.c_str());
+                if (!(strcmp (interface.c_str(), "ETHERNET") == 0 || strcmp (interface.c_str(), "WIFI") == 0))
+                {
+                    LOGERR ("Call for %s failed due to invalid interface [%s]", IARM_BUS_NETSRVMGR_API_setDefaultInterface, interface.c_str());
                     returnResponse (result)
-		}
+                }
 
                 getBoolParameter("persist", persist)
 
@@ -443,11 +457,11 @@ namespace WPEFramework
                 string interface = "";
                 getStringParameter("interface", interface)
 
-		if (!(strcmp (interface.c_str(), "ETHERNET") == 0 || strcmp (interface.c_str(), "WIFI") == 0))
-	        {
+                if (!(strcmp (interface.c_str(), "ETHERNET") == 0 || strcmp (interface.c_str(), "WIFI") == 0))
+                {
                     LOGERR ("Call for %s failed due to invalid interface [%s]", IARM_BUS_NETSRVMGR_API_isInterfaceEnabled, interface.c_str());
                     returnResponse (result)
-		}
+                }
 
                 IARM_BUS_NetSrvMgr_Iface_EventData_t param = {0};
                 strncpy(param.setInterface, interface.c_str(), INTERFACE_SIZE);
@@ -805,6 +819,68 @@ namespace WPEFramework
             returnResponse(result);
         }
 
+        uint32_t Network::getPublicIP(const JsonObject& parameters, JsonObject& response)
+        {
+            bool result = false;
+
+            IARM_BUS_NetSrvMgr_Iface_StunRequest_t iarmData = { 0 };
+            string server, iface;
+
+            getDefaultStringParameter("server", server, "");
+            if (server.length() > MAX_HOST_NAME_LEN - 1)
+            {
+                LOGWARN("invalid args: server exceeds max length of %u", MAX_HOST_NAME_LEN);
+                returnResponse(false)               
+            }
+
+            getDefaultNumberParameter("port", iarmData.port, 0);
+
+            /*only makes sense to get both server and port or neither*/
+            if (!server.empty() && !iarmData.port)
+            {
+                LOGWARN("invalid args: port missing");
+                returnResponse(false)
+            } 
+            if (iarmData.port && server.empty())
+            {
+                LOGWARN("invalid args: server missing");
+                returnResponse(false)
+            }
+
+            getDefaultStringParameter("iface", iface, "");
+            if (iface.length() > 16 - 1)
+            {
+                LOGWARN("invalid args: interface exceeds max length of 16");
+                returnResponse(false)               
+            }
+	    
+            if (!(strcmp (iface.c_str(), "ETHERNET") == 0 || strcmp (iface.c_str(), "WIFI") == 0))
+            {
+                LOGERR ("Call for %s failed due to invalid interface [%s]", IARM_BUS_NETSRVMGR_API_getPublicIP, iface.c_str());
+                returnResponse (result)
+            }
+
+            getDefaultBoolParameter("ipv6", iarmData.ipv6, false);
+            getDefaultBoolParameter("sync", iarmData.sync, true);
+            getDefaultNumberParameter("timeout", iarmData.bind_timeout, 0);
+            getDefaultNumberParameter("cache_timeout", iarmData.cache_timeout, 0);
+
+            strncpy(iarmData.server, server.c_str(), MAX_HOST_NAME_LEN);
+            strncpy(iarmData.interface, iface.c_str(), 16);
+
+            iarmData.public_ip[0] = '\0';
+
+            LOGWARN("getPublicIP called with server=%s port=%u iface=%s ipv6=%u timeout=%u cache_timeout=%u\n", 
+                iarmData.server, iarmData.port, iarmData.interface, iarmData.ipv6, iarmData.bind_timeout, iarmData.cache_timeout);
+
+            if (IARM_RESULT_SUCCESS == IARM_Bus_Call (IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_NETSRVMGR_API_getPublicIP, (void *)&iarmData, sizeof(iarmData)))
+            {
+                response["public_ip"] = string(iarmData.public_ip);
+                result = true;
+            }
+            returnResponse(result)
+        }
+
         /*
          * Notifications
          */
@@ -861,12 +937,12 @@ namespace WPEFramework
         {
             if (strcmp(owner, IARM_BUS_NM_SRV_MGR_NAME) != 0)
             {
-                LOGERR("ERROR - unexpected event: owner %s, eventId: %d, data: %p, size: %d.", owner, (int)eventId, data, len);
+                LOGERR("ERROR - unexpected event: owner %s, eventId: %d, data: %p, size: %ld.", owner, (int)eventId, data, len);
                 return;
             }
             if (data == nullptr || len == 0)
             {
-                LOGERR("ERROR - event with NO DATA: eventId: %d, data: %p, size: %d.", (int)eventId, data, len);
+                LOGERR("ERROR - event with NO DATA: eventId: %d, data: %p, size: %ld.", (int)eventId, data, len);
                 return;
             }
 

--- a/Network/Network.h
+++ b/Network/Network.h
@@ -74,6 +74,7 @@ namespace WPEFramework {
             uint32_t getSTBIPFamily(const JsonObject& parameters, JsonObject& response);
             uint32_t isConnectedToInternet(const JsonObject& parameters, JsonObject& response);
             uint32_t setConnectivityTestEndpoints(const JsonObject& parameters, JsonObject& response);
+            uint32_t getPublicIP(const JsonObject& parameters, JsonObject& response);
 
             void onInterfaceEnabledStatusChanged(std::string interface, bool enabled);
             void onInterfaceConnectionStatusChanged(std::string interface, bool connected);

--- a/Network/Network.json
+++ b/Network/Network.json
@@ -142,6 +142,31 @@
             "summary": "Update `RDK-20093` string",
             "type": "string",
             "example": "RDK-20093"
+	},
+	"server":{
+            "summary": "STUN server",
+            "type": "string",
+            "example": "global.stun.twilio.com"
+        },
+        "port":{
+            "summary": "STUN server port",
+            "type": "integer",
+            "example": "3478"
+        },
+        "sync":{
+            "summary": "STUN server sync",
+            "type": "boolean",
+            "example": "true"
+        },
+        "timeout":{
+            "summary": "STUN server bind timeout",
+            "type": "integer",
+            "example": "30"
+        },
+        "cache_timeout":{
+            "summary": "STUN server cache timeout",
+            "type": "integer",
+            "example": "0"
         }
     },
     "methods": {
@@ -690,6 +715,61 @@
                 "required": [
                     "supported",
                     "success"  
+                ]
+            }
+        },
+         "getPublicIP":{
+            "summary": "Determine WAN ip address",
+            "params": {
+                "type":"object",
+                "properties": {
+                    "server": {
+                        "$ref": "#/definitions/server"
+                    },
+                    "port": {
+                        "$ref": "#/definitions/port"
+                    },
+                    "iface": {
+                        "$ref": "#/definitions/interface"
+                    },
+                    "ipv6": {
+                        "$ref": "#/definitions/ipversion"
+                    },
+                    "sync": {
+                        "$ref": "#/definitions/sync"
+                    },
+                    "timeout": {
+                        "$ref": "#/definitions/timeout"
+                    },
+                    "cache_timeout": {
+                        "$ref": "#/definitions/cache_timeout"
+                    }
+                },
+                "required": [
+                    "server",
+                    "port",
+                    "iface",
+                    "ipv6",
+                    "sync",
+                    "timeout",
+                    "cache_timeout"
+                ]
+            },
+            "result": {
+                "type": "object",
+                "properties": {
+                    "public_ip":{
+                        "summary": "Returns an public ip of the device ,if ipv6 is `true`,returns IPv6 public ip , otherwise returns IPv4 public ip",
+                        "type":"string",
+                        "example": "69.136.49.95"
+                    },
+                    "success": {
+                        "$ref": "#/definitions/success"
+                    }
+	       },
+                "required": [
+                    "public_ip",
+                    "success"
                 ]
             }
         },

--- a/Network/doc/NetworkPlugin.md
+++ b/Network/doc/NetworkPlugin.md
@@ -108,6 +108,7 @@ Network interface methods:
 | [setDefaultInterface](#method.setDefaultInterface) | Sets the default interface |
 | [setInterfaceEnabled](#method.setInterfaceEnabled) | Enables the specified interface |
 | [setIPSettings](#method.setIPSettings) | Sets the IP settings |
+| [getPublicIP](#method.getPublicIP) | Determine WAN ip address |
 | [trace](#method.trace) | Traces the specified endpoint with the specified number of packets using `traceroute` |
 | [traceNamedEndpoint](#method.traceNamedEndpoint) | Traces the specified named endpoint with the specified number of packets using `traceroute` |
 
@@ -883,6 +884,64 @@ Sets the IP settings.
     "id": 42,
     "result": {
         "supported": true,
+        "success": true
+    }
+}
+```
+<a name="method.getPublicIP"></a>
+## *getPublicIP [<sup>method</sup>](#head.Methods)*
+Determine WAN ip address.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.server | string | STUN server |
+| params.port | integer | STUN server port |
+| params.iface | string | An interface, such as `ETHERNET` or `WIFI`, depending upon availability of the given interface in `getInterfaces` |
+| params.ipv6 | string | either IPv4 or IPv6 |
+| params.sync | boolean | STUN server sync |
+| params.timeout | integer | STUN server bind timeout |
+| params.cache_timeout | integer | STUN server cache timeout |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.public_ip | string | Returns an public ip of the device ,if ipv6 is `true`,returns IPv6 public ip , otherwise returns IPv4 public ip |
+| result.success | boolean | Whether the request succeeded |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "org.rdk.Network.1.getPublicIP",
+    "params": {
+        "server": "global.stun.twilio.com",
+        "port": 3478,
+        "iface": "WIFI",
+        "ipv6": "IPv4",
+        "sync": true,
+        "timeout": 30,
+        "cache_timeout": 0
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": {
+        "public_ip": "69.136.49.95",
         "success": true
     }
 }

--- a/helpers/utils.h
+++ b/helpers/utils.h
@@ -179,6 +179,15 @@
         param = parameters[paramName].String() == "true" || parameters[paramName].String() == "1"; \
 }
 
+#define getDefaultBoolParameter(paramName, param, default) { \
+    if (parameters.HasLabel(paramName)) { \
+        if (Core::JSON::Variant::type::BOOLEAN == parameters[paramName].Content()) \
+            param = parameters[paramName].Boolean(); \
+        else \
+            param = parameters[paramName].String() == "true" || parameters[paramName].String() == "1"; \
+     } else param = default; \
+}
+
 #define getStringParameter(paramName, param) { \
     if (Core::JSON::Variant::type::STRING == parameters[paramName].Content()) \
         param = parameters[paramName].String(); \
@@ -407,7 +416,7 @@ namespace Utils
 #endif
         };
 
-        static void sendError(char* format, ...)
+        static void sendError(const char* format, ...)
         {
 #ifdef ENABLE_TELEMETRY_LOGGING
             va_list parameters;


### PR DESCRIPTION
Reason for change: XRE wants to obtain the public facing wan ip
Also fixed a few compiler warnings.
Test Procedure: json-rpc curl commands from command line on both desktop and device.  later xre will test.
Risks: Low
Signed-off-by: mrollins <mark_rollins@cable.comcast.com>
(cherry picked from commit b0fb311e3d617b2277f9e8ad728e95296f8b2268)

RDK-35060: update the documentation for the getPublicIP()

Reason for change: added the getPublicIP api into network plugin documentation
Test Procedure: please verify from ticket
Risks: Low
Signed-off-by: Thamim Razith <ThamimRazith_AbbasAli@comcast.com>
(cherry picked from commit da100a28085960f0277440eff0421d93a9fcbaab)