### PR TITLE
RDK-35348: Update the getPublicIP() for phase2

### DIFF
--- a/Network/Network.h
+++ b/Network/Network.h
@@ -75,6 +75,7 @@ namespace WPEFramework {
             uint32_t isConnectedToInternet(const JsonObject& parameters, JsonObject& response);
             uint32_t setConnectivityTestEndpoints(const JsonObject& parameters, JsonObject& response);
             uint32_t getPublicIP(const JsonObject& parameters, JsonObject& response);
+	    uint32_t setStunEndPoints(const JsonObject& parameters, JsonObject& response);
 
             void onInterfaceEnabledStatusChanged(std::string interface, bool enabled);
             void onInterfaceConnectionStatusChanged(std::string interface, bool connected);
@@ -109,6 +110,7 @@ namespace WPEFramework {
             virtual const std::string Initialize(PluginHost::IShell* service) override;
             virtual void Deinitialize(PluginHost::IShell* service) override;
             virtual std::string Information() const override;
+	    uint32_t getPublicIPInternal(const JsonObject& parameters, JsonObject& response);
 
         public:
             static Network *_instance;

--- a/Network/Network.json
+++ b/Network/Network.json
@@ -723,6 +723,41 @@
             "params": {
                 "type":"object",
                 "properties": {
+                    "iface": {
+                        "$ref": "#/definitions/interface"
+                    },
+                    "ipv6": {
+                        "$ref": "#/definitions/ipversion"
+                    }
+                },
+                "required": [
+                    "iface",
+                    "ipv6"
+                ]
+            },
+            "result": {
+                "type": "object",
+                "properties": {
+                    "public_ip":{
+                        "summary": "Returns an public ip of the device ,if ipv6 is `true`,returns IPv6 public ip , otherwise returns IPv4 public ip",
+                        "type":"string",
+                        "example": "69.136.49.95"
+                    },
+                    "success": {
+                        "$ref": "#/definitions/success"
+                    }
+	       },
+                "required": [
+                    "public_ip",
+                    "success"
+                ]
+            }
+        },
+	 "setStunEndPoints":{
+            "summary": "Set the list of Stun Endpoints used for getPublicIP",
+            "params": {
+                "type":"object",
+                "properties": {
                     "server": {
                         "$ref": "#/definitions/server"
                     },
@@ -758,15 +793,10 @@
             "result": {
                 "type": "object",
                 "properties": {
-                    "public_ip":{
-                        "summary": "Returns an public ip of the device ,if ipv6 is `true`,returns IPv6 public ip , otherwise returns IPv4 public ip",
-                        "type":"string",
-                        "example": "69.136.49.95"
-                    },
                     "success": {
                         "$ref": "#/definitions/success"
                     }
-	       },
+               },
                 "required": [
                     "public_ip",
                     "success"

--- a/Network/doc/NetworkPlugin.md
+++ b/Network/doc/NetworkPlugin.md
@@ -101,6 +101,7 @@ Network interface methods:
 | [setInterfaceEnabled](#method.setInterfaceEnabled) | Enables the specified interface |
 | [setIPSettings](#method.setIPSettings) | Sets the IP settings |
 | [getPublicIP](#method.getPublicIP) | Determine WAN ip address |
+| [setStunEndPoints](#method.setStunEndPoints) | Set the list of Stun Endpoints used for `getPublicIP`  |
 | [trace](#method.trace) | Traces the specified endpoint with the specified number of packets using `traceroute` |
 | [traceNamedEndpoint](#method.traceNamedEndpoint) | Traces the specified named endpoint with the specified number of packets using `traceroute` |
 
@@ -882,20 +883,15 @@ Sets the IP settings.
 ```
 <a name="method.getPublicIP"></a>
 ## *getPublicIP [<sup>method</sup>](#head.Methods)*
-Determine WAN ip address.
+getPublicIP allows either zero parameter or with only interface and ipv6 parameter to determine WAN ip address.
 
 ### Parameters
 
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
-| params | object |  |
-| params.server | string | STUN server |
-| params.port | integer | STUN server port |
+| params | object | it allows empty parameter too |
 | params.iface | string | An interface, such as `ETHERNET` or `WIFI`, depending upon availability of the given interface in `getInterfaces` |
-| params.ipv6 | string | either IPv4 or IPv6 |
-| params.sync | boolean | STUN server sync |
-| params.timeout | integer | STUN server bind timeout |
-| params.cache_timeout | integer | STUN server cache timeout |
+| params.ipv6 | boolean | either IPv4 or IPv6 , by default  using IPv4  |
 
 ### Result
 
@@ -915,13 +911,8 @@ Determine WAN ip address.
     "id": 1234567890,
     "method": "org.rdk.Network.1.getPublicIP",
     "params": {
-        "server": "global.stun.twilio.com",
-        "port": 3478,
         "iface": "WIFI",
-        "ipv6": "IPv4",
-        "sync": true,
-        "timeout": 30,
-        "cache_timeout": 0
+        "ipv6": false,
     }
 }
 ```
@@ -938,7 +929,62 @@ Determine WAN ip address.
     }
 }
 ```
+<a name="method.setStunEndPoints"></a>
+## *setStunEndPoints [<sup>method</sup>](#head.Methods)*
+Set the list of Stun endpoints used for getPublicIP
 
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.server | string | STUN server |
+| params.port | integer | STUN server port |
+| params.iface | string | An interface, such as `ETHERNET` or `WIFI`, depending upon availability of the given interface in `getInterfaces` |
+| params.ipv6 | string | either IPv4 or IPv6 , by default  using IPv4 |
+| params.sync | boolean | STUN server sync |
+| params.timeout | integer | STUN server bind timeout |
+| params.cache_timeout | integer | STUN server cache timeout |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.success | boolean | Whether the request succeeded |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "org.rdk.Network.1.setStunEndPoints",
+    "params": {
+        "server": "stun.l.google.com",
+        "port": 19302,
+        "iface": "WIFI",
+        "ipv6": false,
+        "sync": true,
+        "timeout": 30,
+        "cache_timeout": 0
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": {
+        "success": true
+    }
+}
+```
 <a name="method.trace"></a>
 ## *trace [<sup>method</sup>](#head.Methods)*
 


### PR DESCRIPTION
[RDK-35348: Update the getPublicIP() for phase2]

Reason for change: updated the getPublicIP api to allow only interface and ipv6 parameter and also document changes 
Test Procedure: please referred from RDK-35348
Risks: Low
Signed-off-by: Thamim Razith <ThamimRazith_AbbasAli@comcast.com>