### PR TITLE
RDK-29308 [AAMP] support for custom http headers

### DIFF
--- a/WebKitBrowser/InjectedBundle/AAMPJSBindings.cpp
+++ b/WebKitBrowser/InjectedBundle/AAMPJSBindings.cpp
@@ -23,6 +23,7 @@
 extern "C" {
     void aamp_LoadJSController(JSGlobalContextRef context);
     void aamp_UnloadJSController(JSGlobalContextRef context);
+    void aamp_SetPageHttpHeaders(const char* headers);
 }
 
 namespace WPEFramework {
@@ -71,6 +72,12 @@ void UnloadJSBindings(WKBundleFrameRef frame) {
         if (JSObjectHasProperty(context, global, aampStr))
             aamp_UnloadJSController(context);
     }
+}
+
+// Just pass headers json to aamp plugin. SetHttpHeaders Called from RequestHeaders.cpp
+void SetHttpHeaders(const char * headerJson)
+{
+    aamp_SetPageHttpHeaders(headerJson);
 }
 
 }  // namespace AAMP

--- a/WebKitBrowser/InjectedBundle/AAMPJSBindings.h
+++ b/WebKitBrowser/InjectedBundle/AAMPJSBindings.h
@@ -30,6 +30,8 @@ void LoadJSBindings(WKBundleFrameRef frame);
 
 void UnloadJSBindings(WKBundleFrameRef frame);
 
+void SetHttpHeaders(const char * headerJson);
+
 }  // namespace AAMP
 }  // namespace JavaScript
 }  // namespace WPEFramework

--- a/WebKitBrowser/InjectedBundle/RequestHeaders.cpp
+++ b/WebKitBrowser/InjectedBundle/RequestHeaders.cpp
@@ -29,6 +29,10 @@
 
 #include <core/JSON.h>
 
+#if defined(ENABLE_AAMP_JSBINDINGS)
+#include "AAMPJSBindings.h"
+#endif
+
 #include "Utils.h"
 
 namespace WPEFramework {
@@ -76,6 +80,12 @@ void SetRequestHeaders(WKBundlePageRef page, WKTypeRef messageBody)
         return;
 
     string message = WPEFramework::WebKit::Utils::WKStringToString(static_cast<WKStringRef>(messageBody));
+
+#if defined(ENABLE_AAMP_JSBINDINGS)
+    // Pass on HTTP headers to AAMP , if empty, AAMP should clear previose headers set
+    JavaScript::AAMP::SetHttpHeaders(message.c_str());
+#endif
+
     if (message.empty()) {
         RemoveRequestHeaders(page);
         return;


### PR DESCRIPTION
Signed-off-by: shripad bankar <Shripad_Bankar@cable.comcast.com>
(cherry picked from commit 7e5d77b5d4f560112e817913e8c1f28fcb019bfb)

RDK-29308 [AAMP] support for custom http headers

(cherry picked from commit 9af19e33db5183333b0a018d72a11a6b803a3650)