### PR TITLE
RDKTV-11322: RA needs to differentiate the restart reason by querying…

### DIFF
--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -138,6 +138,7 @@ const string WPEFramework::Plugin::RDKShell::RDKSHELL_EVENT_DEVICE_CRITICALLY_LO
 const string WPEFramework::Plugin::RDKShell::RDKSHELL_EVENT_ON_EASTER_EGG = "onEasterEgg";
 const string WPEFramework::Plugin::RDKShell::RDKSHELL_EVENT_ON_WILL_DESTROY = "onWillDestroy";
 const string WPEFramework::Plugin::RDKShell::RDKSHELL_EVENT_ON_SCREENSHOT_COMPLETE = "onScreenshotComplete";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_EVENT_ON_CLIENT_REBOOT_REASON = "getClientRebootStatus";
 
 using namespace std;
 using namespace RdkShell;
@@ -183,6 +184,10 @@ static uint32_t gWillDestroyEventWaitTime = RDKSHELL_WILLDESTROY_EVENT_WAITTIME;
 #define REMOTECONTROL_CALLSIGN "org.rdk.RemoteControl.1"
 #define KEYCODE_INVALID -1
 #define RETRY_INTERVAL_250MS 250000
+
+#define NORMALBOOT   "NormalBoot"
+#define CRASHBOOT    "CrashBoot"
+#define REQUESTBOOT  "RequestBoot"
 
 enum FactoryAppLaunchStatus
 {
@@ -373,6 +378,7 @@ namespace WPEFramework {
         std::vector<RDKShellStartupConfig> gStartupConfigs;
         std::map<std::string, bool> gDestroyApplications;
         std::map<std::string, bool> gLaunchApplications;
+        std::map<std::string, std::string> gClientsResetReason;
         
         uint32_t getKeyFlag(std::string modifier)
         {
@@ -544,12 +550,49 @@ namespace WPEFramework {
             }
             return exist;
         }
+                   
+       static void addClientRebootStatus(string client,PluginHost::IShell::state currentState,PluginHost::IShell::reason stateChangeReason)
+       {
+         if(currentState == PluginHost::IShell::ACTIVATED)
+         { 
+           std::map<std::string, std::string>::iterator it;
+           it=gClientsResetReason.find(client);
+           if(!(it != gClientsResetReason.end()))
+           {
+              std::cout<<"kathiravan normal boot "<<client<<std::endl;
+              gRdkShellMutex.lock();
+              gClientsResetReason.insert(pair<string, string>(client,NORMALBOOT));
+              gRdkShellMutex.unlock();
+	   }
+         }
+	 if(stateChangeReason == PluginHost::IShell::FAILURE)
+         {
+            std::map<std::string, std::string>::iterator it; 
+	    it=gClientsResetReason.find(client);
+            if(it != gClientsResetReason.end())
+            {
+                it->second=CRASHBOOT;
+            }
+	 }
+         else if ((currentState == PluginHost::IShell::DEACTIVATED) || (currentState == PluginHost::IShell::DESTROYED)) 
+	 {
+             std::map<std::string, std::string>::iterator it;
+             it=gClientsResetReason.find(client);
+             if(it != gClientsResetReason.end())
+             {
+                it->second=REQUESTBOOT;
+             }
+         }
+         else {}
+        }
 
         void RDKShell::MonitorClients::StateChange(PluginHost::IShell* service)
         {
             if (service)
             {
                 PluginHost::IShell::state currentState(service->State());
+				
+	        addClientRebootStatus(service->Callsign(),service->State(),service->Reason());
                 if (currentState == PluginHost::IShell::ACTIVATION)
                 {
                    std::string configLine = service->ConfigLine();
@@ -785,6 +828,7 @@ namespace WPEFramework {
 
             registerMethod(RDKSHELL_METHOD_ENABLE_LOGS_FLUSHING, &RDKShell::enableLogsFlushingWrapper, this);
             registerMethod(RDKSHELL_METHOD_GET_LOGS_FLUSHING_ENABLED, &RDKShell::getLogsFlushingEnabledWrapper, this);
+	    registerMethod(RDKSHELL_EVENT_ON_CLIENT_REBOOT_REASON, &RDKShell::getClientRebootStatus, this);
 	    m_timer.connect(std::bind(&RDKShell::onTimer, this));
         }
 
@@ -1276,6 +1320,9 @@ namespace WPEFramework {
             {
                RdkShell::CompositorController::removeListener((*ptr),mEventListener);
             }
+	    gRdkShellMutex.lock();
+            gClientsResetReason.clear();
+	    gRdkShellMutex.unlock();
             mCurrentService = nullptr;
             service->Unregister(mClientsMonitor);
             mClientsMonitor->Release();
@@ -5171,7 +5218,28 @@ namespace WPEFramework {
 
             returnResponse(true);
         }
-        // Registered methods end
+         uint32_t RDKShell::getClientRebootStatus(const JsonObject& parameters, JsonObject& response)
+         {
+            LOGINFOMETHOD();
+            if (parameters.HasLabel("client"))
+            {
+	       std::cout<<"kathiravan mew implementation"<<std::endl;	    
+	       std::string clientidentifier = parameters["client"].String();
+	       std::map<std::string, std::string>::iterator it;
+	       it=gClientsResetReason.find(clientidentifier);
+	       if(it != gClientsResetReason.end())
+	       {
+                    response["reason"] = it->second;
+	       }
+	       else
+	       {				  
+		    returnResponse(false);
+               }
+            returnResponse(true);
+           }
+	  }
+		
+		// Registered methods end
 
         // Events begin
         void RDKShell::notify(const std::string& event, const JsonObject& parameters)

--- a/RDKShell/RDKShell.h
+++ b/RDKShell/RDKShell.h
@@ -147,6 +147,7 @@ namespace WPEFramework {
             static const string RDKSHELL_EVENT_ON_EASTER_EGG;
             static const string RDKSHELL_EVENT_ON_WILL_DESTROY;
             static const string RDKSHELL_EVENT_ON_SCREENSHOT_COMPLETE;
+	    static const string RDKSHELL_EVENT_ON_CLIENT_REBOOT_REASON;
 
             void notify(const std::string& event, const JsonObject& parameters);
             void pluginEventHandler(const JsonObject& parameters);
@@ -227,6 +228,7 @@ namespace WPEFramework {
             uint32_t enableEasterEggsWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t enableLogsFlushingWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t getLogsFlushingEnabledWrapper(const JsonObject& parameters, JsonObject& response);
+	    uint32_t getClientRebootStatus(const JsonObject& parameters, JsonObject& response);
 
         private/*internal methods*/:
             RDKShell(const RDKShell&) = delete;


### PR DESCRIPTION
… RDKShell

From: kchinn681 <kathiravan_chinnadurai@comcast.com>

Subject: RA needs to differentiate the restart reason by querying RDKShell
Reason for change: curl command support for reset reason
Test Procedure: inspect reset client reason using getClientRbooStatus Api
Risks: Low
Signed-off-by: kathiravan chinnadurai <kathiravan_chinnadurai@comcast.com>
Source: COMCAST
License: GPLV2
Upstream-Status: Pending