### PR TITLE
RDK-35544: HdmiInput thunder plugin changes for ALLM method/event

### DIFF
--- a/HdmiInput/HdmiInput.h
+++ b/HdmiInput/HdmiInput.h
@@ -64,6 +64,8 @@ namespace WPEFramework {
             uint32_t stopHdmiInput(const JsonObject& parameters, JsonObject& response);
 
             uint32_t setVideoRectangleWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t getSupportedGameFeatures(const JsonObject& parameters, JsonObject& response);
+            uint32_t getHdmiALLMStatusWrapper(const JsonObject& parameters, JsonObject& response);
             //End methods
 
             JsonArray getHDMIInputDevices();
@@ -73,7 +75,7 @@ namespace WPEFramework {
             std::string getHDMISPD(int iPort);
             int setEdidVersion(int iPort, int iEdidVer);
             int getEdidVersion(int iPort);
-
+            bool getHdmiALLMStatus(int iPort);
 
             bool setVideoRectangle(int x, int y, int width, int height);
 
@@ -88,6 +90,9 @@ namespace WPEFramework {
 
 	    void hdmiInputVideoModeUpdate( int port , dsVideoPortResolution_t resolution);
 	    static void dsHdmiVideoModeEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
+
+            void hdmiInputALLMChange( int port , bool allmMode);
+            static void dsHdmiALLMStatusEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
 
         public:
             HdmiInput();

--- a/HdmiInput/HdmiInput.json
+++ b/HdmiInput/HdmiInput.json
@@ -331,6 +331,57 @@
             "result": {
                 "$ref": "#/definitions/result"
             }
+        },
+        "getSupportedGameFeatures":{
+            "summary": "Returns the list of supported game features.\n \n### Events\n \nNo Events.",
+            "result": {
+                "type": "object",
+                "properties": {
+                    "suppoortedGameFeatures": {
+                        "summary": "The supported game Features",
+                        "type": "string",
+                        "example": "ALLM"
+                    },
+                    "success": {
+                        "$ref": "#/definitions/success"
+                    }
+                },
+                "required": [
+                    "suppoortedGameFeatures",
+                    "success"
+                ]
+            }
+        },
+       "getHdmiALLMStatus":{
+            "summary": "Returns the ALLM Status.\n \n### Events\n \nNo Events.",
+            "params": {
+                "type":"object",
+                "properties": {
+                    "portId":{
+                        "$ref": "#/definitions/portId"
+                    }
+                },
+                "required": [
+                    "portid"
+                ]
+            },
+            "result": {
+                "type": "object",
+                "properties": {
+                    "ALLM_Mode": {
+                        "summary": "The ALLM status",
+                        "type": "boolean",
+                        "example": "true"
+                    },
+                    "success": {
+                        "$ref": "#/definitions/success"
+                    }
+                },
+                "required": [
+                    "ALLM_Mode",
+                    "success"
+                ]
+            }
         }
     },
     "events": {
@@ -441,6 +492,26 @@
                     "progressive",
                     "frameRateN",
                     "frameRateD"
+                ]
+            }
+        },
+        "hdmiALLMStatusUpdate": {
+            "summary": "Triggered whenever the ALLM status changes for an HDMI Input",
+            "params": {
+                "type": "object",
+                "properties": {
+                   "portId": {
+                        "$ref": "#/definitions/portId"
+                    },
+                    "ALLM_Mode": {
+                        "summary": "The ALLM status",
+                        "type": "boolean",
+                        "example": "true"
+                    }
+                },
+                "required": [
+                    "portId",
+                    "ALLM_Mode"
                 ]
             }
         }

--- a/HdmiInput/doc/HdmiInputPlugin.md
+++ b/HdmiInput/doc/HdmiInputPlugin.md
@@ -95,6 +95,8 @@ HdmiInput interface methods:
 | [setEdidVersion](#method.setEdidVersion) | (Version 2) Sets an HDMI EDID version |
 | [setVideoRectangle](#method.setVideoRectangle) | Sets an HDMI Input video window |
 | [writeEDID](#method.writeEDID) | Changes a current EDID value |
+| [getSupportedGameFeatures](#method.getSupportedGameFeatures) | Returns the list of supported game features |
+| [getHdmiALLMStatus](#method.getHdmiALLMStatus) | Returns the ALLM Status |
 
 
 <a name="method.getHDMIInputDevices"></a>
@@ -622,6 +624,104 @@ No Events.
 }
 ```
 
+<a name="method.getSupportedGameFeatures"></a>
+## *getSupportedGameFeatures [<sup>method</sup>](#head.Methods)*
+
+Returns the list of supported game features.
+ 
+### Events
+ 
+No Events.
+
+### Parameters
+
+This method takes no parameters.
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.suppoortedGameFeatures | string | The supported game Features |
+| result.success | boolean | Whether the request succeeded |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.HdmiInput.1.getSupportedGameFeatures"
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "suppoortedGameFeatures": "ALLM",
+        "success": true
+    }
+}
+```
+
+<a name="method.getHdmiALLMStatus"></a>
+## *getHdmiALLMStatus [<sup>method</sup>](#head.Methods)*
+
+Returns the ALLM Status.
+ 
+### Events
+ 
+No Events.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params?.portId | string | <sup>*(optional)*</sup> An ID of an HDMI Input port as returned by the `getHdmiInputDevices` method |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.ALLM_Mode | boolean | The ALLM status |
+| result.success | boolean | Whether the request succeeded |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.HdmiInput.1.getHdmiALLMStatus",
+    "params": {
+        "portId": "0"
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "ALLM_Mode": true,
+        "success": true
+    }
+}
+```
+
 <a name="head.Notifications"></a>
 # Notifications
 
@@ -637,6 +737,7 @@ HdmiInput interface events:
 | [onInputStatusChanged](#event.onInputStatusChanged) | Triggered whenever the status changes for an HDMI Input |
 | [onSignalChanged](#event.onSignalChanged) | Triggered whenever the signal status changes for an HDMI Input |
 | [videoStreamInfoUpdate](#event.videoStreamInfoUpdate) | Triggered whenever there is an update in HDMI Input video stream info |
+| [hdmiALLMStatusUpdate](#event.hdmiALLMStatusUpdate) | Triggered whenever the ALLM status changes for an HDMI Input |
 
 
 <a name="event.onDevicesChanged"></a>
@@ -761,6 +862,32 @@ Triggered whenever there is an update in HDMI Input video stream info.
         "progressive": true,
         "frameRateN": 60000,
         "frameRateD": 1001
+    }
+}
+```
+
+<a name="event.hdmiALLMStatusUpdate"></a>
+## *hdmiALLMStatusUpdate [<sup>event</sup>](#head.Notifications)*
+
+Triggered whenever the ALLM status changes for an HDMI Input.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.portId | string | An ID of an HDMI Input port as returned by the `getHdmiInputDevices` method |
+| params.ALLM_Mode | boolean | The ALLM status |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.1.hdmiALLMStatusUpdate",
+    "params": {
+        "portId": "0",
+        "ALLM_Mode": true
     }
 }
 ```


### PR DESCRIPTION
Reason for change: added code for getSupportedGameFeatures,
getHdmiALLMStatus
and the event HdmiALLMStatusUpdate
Test Procedure: available in Jira
Risks: Low
Signed-off-by: Dhivya Ilangovan <dhivya.dilangovan@sky.uk>