### PR TITLE
RDK-33778: Query WAN IP address using getPlatformConfiguration

### DIFF
--- a/SystemServices/doc/SystemPlugin.md
+++ b/SystemServices/doc/SystemPlugin.md
@@ -3333,6 +3333,7 @@ This method takes no parameters.
 | result?.DeviceInfo?.webBrowser.userAgent | string |  |
 | result?.DeviceInfo?.HdrCapability | string | <sup>*(optional)*</sup> e.g. HDR10,Dolby Vision,Technicolor Prime |
 | result?.DeviceInfo?.canMixPCMWithSurround | boolean | <sup>*(optional)*</sup>  |
+| result?.DeviceInfo?.publicIP | string | Public IP |
 | result.success | boolean | Whether the request succeeded |
 
 ### Example
@@ -3343,9 +3344,9 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.getPlatformConfiguration",
+    "method": "org.rdk.System.2.getPlatformConfiguration",
     "params": {
-        "query": "..."
+        "query": ""
     }
 }
 ```
@@ -3383,7 +3384,8 @@ This method takes no parameters.
                 "userAgent": "Mozilla/5.0 (Linux; x86_64 GNU/Linux) AppleWebKit/601.1 (KHTML, like Gecko) Version/8.0 Safari/601.1 WPE"
             },
             "HdrCapability": "none",
-            "canMixPCMWithSurround": true
+            "canMixPCMWithSurround": true,
+            "publicIP": "12.34.56.78"
         },
         "success": true
     }

--- a/SystemServices/platformcaps/platformcaps.cpp
+++ b/SystemServices/platformcaps/platformcaps.cpp
@@ -184,6 +184,11 @@ bool PlatformCaps::DeviceInfo::Load(const string &query) {
     Add(_T("canMixPCMWithSurround"), &canMixPCMWithSurround);
   }
 
+  if (query.empty() || query == _T("publicIP")) {
+    publicIP = data.GetPublicIP();
+    Add(_T("publicIP"), &publicIP);
+  }
+
   return result;
 }
 

--- a/SystemServices/platformcaps/platformcaps.h
+++ b/SystemServices/platformcaps/platformcaps.h
@@ -78,6 +78,7 @@ public:
     WebBrowser webBrowser;
     Core::JSON::String HdrCapability;
     Core::JSON::Boolean canMixPCMWithSurround;
+    Core::JSON::String publicIP;
   };
 
 public:

--- a/SystemServices/platformcaps/platformcapsdata.h
+++ b/SystemServices/platformcaps/platformcapsdata.h
@@ -57,6 +57,7 @@ public:
   bool XCALSessionTokenAvailable();
   string GetExperience();
   string GetDdeviceMACAddress();
+  string GetPublicIP();
 
 private:
   class JsonRpc {

--- a/SystemServices/platformcaps/platformcapsdatarpc.cpp
+++ b/SystemServices/platformcaps/platformcapsdatarpc.cpp
@@ -123,6 +123,12 @@ string PlatformCapsData::GetDdeviceMACAddress() {
       .Get(_T("estb_mac")).String();
 }
 
+string PlatformCapsData::GetPublicIP() {
+  return jsonRpc.invoke(_T("org.rdk.Network.1"),
+                        _T("getPublicIP"), 5000)
+      .Get(_T("public_ip")).String();
+}
+
 JsonObject PlatformCapsData::JsonRpc::invoke(const string &callsign,
     const string &method, const uint32_t waitTime) {
   JsonObject params, result;


### PR DESCRIPTION
Reason for change: Enhance the existing getPlatformConfiguration() method of SystemService thunder plugin include publicIP as additional information under DeviceInfo**
Test Procedure: curl getPlatformConfiguration
Risks: Medium
Signed-off-by: Kumar Santhanam <Kumar_Santhanam@comcast.com>