### PR TITLE
RDK-35171: Unit tests option to run with GDB

### DIFF
--- a/RdkServicesTest/README.md
+++ b/RdkServicesTest/README.md
@@ -24,7 +24,10 @@ Make sure you have packages _python3 python3-pip libsqlite3-dev libcurl4-openssl
 
 ```shell script
 cd RdkServicesTest
-./Scripts/run.sh
+./Scripts/run.sh [-d]
+
+options:
+  -d                   Run with vgdb. 'target remote' args: "| vgdb"
 ```
 
 This runs all tests, generates Valgrind report valgrind_log, and coverage info.

--- a/RdkServicesTest/Scripts/build.sh
+++ b/RdkServicesTest/Scripts/build.sh
@@ -138,9 +138,12 @@ checkRequirements() {
     echo "pip3 should be installed (for Thunder)"
     exit 1
   fi
-
   if ! checkPackage "sqlite3"; then
     echo "sqlite3 should be installed (for PersistentStore)"
+    exit 1
+  fi
+  if ! checkPackage "libcurl"; then
+    echo "libcurl should be installed (for DataCapture, DeviceDiagnostics)"
     exit 1
   fi
 }

--- a/RdkServicesTest/Scripts/run.sh
+++ b/RdkServicesTest/Scripts/run.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+GDB=0
+
 THUNDER_ROOT=$(pwd)/thunder
 THUNDER_INSTALL_DIR=${THUNDER_ROOT}/install
 VALGRINDLOG=$(pwd)/valgrind_log
@@ -23,23 +25,48 @@ stopDummyServerDeviceDiagnostic() {
   pkill -f Scripts/DeviceDiagnosticMock.py
 }
 
-if ! checkInstalled "valgrind"; then
-  echo "valgrind should be installed"
-  exit 1
-fi
+checkRequirements() {
+  if ! checkInstalled "valgrind"; then
+    echo "valgrind should be installed"
+    exit 1
+  fi
+}
+
+runUnitTests() {
+  VGDB=""
+  if [ "${GDB}" = "1" ]; then
+    VGDB="--vgdb=yes --vgdb-error=0"
+  fi
+
+  # shellcheck disable=SC2086
+  PATH=${THUNDER_INSTALL_DIR}/usr/bin:${PATH} \
+    LD_LIBRARY_PATH=${THUNDER_INSTALL_DIR}/usr/lib:${THUNDER_INSTALL_DIR}/usr/lib/wpeframework/plugins:${LD_LIBRARY_PATH} \
+    valgrind \
+    --tool=memcheck \
+    --log-file="${VALGRINDLOG}" \
+    --leak-check=yes \
+    --show-reachable=yes \
+    --track-fds=yes \
+    --fair-sched=try \
+    ${VGDB} \
+    RdkServicesTest
+}
+
+while getopts "d" option; do
+  case $option in
+  d)
+    GDB=1
+    ;;
+  *) ;;
+
+  esac
+done
+
+checkRequirements
 
 startDummyServerDeviceDiagnostic
 
-PATH=${THUNDER_INSTALL_DIR}/usr/bin:${PATH} \
-  LD_LIBRARY_PATH=${THUNDER_INSTALL_DIR}/usr/lib:${THUNDER_INSTALL_DIR}/usr/lib/wpeframework/plugins:${LD_LIBRARY_PATH} \
-  valgrind \
-  --tool=memcheck \
-  --log-file="${VALGRINDLOG}" \
-  --leak-check=yes \
-  --show-reachable=yes \
-  --track-fds=yes \
-  --fair-sched=try \
-  RdkServicesTest
+runUnitTests
 
 stopDummyServerDeviceDiagnostic
 


### PR DESCRIPTION
Reason for change: Run with GDB.
Test Procedure: Run unit tests.
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>