### PR TITLE
RDKTV-11118 : WPEFramework Crash in malloc_printerr

### DIFF
--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -1773,64 +1773,22 @@ namespace WPEFramework {
         /***
          * @brief : Populates device serial number from TR069 Support/Query.
          */
-        bool SystemServices::getSerialNumberTR069(JsonObject& response)
+	bool SystemServices::getSerialNumberTR069(JsonObject& response)
         {
-            bool ret = false;
-            std::string curlResponse;
-            struct write_result write_result_buf;
-            CURLcode res = CURLE_OK;
-            CURL *curl = curl_easy_init();
-            char *data;
-            long http_code = 0;
-            struct curl_slist *headers = NULL;
-
-            data = (char*)malloc(CURL_BUFFER_SIZE);
-            if (!data) {
-                LOGERR("Error allocating %d bytes.\n", CURL_BUFFER_SIZE);
-                populateResponseWithError(SysSrv_DynamicMemoryAllocationFailed, response);
-                return ret;
+            bool ret =  false;
+            std::string paramValue;
+            RFC_ParamData_t param = {0};
+            param.type = WDMP_NONE;
+            WDMP_STATUS status = getRFCParameter(NULL, "Device.DeviceInfo.SerialNumber", &param);
+            if(WDMP_SUCCESS == status)
+            {
+                paramValue = param.value;
+                response["serialNumber"] = paramValue;
+                ret = true;
             }
-            write_result_buf.data = data;
-            write_result_buf.pos = 0;
+            else
+                populateResponseWithError(SysSrv_Unexpected, response);
 
-            if (curl) {
-                curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "POST");
-                curl_easy_setopt(curl, CURLOPT_URL, "http://127.0.0.1:10999/");
-                headers = curl_slist_append(headers, "cache-control: no-cache");
-                headers = curl_slist_append(headers, "content-type: application/json");
-                curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
-                curl_easy_setopt(curl, CURLOPT_POSTFIELDS,
-                        "{\"paramList\":[{\"name\":\"Device.DeviceInfo.SerialNumber\"}]}");
-                curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1);
-                curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, curl_write);
-                curl_easy_setopt(curl, CURLOPT_WRITEDATA, &write_result_buf);
-                res = curl_easy_perform(curl);
-                curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
-
-                /* null terminate the string */
-                data[write_result_buf.pos] = '\0';
-                curlResponse = data;
-                free(data);
-                curl_easy_cleanup(curl);
-            }
-            if (CURLE_OK == res) {
-                /* Eg: {"paramList":[{"name":"Device.DeviceInfo.SerialNumber",
-                   "value":"M11806TK0519"}]} */
-                LOGWARN("curl response : %s\n", curlResponse.c_str());
-                JsonObject curlRespJson;
-                JsonArray paramListJson;
-                curlRespJson.FromString(curlResponse);
-                paramListJson = curlRespJson["paramList"].Array();
-
-                for (int i = 0; i < paramListJson.Length(); i++) {
-                    curlRespJson = paramListJson[i].Object();
-                    response["serialNumber"] = curlRespJson["value"].String();
-                    ret = true;
-                    break;
-                }
-            } else {
-                populateResponseWithError(SysSrv_LibcurlError, response);
-            }
             return ret;
         }
 


### PR DESCRIPTION
Reason for change: adding new implementation for getSerialNumberTR069 using getRfCParameter.
Test Procedure: sanity test
Risks: None
Signed-off-by: Neeraj_Sahu@comcast.com