### PR TITLE
RDK-35171: Build fix and cleanup

### DIFF
--- a/DataCapture/socket_adaptor.cpp
+++ b/DataCapture/socket_adaptor.cpp
@@ -44,7 +44,7 @@ socket_adaptor::socket_adaptor() : m_listen_fd(-1), m_write_fd(-1), m_read_fd(-1
 	if(!g_one_time_init_complete)
 	{
 		/*SIGPIPE must be ignored or process will exit when client closes connection*/
-		struct sigaction sig_settings;
+		struct sigaction sig_settings = { 0 };
 		sig_settings.sa_handler = SIG_IGN;
 		sigaction(SIGPIPE, &sig_settings, NULL);
 		g_one_time_init_complete = true;

--- a/RdkServicesTest/Scripts/build.sh
+++ b/RdkServicesTest/Scripts/build.sh
@@ -113,7 +113,7 @@ buildAndInstallRdkservices() {
   cmake -H../.. -Bbuild/rdkservices \
     -DCMAKE_INSTALL_PREFIX="${THUNDER_INSTALL_DIR}/usr" \
     -DCMAKE_MODULE_PATH="${THUNDER_INSTALL_DIR}/tools/cmake" \
-    -DCMAKE_CXX_FLAGS="-I ${INCLUDE_DIR} --coverage -Wall -Werror -Wno-unused-parameter" \
+    -DCMAKE_CXX_FLAGS="-I ${INCLUDE_DIR} --coverage -Wall -Werror -Wno-unused-parameter -Wno-unused-result" \
     -DCOMCAST_CONFIG=OFF \
     -DPLUGIN_DATACAPTURE=ON \
     -DPLUGIN_DEVICEDIAGNOSTICS=ON \

--- a/RdkServicesTest/Tests/AVInputTest.cpp
+++ b/RdkServicesTest/Tests/AVInputTest.cpp
@@ -154,7 +154,7 @@ TEST_F(AVInputTestFixture, Plugin)
     EXPECT_CALL(service, Submit(::testing::_, ::testing::_))
         .Times(1)
         .WillOnce(::testing::Invoke(
-            [&](const uint32_t, const WPEFramework::Core::ProxyType<WPEFramework::Core::JSON::IElement>& json) {
+            [&](const uint32_t, const Core::ProxyType<Core::JSON::IElement>& json) {
                 string text;
                 EXPECT_TRUE(json->ToString(text));
                 EXPECT_EQ(text, string(_T("{"

--- a/RdkServicesTest/Tests/DataCaptureTest.cpp
+++ b/RdkServicesTest/Tests/DataCaptureTest.cpp
@@ -91,7 +91,7 @@ using testing::NiceMock;
 using testing::Return;
 using testing::Test;
 
-namespace WPEFramework {
+using namespace WPEFramework;
 
 class DataCaptureTest : public Test {
 public:
@@ -186,7 +186,7 @@ public:
                 });
 
         string response;
-        EXPECT_EQ(WPEFramework::Core::ERROR_NONE, handler_.Invoke(connection_, _T("enableAudioCapture"), _T("{\"bufferMaxDuration\":6}"), response));
+        EXPECT_EQ(Core::ERROR_NONE, handler_.Invoke(connection_, _T("enableAudioCapture"), _T("{\"bufferMaxDuration\":6}"), response));
         EXPECT_EQ(response, _T("{\"error\":0,\"success\":true}"));
     }
 
@@ -209,10 +209,10 @@ TEST_F(DataCaptureTest, ShouldRegisterMethod)
 TEST_F(DataCaptureTest, ShouldReturnErrorWhenParamsAreEmpty)
 {
     string response;
-    EXPECT_EQ(WPEFramework::Core::ERROR_NONE, handler_.Invoke(connection_, _T("enableAudioCapture"), _T(""), response));
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Invoke(connection_, _T("enableAudioCapture"), _T(""), response));
     EXPECT_EQ(response, _T("{\"success\":false}"));
 
-    EXPECT_EQ(WPEFramework::Core::ERROR_NONE,
+    EXPECT_EQ(Core::ERROR_NONE,
         handler_.Invoke(connection_,
             _T("getAudioClip"),
             _T(""),
@@ -235,7 +235,7 @@ TEST_F(DataCaptureTest, ShouldTurnOnAudioCapture)
             });
 
     string response;
-    EXPECT_EQ(WPEFramework::Core::ERROR_NONE,
+    EXPECT_EQ(Core::ERROR_NONE,
         handler_.Invoke(connection_,
             _T("getAudioClip"),
             _T("{\"clipRequest\":{\"stream\":\"primary\",\"url\":\"https://192.168.0.1\",\"duration\":8,\"captureMode\":\"preCapture\"}}"),
@@ -268,7 +268,7 @@ TEST_F(DataCaptureTest, ShouldTurnOffAudioCapture)
 
     string response;
     // Turn off audio capture
-    EXPECT_EQ(WPEFramework::Core::ERROR_NONE, handler_.Invoke(connection_, _T("enableAudioCapture"), _T("{\"bufferMaxDuration\":0}"), response));
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Invoke(connection_, _T("enableAudioCapture"), _T("{\"bufferMaxDuration\":0}"), response));
     EXPECT_EQ(response, _T("{\"error\":0,\"success\":true}"));
 }
 
@@ -284,7 +284,7 @@ TEST_F(DataCaptureTest, ShouldUploadData)
     std::promise<bool> socketReady;
     auto socketReadyFuture = socketReady.get_future();
     std::thread socketThread(runSocket, std::move(socketReady), std::string(dataLocator));
-    
+
     // Wait for server and socket thread
     serverReadyFuture.wait();
     socketReadyFuture.wait();
@@ -300,7 +300,7 @@ TEST_F(DataCaptureTest, ShouldUploadData)
 
     EXPECT_CALL(service_, Submit)
         .WillOnce(
-            [&](const uint32_t, const WPEFramework::Core::ProxyType<WPEFramework::Core::JSON::IElement>& json) {
+            [&](const uint32_t, const Core::ProxyType<Core::JSON::IElement>& json) {
                 string text;
                 EXPECT_TRUE(json->ToString(text));
                 EXPECT_EQ(text, string(_T("{"
@@ -326,7 +326,7 @@ TEST_F(DataCaptureTest, ShouldUploadData)
 
     // setup http://127.0.0.1:9999 as url
     string response;
-    EXPECT_EQ(WPEFramework::Core::ERROR_NONE,
+    EXPECT_EQ(Core::ERROR_NONE,
         handler_.Invoke(connection_,
             _T("getAudioClip"),
             _T("{\"clipRequest\":{\"stream\":\"primary\",\"url\":\"http://127.0.0.1:9999\",\"duration\":8,\"captureMode\":\"preCapture\"}}"),
@@ -345,5 +345,3 @@ TEST_F(DataCaptureTest, ShouldUploadData)
     serverThread.join();
     socketThread.join();
 }
-
-} // namespace WPEFramework

--- a/RdkServicesTest/Tests/DeviceDiagnosticsTest.cpp
+++ b/RdkServicesTest/Tests/DeviceDiagnosticsTest.cpp
@@ -21,7 +21,7 @@
 
 #include "DeviceDiagnostics.h"
 
-namespace WPEFramework {
+using namespace WPEFramework;
 
 class DeviceDiagnosticsTest : public ::testing::Test {
 public:
@@ -47,12 +47,10 @@ TEST_F(DeviceDiagnosticsTest, RegisterMethod)
 TEST_F(DeviceDiagnosticsTest, ShouldReturnResponse)
 {
     string response;
-    EXPECT_EQ(WPEFramework::Core::ERROR_NONE, handler_.Invoke(connection_, _T("getConfiguration"), _T("{\"names\":[\"test\"]}"), response));
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Invoke(connection_, _T("getConfiguration"), _T("{\"names\":[\"test\"]}"), response));
     // TODO pass here expected response
     EXPECT_EQ(response, _T("{\"paramList\":[\"Device.X_CISCO_COM_LED.RedPwm\":123],\"success\":true}"));
 
-    EXPECT_EQ(WPEFramework::Core::ERROR_NONE, handler_.Invoke(connection_, _T("getAVDecoderStatus"), _T("{}"), response));
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Invoke(connection_, _T("getAVDecoderStatus"), _T("{}"), response));
     EXPECT_EQ(response, _T("{\"avDecoderStatus\":\"IDLE\",\"success\":true}"));
 }
-
-} // namespace WPEFramework

--- a/RdkServicesTest/Tests/FrameRateTest.cpp
+++ b/RdkServicesTest/Tests/FrameRateTest.cpp
@@ -215,7 +215,7 @@ TEST_F(FrameRateTestFixture, Plugin)
     EXPECT_CALL(service, Submit(::testing::_, ::testing::_))
         .Times(2)
         .WillOnce(::testing::Invoke(
-            [&](const uint32_t, const WPEFramework::Core::ProxyType<WPEFramework::Core::JSON::IElement>& json) {
+            [&](const uint32_t, const Core::ProxyType<Core::JSON::IElement>& json) {
                 string text;
                 EXPECT_TRUE(json->ToString(text));
                 EXPECT_EQ(text, string(_T("{"
@@ -227,7 +227,7 @@ TEST_F(FrameRateTestFixture, Plugin)
                 return Core::ERROR_NONE;
             }))
         .WillOnce(::testing::Invoke(
-            [&](const uint32_t, const WPEFramework::Core::ProxyType<WPEFramework::Core::JSON::IElement>& json) {
+            [&](const uint32_t, const Core::ProxyType<Core::JSON::IElement>& json) {
                 string text;
                 EXPECT_TRUE(json->ToString(text));
                 EXPECT_EQ(text, string(_T("{"


### PR DESCRIPTION
Reason for change: Release build failed due to
-Werror=unused-result. Valgrind reported
uninitialised byte(s) in socket_adaptor().
'WPEFramework::' was unnecesary in some places.
Test Procedure: Run unit tests.
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>