### PR TITLE
RDK-33778: Should not print the public IP in the log file

### DIFF
--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -3946,7 +3946,6 @@ namespace WPEFramework {
 
           response.Load(query);
 
-          LOGTRACEMETHODFIN();
           return Core::ERROR_NONE;
         }
     } /* namespace Plugin */


### PR DESCRIPTION
Reason for change: wpeframework.log or netsrvmgr.log should not print the public IP in the log file as it is Customer Private Information.
Test Procedure: curl getPlatformConfiguration
Risks: Medium
Signed-off-by: Kumar Santhanam <Kumar_Santhanam@comcast.com>