### PR TITLE
RDK-35523: Unit Tests for DeviceIdentification

### DIFF
--- a/RdkServicesTest/CMakeLists.txt
+++ b/RdkServicesTest/CMakeLists.txt
@@ -35,8 +35,17 @@ add_executable(${PROJECT_NAME}
         Module.cpp
         )
 
-include_directories(../LocationSync ../PersistentStore ../SecurityAgent ../helpers)
-link_directories(../LocationSync ../PersistentStore ../SecurityAgent)
+include_directories(../LocationSync
+        ../PersistentStore
+        ../SecurityAgent
+        ../DeviceIdentification
+        ../helpers
+        )
+link_directories(../LocationSync
+        ../PersistentStore
+        ../SecurityAgent
+        ../DeviceIdentification
+        )
 
 target_link_libraries(${PROJECT_NAME}
         gmock_main
@@ -44,6 +53,7 @@ target_link_libraries(${PROJECT_NAME}
         ${NAMESPACE}LocationSync
         ${NAMESPACE}PersistentStore
         ${NAMESPACE}SecurityAgent
+        ${NAMESPACE}DeviceIdentification
         )
 
 target_include_directories(${PROJECT_NAME}

--- a/RdkServicesTest/Scripts/build.sh
+++ b/RdkServicesTest/Scripts/build.sh
@@ -113,6 +113,7 @@ buildAndInstallRdkservices() {
     -DPLUGIN_LOCATIONSYNC=ON \
     -DPLUGIN_PERSISTENTSTORE=ON \
     -DPLUGIN_SECURITYAGENT=ON \
+    -DPLUGIN_DEVICEIDENTIFICATION=ON -DBUILD_REALTEK=ON \
     -DRDK_SERVICES_TEST=ON
 
   make -C build/rdkservices && make -C build/rdkservices install

--- a/RdkServicesTest/Source/DeviceImplementation.h
+++ b/RdkServicesTest/Source/DeviceImplementation.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include "Module.h"
+
+#include <interfaces/IDeviceIdentification.h>
+
+namespace WPEFramework {
+namespace Plugin {
+
+    class DeviceImplementation : public Exchange::IDeviceProperties,
+                                 public PluginHost::ISubSystem::IIdentifier {
+    public:
+        DeviceImplementation()
+            : _chipset("testChipset")
+            , _firmwareVersion("testFirmwareVersion")
+            , _identity("testIdentity")
+        {
+        }
+
+        DeviceImplementation(const DeviceImplementation&) = delete;
+        DeviceImplementation& operator=(const DeviceImplementation&) = delete;
+        virtual ~DeviceImplementation()
+        {
+        }
+
+    public:
+        // Device Properties interface
+        const string Chipset() const override
+        {
+            return _chipset;
+        }
+        const string FirmwareVersion() const override
+        {
+            return _firmwareVersion;
+        }
+
+        // Identifier interface
+        uint8_t Identifier(const uint8_t length, uint8_t buffer[]) const override
+        {
+            uint8_t result = 0;
+            if ((_identity.length())) {
+                result = (_identity.length() > length ? length : _identity.length());
+                ::memcpy(buffer, _identity.c_str(), result);
+            } else {
+                SYSLOG(Logging::Notification, (_T("Cannot determine system identity")));
+            }
+            return result;
+        }
+
+        BEGIN_INTERFACE_MAP(DeviceImplementation)
+        INTERFACE_ENTRY(Exchange::IDeviceProperties)
+        INTERFACE_ENTRY(PluginHost::ISubSystem::IIdentifier)
+        END_INTERFACE_MAP
+
+    private:
+        string _chipset;
+        string _firmwareVersion;
+        string _identity;
+    };
+
+}
+}

--- a/RdkServicesTest/Tests/DeviceIdentificationTest.cpp
+++ b/RdkServicesTest/Tests/DeviceIdentificationTest.cpp
@@ -1,0 +1,102 @@
+#include <gtest/gtest.h>
+
+#include "DeviceIdentification.h"
+
+#include "DeviceImplementation.h"
+#include "ServiceMock.h"
+#include "Source/SystemInfo.h"
+
+namespace WPEFramework {
+namespace Plugin {
+    SERVICE_REGISTRATION(DeviceImplementation, 1, 0);
+}
+}
+
+using namespace WPEFramework;
+
+class DeviceIdentificationTestFixture : public ::testing::Test {
+protected:
+    Core::ProxyType<Plugin::DeviceIdentification> plugin;
+    Core::JSONRPC::Handler& handler;
+    Core::JSONRPC::Connection connection;
+    Core::Sink<SystemInfo> subSystem;
+    Exchange::IDeviceProperties* device;
+    PluginHost::ISubSystem::IIdentifier* identifier;
+    ServiceMock service;
+    string response;
+
+    DeviceIdentificationTestFixture()
+        : plugin(Core::ProxyType<Plugin::DeviceIdentification>::Create())
+        , handler(*plugin)
+        , connection(1, 0)
+    {
+    }
+    virtual ~DeviceIdentificationTestFixture()
+    {
+    }
+};
+
+TEST_F(DeviceIdentificationTestFixture, registeredMethods)
+{
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("deviceidentification")));
+}
+
+TEST_F(DeviceIdentificationTestFixture, deviceidentification)
+{
+    EXPECT_CALL(service, ConfigLine())
+        .Times(1)
+        .WillOnce(::testing::Return("{\n"
+                                    "   \"root\":{\n"
+                                    "      \"outofprocess\":false\n"
+                                    "   }\n"
+                                    "}"));
+
+    EXPECT_CALL(service, Locator())
+        .Times(1)
+        .WillOnce(::testing::Return(string()));
+
+    EXPECT_CALL(service, SubSystems())
+        .Times(2)
+        .WillRepeatedly(::testing::Invoke(
+            [&]() {
+                PluginHost::ISubSystem* result = (&subSystem);
+                result->AddRef();
+                return result;
+            }));
+
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+
+    device = const_cast<Exchange::IDeviceProperties*>(
+        dynamic_cast<const Exchange::IDeviceProperties*>(
+            subSystem.Get(PluginHost::ISubSystem::IDENTIFIER)));
+
+    EXPECT_TRUE(device != nullptr);
+    EXPECT_EQ(string("testChipset"), device->Chipset());
+    EXPECT_EQ(string("testFirmwareVersion"), device->FirmwareVersion());
+
+    identifier = device->QueryInterface<PluginHost::ISubSystem::IIdentifier>();
+
+    EXPECT_TRUE(identifier != nullptr);
+    uint8_t buf[64];
+    buf[0] = identifier->Identifier(sizeof(buf) - 1, &(buf[1]));
+    EXPECT_EQ(string("testIdentity"), string((const char*)&(buf[1]), buf[0]));
+
+    identifier->Release();
+
+    EXPECT_EQ(Core::ERROR_NONE,
+        handler.Invoke(connection, _T("deviceidentification"), _T(""), response));
+    EXPECT_TRUE(response.empty() == false);
+
+    JsonObject params;
+
+    EXPECT_TRUE(params.FromString(response));
+    EXPECT_TRUE(params.HasLabel(_T("firmwareversion")));
+    EXPECT_TRUE(params.HasLabel(_T("chipset")));
+    EXPECT_TRUE(params.HasLabel(_T("deviceid")));
+
+    EXPECT_EQ(string("testFirmwareVersion"), params[_T("firmwareversion")].Value());
+    EXPECT_EQ(string("testChipset"), params[_T("chipset")].Value());
+    EXPECT_EQ(string("WPEdGVzdElkZW50aXR5"), params[_T("deviceid")].Value());
+
+    plugin->Deinitialize(&service);
+}


### PR DESCRIPTION
Reason for change: Add Unit Tests.
Test Procedure: Run Unit Tests.
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>