### PR TITLE
AMLOGIC-3042: Increase standby message broadcast timeout

### DIFF
--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -788,7 +788,7 @@ namespace WPEFramework
 				return;
 			}
 
-			_instance->smConnection->sendTo(LogicalAddress(LogicalAddress::BROADCAST), MessageEncoder().encode(Standby()), 100);
+			_instance->smConnection->sendTo(LogicalAddress(LogicalAddress::BROADCAST), MessageEncoder().encode(Standby()), 1000);
        } 
 
 	   void HdmiCecSink::wakeupFromStandby()


### PR DESCRIPTION
Reason for change: Increase timeout of standby broadcast message
so that retry possibility increases if message broadcast
fails
Test Procedure: Refer Ticket
Risks: Low

Signed-off-by: Deekshit Devadas deekshit.devadasy@sky.uk