### PR TITLE
LLAMA-5682: System Audio Player: Occasional Audio loss in Cherry usecase

### DIFF
--- a/SystemAudioPlayer/ISystemAudioPlayer.h
+++ b/SystemAudioPlayer/ISystemAudioPlayer.h
@@ -34,6 +34,7 @@ namespace Exchange {
         virtual uint32_t SetMixerLevels(const string &input, string &output /* @out */) = 0;
         virtual uint32_t IsPlaying(const string &input, string &output /* @out */) = 0;
 	virtual uint32_t Config(const string &input, string &output /* @out */) = 0;
+        virtual uint32_t GetPlayerSessionId(const string &input, string &output /* @out */) = 0;
 
     };
 

--- a/SystemAudioPlayer/ProxyStubs_SystemAudioPlayer.cpp
+++ b/SystemAudioPlayer/ProxyStubs_SystemAudioPlayer.cpp
@@ -337,6 +337,26 @@ namespace ProxyStubs {
             writer.Text(param1);
         },
 
+        // virtual uint32_t GetPlayerSessionId(const string &input, string &output /* @out */)
+        [](Core::ProxyType<Core::IPCChannel>& channel VARIABLE_IS_NOT_USED, Core::ProxyType<RPC::InvokeMessage>& message) {
+            RPC::Data::Input& input(message->Parameters());
+
+            // read parameters
+            RPC::Data::Frame::Reader reader(input.Reader());
+            const string param0 = reader.Text();
+            string param1{}; // storage
+
+            // call implementation
+            ISystemAudioPlayer* implementation = reinterpret_cast<ISystemAudioPlayer*>(input.Implementation());
+            ASSERT((implementation != nullptr) && "Null ISystemAudioPlayer implementation pointer");
+            const uint32_t output = implementation->GetPlayerSessionId(param0, param1);
+
+            // write return values
+            RPC::Data::Frame::Writer writer(message->Response().Writer());
+            writer.Number<const uint32_t>(output);
+            writer.Text(param1);
+        },
+
         nullptr
     }; // SystemAudioPlayerStubMethods[]
 
@@ -634,6 +654,26 @@ namespace ProxyStubs {
          uint32_t Config(const string& param0, string& /* out */ param1) override
         {
             IPCMessage newMessage(BaseClass::Message(12));
+
+            // write parameters
+            RPC::Data::Frame::Writer writer(newMessage->Parameters().Writer());
+            writer.Text(param0);
+
+            // invoke the method handler
+            uint32_t output{};
+            if ((output = Invoke(newMessage)) == Core::ERROR_NONE) {
+                // read return values
+                RPC::Data::Frame::Reader reader(newMessage->Response().Reader());
+                output = reader.Number<uint32_t>();
+                param1 = reader.Text();
+            }
+
+            return output;
+        }
+    
+        uint32_t GetPlayerSessionId(const string& param0, string& /* out */ param1) override
+        {
+            IPCMessage newMessage(BaseClass::Message(13));
 
             // write parameters
             RPC::Data::Frame::Writer writer(newMessage->Parameters().Writer());

--- a/SystemAudioPlayer/SystemAudioPlayer.h
+++ b/SystemAudioPlayer/SystemAudioPlayer.h
@@ -112,6 +112,7 @@ namespace Plugin {
         uint32_t SetMixerLevels(const JsonObject& parameters, JsonObject& response);
         uint32_t IsPlaying(const JsonObject& parameters, JsonObject& response);
 	uint32_t Config(const JsonObject& parameters, JsonObject& response);
+        uint32_t GetPlayerSessionId(const JsonObject& parameters, JsonObject& response);
 
         //version number API's
         uint32_t getapiversion(const JsonObject& parameters, JsonObject& response);

--- a/SystemAudioPlayer/SystemAudioPlayer.json
+++ b/SystemAudioPlayer/SystemAudioPlayer.json
@@ -301,8 +301,37 @@
             "result": {
                 "$ref": "#/definitions/result"
             }
+        },
+        "getPlayerSessionId": {
+            "summary": "Get the session ID by providing the URL as the input parameter. Session is nothing but the id returned in open cal\n \n### Events \n\n No Events ",
+            "params": {
+                "type": "object",
+                "properties": {
+                      "url": {
+                        "summary": "url queried to get the session id",
+                        "type": "string",
+                        "example": "http://localhost:50050/nuanceEve/tts?voice=ava&language=en-US&rate=50&text=SETTINGS"
+                    }
+
+                },
+                "required": [
+                    "url"
+                ]
+            },
+            "result": {
+                "type": "object",
+                "properties": {
+                    "sessionId": {
+                        "$ref": "#/definitions/id"
+                    },
+                    "success":{
+                        "$ref": "#/definitions/success"
+                    }
+                }
+            }
         }
     },
+      
     "events": {
         "onsapevents": {
             "summary": "Triggered during playback for each player. Events from each player are broadcast to all registered clients. The client is responsible for checking the player `id` attribute and discarding events for unwanted players. \n\n### Notifications  \n\nThe following events are supported.  \n| Event Name | Description |  \n| :-------- | :-------- |  \n| PLAYBACK_STARTED| Triggered when playback starts  |  \n| PLAYBACK_FINISHED | Triggered when playback finishes normally. **Note**: Web socket playback is continuous and does not receive the `PLAYBACK_FINISHED` event until the stream contains `EOS`. |  \n| PLAYBACK_PAUSED| Triggered when playback is paused | \n |PLAYBACK_RESUMED | Triggered when playback resumes |  \n| NETWORK_ERROR | Triggered when a playback network error occurs (httpsrc/web socket) |  \n| PLAYBACK_ERROR| Triggered when any other playback error occurs (internal issue)|  \n| NEED_DATA|  Triggered when the buffer needs more data to play|",

--- a/SystemAudioPlayer/SystemAudioPlayerImplementation.cpp
+++ b/SystemAudioPlayer/SystemAudioPlayerImplementation.cpp
@@ -155,7 +155,28 @@ namespace Plugin {
         }
         returnResponse(false);
     }
-
+    
+    uint32_t SystemAudioPlayerImplementation::GetPlayerSessionId(const string &input, string &output)
+    {
+        SAPLOG_INFO("SystemAudioPlayerImplementation Got GetPlayerSessionID request :%s\n",input.c_str());
+        CONVERT_PARAMETERS_TOJSON();
+        CHECK_SAP_PARAMETER_RETURN_ON_FAIL("url");
+        string url;
+        int playerid;
+        url = parameters["url"].String();
+        extractFileProtocol(url); //we do not store file:// for file playback
+        _adminLock.Lock();
+        if(GetSessionFromUrl(url,playerid))
+        {
+            response["sessionId"] = (int) playerid;
+        }
+        else
+        {
+            response["sessionId"] = (int) -1;
+        }
+        _adminLock.Unlock();
+        returnResponse(true);
+    }
 
     uint32_t SystemAudioPlayerImplementation::Play(const string &input, string &output)
     {
@@ -383,6 +404,24 @@ namespace Plugin {
         AudioPlayer *obj=new AudioPlayer(audioType,sourceType,mode,playerid);
         objectMap[playerid] = obj;
         SAPLOG_INFO("SAP: SystemAudioPlayerImplementation New player created\n");
+    }
+   
+    bool SystemAudioPlayerImplementation::GetSessionFromUrl(string url,int &playerid)
+    {
+        std::map<int,AudioPlayer*>::iterator it = objectMap.begin();
+        while (it != objectMap.end())
+        {
+            AudioPlayer *iplayer = it->second;
+            if((url.compare(iplayer->getUrl())) == 0)
+            {
+               playerid = iplayer->getObjectIdentifier();
+               SAPLOG_INFO("SAP: GetSessionFromUrl url %s found in list id: %d \n",url.c_str(),playerid);
+               return true;
+            }
+            it++;
+        }
+        SAPLOG_INFO("SAP: GetSessionFromUrl url %s Not found in list \n",url.c_str());
+        return false;
     }
 
     /*

--- a/SystemAudioPlayer/SystemAudioPlayerImplementation.h
+++ b/SystemAudioPlayer/SystemAudioPlayerImplementation.h
@@ -115,6 +115,7 @@ namespace Plugin {
         virtual uint32_t SetMixerLevels(const string &input, string &output /* @out */) override ;
         virtual uint32_t IsPlaying(const string &input, string &output /* @out */) override ;
 	virtual uint32_t Config(const string &input, string &output /* @out */) override ;
+        virtual uint32_t GetPlayerSessionId(const string &input, string &output /* @out */) override ;
 
         virtual void onSAPEvent(uint32_t id,std::string message) override; 
       
@@ -131,6 +132,7 @@ namespace Plugin {
         void dispatchEvent(Event, JsonObject &params);
         void Dispatch(Event event, string data);
         void OpenMapping(AudioType audioType,SourceType sourceType,PlayMode mode,int &playerid);
+        bool GetSessionFromUrl(string url,int &playerid);
         bool SameModeNotPlaying(AudioPlayer*,int &playerid);
         bool CloseMapping(int key);
 

--- a/SystemAudioPlayer/SystemAudioPlayerJsonRpc.cpp
+++ b/SystemAudioPlayer/SystemAudioPlayerJsonRpc.cpp
@@ -34,6 +34,7 @@ namespace Plugin {
         registerMethod("setMixerLevels", &SystemAudioPlayer::SetMixerLevels, this);
         registerMethod("isspeaking", &SystemAudioPlayer::IsPlaying, this);
 	registerMethod("config", &SystemAudioPlayer::Config, this);
+        registerMethod("getPlayerSessionId", &SystemAudioPlayer::GetPlayerSessionId, this);
     }
     
    
@@ -55,6 +56,18 @@ namespace Plugin {
             string params, result;
             parameters.ToString(params);
             uint32_t ret= _sap->Config(params, result);
+            response.FromString(result);
+            return ret;
+        }
+        return Core::ERROR_NONE;
+    }
+
+    uint32_t SystemAudioPlayer::GetPlayerSessionId(const JsonObject& parameters, JsonObject& response)
+    {
+        if(_sap) {
+            string params, result;
+            parameters.ToString(params);
+            uint32_t ret= _sap->GetPlayerSessionId(params, result);
             response.FromString(result);
             return ret;
         }

--- a/SystemAudioPlayer/doc/SystemAudioPlayerPlugin.md
+++ b/SystemAudioPlayer/doc/SystemAudioPlayerPlugin.md
@@ -97,6 +97,7 @@ SystemAudioPlayer interface methods:
 | [resume](#method.resume) | Resumes playback on the specified player |
 | [setMixerLevels](#method.setMixerLevels) | Sets the audio level on the specified player |
 | [stop](#method.stop) | Stops playback on the specified player |
+| [getPlayerSessionId](#method.getPlayerSessionId) | Get the sessionid by providing the URL |
 
 
 <a name="method.close"></a>
@@ -644,7 +645,57 @@ Stops playback on the specified player.
     }
 }
 ```
+<a name="method.getPlayerSessionId"></a>
+## *getPlayerSessionId [<sup>method</sup>](#head.Methods)*
 
+Get the session ID by providing the URL as the input parameter.
+Session is nothing but the id returned in [open](#method.open) call.
+ 
+### Events 
+
+ No Events.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.url | string | url queried to get the session id |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.success | boolean | Whether the request succeeded |
+| result.sessionId | string | Returns the session ID  if url is present ,if not returns -1  |
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.SystemAudioPlayer.1.getPlayerSessionId",
+    "params": {
+        "url": "ws://100.64.12.27:40001"
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "success": true,
+        "sessionId": 1
+    }
+}
+```
 <a name="head.Notifications"></a>
 # Notifications
 

--- a/SystemAudioPlayer/impl/AudioPlayer.cpp
+++ b/SystemAudioPlayer/impl/AudioPlayer.cpp
@@ -803,6 +803,11 @@ int AudioPlayer::getObjectIdentifier()
     return objectIdentifier;
 }
 
+std::string AudioPlayer::getUrl()
+{
+    return m_url;
+}
+
 bool AudioPlayer::loadInitAudioDev()
 {
     //TTSLOG_WARNING("Destroying Pipeline...");

--- a/SystemAudioPlayer/impl/AudioPlayer.h
+++ b/SystemAudioPlayer/impl/AudioPlayer.h
@@ -144,6 +144,7 @@ class AudioPlayer
     static int GstBusCallback(GstBus *bus, GstMessage *message, gpointer data); 
     static void event_loop();
     int getObjectIdentifier();
+    std::string getUrl();
     bool isPlaying();
     bool configPCMCaps(const std::string format, int rate, int channels, const std::string layout);
 };

--- a/SystemAudioPlayer/test/SAPThunderAPITest.cpp
+++ b/SystemAudioPlayer/test/SAPThunderAPITest.cpp
@@ -54,6 +54,7 @@ static int currentSpeechId = 0;
 #define OPT_PAUSE          7
 #define OPT_RESUME         8
 #define OPT_CONFIG         9
+#define OPT_GETSESSION     10
 
 void showMenu()
 {
@@ -68,6 +69,7 @@ void showMenu()
     cout << OPT_PAUSE          << ".pause" << endl;
     cout << OPT_RESUME         << ".resume" << endl;
     cout << OPT_CONFIG         << ".config" << endl;
+    cout << OPT_GETSESSION     << ".getPlayerSessionId" << endl;
     cout << "------------------------" << endl;
 }
 
@@ -382,6 +384,23 @@ int main(int argc, char *argv[]) {
 
                     }
                     break;  
+                    case OPT_GETSESSION:
+                    {
+                        JsonObject params;
+                        JsonObject result;
+                        std::string url;
+                        stream.getInput(url,"Enter url");
+                        params["url"] = url;
+                        ret = remoteObject->Invoke<JsonObject, JsonObject>(2000,
+                                _T("getPlayerSessionId"), params, result);
+                        if (result["success"].Boolean()) {
+                            cout << "getPlayerSessionId success: " << endl;
+                            cout << "session id : "<<result["sessionId"].Number();  
+                        } else {
+                            cout << "getPlayerSessionId failed" << endl;
+                        }
+                    }
+                    break;
                 }
             }
         }


### PR DESCRIPTION

Reason for change: get session ID  which will be used by audio cast to close in case of h/w error
Test Procedure: Test app included
Risks: Low

Signed-off-by: vdinak240 <Vishnu_Dinakaran@comcast.com>