### PR TITLE
RDK-35050: Warehouse lightReset update

### DIFF
--- a/Warehouse/Warehouse.cpp
+++ b/Warehouse/Warehouse.cpp
@@ -577,6 +577,9 @@ namespace WPEFramework
 
             std::string error;
             bool ok = RunScriptIARM(script, error);
+
+            remove("/opt/secure/persistent/rdkservicestore");
+
             response[PARAM_SUCCESS] = ok;
             if (ok)
             {


### PR DESCRIPTION
Reason for change: Reset is not cleaning
"/opt/secure/persistent/rdkservicestore".
Test Procedure: Try lightReset,
see rdkservicestore is cleared.
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>