### PR TITLE
RDKDEV-255: WebKitBrowser: Allow configuring of Youtube base URL and URL query string

### DIFF
--- a/WebKitBrowser/CMakeLists.txt
+++ b/WebKitBrowser/CMakeLists.txt
@@ -66,6 +66,8 @@ set(PLUGIN_WEBKITBROWSER_LOCALSTORAGE_ENABLE true CACHE STRING "Enable LocalStor
 set(PLUGIN_WEBKITBROWSER_THUNDER_DECRYPTOR_PREFERENCE true CACHE STRING "Enable Thunder decryptor preference in WebKit")
 
 set(PLUGIN_YOUTUBE_AUTOSTART false CACHE STRING "Automatically start Youtube plugin")
+set(PLUGIN_YOUTUBE_STARTURL "https://www.youtube.com/tv" CACHE STRING "Initial URL for YouTube plugin")
+set(PLUGIN_YOUTUBE_STARTURL_QUERYSTRING "" CACHE STRING "Initial URL Query String for YouTube plugin")
 set(PLUGIN_YOUTUBE_USERAGENT ${PLUGIN_WEBKITBROWSER_USERAGENT} CACHE STRING "User agent string YouTube")
 set(PLUGIN_YOUTUBE_WEBINSPECTOR_ADDRESS 0.0.0.0:9999 CACHE STRING "IP:Port for WebInspector of YouTube")
 set(PLUGIN_YOUTUBE_LOCALSTORAGE_ENABLE true CACHE STRING "Enable LocalStorage of YouTube App")

--- a/WebKitBrowser/YouTube.config
+++ b/WebKitBrowser/YouTube.config
@@ -14,7 +14,7 @@ end()
 ans(rootobject)
 
 map()
-    kv(url "https://www.youtube.com/tv")
+    kv(url "${PLUGIN_YOUTUBE_STARTURL}${PLUGIN_YOUTUBE_STARTURL_QUERYSTRING}")
     kv(useragent ${PLUGIN_YOUTUBE_USERAGENT})
     kv(injectedbundle "libWPEInjectedBundle${CMAKE_SHARED_LIBRARY_SUFFIX}")
     kv(transparent ${PLUGIN_WEBKITBROWSER_TRANSPARENT})


### PR DESCRIPTION
Allows configuring for the base YouTube start URL, defaulting to "https://www.youtube.com/tv"
(the previously hardcoded value), as well as a URL query string, defaulting to empty, which can be used e.g.
for selecting a specific language for Youtube ("?hl=pt-PT").