### PR TITLE
RDKTV-14981: WPEFramework crash in libc-2.31.so

### DIFF
--- a/Network/Network.h
+++ b/Network/Network.h
@@ -55,7 +55,8 @@ namespace WPEFramework {
             Network& operator=(const Network&) = delete;
 
             //Private variables
-            std::atomic_bool m_isPluginInited{false};
+            std::atomic_bool m_isPluginReady{false};
+            std::atomic_bool m_exitRetryThread{false};
             std::thread m_registrationThread;
 
             //Begin methods


### PR DESCRIPTION
Reason for change: Return empty string on Network plugin init function
Test Procedure: Refer to ticket for details
Risks: Medium
Signed-off-by: Zameerun Rasheed M S <zmamoo711@cable.comcast.com>