### PR TITLE
RDK-35488:Issues in CMF-RPi Dunfell Builds when rdkshell in surfacemode

### DIFF
--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -3073,15 +3073,20 @@ namespace WPEFramework {
                 {
                     focus = parameters["focus"].Boolean();
                 }
-                if (parameters.HasLabel("autodestroy"))
+
+                if ((parameters.HasLabel("autodestroy")) && (gRdkShellSurfaceModeEnabled))
                 {
                   gRDKShellSurfaceModeAutoDestroy = parameters["autodestroy"].Boolean();
                 }
-		else
+		else if ((parameters.HasLabel("autodestroy")) && (!gRdkShellSurfaceModeEnabled))
 	        {
-                  gRDKShellSurfaceModeAutoDestroy = true ;
+                   response["message"]= " RDKShell in nested mode";
+		   returnResponse(false);
 	        }
-
+                else if ((!parameters.HasLabel("autodestroy")) && (gRdkShellSurfaceModeEnabled))
+	        {
+                   gRDKShellSurfaceModeAutoDestroy = true ;
+	        }
                 //check to see if plugin already exists
                 bool newPluginFound = false;
                 bool originalPluginFound = false;

--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -2911,8 +2911,7 @@ namespace WPEFramework {
             LOGINFOMETHOD();
 
             double launchStartTime = RdkShell::seconds();
-            bool result = true;
-	  
+            bool result = true; 
             if (!parameters.HasLabel("callsign"))
             {
                 result = false;


### PR DESCRIPTION
From: kchinn681 [kathiravan_chinnadurai@comcast.com](mailto:kathiravan_chinnadurai@comcast.com)

Subject: Crash observed when few plugins are activated from Controller UI in CMF-RPi
Reason for change:Crash observed when few plugins are activated from Controller UI in CMF-RPi
Test Procedure: activate html app using controller.ui
Risks: Low
Signed-off-by: kathiravan chinnadurai [kathiravan_chinnadurai@comcast.com](mailto:kathiravan_chinnadurai@comcast.com)
Source: COMCAST
License: GPLV2
Upstream-Status: Pending