### PR TITLE
DELIA-55413: Upstream to Thunder R2-v1.9

### DIFF
--- a/RdkServicesTest/Scripts/build.sh
+++ b/RdkServicesTest/Scripts/build.sh
@@ -13,7 +13,7 @@ THUNDER_PORT=55555
 
 THUNDER_URL=https://github.com/rdkcentral/Thunder
 THUNDER_BRANCH=R2
-THUNDER_REV=54c2404197f16255cc47543e2d861e2c8137ee51
+THUNDER_REV=tags/R2-v1.9
 
 INTERFACES_URL=https://github.com/rdkcentral/ThunderInterfaces
 INTERFACES_BRANCH=R2

--- a/RdkServicesTest/Tests/SecurityAgentTest.cpp
+++ b/RdkServicesTest/Tests/SecurityAgentTest.cpp
@@ -189,6 +189,20 @@ TEST_F(SecurityAgentTestFixture, rpcCom)
 
     interface->Release();
 
+    /**
+     * IUnknown Release() times out and
+    returns without server response. The next action of the
+    unit test is to destroy the server. When the server
+    is being destroyed it also submits that response hence
+    an ASSERT is hit. The problem with Release()
+    happens due to the following commit in Thunder R2-v1.9
+    e70fe4856c7cef952238decf9730e8b5283658e5 which
+    introduces a lock for IUnknown Release() which
+    blocks both RPC-COM client and server if they are
+    in the same process.
+     */
+    sleep(1);
+
     client.Release();
     engine.Release();
 


### PR DESCRIPTION
Reason for change: Upstream and add a workaround for
IUnknown Release() bug introduced as part of Thunder R2-v1.9.
Test Procedure: Run unit tests.
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>