### PR TITLE
RDK-36049: Get DHCP Server address of my network interface

### DIFF
--- a/Network/Network.cpp
+++ b/Network/Network.cpp
@@ -97,6 +97,7 @@ typedef struct {
     char ipaddress[MAX_IP_ADDRESS_LEN];
     char netmask[MAX_IP_ADDRESS_LEN];
     char gateway[MAX_IP_ADDRESS_LEN];
+    char dhcpserver[MAX_IP_ADDRESS_LEN];
     char primarydns[MAX_IP_ADDRESS_LEN];
     char secondarydns[MAX_IP_ADDRESS_LEN];
     bool isSupported;
@@ -1030,7 +1031,11 @@ namespace WPEFramework
                      {
                          response["interface"] = InternalResponse["interface"];
                          response["ipversion"] = InternalResponse["ipversion"];
+                         std::string sIPVersion = InternalResponse["ipversion"].String();
                          response["autoconfig"] = InternalResponse["autoconfig"];
+                         std::string sAutoconfig =  InternalResponse["autoconfig"].String();
+                         if (!sAutoconfig.compare("true") && !(sIPVersion.compare("IPv4")))
+                             response["dhcpserver"] = InternalResponse["dhcpserver"];
                          response["ipaddress"] = InternalResponse["ipaddr"];
                          response["netmask"] = InternalResponse["netmask"];
                          response["gateway"] = InternalResponse["gateway"];
@@ -1071,6 +1076,7 @@ namespace WPEFramework
                 response["autoconfig"] = iarmData.autoconfig;
                 response["ipaddr"] = string(iarmData.ipaddress,MAX_IP_ADDRESS_LEN - 1);
                 response["netmask"] = string(iarmData.netmask,MAX_IP_ADDRESS_LEN - 1);
+                response["dhcpserver"] = string(iarmData.dhcpserver,MAX_IP_ADDRESS_LEN - 1);
                 response["gateway"] = string(iarmData.gateway,MAX_IP_ADDRESS_LEN - 1);
                 response["primarydns"] = string(iarmData.primarydns,MAX_IP_ADDRESS_LEN - 1);
                 response["secondarydns"] = string(iarmData.secondarydns,MAX_IP_ADDRESS_LEN - 1);

--- a/Network/Network.json
+++ b/Network/Network.json
@@ -27,6 +27,11 @@
             "type": "boolean",
             "example": true
         },
+        "dhcpserver": {
+            "summary": "The DHCP Server address",
+            "type": "string",
+            "example": "192.168.1.1"
+        },
         "ipaddr": {
             "summary": "The IP address",
             "type": "string",
@@ -263,6 +268,9 @@
                     },
                     "autoconfig": {
                         "$ref": "#/definitions/autoconfig"
+                    },
+                    "dhcpserver": {
+                        "$ref": "#/definitions/dhcpserver"
                     },
                     "ipaddr": {
                         "$ref": "#/definitions/ipaddr"

--- a/Network/doc/NetworkPlugin.md
+++ b/Network/doc/NetworkPlugin.md
@@ -223,6 +223,7 @@ Gets the IP settings of the interface. If the interface is not passed, it will r
 | result.interface | string | An interface, such as `ETHERNET` or `WIFI`, depending upon availability of the given interface in `getInterfaces` |
 | result.ipversion | string | either IPv4 or IPv6 |
 | result.autoconfig | boolean | `true` if DHCP is used, `false` if IP is configured manually |
+| result.dhcpserver | string | The DHCP Server address |
 | result.ipaddr | string | The IP address |
 | result.netmask | string | The network mask address |
 | result.gateway | string | The gateway address |
@@ -256,6 +257,7 @@ Gets the IP settings of the interface. If the interface is not passed, it will r
         "interface": "WIFI",
         "ipversion": "IPv4",
         "autoconfig": true,
+        "dhcpserver": "192.168.1.1",
         "ipaddr": "192.168.1.101",
         "netmask": "255.255.255.0",
         "gateway": "192.168.1.1",


### PR DESCRIPTION
Reason for change: To get DHCP ServerIP Address
Test Procedure: As RDK Developer, I must be able to get DHCP Server address of my network interface.
                This DHCP Server address will be used to pass it to DVB-CI+ implementation.
Risks: High
Signed-off-by: Kumar Santhanam <Kumar_Santhanam@comcast.com>