### PR TITLE
RDK-35171: Mock JSON-RPC events

### DIFF
--- a/RdkServicesTest/Source/FactoriesImplementation.h
+++ b/RdkServicesTest/Source/FactoriesImplementation.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "Module.h"
+
+class FactoriesImplementation : public WPEFramework::PluginHost::IFactories {
+public:
+    FactoriesImplementation(const FactoriesImplementation&) = delete;
+    FactoriesImplementation& operator=(const FactoriesImplementation&) = delete;
+
+    FactoriesImplementation()
+        : _requestFactory(5)
+        , _responseFactory(5)
+        , _fileBodyFactory(5)
+        , _jsonRPCFactory(5)
+    {
+    }
+    ~FactoriesImplementation() override = default;
+
+public:
+    void Statistics(uint32_t& requests, uint32_t& responses, uint32_t& fileBodies, uint32_t& jsonrpc) const
+    {
+        requests = 5;
+        responses = 5;
+        fileBodies = 5;
+        jsonrpc = 5;
+    }
+    WPEFramework::Core::ProxyType<WPEFramework::Web::Request> Request() override
+    {
+        return (_requestFactory.Element());
+    }
+    WPEFramework::Core::ProxyType<WPEFramework::Web::Response> Response() override
+    {
+        return (_responseFactory.Element());
+    }
+    WPEFramework::Core::ProxyType<WPEFramework::Web::FileBody> FileBody() override
+    {
+        return (_fileBodyFactory.Element());
+    }
+    WPEFramework::Core::ProxyType<WPEFramework::Web::JSONBodyType<WPEFramework::Core::JSONRPC::Message>> JSONRPC() override
+    {
+        return (WPEFramework::Core::ProxyType<WPEFramework::Web::JSONBodyType<WPEFramework::Core::JSONRPC::Message>>(_jsonRPCFactory.Element()));
+    }
+
+private:
+    WPEFramework::Core::ProxyPoolType<WPEFramework::Web::Request> _requestFactory;
+    WPEFramework::Core::ProxyPoolType<WPEFramework::Web::Response> _responseFactory;
+    WPEFramework::Core::ProxyPoolType<WPEFramework::Web::FileBody> _fileBodyFactory;
+    WPEFramework::Core::ProxyPoolType<WPEFramework::PluginHost::JSONRPCMessage> _jsonRPCFactory;
+};


### PR DESCRIPTION
Reason for change: Cover events.
Test Procedure: Run Unit Tests.
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>