### PR TITLE
RDK-35488:Issues in CMF-RPi Dunfell Builds when rdkshell in surfacemode

### DIFF
--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -407,7 +407,7 @@ namespace WPEFramework {
 
         struct CreateDisplayRequest
         {
-            CreateDisplayRequest(std::string client, std::string displayName, uint32_t displayWidth=0, uint32_t displayHeight=0, bool virtualDisplayEnabled=false, uint32_t virtualWidth=0, uint32_t virtualHeight=0, bool topmost = false, bool focus = false): mClient(client), mDisplayName(displayName), mDisplayWidth(displayWidth), mDisplayHeight(displayHeight), mVirtualDisplayEnabled(virtualDisplayEnabled), mVirtualWidth(virtualWidth),mVirtualHeight(virtualHeight), mTopmost(topmost), mFocus(focus), mResult(false)
+            CreateDisplayRequest(std::string client, std::string displayName, uint32_t displayWidth=0, uint32_t displayHeight=0, bool virtualDisplayEnabled=false, uint32_t virtualWidth=0, uint32_t virtualHeight=0, bool topmost = false, bool focus = false): mClient(client), mDisplayName(displayName), mDisplayWidth(displayWidth), mDisplayHeight(displayHeight), mVirtualDisplayEnabled(virtualDisplayEnabled), mVirtualWidth(virtualWidth),mVirtualHeight(virtualHeight), mTopmost(topmost), mFocus(focus), mResult(false) , mAutoDestroy(autodestory)
             {
                 sem_init(&mSemaphore, 0, 0);
             }
@@ -428,6 +428,7 @@ namespace WPEFramework {
             bool mFocus;
             sem_t mSemaphore;
             bool mResult;
+	    bool mAutoDestroy;
         };
 
         struct KillClientRequest
@@ -962,7 +963,7 @@ namespace WPEFramework {
                           gCreateDisplayRequests.erase(gCreateDisplayRequests.begin());
                           continue;
                       }
-                      request->mResult = CompositorController::createDisplay(request->mClient, request->mDisplayName, request->mDisplayWidth, request->mDisplayHeight, request->mVirtualDisplayEnabled, request->mVirtualWidth, request->mVirtualHeight, request->mTopmost, request->mFocus);
+                      request->mResult = CompositorController::createDisplay(request->mClient, request->mDisplayName, request->mDisplayWidth, request->mDisplayHeight, request->mVirtualDisplayEnabled, request->mVirtualWidth, request->mVirtualHeight, request->mTopmost, request->mFocus , request->mAutoDestroy);
                       gCreateDisplayRequests.erase(gCreateDisplayRequests.begin());
                       sem_post(&request->mSemaphore);
                   }
@@ -2904,6 +2905,8 @@ namespace WPEFramework {
 
             double launchStartTime = RdkShell::seconds();
             bool result = true;
+	    bool autoDestroy = true;
+
             if (!parameters.HasLabel("callsign"))
             {
                 result = false;
@@ -3065,6 +3068,10 @@ namespace WPEFramework {
                 {
                     focus = parameters["focus"].Boolean();
                 }
+                if (parameters.HasLabel("autodestroy"))
+                {
+                  autoDestroy = parameters["autodestroy"].Boolean();
+                }
 
                 //check to see if plugin already exists
                 bool newPluginFound = false;
@@ -3175,7 +3182,7 @@ namespace WPEFramework {
                     gRdkShellMutex.unlock();
                     if (!isClientExists(callsign))
                     {
-                        std::shared_ptr<CreateDisplayRequest> request = std::make_shared<CreateDisplayRequest>(callsign, displayName, width, height);
+                        std::shared_ptr<CreateDisplayRequest> request = std::make_shared<CreateDisplayRequest>(callsign, displayName, width, height ,autoDestroy);
                         lockRdkShellMutex();
                         gCreateDisplayRequests.push_back(request);
                         gRdkShellMutex.unlock();


### PR DESCRIPTION
From: kchinn681 kathiravan_chinnadurai@comcast.com

Subject: issues in CMF-RPi Dunfell Builds when "RDKSHELL_COMPOSITOR_TYPE" is set to "surface"
Reason for change: to handle multiple rendering in surface mode
Test Procedure: to launch cnn app , run any video and see cnn app is exiting
Risks: Low
Signed-off-by: kathiravan chinnadurai kathiravan_chinnadurai@comcast.com
Source: COMCAST
License: GPLV2
Upstream-Status: Pending