### PR TITLE
RDK-34330-Add Mfr to Device Info API for Element

### DIFF
--- a/SystemServices/SystemServices.h
+++ b/SystemServices/SystemServices.h
@@ -102,6 +102,7 @@ namespace WPEFramework {
                 static JsonObject _systemParams;
                 static const string MODEL_NAME;
                 static const string HARDWARE_ID;
+		static const string FRIENDLY_ID;
 
                 enum class FWUpdateAvailableEnum { FW_UPDATE_AVAILABLE, FW_MATCH_CURRENT_VER, NO_FW_VERSION, EMPTY_SW_UPDATE_CONF };
                 // We do not allow this plugin to be copied !!
@@ -130,10 +131,12 @@ namespace WPEFramework {
 #ifdef ENABLE_DEVICE_MANUFACTURER_INFO
                 bool getManufacturerData(const string& parameter, JsonObject& response);
                 uint32_t getMfgSerialNumber(const JsonObject& parameters, JsonObject& response);
+                bool getModelName(const string& parameter, JsonObject& response);
                 std::string m_ManufacturerData;
                 bool m_ManufacturerDataValid;
                 std::string m_MfgSerialNumber;
                 bool m_MfgSerialNumberValid;
+		
 #endif
             public:
                 SystemServices();


### PR DESCRIPTION
Reason for change: Friendly_id will return from Mfr lib
Test Procedure: Get frindly_id
Risks: None
Signed-off-by: Mallikarjun_manjari@comcast.com
(cherry picked from commit 07f4b03b8bf709c9a8ce7c7fc168b9f402aca15d)

RDK-34330-Add Mfr to Device Info API for Element

Reason for change: Friendly_id will return from Mfr lib
Test Procedure: Get frindly_id
Risks: None
Signed-off-by: Mallikarjun_manjari@comcast.com
(cherry picked from commit 0bb37fc5355996611c8b3b8df9ac401ae6ff1f2d)

RDK-34330-Add Mfr to Device Info API for Element

Reason for change: Friendly_id will return from Mfr lib
Test Procedure: Get frindly_id
Risks: None
Signed-off-by: Mallikarjun_manjari@comcast.com
(cherry picked from commit 1f1a84c3e50b26bebd609d3d6eb0b849d5139a0a)

RDK-34330 - Add Mfr to Device Info API

Reason for change: Friendly_id will return from Mfr lib
Test Procedure: Get frindly_id
Risks: None
Signed-off-by: Mallikarjun_manjari@comcast.com
(cherry picked from commit 804df8dcb85d8cf1e826202842dc2a67476380ff)

RDK-34330-Add Mfr to Device Info API for Element

Reason for change: Friendly_id will return from Mfr lib
Test Procedure: Get frindly_id
Risks: None
Signed-off-by: Mallikarjun_manjari@comcast.com
(cherry picked from commit 0aeba5f664ee0bec0842974747cc29d55efbffcd)

RDK-34330-getDeviceInfo without params

(cherry picked from commit afb1f9a4ce2cf7e97dc4d0badd4b65bdcc9bdead)