### PR TITLE
RDK-35523: Unit Tests for FrameRate

### DIFF
--- a/FrameRate/CMakeLists.txt
+++ b/FrameRate/CMakeLists.txt
@@ -23,8 +23,7 @@ find_package(${NAMESPACE}Plugins REQUIRED)
 add_library(${MODULE_NAME} SHARED
         FrameRate.cpp
         Module.cpp
-        ../helpers/tptimer.cpp
-	../helpers/utils.cpp)
+        ../helpers/tptimer.cpp)
 
 set_target_properties(${MODULE_NAME} PROPERTIES
         CXX_STANDARD 11
@@ -41,7 +40,9 @@ target_include_directories(${MODULE_NAME} PRIVATE ${DS_INCLUDE_DIRS})
 target_include_directories(${MODULE_NAME} PRIVATE ${IARMBUS_INCLUDE_DIRS})
 target_include_directories(${MODULE_NAME} PRIVATE ../helpers)
 
-target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins ${NAMESPACE}SecurityUtil ${IARMBUS_LIBRARIES} ${DS_LIBRARIES} "-ltr181api")
+set_source_files_properties(FrameRate.cpp PROPERTIES COMPILE_FLAGS "-fexceptions")
+
+target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins ${IARMBUS_LIBRARIES} ${DS_LIBRARIES})
 
 install(TARGETS ${MODULE_NAME}
         DESTINATION lib/${STORAGE_DIRECTORY}/plugins)

--- a/FrameRate/FrameRate.h
+++ b/FrameRate/FrameRate.h
@@ -22,27 +22,16 @@
 #include <mutex>
 
 #include "Module.h"
+
 #include "tptimer.h"
-#include "utils.h"
-#include "AbstractPlugin.h"
+
+#include "libIARM.h"
 
 namespace WPEFramework {
 
     namespace Plugin {
 
-        // This is a server for a JSONRPC communication channel. 
-        // For a plugin to be capable to handle JSONRPC, inherit from PluginHost::JSONRPC.
-        // By inheriting from this class, the plugin realizes the interface PluginHost::IDispatcher.
-        // This realization of this interface implements, by default, the following methods on this plugin
-        // - exists
-        // - register
-        // - unregister
-        // Any other methood to be handled by this plugin  can be added can be added by using the
-        // templated methods Register on the PluginHost::JSONRPC class.
-        // As the registration/unregistration of notifications is realized by the class PluginHost::JSONRPC,
-        // this class exposes a public method called, Notify(), using this methods, all subscribed clients
-        // will receive a JSONRPC message as a notification, in case this method is called.
-        class FrameRate : public AbstractPlugin {
+        class FrameRate : public PluginHost::IPlugin, public PluginHost::JSONRPC {
         private:
 
             // We do not allow this plugin to be copied !!
@@ -89,6 +78,13 @@ namespace WPEFramework {
             virtual ~FrameRate();
 	    virtual const string Initialize(PluginHost::IShell* service) override;
             virtual void Deinitialize(PluginHost::IShell* service) override;
+
+            virtual string Information() const override;
+
+            BEGIN_INTERFACE_MAP(FrameRate)
+            INTERFACE_ENTRY(PluginHost::IPlugin)
+            INTERFACE_ENTRY(PluginHost::IDispatcher)
+            END_INTERFACE_MAP
 
         public:
             static FrameRate* _instance;

--- a/RdkServicesTest/CMakeLists.txt
+++ b/RdkServicesTest/CMakeLists.txt
@@ -40,6 +40,7 @@ include_directories(../LocationSync
         ../SecurityAgent
         ../DeviceIdentification
         ../DeviceDiagnostics
+        ../FrameRate
         ../helpers
         )
 link_directories(../LocationSync
@@ -47,6 +48,7 @@ link_directories(../LocationSync
         ../SecurityAgent
         ../DeviceIdentification
         ../DeviceDiagnostics
+        ../FrameRate
         )
 
 target_link_libraries(${PROJECT_NAME}
@@ -57,6 +59,7 @@ target_link_libraries(${PROJECT_NAME}
         ${NAMESPACE}PersistentStore
         ${NAMESPACE}SecurityAgent
         ${NAMESPACE}DeviceIdentification
+        ${NAMESPACE}FrameRate
         )
 
 target_include_directories(${PROJECT_NAME}

--- a/RdkServicesTest/Include/dsMgr.h
+++ b/RdkServicesTest/Include/dsMgr.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#define IARM_BUS_DSMGR_NAME "DSMgr"
+
+typedef enum _DSMgr_EventId_t {
+    IARM_BUS_DSMGR_EVENT_DISPLAY_FRAMRATE_PRECHANGE,
+    IARM_BUS_DSMGR_EVENT_DISPLAY_FRAMRATE_POSTCHANGE,
+} IARM_Bus_DSMgr_EventId_t;
+
+typedef enum _dsHDRStandard_t {
+    dsHDRSTANDARD_NONE = 0x0,
+} dsHDRStandard_t;

--- a/RdkServicesTest/Include/exception.hpp
+++ b/RdkServicesTest/Include/exception.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <exception>
+#include <string>
+
+namespace device {
+
+class Exception : public std::exception {
+    int _err;
+    std::string _msg;
+
+public:
+    Exception(const char* msg = "No Message for this exception") throw()
+        : _msg(msg)
+    {
+    }
+
+    Exception(int err, const char* msg = "No Message for this Exception") throw()
+        : _err(err)
+        , _msg(msg){};
+
+    virtual const std::string& getMessage() const
+    {
+        return _msg;
+    }
+
+    virtual int getCode() const
+    {
+        return _err;
+    }
+
+    virtual const char* what() const throw()
+    {
+        return _msg.c_str();
+    }
+
+    virtual ~Exception() throw(){};
+};
+
+}

--- a/RdkServicesTest/Include/host.hpp
+++ b/RdkServicesTest/Include/host.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <vector>
+
+namespace device {
+
+template <class T>
+using List = std::vector<T>;
+
+class VideoDevice {
+public:
+    virtual ~VideoDevice() = default;
+
+    virtual int getFRFMode(int* frfmode) const = 0;
+    virtual int setFRFMode(int frfmode) const = 0;
+    virtual int getCurrentDisframerate(char* framerate) const = 0;
+    virtual int setDisplayframerate(const char* framerate) const = 0;
+};
+
+class HostImpl {
+public:
+    virtual ~HostImpl() = default;
+
+    virtual List<std::reference_wrapper<VideoDevice>> getVideoDevices() = 0;
+};
+
+extern HostImpl* gHostImpl;
+
+class Host {
+public:
+    static Host& getInstance()
+    {
+        static Host instance;
+        return instance;
+    }
+
+    List<std::reference_wrapper<VideoDevice>> getVideoDevices()
+    {
+        return gHostImpl->getVideoDevices();
+    }
+};
+
+}

--- a/RdkServicesTest/Include/libIARM.h
+++ b/RdkServicesTest/Include/libIARM.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#define IARM_BUS_NAME "com.comcast.rdk.iarm.bus"
+#define IARM_MAX_NAME_LEN 64
+
+typedef int IARM_EventId_t;
+
+typedef enum _IARM_Result_t
+{
+  IARM_RESULT_SUCCESS,  
+  IARM_RESULT_INVALID_PARAM,
+  IARM_RESULT_INVALID_STATE,
+  IARM_RESULT_IPCCORE_FAIL,
+  IARM_RESULT_OOM,
+
+} IARM_Result_t;
+
+#define IARM_METHOD_IPC_TIMEOUT_DEFAULT    (-1)
+#define IARM_METHOD_IPC_TIMEOUT_INFINITE   ((int) 0x7fffffff)

--- a/RdkServicesTest/Include/libIBus.h
+++ b/RdkServicesTest/Include/libIBus.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "libIARM.h"
+
+typedef void (*IARM_EventHandler_t)(const char* owner, IARM_EventId_t eventId, void* data, size_t len);
+
+class IarmBusImpl {
+public:
+    virtual ~IarmBusImpl() = default;
+
+    virtual IARM_Result_t IARM_Bus_Init(const char* name) = 0;
+    virtual IARM_Result_t IARM_Bus_Connect() = 0;
+    virtual IARM_Result_t IARM_Bus_IsConnected(const char* memberName, int* isRegistered) = 0;
+    virtual IARM_Result_t IARM_Bus_RegisterEventHandler(const char* ownerName, IARM_EventId_t eventId, IARM_EventHandler_t handler) = 0;
+    virtual IARM_Result_t IARM_Bus_UnRegisterEventHandler(const char* ownerName, IARM_EventId_t eventId) = 0;
+};
+
+extern IarmBusImpl* gIarmBusImpl;
+
+IARM_Result_t IARM_Bus_Init(const char* name)
+{
+    return gIarmBusImpl->IARM_Bus_Init(name);
+}
+
+IARM_Result_t IARM_Bus_Connect()
+{
+    return gIarmBusImpl->IARM_Bus_Connect();
+}
+
+IARM_Result_t IARM_Bus_IsConnected(const char* memberName, int* isRegistered)
+{
+    return gIarmBusImpl->IARM_Bus_IsConnected(memberName, isRegistered);
+}
+
+IARM_Result_t IARM_Bus_RegisterEventHandler(const char* ownerName, IARM_EventId_t eventId, IARM_EventHandler_t handler)
+{
+    return gIarmBusImpl->IARM_Bus_RegisterEventHandler(ownerName, eventId, handler);
+}
+
+IARM_Result_t IARM_Bus_UnRegisterEventHandler(const char* ownerName, IARM_EventId_t eventId)
+{
+    return gIarmBusImpl->IARM_Bus_UnRegisterEventHandler(ownerName, eventId);
+}

--- a/RdkServicesTest/Mocks/HostMock.h
+++ b/RdkServicesTest/Mocks/HostMock.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include "host.hpp"
+
+class HostImplMock : public device::HostImpl {
+public:
+    virtual ~HostImplMock() = default;
+
+    MOCK_METHOD(device::List<std::reference_wrapper<device::VideoDevice>>, getVideoDevices, (), (override));
+};

--- a/RdkServicesTest/Mocks/IarmBusMock.h
+++ b/RdkServicesTest/Mocks/IarmBusMock.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include "libIBus.h"
+
+class IarmBusImplMock : public IarmBusImpl {
+public:
+    virtual ~IarmBusImplMock() = default;
+
+    MOCK_METHOD(IARM_Result_t, IARM_Bus_Init, (const char* name), (override));
+    MOCK_METHOD(IARM_Result_t, IARM_Bus_Connect, (), (override));
+    MOCK_METHOD(IARM_Result_t, IARM_Bus_IsConnected, (const char* memberName, int* isRegistered), (override));
+    MOCK_METHOD(IARM_Result_t, IARM_Bus_RegisterEventHandler, (const char* ownerName, IARM_EventId_t eventId, IARM_EventHandler_t handler), (override));
+    MOCK_METHOD(IARM_Result_t, IARM_Bus_UnRegisterEventHandler, (const char* ownerName, IARM_EventId_t eventId), (override));
+};

--- a/RdkServicesTest/Mocks/VideoDeviceMock.h
+++ b/RdkServicesTest/Mocks/VideoDeviceMock.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include "host.hpp"
+
+class VideoDeviceMock : public device::VideoDevice {
+public:
+    virtual ~VideoDeviceMock() = default;
+
+    MOCK_METHOD(int, getFRFMode, (int* frfmode), (const, override));
+    MOCK_METHOD(int, setFRFMode, (int frfmode), (const, override));
+    MOCK_METHOD(int, getCurrentDisframerate, (char* framerate), (const, override));
+    MOCK_METHOD(int, setDisplayframerate, (const char* framerate), (const, override));
+};

--- a/RdkServicesTest/Scripts/build.sh
+++ b/RdkServicesTest/Scripts/build.sh
@@ -19,6 +19,8 @@ INTERFACES_URL=https://github.com/rdkcentral/ThunderInterfaces
 INTERFACES_BRANCH=R2
 INTERFACES_REV=4ec7c6f8e14b152143a105a41f4c62b6723372c4
 
+INCLUDE_DIR=$(pwd)/Include
+
 checkPython() {
   case "$(python --version)" in
   *"$1"*) true ;;
@@ -111,13 +113,15 @@ buildAndInstallRdkservices() {
   cmake -H../.. -Bbuild/rdkservices \
     -DCMAKE_INSTALL_PREFIX="${THUNDER_INSTALL_DIR}/usr" \
     -DCMAKE_MODULE_PATH="${THUNDER_INSTALL_DIR}/tools/cmake" \
-    -DCMAKE_CXX_FLAGS="--coverage -Wall -Werror -Wno-unused-parameter" \
+    -DCMAKE_CXX_FLAGS="-I ${INCLUDE_DIR} --coverage -Wall -Werror -Wno-unused-parameter" \
     -DCOMCAST_CONFIG=OFF \
     -DPLUGIN_DEVICEDIAGNOSTICS=ON \
     -DPLUGIN_LOCATIONSYNC=ON \
     -DPLUGIN_PERSISTENTSTORE=ON \
     -DPLUGIN_SECURITYAGENT=ON \
     -DPLUGIN_DEVICEIDENTIFICATION=ON -DBUILD_REALTEK=ON \
+    -DPLUGIN_FRAMERATE=ON \
+    -DCMAKE_DISABLE_FIND_PACKAGE_DS=ON -DCMAKE_DISABLE_FIND_PACKAGE_IARMBus=ON \
     -DRDK_SERVICES_TEST=ON \
     -DCMAKE_BUILD_TYPE=$MODE
 

--- a/RdkServicesTest/Tests/FrameRateTest.cpp
+++ b/RdkServicesTest/Tests/FrameRateTest.cpp
@@ -1,0 +1,256 @@
+#include <gtest/gtest.h>
+
+#include "FrameRate.h"
+
+#include "HostMock.h"
+#include "IarmBusMock.h"
+#include "VideoDeviceMock.h"
+#include "dsMgr.h"
+
+using namespace WPEFramework;
+
+namespace {
+const string iarmName = _T("Thunder_Plugins");
+}
+
+IarmBusImpl* gIarmBusImpl = nullptr;
+
+namespace device {
+HostImpl* gHostImpl = nullptr;
+}
+
+class FrameRateTestFixture : public ::testing::Test {
+protected:
+    Core::ProxyType<Plugin::FrameRate> plugin;
+    Core::JSONRPC::Handler& handler;
+    Core::JSONRPC::Handler& handlerV2;
+    Core::JSONRPC::Connection connection;
+    IarmBusImplMock iarmBusImplMock;
+    HostImplMock hostImplMock;
+    VideoDeviceMock videoDeviceMock;
+    IARM_EventHandler_t handlerOnDisplayFrameRateChanging;
+    IARM_EventHandler_t handlerOnDisplayFrameRateChanged;
+    int frfmode;
+    string framerate;
+    string response;
+
+    FrameRateTestFixture()
+        : plugin(Core::ProxyType<Plugin::FrameRate>::Create())
+        , handler(*(plugin))
+        , handlerV2(*(plugin->GetHandler(2)))
+        , connection(1, 0)
+    {
+    }
+    virtual ~FrameRateTestFixture()
+    {
+    }
+
+    virtual void SetUp()
+    {
+        gIarmBusImpl = &iarmBusImplMock;
+        device::gHostImpl = &hostImplMock;
+    }
+
+    virtual void TearDown()
+    {
+        gIarmBusImpl = nullptr;
+        device::gHostImpl = nullptr;
+    }
+};
+
+TEST_F(FrameRateTestFixture, RegisteredMethods)
+{
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("setCollectionFrequency")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("startFpsCollection")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("stopFpsCollection")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("updateFps")));
+
+    EXPECT_EQ(Core::ERROR_NONE, handlerV2.Exists(_T("setCollectionFrequency")));
+    EXPECT_EQ(Core::ERROR_NONE, handlerV2.Exists(_T("startFpsCollection")));
+    EXPECT_EQ(Core::ERROR_NONE, handlerV2.Exists(_T("stopFpsCollection")));
+    EXPECT_EQ(Core::ERROR_NONE, handlerV2.Exists(_T("updateFps")));
+    EXPECT_EQ(Core::ERROR_NONE, handlerV2.Exists(_T("setFrmMode")));
+    EXPECT_EQ(Core::ERROR_NONE, handlerV2.Exists(_T("getFrmMode")));
+    EXPECT_EQ(Core::ERROR_NONE, handlerV2.Exists(_T("getDisplayFrameRate")));
+    EXPECT_EQ(Core::ERROR_NONE, handlerV2.Exists(_T("setDisplayFrameRate")));
+}
+
+TEST_F(FrameRateTestFixture, Plugin)
+{
+    // IARM expectations
+
+    // called by FrameRate::InitializeIARM, FrameRate::DeinitializeIARM
+    EXPECT_CALL(iarmBusImplMock, IARM_Bus_IsConnected(::testing::_, ::testing::_))
+        .Times(3)
+        .WillOnce(::testing::Invoke(
+            [](const char* memberName, int* isRegistered) {
+                if (iarmName == string(memberName)) {
+                    *isRegistered = 0;
+                    return IARM_RESULT_SUCCESS;
+                }
+                return IARM_RESULT_INVALID_PARAM;
+            }))
+        .WillOnce(::testing::Invoke(
+            [](const char* memberName, int* isRegistered) {
+                if (iarmName == string(memberName)) {
+                    *isRegistered = 1;
+                    return IARM_RESULT_SUCCESS;
+                }
+                return IARM_RESULT_INVALID_PARAM;
+            }))
+        .WillOnce(::testing::Invoke(
+            [](const char* memberName, int* isRegistered) {
+                if (iarmName == string(memberName)) {
+                    *isRegistered = 1;
+                    return IARM_RESULT_SUCCESS;
+                }
+                return IARM_RESULT_INVALID_PARAM;
+            }));
+
+    // called by FrameRate::InitializeIARM
+    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Init(::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Invoke(
+            [](const char* name) {
+                if (iarmName == string(name)) {
+                    return IARM_RESULT_SUCCESS;
+                }
+                return IARM_RESULT_INVALID_PARAM;
+            }));
+
+    // called by FrameRate::InitializeIARM
+    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Connect())
+        .Times(1)
+        .WillOnce(::testing::Return(IARM_RESULT_SUCCESS));
+
+    // called by FrameRate::InitializeIARM
+    EXPECT_CALL(iarmBusImplMock, IARM_Bus_RegisterEventHandler(::testing::_, ::testing::_, ::testing::_))
+        .Times(2)
+        .WillOnce(::testing::Invoke(
+            [&](const char* ownerName, IARM_EventId_t eventId, IARM_EventHandler_t handler) {
+                if ((string(IARM_BUS_DSMGR_NAME) == string(ownerName)) && (eventId == IARM_BUS_DSMGR_EVENT_DISPLAY_FRAMRATE_PRECHANGE)) {
+                    handlerOnDisplayFrameRateChanging = handler;
+                    return IARM_RESULT_SUCCESS;
+                }
+                return IARM_RESULT_INVALID_PARAM;
+            }))
+        .WillOnce(::testing::Invoke(
+            [&](const char* ownerName, IARM_EventId_t eventId, IARM_EventHandler_t handler) {
+                if ((string(IARM_BUS_DSMGR_NAME) == string(ownerName)) && (eventId == IARM_BUS_DSMGR_EVENT_DISPLAY_FRAMRATE_POSTCHANGE)) {
+                    handlerOnDisplayFrameRateChanged = handler;
+                    return IARM_RESULT_SUCCESS;
+                }
+                return IARM_RESULT_INVALID_PARAM;
+            }));
+
+    // called by FrameRate::DeinitializeIARM
+    EXPECT_CALL(iarmBusImplMock, IARM_Bus_UnRegisterEventHandler(::testing::_, ::testing::_))
+        .Times(2)
+        .WillOnce(::testing::Invoke(
+            [&](const char* ownerName, IARM_EventId_t eventId) {
+                if ((string(IARM_BUS_DSMGR_NAME) == string(ownerName)) && (eventId == IARM_BUS_DSMGR_EVENT_DISPLAY_FRAMRATE_PRECHANGE)) {
+                    handlerOnDisplayFrameRateChanging = nullptr;
+                    return IARM_RESULT_SUCCESS;
+                }
+                return IARM_RESULT_INVALID_PARAM;
+            }))
+        .WillOnce(::testing::Invoke(
+            [&](const char* ownerName, IARM_EventId_t eventId) {
+                if ((string(IARM_BUS_DSMGR_NAME) == string(ownerName)) && (eventId == IARM_BUS_DSMGR_EVENT_DISPLAY_FRAMRATE_POSTCHANGE)) {
+                    handlerOnDisplayFrameRateChanged = nullptr;
+                    return IARM_RESULT_SUCCESS;
+                }
+                return IARM_RESULT_INVALID_PARAM;
+            }));
+
+    // VideoDevice expectations
+
+    EXPECT_CALL(videoDeviceMock, setFRFMode(::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Invoke(
+            [&](int param) {
+                frfmode = param;
+                return 0;
+            }));
+
+    EXPECT_CALL(videoDeviceMock, getFRFMode(::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Invoke(
+            [&](int* param) {
+                *param = frfmode;
+                return 0;
+            }));
+
+    EXPECT_CALL(videoDeviceMock, setDisplayframerate(::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Invoke(
+            [&](const char* param) {
+                framerate = param;
+                return 0;
+            }));
+
+    EXPECT_CALL(videoDeviceMock, getCurrentDisframerate(::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Invoke(
+            [&](char* param) {
+                ::memcpy(param, framerate.c_str(), framerate.length());
+                return 0;
+            }));
+
+    // Host expectations
+
+    // called by FrameRate::getDisplayFrameRate, FrameRate::setDisplayFrameRate, FrameRate::getFrmMode, FrameRate::setFrmMode
+    EXPECT_CALL(hostImplMock, getVideoDevices())
+        .Times(4)
+        .WillRepeatedly(::testing::Invoke(
+            [&]() {
+                device::List<std::reference_wrapper<device::VideoDevice>> result{ videoDeviceMock };
+                return result;
+            }));
+
+    // Initialize
+
+    EXPECT_EQ(string(""), plugin->Initialize(nullptr));
+
+    // JSON-RPC methods
+
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("setCollectionFrequency"), _T("{\"frequency\":1000}"), response));
+    EXPECT_EQ(response, string("{\"success\":true}"));
+
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("startFpsCollection"), _T("{}"), response));
+    EXPECT_EQ(response, string("{\"success\":true}"));
+
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("stopFpsCollection"), _T("{}"), response));
+    EXPECT_EQ(response, string("{\"success\":true}"));
+
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("updateFps"), _T("{\"newFpsValue\":60}"), response));
+    EXPECT_EQ(response, string("{\"success\":true}"));
+
+    EXPECT_EQ(Core::ERROR_NONE, handlerV2.Invoke(connection, _T("setFrmMode"), _T("{\"frmmode\":0}"), response));
+    EXPECT_EQ(response, string("{\"success\":true}"));
+
+    EXPECT_EQ(Core::ERROR_NONE, handlerV2.Invoke(connection, _T("getFrmMode"), _T("{}"), response));
+    EXPECT_EQ(response, string("{\"auto-frm-mode\":0,\"success\":true}"));
+
+    EXPECT_EQ(Core::ERROR_NONE, handlerV2.Invoke(connection, _T("setDisplayFrameRate"), _T("{\"framerate\":\"3840x2160px48\"}"), response));
+    EXPECT_EQ(response, string("{\"success\":true}"));
+
+    EXPECT_EQ(Core::ERROR_NONE, handlerV2.Invoke(connection, _T("getDisplayFrameRate"), _T("{}"), response));
+    EXPECT_EQ(response, string("{\"framerate\":\"3840x2160px48\",\"success\":true}"));
+
+    // JSON-RPC events
+
+    EXPECT_TRUE(handlerOnDisplayFrameRateChanging != nullptr);
+    EXPECT_TRUE(handlerOnDisplayFrameRateChanged != nullptr);
+
+    // events are logged, there's no way to mock
+    handlerOnDisplayFrameRateChanging(
+        IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_DISPLAY_FRAMRATE_PRECHANGE, nullptr, 0);
+
+    handlerOnDisplayFrameRateChanged(
+        IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_DISPLAY_FRAMRATE_POSTCHANGE, nullptr, 0);
+
+    // Deinitialize
+
+    plugin->Deinitialize(nullptr);
+}

--- a/helpers/UtilsLogging.h
+++ b/helpers/UtilsLogging.h
@@ -5,3 +5,7 @@
 #define LOGINFO(fmt, ...) do { fprintf(stderr, "[%d] INFO [%s:%d] %s: " fmt "\n", (int)syscall(SYS_gettid), WPEFramework::Core::FileNameOnly(__FILE__), __LINE__, __FUNCTION__, ##__VA_ARGS__); fflush(stderr); } while (0)
 #define LOGWARN(fmt, ...) do { fprintf(stderr, "[%d] WARN [%s:%d] %s: " fmt "\n", (int)syscall(SYS_gettid), WPEFramework::Core::FileNameOnly(__FILE__), __LINE__, __FUNCTION__, ##__VA_ARGS__); fflush(stderr); } while (0)
 #define LOGERR(fmt, ...) do { fprintf(stderr, "[%d] ERROR [%s:%d] %s: " fmt "\n", (int)syscall(SYS_gettid), WPEFramework::Core::FileNameOnly(__FILE__), __LINE__, __FUNCTION__, ##__VA_ARGS__); fflush(stderr); } while (0)
+
+#define LOG_DEVICE_EXCEPTION0() LOGWARN("Exception caught: code=%d message=%s", err.getCode(), err.what());
+#define LOG_DEVICE_EXCEPTION1(param1) LOGWARN("Exception caught" #param1 "=%s code=%d message=%s", param1.c_str(), err.getCode(), err.what());
+#define LOG_DEVICE_EXCEPTION2(param1, param2) LOGWARN("Exception caught " #param1 "=%s " #param2 "=%s code=%d message=%s", param1.c_str(), param2.c_str(), err.getCode(), err.what());


### PR DESCRIPTION
Reason for change: Add Unit Tests.
Test Procedure: Run Unit Tests.
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>