### PR TITLE
RDK-35488:Issues in CMF-RPi Dunfell Builds when "RDKSHELL_COMPOSITOR_…

### DIFF
--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -3889,6 +3889,7 @@ namespace WPEFramework {
                 {
                     bool topmost = false;
                     bool focus = false;
+                    bool autoDestory = true ;
 
                     if (parameters.HasLabel("topmost"))
                     {
@@ -3898,9 +3899,13 @@ namespace WPEFramework {
                     {
                         focus = parameters["focus"].Boolean();
                     }
+		    if (parameters.HasLabel("autoDestory"))
+                    {
+                        autoDestory = parameters["autoDestory"].Boolean();
+                    }
 
                     gRdkShellMutex.lock();
-                    result = CompositorController::launchApplication(client, uri, mimeType, topmost, focus);
+                    result = CompositorController::launchApplication(client, uri, mimeType, topmost, focus, autoDestory);
                     gRdkShellMutex.unlock();
 
                     if (!result)

--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -3889,7 +3889,7 @@ namespace WPEFramework {
                 {
                     bool topmost = false;
                     bool focus = false;
-                    bool autoDestory = true ;
+                    bool autoDestroy = true ;
 
                     if (parameters.HasLabel("topmost"))
                     {
@@ -3899,13 +3899,13 @@ namespace WPEFramework {
                     {
                         focus = parameters["focus"].Boolean();
                     }
-		    if (parameters.HasLabel("autoDestory"))
+		    if (parameters.HasLabel("autoDestroy"))
                     {
-                        autoDestory = parameters["autoDestory"].Boolean();
+                        autoDestory = parameters["autoDestroy"].Boolean();
                     }
 
                     gRdkShellMutex.lock();
-                    result = CompositorController::launchApplication(client, uri, mimeType, topmost, focus, autoDestory);
+                    result = CompositorController::launchApplication(client, uri, mimeType, topmost, focus, autoDestroy);
                     gRdkShellMutex.unlock();
 
                     if (!result)


### PR DESCRIPTION
…TYPE" is set to "surface"

From: kchinn681 <kathiravan_chinnadurai@comcast.com>

Subject: issues in CMF-RPi Dunfell Builds when "RDKSHELL_COMPOSITOR_TYPE" is set to "surface"
Reason for change: to handle multiple rendering in surface mode
Test Procedure: to launch cnn app , run any video and see cnn  app is exiting
Risks: Low
Signed-off-by: kathiravan chinnadurai <kathiravan_chinnadurai@comcast.com>
Source: COMCAST
License: GPLV2
Upstream-Status: Pending