### PR TITLE
RDK-33778 - Determine WAN IP Address - Phase 2

### DIFF
--- a/Network/Network.cpp
+++ b/Network/Network.cpp
@@ -181,8 +181,14 @@ namespace WPEFramework
             Register("setConnectivityTestEndpoints", &Network::setConnectivityTestEndpoints, this);
 
             Register("getPublicIP", &Network::getPublicIP, this);
+            Register("setStunEndPoint", &Network::setStunEndPoint, this);
 
             m_netUtils.InitialiseNetUtils();
+            m_stunEndPoint = "stun.l.google.com";
+            m_stunPort = 19302;
+            m_stunBindTimeout = 30;
+            m_stunCacheTimeout = 0;
+            m_stunSync = true;
         }
 
         Network::~Network()
@@ -251,6 +257,7 @@ namespace WPEFramework
             Unregister("isConnectedToInternet");
             Unregister("setConnectivityTestEndpoints");
             Unregister("getPublicIP");
+            Unregister("setStunEndPoint");
 
             Network::_instance = nullptr;
         }
@@ -821,64 +828,88 @@ namespace WPEFramework
 
         uint32_t Network::getPublicIP(const JsonObject& parameters, JsonObject& response)
         {
+            JsonObject internal;
+            internal ["server"] = m_stunEndPoint;
+            internal ["port"] = m_stunPort;
+            internal ["timeout"] = m_stunBindTimeout;
+            internal ["cache_timeout"] = m_stunCacheTimeout;
+            internal ["sync"] = m_stunSync;
+
+            if (parameters.HasLabel("iface"))
+                internal ["iface"] = parameters["iface"];
+
+            if (parameters.HasLabel("ipv6"))
+                internal ["ipv6"] = parameters["ipv6"];
+
+            return  getPublicIPInternal(internal, response);
+        }
+
+        uint32_t Network::setStunEndPoint(const JsonObject& parameters, JsonObject& response)
+        {
+            getDefaultStringParameter("server", m_stunEndPoint, "stun.l.google.com");
+            getDefaultNumberParameter("port", m_stunPort, 19302);
+            getDefaultBoolParameter("sync", m_stunSync, true);
+            getDefaultNumberParameter("timeout", m_stunBindTimeout, 30);
+            getDefaultNumberParameter("cache_timeout", m_stunCacheTimeout, 0);
+
+            returnResponse(true);
+	}
+
+        uint32_t Network::getPublicIPInternal(const JsonObject& parameters, JsonObject& response)
+        {
             bool result = false;
 
             IARM_BUS_NetSrvMgr_Iface_StunRequest_t iarmData = { 0 };
             string server, iface;
 
-            getDefaultStringParameter("server", server, "");
+            getStringParameter("server", server);
             if (server.length() > MAX_HOST_NAME_LEN - 1)
             {
                 LOGWARN("invalid args: server exceeds max length of %u", MAX_HOST_NAME_LEN);
-                returnResponse(false)               
+                returnResponse(result)
             }
 
-            getDefaultNumberParameter("port", iarmData.port, 0);
+            getNumberParameter("port", iarmData.port);
 
             /*only makes sense to get both server and port or neither*/
             if (!server.empty() && !iarmData.port)
             {
                 LOGWARN("invalid args: port missing");
-                returnResponse(false)
+                returnResponse(result)
             } 
             if (iarmData.port && server.empty())
             {
                 LOGWARN("invalid args: server missing");
-                returnResponse(false)
+                returnResponse(result)
             }
 
             getDefaultStringParameter("iface", iface, "");
             if (iface.length() > 16 - 1)
             {
                 LOGWARN("invalid args: interface exceeds max length of 16");
-                returnResponse(false)               
+                returnResponse(result)
             }
 	    
-            if (!(strcmp (iface.c_str(), "ETHERNET") == 0 || strcmp (iface.c_str(), "WIFI") == 0))
-            {
-                LOGERR ("Call for %s failed due to invalid interface [%s]", IARM_BUS_NETSRVMGR_API_getPublicIP, iface.c_str());
-                returnResponse (result)
-            }
-
-            getDefaultBoolParameter("ipv6", iarmData.ipv6, false);
-            getDefaultBoolParameter("sync", iarmData.sync, true);
-            getDefaultNumberParameter("timeout", iarmData.bind_timeout, 0);
-            getDefaultNumberParameter("cache_timeout", iarmData.cache_timeout, 0);
+            getBoolParameter("ipv6", iarmData.ipv6);
+            getBoolParameter("sync", iarmData.sync);
+            getNumberParameter("timeout", iarmData.bind_timeout);
+            getNumberParameter("cache_timeout", iarmData.cache_timeout);
 
             strncpy(iarmData.server, server.c_str(), MAX_HOST_NAME_LEN);
             strncpy(iarmData.interface, iface.c_str(), 16);
 
             iarmData.public_ip[0] = '\0';
 
-            LOGWARN("getPublicIP called with server=%s port=%u iface=%s ipv6=%u timeout=%u cache_timeout=%u\n", 
-                iarmData.server, iarmData.port, iarmData.interface, iarmData.ipv6, iarmData.bind_timeout, iarmData.cache_timeout);
+            LOGWARN("getPublicIP called with server=%s port=%u iface=%s ipv6=%u sync=%u timeout=%u cache_timeout=%u\n", 
+                iarmData.server, iarmData.port, iarmData.interface, iarmData.ipv6, iarmData.sync, iarmData.bind_timeout, iarmData.cache_timeout);
 
             if (IARM_RESULT_SUCCESS == IARM_Bus_Call (IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_NETSRVMGR_API_getPublicIP, (void *)&iarmData, sizeof(iarmData)))
             {
                 response["public_ip"] = string(iarmData.public_ip);
                 result = true;
             }
-            returnResponse(result)
+            response["success"] = result;
+            return (Core::ERROR_NONE);
         }
 
         /*

--- a/Network/Network.h
+++ b/Network/Network.h
@@ -75,6 +75,7 @@ namespace WPEFramework {
             uint32_t isConnectedToInternet(const JsonObject& parameters, JsonObject& response);
             uint32_t setConnectivityTestEndpoints(const JsonObject& parameters, JsonObject& response);
             uint32_t getPublicIP(const JsonObject& parameters, JsonObject& response);
+            uint32_t setStunEndPoint(const JsonObject& parameters, JsonObject& response);
 
             void onInterfaceEnabledStatusChanged(std::string interface, bool enabled);
             void onInterfaceConnectionStatusChanged(std::string interface, bool connected);
@@ -109,6 +110,7 @@ namespace WPEFramework {
             virtual const std::string Initialize(PluginHost::IShell* service) override;
             virtual void Deinitialize(PluginHost::IShell* service) override;
             virtual std::string Information() const override;
+            uint32_t getPublicIPInternal(const JsonObject& parameters, JsonObject& response);
 
         public:
             static Network *_instance;
@@ -116,6 +118,11 @@ namespace WPEFramework {
 
         private:
             NetUtils m_netUtils;
+            string m_stunEndPoint;
+            uint16_t m_stunPort;
+            uint16_t m_stunBindTimeout;
+            uint16_t m_stunCacheTimeout;
+            bool m_stunSync;
         };
     } // namespace Plugin
 } // namespace WPEFramework

--- a/Network/Network.json
+++ b/Network/Network.json
@@ -723,36 +723,16 @@
             "params": {
                 "type":"object",
                 "properties": {
-                    "server": {
-                        "$ref": "#/definitions/server"
-                    },
-                    "port": {
-                        "$ref": "#/definitions/port"
-                    },
                     "iface": {
                         "$ref": "#/definitions/interface"
                     },
                     "ipv6": {
                         "$ref": "#/definitions/ipversion"
-                    },
-                    "sync": {
-                        "$ref": "#/definitions/sync"
-                    },
-                    "timeout": {
-                        "$ref": "#/definitions/timeout"
-                    },
-                    "cache_timeout": {
-                        "$ref": "#/definitions/cache_timeout"
                     }
                 },
                 "required": [
-                    "server",
-                    "port",
                     "iface",
-                    "ipv6",
-                    "sync",
-                    "timeout",
-                    "cache_timeout"
+                    "ipv6"
                 ]
             },
             "result": {
@@ -767,6 +747,48 @@
                         "$ref": "#/definitions/success"
                     }
 	       },
+                "required": [
+                    "public_ip",
+                    "success"
+                ]
+            }
+        },
+	 "setStunEndPoint":{
+            "summary": "Set the Stun Endpoint used for getPublicIP",
+            "params": {
+                "type":"object",
+                "properties": {
+                    "server": {
+                        "$ref": "#/definitions/server"
+                    },
+                    "port": {
+                        "$ref": "#/definitions/port"
+                    },
+                    "sync": {
+                        "$ref": "#/definitions/sync"
+                    },
+                    "timeout": {
+                        "$ref": "#/definitions/timeout"
+                    },
+                    "cache_timeout": {
+                        "$ref": "#/definitions/cache_timeout"
+                    }
+                },
+                "required": [
+                    "server",
+                    "port",
+                    "sync",
+                    "timeout",
+                    "cache_timeout"
+                ]
+            },
+            "result": {
+                "type": "object",
+                "properties": {
+                    "success": {
+                        "$ref": "#/definitions/success"
+                    }
+               },
                 "required": [
                     "public_ip",
                     "success"

--- a/Network/doc/NetworkPlugin.md
+++ b/Network/doc/NetworkPlugin.md
@@ -101,6 +101,7 @@ Network interface methods:
 | [setInterfaceEnabled](#method.setInterfaceEnabled) | Enables the specified interface |
 | [setIPSettings](#method.setIPSettings) | Sets the IP settings |
 | [getPublicIP](#method.getPublicIP) | Determine WAN ip address |
+| [setStunEndPoint](#method.setStunEndPoint) | Set the Stun Endpoint used for `getPublicIP`  |
 | [trace](#method.trace) | Traces the specified endpoint with the specified number of packets using `traceroute` |
 | [traceNamedEndpoint](#method.traceNamedEndpoint) | Traces the specified named endpoint with the specified number of packets using `traceroute` |
 
@@ -882,20 +883,15 @@ Sets the IP settings.
 ```
 <a name="method.getPublicIP"></a>
 ## *getPublicIP [<sup>method</sup>](#head.Methods)*
-Determine WAN ip address.
+getPublicIP allows either zero parameter or with only interface and ipv6 parameter to determine WAN ip address.
 
 ### Parameters
 
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
-| params | object |  |
-| params.server | string | STUN server |
-| params.port | integer | STUN server port |
+| params | object | it allows empty parameter too |
 | params.iface | string | An interface, such as `ETHERNET` or `WIFI`, depending upon availability of the given interface in `getInterfaces` |
-| params.ipv6 | string | either IPv4 or IPv6 |
-| params.sync | boolean | STUN server sync |
-| params.timeout | integer | STUN server bind timeout |
-| params.cache_timeout | integer | STUN server cache timeout |
+| params.ipv6 | boolean | either IPv4 or IPv6 , by default  using IPv4  |
 
 ### Result
 
@@ -915,13 +911,8 @@ Determine WAN ip address.
     "id": 1234567890,
     "method": "org.rdk.Network.1.getPublicIP",
     "params": {
-        "server": "global.stun.twilio.com",
-        "port": 3478,
         "iface": "WIFI",
-        "ipv6": "IPv4",
-        "sync": true,
-        "timeout": 30,
-        "cache_timeout": 0
+        "ipv6": false,
     }
 }
 ```
@@ -938,7 +929,58 @@ Determine WAN ip address.
     }
 }
 ```
+<a name="method.setStunEndPoint"></a>
+## *setStunEndPoint [<sup>method</sup>](#head.Methods)*
+Set the Stun Endpoint used for getPublicIP
 
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.server | string | STUN server |
+| params.port | integer | STUN server port |
+| params.sync | boolean | STUN server sync |
+| params.timeout | integer | STUN server bind timeout |
+| params.cache_timeout | integer | STUN server cache timeout |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.success | boolean | Whether the request succeeded |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "method": "org.rdk.Network.1.setStunEndPoint",
+    "params": {
+        "server": "stun.l.google.com",
+        "port": 19302,
+        "sync": true,
+        "timeout": 30,
+        "cache_timeout": 0
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1234567890,
+    "result": {
+        "success": true
+    }
+}
+```
 <a name="method.trace"></a>
 ## *trace [<sup>method</sup>](#head.Methods)*
 

--- a/SystemServices/System.json
+++ b/SystemServices/System.json
@@ -244,6 +244,11 @@
                 "canMixPCMWithSurround": {
                     "type": "boolean",
                     "example": true
+                },
+                "publicIP": {
+                    "summary": "Public IP",
+                    "type": "string",
+                    "example": "12.34.56.78"
                 }
             },
             "required": []

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -3879,7 +3879,6 @@ namespace WPEFramework {
 
           response.Load(query);
 
-          LOGTRACEMETHODFIN();
           return Core::ERROR_NONE;
         }
     } /* namespace Plugin */

--- a/SystemServices/doc/SystemPlugin.md
+++ b/SystemServices/doc/SystemPlugin.md
@@ -3333,6 +3333,7 @@ This method takes no parameters.
 | result?.DeviceInfo?.webBrowser.userAgent | string |  |
 | result?.DeviceInfo?.HdrCapability | string | <sup>*(optional)*</sup> e.g. HDR10,Dolby Vision,Technicolor Prime |
 | result?.DeviceInfo?.canMixPCMWithSurround | boolean | <sup>*(optional)*</sup>  |
+| result?.DeviceInfo?.publicIP | string | Public IP |
 | result.success | boolean | Whether the request succeeded |
 
 ### Example
@@ -3343,9 +3344,9 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.getPlatformConfiguration",
+    "method": "org.rdk.System.2.getPlatformConfiguration",
     "params": {
-        "query": "..."
+        "query": ""
     }
 }
 ```
@@ -3383,7 +3384,8 @@ This method takes no parameters.
                 "userAgent": "Mozilla/5.0 (Linux; x86_64 GNU/Linux) AppleWebKit/601.1 (KHTML, like Gecko) Version/8.0 Safari/601.1 WPE"
             },
             "HdrCapability": "none",
-            "canMixPCMWithSurround": true
+            "canMixPCMWithSurround": true,
+            "publicIP": "12.34.56.78"
         },
         "success": true
     }

--- a/SystemServices/platformcaps/platformcaps.cpp
+++ b/SystemServices/platformcaps/platformcaps.cpp
@@ -184,6 +184,11 @@ bool PlatformCaps::DeviceInfo::Load(const string &query) {
     Add(_T("canMixPCMWithSurround"), &canMixPCMWithSurround);
   }
 
+  if (query.empty() || query == _T("publicIP")) {
+    publicIP = data.GetPublicIP();
+    Add(_T("publicIP"), &publicIP);
+  }
+
   return result;
 }
 

--- a/SystemServices/platformcaps/platformcaps.h
+++ b/SystemServices/platformcaps/platformcaps.h
@@ -78,6 +78,7 @@ public:
     WebBrowser webBrowser;
     Core::JSON::String HdrCapability;
     Core::JSON::Boolean canMixPCMWithSurround;
+    Core::JSON::String publicIP;
   };
 
 public:

--- a/SystemServices/platformcaps/platformcapsdata.h
+++ b/SystemServices/platformcaps/platformcapsdata.h
@@ -57,6 +57,7 @@ public:
   bool XCALSessionTokenAvailable();
   string GetExperience();
   string GetDdeviceMACAddress();
+  string GetPublicIP();
 
 private:
   class JsonRpc {

--- a/SystemServices/platformcaps/platformcapsdatarpc.cpp
+++ b/SystemServices/platformcaps/platformcapsdatarpc.cpp
@@ -123,6 +123,12 @@ string PlatformCapsData::GetDdeviceMACAddress() {
       .Get(_T("estb_mac")).String();
 }
 
+string PlatformCapsData::GetPublicIP() {
+  return jsonRpc.invoke(_T("org.rdk.Network.1"),
+                        _T("getPublicIP"), 5000)
+      .Get(_T("public_ip")).String();
+}
+
 JsonObject PlatformCapsData::JsonRpc::invoke(const string &callsign,
     const string &method, const uint32_t waitTime) {
   JsonObject params, result;


### PR DESCRIPTION
RDK-35348: Update the getPublicIP() for phase2
Reason for change: updated the getPublicIP api to allow only interface and ipv6 parameter and also update document changes
Test Procedure: please referred from RDK-35348
Risks: Low
Signed-off-by: Thamim Razith <ThamimRazith_AbbasAli@comcast.com>
(cherry picked from commit 532965865700be41c7574cf5d937841f054c665d)

RDK-33778: Query WAN IP address using getPlatformConfiguration

Reason for change: Enhance the existing getPlatformConfiguration() method of SystemService thunder plugin include publicIP as additional information under DeviceInfo**
Test Procedure: curl getPlatformConfiguration
Risks: Medium
Signed-off-by: Kumar Santhanam <Kumar_Santhanam@comcast.com>
(cherry picked from commit ebd6be25f17dd2eab2a6c0c925ea0a32d47b3596)

RDK-33778: Should not print the public IP in the log file

Reason for change: wpeframework.log or netsrvmgr.log should not print the public IP in the log file as it is Customer Private Information.
Test Procedure: curl getPlatformConfiguration
Risks: Medium
Signed-off-by: Kumar Santhanam <Kumar_Santhanam@comcast.com>
(cherry picked from commit 6b4f0fdf840a2016f8818a405ea4165d37b73b20)

RDK-35340: Update System JSON Definition

Reason for change: Update the JSON Schema to include updated methods and generate md accordingly.
Test Procedure: verify it SystemPlugin.md
Risks: Medium
Signed-off-by: Kumar Santhanam <Kumar_Santhanam@comcast.com>
(cherry picked from commit 2d6613f445021200f605125e51a7b67d15589058)