### PR TITLE
DELIA-54683: refactoring

### DIFF
--- a/DataCapture/CMakeLists.txt
+++ b/DataCapture/CMakeLists.txt
@@ -23,8 +23,7 @@ find_package(${NAMESPACE}Plugins REQUIRED)
 add_library(${MODULE_NAME} SHARED
         socket_adaptor.cpp
         DataCapture.cpp
-        Module.cpp
-        ../helpers/utils.cpp)
+        Module.cpp)
 
 set_target_properties(${MODULE_NAME} PROPERTIES
         CXX_STANDARD 11

--- a/DataCapture/DataCapture.cpp
+++ b/DataCapture/DataCapture.cpp
@@ -25,6 +25,112 @@
 #include "DataCapture.h"
 #include <curl/curl.h>
 #include "socket_adaptor.h"
+#include "libIBus.h"
+
+/**
+ * from utils.h
+ * TODO: cannot use utils.h because it has too many include-s
+ */
+#include <syscall.h>
+#define C_STR(x) (x).c_str()
+#define LOGINFO(fmt, ...) do { fprintf(stderr, "[%d] INFO [%s:%d] %s: " fmt "\n", (int)syscall(SYS_gettid), WPEFramework::Core::FileNameOnly(__FILE__), __LINE__, __FUNCTION__, ##__VA_ARGS__); fflush(stderr); } while (0)
+#define LOGWARN(fmt, ...) do { fprintf(stderr, "[%d] WARN [%s:%d] %s: " fmt "\n", (int)syscall(SYS_gettid), WPEFramework::Core::FileNameOnly(__FILE__), __LINE__, __FUNCTION__, ##__VA_ARGS__); fflush(stderr); } while (0)
+#define LOGERR(fmt, ...) do { fprintf(stderr, "[%d] ERROR [%s:%d] %s: " fmt "\n", (int)syscall(SYS_gettid), WPEFramework::Core::FileNameOnly(__FILE__), __LINE__, __FUNCTION__, ##__VA_ARGS__); fflush(stderr); } while (0)
+#define LOGINFOMETHOD() { std::string json; parameters.ToString(json); LOGINFO( "params=%s", json.c_str() ); }
+#define LOGTRACEMETHODFIN() { std::string json; response.ToString(json); LOGINFO( "response=%s", json.c_str() ); }
+#define returnResponse(success) \
+    { \
+        response["success"] = success; \
+        LOGTRACEMETHODFIN(); \
+        return (Core::ERROR_NONE); \
+    }
+#define returnIfParamNotFound(param, name) \
+    if (!param.HasLabel(name)) \
+    { \
+        LOGERR("No argument '%s'", name); \
+        returnResponse(false); \
+    }
+#define returnIfStringParamNotFound(param, name) \
+    if (!param.HasLabel(name) || param[name].Content() != Core::JSON::Variant::type::STRING) \
+    {\
+        LOGERR("No argument '%s' or it has incorrect type", name); \
+        returnResponse(false); \
+    }
+#define returnIfNumberParamNotFound(param, name) \
+    if (!param.HasLabel(name) || param[name].Content() != Core::JSON::Variant::type::NUMBER) \
+    { \
+        LOGERR("No argument '%s' or it has incorrect type", name); \
+        returnResponse(false); \
+    }
+#define sendNotify(event,params) { \
+    std::string json; \
+    params.ToString(json); \
+    LOGINFO("Notify %s %s", event, json.c_str()); \
+    Notify(event,params); \
+}
+#define IARM_CHECK(FUNC) { \
+    if ((res = FUNC) != IARM_RESULT_SUCCESS) { \
+        LOGINFO("IARM %s: %s", #FUNC, \
+            res == IARM_RESULT_INVALID_PARAM ? "invalid param" : ( \
+            res == IARM_RESULT_INVALID_STATE ? "invalid state" : ( \
+            res == IARM_RESULT_IPCCORE_FAIL ? "ipcore fail" : ( \
+            res == IARM_RESULT_OOM ? "oom" : "unknown")))); \
+    } \
+    else \
+    { \
+        LOGINFO("IARM %s: success", #FUNC); \
+    } \
+}
+
+namespace Utils {
+struct IARM {
+    static bool init();
+    static bool isConnected();
+
+    static const char* NAME;
+};
+
+const char* IARM::NAME = "Thunder_Plugins";
+
+bool IARM::isConnected() {
+    IARM_Result_t res;
+    int isRegistered = 0;
+    res = IARM_Bus_IsConnected(NAME, &isRegistered);
+    LOGINFO("IARM_Bus_IsConnected: %d (%d)", res, isRegistered);
+
+    return (isRegistered == 1);
+}
+
+bool IARM::init() {
+    IARM_Result_t res;
+    bool result = false;
+
+    if (isConnected()) {
+        LOGINFO("IARM already connected");
+        result = true;
+    } else {
+        res = IARM_Bus_Init(NAME);
+        LOGINFO("IARM_Bus_Init: %d", res);
+        if (res == IARM_RESULT_SUCCESS ||
+            res == IARM_RESULT_INVALID_STATE /* already inited or connected */) {
+
+            res = IARM_Bus_Connect();
+            LOGINFO("IARM_Bus_Connect: %d", res);
+            if (res == IARM_RESULT_SUCCESS ||
+                res == IARM_RESULT_INVALID_STATE /* already connected or not inited */) {
+
+                result = isConnected();
+            } else {
+                LOGERR("IARM_Bus_Connect failure: %d", res);
+            }
+        } else {
+            LOGERR("IARM_Bus_Init failure: %d", res);
+        }
+    }
+
+    return result;
+}
+}
 
 const string WPEFramework::Plugin::DataCapture::SERVICE_NAME = "org.rdk.DataCapture";
 const string WPEFramework::Plugin::DataCapture::METHOD_ENABLE_AUDIO_CAPTURE = "enableAudioCapture";
@@ -68,7 +174,7 @@ namespace WPEFramework {
         DataCapture* DataCapture::_instance = nullptr;
 
         DataCapture::DataCapture()
-            : AbstractPlugin()
+            : PluginHost::JSONRPC()
             , _session_id(-1)
             , _max_supported_duration(0)
             , _is_precapture(false)
@@ -88,6 +194,8 @@ namespace WPEFramework {
         DataCapture::~DataCapture()
         {
             //LOGINFO("dtor");
+            Unregister(METHOD_ENABLE_AUDIO_CAPTURE);
+            Unregister(METHOD_GET_AUDIO_CLIP);
         }
 
         const string DataCapture::Initialize(PluginHost::IShell* /* service */)

--- a/DataCapture/DataCapture.h
+++ b/DataCapture/DataCapture.h
@@ -20,16 +20,13 @@
 #pragma once
 
 #include "Module.h"
-#include "utils.h"
-#include "AbstractPlugin.h"
-#include "libIBus.h"
-//#include "irMgr.h"
+#include "libIARM.h"
 
 class socket_adaptor;
 
 namespace WPEFramework {
     namespace Plugin {
-        class DataCapture : public AbstractPlugin {
+        class DataCapture : public PluginHost::IPlugin, public PluginHost::JSONRPC {
         public:
             DataCapture();
             virtual ~DataCapture();
@@ -37,6 +34,11 @@ namespace WPEFramework {
             virtual void Deinitialize(PluginHost::IShell* service) override;
             virtual string Information() const override;
             void eventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
+
+            BEGIN_INTERFACE_MAP(MODULE_NAME)
+            INTERFACE_ENTRY(PluginHost::IPlugin)
+            INTERFACE_ENTRY(PluginHost::IDispatcher)
+            END_INTERFACE_MAP
 
         public/*members*/:
             static DataCapture* _instance;

--- a/DeviceDiagnostics/DeviceDiagnostics.h
+++ b/DeviceDiagnostics/DeviceDiagnostics.h
@@ -27,29 +27,11 @@
 
 #include "Module.h"
 
-#include "utils.h"
-#include "AbstractPlugin.h"
-
 namespace WPEFramework {
 
     namespace Plugin {
-
-		// This is a server for a JSONRPC communication channel.
-		// For a plugin to be capable to handle JSONRPC, inherit from PluginHost::JSONRPC.
-		// By inheriting from this class, the plugin realizes the interface PluginHost::IDispatcher.
-		// This realization of this interface implements, by default, the following methods on this plugin
-		// - exists
-		// - register
-		// - unregister
-		// Any other methood to be handled by this plugin  can be added can be added by using the
-		// templated methods Register on the PluginHost::JSONRPC class.
-		// As the registration/unregistration of notifications is realized by the class PluginHost::JSONRPC,
-		// this class exposes a public method called, Notify(), using this methods, all subscribed clients
-		// will receive a JSONRPC message as a notification, in case this method is called.
-        class DeviceDiagnostics : public AbstractPlugin {
+        class DeviceDiagnostics : public PluginHost::IPlugin, public PluginHost::JSONRPC {
         private:
-
-            // We do not allow this plugin to be copied !!
             DeviceDiagnostics(const DeviceDiagnostics&) = delete;
             DeviceDiagnostics& operator=(const DeviceDiagnostics&) = delete;
 
@@ -78,6 +60,12 @@ namespace WPEFramework {
             virtual ~DeviceDiagnostics();
             virtual void Deinitialize(PluginHost::IShell* service) override;
             virtual const string Initialize(PluginHost::IShell* service) override;
+            virtual string Information() const override;
+
+            BEGIN_INTERFACE_MAP(MODULE_NAME)
+            INTERFACE_ENTRY(PluginHost::IPlugin)
+            INTERFACE_ENTRY(PluginHost::IDispatcher)
+            END_INTERFACE_MAP
 
         public:
             static DeviceDiagnostics* _instance;

--- a/FrameRate/CMakeLists.txt
+++ b/FrameRate/CMakeLists.txt
@@ -23,8 +23,7 @@ find_package(${NAMESPACE}Plugins REQUIRED)
 add_library(${MODULE_NAME} SHARED
         FrameRate.cpp
         Module.cpp
-        ../helpers/tptimer.cpp
-	../helpers/utils.cpp)
+        ../helpers/tptimer.cpp)
 
 set_target_properties(${MODULE_NAME} PROPERTIES
         CXX_STANDARD 11
@@ -41,7 +40,7 @@ target_include_directories(${MODULE_NAME} PRIVATE ${DS_INCLUDE_DIRS})
 target_include_directories(${MODULE_NAME} PRIVATE ${IARMBUS_INCLUDE_DIRS})
 target_include_directories(${MODULE_NAME} PRIVATE ../helpers)
 
-target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins ${NAMESPACE}SecurityUtil ${IARMBUS_LIBRARIES} ${DS_LIBRARIES} "-ltr181api")
+target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins ${IARMBUS_LIBRARIES} ${DS_LIBRARIES})
 
 install(TARGETS ${MODULE_NAME}
         DESTINATION lib/${STORAGE_DIRECTORY}/plugins)

--- a/FrameRate/FrameRate.cpp
+++ b/FrameRate/FrameRate.cpp
@@ -22,6 +22,7 @@
 #include "exception.hpp"
 #include "dsMgr.h"
 #include "libIBus.h"
+#include "tptimer.h"
 
 // Methods
 #define METHOD_SET_COLLECTION_FREQUENCY "setCollectionFrequency"
@@ -143,9 +144,14 @@ namespace WPEFramework
 
         FrameRate::FrameRate()
             : PluginHost::JSONRPC()
-          , m_fpsCollectionFrequencyInMs(DEFAULT_FPS_COLLECTION_TIME_IN_MILLISECONDS)
-          , m_minFpsValue(DEFAULT_MIN_FPS_VALUE), m_maxFpsValue(DEFAULT_MAX_FPS_VALUE)
-          , m_totalFpsValues(0), m_numberOfFpsUpdates(0), m_fpsCollectionInProgress(false), m_lastFpsValue(-1)
+            , m_fpsCollectionFrequencyInMs(DEFAULT_FPS_COLLECTION_TIME_IN_MILLISECONDS)
+            , m_minFpsValue(DEFAULT_MIN_FPS_VALUE)
+            , m_maxFpsValue(DEFAULT_MAX_FPS_VALUE)
+            , m_totalFpsValues(0)
+            , m_numberOfFpsUpdates(0)
+            , m_fpsCollectionInProgress(false)
+            , m_reportFpsTimer(Core::ProxyType<TpTimer>::Create())
+            , m_lastFpsValue(-1)
         {
             FrameRate::_instance = this;
 
@@ -159,7 +165,7 @@ namespace WPEFramework
             GetHandler(2)->Register<JsonObject, JsonObject>(METHOD_GET_DISPLAY_FRAME_RATE, &FrameRate::getDisplayFrameRate, this);
             GetHandler(2)->Register<JsonObject, JsonObject>(METHOD_SET_DISPLAY_FRAME_RATE, &FrameRate::setDisplayFrameRate, this);
 
-            m_reportFpsTimer.connect(std::bind(&FrameRate::onReportFpsTimer, this));
+            m_reportFpsTimer->connect(std::bind(&FrameRate::onReportFpsTimer, this));
         }
 
         FrameRate::~FrameRate()
@@ -414,9 +420,9 @@ namespace WPEFramework
             {
                 return false;
             }
-            if (m_reportFpsTimer.isActive())
+            if (m_reportFpsTimer->isActive())
             {
-                m_reportFpsTimer.stop();
+                m_reportFpsTimer->stop();
             }
             m_minFpsValue = DEFAULT_MIN_FPS_VALUE;
             m_maxFpsValue = DEFAULT_MAX_FPS_VALUE;
@@ -428,7 +434,7 @@ namespace WPEFramework
             {
                 fpsCollectionFrequency = MINIMUM_FPS_COLLECTION_TIME_IN_MILLISECONDS;
             }
-            m_reportFpsTimer.start(fpsCollectionFrequency);
+            m_reportFpsTimer->start(fpsCollectionFrequency);
             enableFpsCollection();
             return true;
         }
@@ -443,9 +449,9 @@ namespace WPEFramework
         */
         bool FrameRate::stopFpsCollection()
         {
-            if (m_reportFpsTimer.isActive())
+            if (m_reportFpsTimer->isActive())
             {
-                m_reportFpsTimer.stop();
+                m_reportFpsTimer->stop();
             }
             if (m_fpsCollectionInProgress)
             {

--- a/FrameRate/FrameRate.h
+++ b/FrameRate/FrameRate.h
@@ -22,12 +22,13 @@
 #include <mutex>
 
 #include "Module.h"
-#include "tptimer.h"
 #include "libIARM.h"
 
 namespace WPEFramework {
 
     namespace Plugin {
+
+        class TpTimer;
 
         class FrameRate : public PluginHost::IPlugin, public PluginHost::JSONRPC {
         private:
@@ -92,8 +93,7 @@ namespace WPEFramework {
             int m_totalFpsValues;
             int m_numberOfFpsUpdates;
             bool m_fpsCollectionInProgress;
-            //QTimer m_reportFpsTimer;
-            TpTimer m_reportFpsTimer;
+            Core::ProxyType<TpTimer> m_reportFpsTimer;
             int m_lastFpsValue;
             
             std::mutex m_callMutex;

--- a/FrameRate/FrameRate.h
+++ b/FrameRate/FrameRate.h
@@ -23,26 +23,13 @@
 
 #include "Module.h"
 #include "tptimer.h"
-#include "utils.h"
-#include "AbstractPlugin.h"
+#include "libIARM.h"
 
 namespace WPEFramework {
 
     namespace Plugin {
 
-        // This is a server for a JSONRPC communication channel. 
-        // For a plugin to be capable to handle JSONRPC, inherit from PluginHost::JSONRPC.
-        // By inheriting from this class, the plugin realizes the interface PluginHost::IDispatcher.
-        // This realization of this interface implements, by default, the following methods on this plugin
-        // - exists
-        // - register
-        // - unregister
-        // Any other methood to be handled by this plugin  can be added can be added by using the
-        // templated methods Register on the PluginHost::JSONRPC class.
-        // As the registration/unregistration of notifications is realized by the class PluginHost::JSONRPC,
-        // this class exposes a public method called, Notify(), using this methods, all subscribed clients
-        // will receive a JSONRPC message as a notification, in case this method is called.
-        class FrameRate : public AbstractPlugin {
+        class FrameRate : public PluginHost::IPlugin, public PluginHost::JSONRPC {
         private:
 
             // We do not allow this plugin to be copied !!
@@ -89,6 +76,12 @@ namespace WPEFramework {
             virtual ~FrameRate();
 	    virtual const string Initialize(PluginHost::IShell* service) override;
             virtual void Deinitialize(PluginHost::IShell* service) override;
+            virtual string Information() const override;
+
+            BEGIN_INTERFACE_MAP(MODULE_NAME)
+            INTERFACE_ENTRY(PluginHost::IPlugin)
+            INTERFACE_ENTRY(PluginHost::IDispatcher)
+            END_INTERFACE_MAP
 
         public:
             static FrameRate* _instance;


### PR DESCRIPTION
Reason for change: Simplify writing unit tests
for DataCapture, DeviceDiagnostics and FrameRate
by removing the unnecessary includes.
Test Procedure: It should build.
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>