### PR TITLE
RDK-35050: Fix config

### DIFF
--- a/RdkServicesTest/Tests/PersistentStoreTest.cpp
+++ b/RdkServicesTest/Tests/PersistentStoreTest.cpp
@@ -347,7 +347,7 @@ TEST_F(PersistentStoreTestFixture, setupLegacyLocation) {
         .Times(1)
         .WillOnce(
             ::testing::Return("{"
-                              "\"path\":\"/tmp/rdkservicestore1\","
+                              "\"path\":\"/tmp/path/to/legacy/location/store\","
                               "\"key\":null,"
                               "\"maxsize\":20,"
                               "\"maxvalue\":10"
@@ -397,7 +397,7 @@ TEST_F(PersistentStoreTestFixture, useLegacyLocation) {
         .Times(1)
         .WillOnce(
             ::testing::Return(std::vector<string> {
-                "/tmp/rdkservicestore1"
+                "/tmp/path/to/legacy/location/store"
             })
         );
 

--- a/helpers/UtilsFile.h
+++ b/helpers/UtilsFile.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <core/core.h>
+
+namespace Utils
+{
+auto MoveFile(
+    const string &from,
+    const string &to) -> bool
+{
+    using namespace WPEFramework::Core;
+
+    File fileFrom(from);
+    File fileTo(to);
+
+    bool result =
+        fileFrom.Exists() &&
+            !fileTo.Exists() &&
+            fileFrom.Open(true) &&
+            fileTo.Create();
+
+    if (result) {
+        const uint32_t bufLen = 1024;
+
+        uint8_t buffer[bufLen];
+
+        do {
+            auto len = fileFrom.Read(buffer, bufLen);
+            if (len <= 0) {
+                break;
+            }
+
+            auto ptr = buffer;
+
+            do {
+                auto count = fileTo.Write(ptr, len);
+                if (count <= 0) {
+                    result = false;
+                    break;
+                }
+
+                len -= count;
+                ptr += count;
+            }
+            while (len > 0);
+        }
+        while (result);
+
+        if (result) {
+            fileFrom.Destroy();
+        }
+        else {
+            fileTo.Destroy();
+        }
+    }
+
+    return result;
+}
+}


### PR DESCRIPTION
Reason for change: Since "classname":"PersistentStore"
and "callsign":"org.rdk.PersistentStore" differ,
configuration is ignored.
Also, for some reason 'rename' fails to move file,
so developed a helper function.
Test Procedure: Plugin activates.
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>