### PR TITLE
RDK-35175: Thunder API for Manual IP Assignment - Phase 2

### DIFF
--- a/Network/Network.cpp
+++ b/Network/Network.cpp
@@ -1050,7 +1050,7 @@ namespace WPEFramework
             returnResponse(result)
         }
 
-        bool Network::getIPSettingsInternal(const JsonObject& parameters, JsonObject response,int errCode)
+        bool Network::getIPSettingsInternal(const JsonObject& parameters, JsonObject& response,int errCode)
         {
             string interface = "";
             string ipversion = "";

--- a/Network/Network.h
+++ b/Network/Network.h
@@ -105,7 +105,7 @@ namespace WPEFramework {
 
             JsonObject _doPing(const std::string& guid, const std::string& endPoint, int packets);
             JsonObject _doPingNamedEndpoint(const std::string& guid, const std::string& endpointName, int packets);
-            bool getIPSettingsInternal(const JsonObject& parameters, JsonObject response,int errCode);
+            bool getIPSettingsInternal(const JsonObject& parameters, JsonObject& response,int errCode);
             uint32_t setIPSettingsInternal(const JsonObject& parameters, JsonObject& response);
 
         public:


### PR DESCRIPTION
Reason for change: Correct the JSON Response parameter for the geIPSetting api
Test Procedure: please referred from RDK-35348
Risks: Low
Signed-off-by: Thamim Razith ThamimRazith_AbbasAli@comcast.com