### PR TITLE
LLAMA-4789: System Audio Player fails to play MP3 files

### DIFF
--- a/SystemAudioPlayer/SystemAudioPlayerImplementation.cpp
+++ b/SystemAudioPlayer/SystemAudioPlayerImplementation.cpp
@@ -111,10 +111,6 @@ namespace Plugin {
         sourceType = sourceTypeFromString( s_sourceType);
         playMode = playModeFromString( s_playMode);
 
-        if(audioType == AudioType::MP3)
-        {
-            playMode = PlayMode::PlayMode_None; 
-        }
         int id;
         _adminLock.Lock();      
         OpenMapping(audioType,sourceType,playMode,id);        

--- a/SystemAudioPlayer/impl/AudioPlayer.cpp
+++ b/SystemAudioPlayer/impl/AudioPlayer.cpp
@@ -339,7 +339,14 @@ void AudioPlayer::createPipeline()
     else
     {  
         //mp3
-        SAPLOG_INFO("SAP: Pipleine for mp3 audioType\n");
+        SAPLOG_INFO("SAP: Pipeline for mp3 audioType\n");
+        if(playMode == SYSTEM)
+        {
+            SAPLOG_INFO("SAP: Pipeline for mp3 audioType with playmode system\n");
+            #if defined(PLATFORM_AMLOGIC)
+            g_object_set(G_OBJECT(m_audioSink), "direct-mode", FALSE, NULL);
+            #endif
+        }
         #if defined(PLATFORM_AMLOGIC)
         GstElement *parser = gst_element_factory_make("mpegaudioparse", NULL);
         GstElement *decodebin = gst_element_factory_make("avdec_mp3", NULL);

--- a/SystemAudioPlayer/test/SAPThunderAPITest.cpp
+++ b/SystemAudioPlayer/test/SAPThunderAPITest.cpp
@@ -228,7 +228,7 @@ int main(int argc, char *argv[]) {
                         if (result["success"].Boolean()) {
                             cout << "play success: " << endl;
                         } else {
-                            cout << "play failed" << endl;
+                            cout << "play failed" << endl << result["message"].String()<< endl;
                         }
                     }
                     break;


### PR DESCRIPTION
Reason for change: System Audio Player fails to play mp3 when main audio is being played
Test Procedure: Test app included
Risks: Low

Signed-off-by: vdinak240 <Vishnu_Dinakaran@comcast.com>