### PR TITLE
RDK-35050: File move fix

### DIFF
--- a/PersistentStore/PersistentStore.cpp
+++ b/PersistentStore/PersistentStore.cpp
@@ -21,6 +21,8 @@
 
 #include "SqliteStore.h"
 
+#include "UtilsFile.h"
+
 namespace WPEFramework {
 namespace Plugin {
 
@@ -53,12 +55,16 @@ const string PersistentStore::Initialize(PluginHost::IShell *service)
 
     ASSERT(!_config.Path.Value().empty());
 
-    Core::Directory(Core::File(_config.Path.Value()).PathName().c_str()).CreatePath();
+    Core::File file(_config.Path.Value());
 
-    if (!Core::File(_config.Path.Value()).Exists()) {
+    Core::Directory(file.PathName().c_str()).CreatePath();
+
+    if (!file.Exists()) {
         for (auto i : LegacyLocations()) {
-            if (Core::File(i).Exists()) {
-                if (!Core::File(i).Move(_config.Path.Value())) {
+            Core::File from(i);
+
+            if (from.Exists()) {
+                if (!Utils::MoveFile(file.Name(), from.Name())) {
                     result = "move failed";
                 }
                 break;

--- a/RdkServicesTest/Tests/PersistentStoreTest.cpp
+++ b/RdkServicesTest/Tests/PersistentStoreTest.cpp
@@ -347,7 +347,7 @@ TEST_F(PersistentStoreTestFixture, setupLegacyLocation) {
         .Times(1)
         .WillOnce(
             ::testing::Return("{"
-                              "\"path\":\"/tmp/rdkservicestore1\","
+                              "\"path\":\"/tmp/path/to/legacy/location/store\","
                               "\"key\":null,"
                               "\"maxsize\":20,"
                               "\"maxvalue\":10"
@@ -397,7 +397,7 @@ TEST_F(PersistentStoreTestFixture, useLegacyLocation) {
         .Times(1)
         .WillOnce(
             ::testing::Return(std::vector<string> {
-                "/tmp/rdkservicestore1"
+                "/tmp/path/to/legacy/location/store"
             })
         );
 

--- a/helpers/UtilsFile.h
+++ b/helpers/UtilsFile.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <core/core.h>
+
+namespace Utils
+{
+auto MoveFile(
+    const string &to,
+    const string &from) -> bool
+{
+    bool result = true;
+
+    using namespace WPEFramework::Core;
+
+    File fileTo(to);
+    File fileFrom(from);
+
+    if (fileFrom.Exists() &&
+        !fileTo.Exists() &&
+        fileFrom.Open(true) &&
+        fileTo.Create()) {
+
+        const uint32_t bufLen = 1024;
+
+        uint32_t len;
+        uint8_t buffer[bufLen];
+
+        do {
+            len = fileFrom.Read(buffer, bufLen);
+
+            if (len != 0) {
+                auto ptr = buffer;
+
+                do {
+                    auto count = fileTo.Write(ptr, len);
+
+                    if (count == 0) {
+                        result = false;
+
+                        break;
+                    }
+
+                    len -= count;
+                    ptr += count;
+                }
+                while (len != 0);
+            }
+            else {
+                break;
+            }
+        }
+        while (result);
+
+        if (result) {
+            fileFrom.Destroy();
+        }
+        else {
+            fileTo.Destroy();
+        }
+    }
+    else {
+        result = false;
+    }
+
+    return result;
+}
+}


### PR DESCRIPTION
Reason for change: Looks like the move functionality
from Thunder fails if the destination is on another
filesystem.
Test Procedure: Plugin activates.
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>