### PR TITLE
DELIA-53546: Connect() call prints redundant logs

### DIFF
--- a/WifiManager/WifiManager.cpp
+++ b/WifiManager/WifiManager.cpp
@@ -178,19 +178,6 @@ namespace WPEFramework
 
         uint32_t WifiManager::connect(const JsonObject &parameters, JsonObject &response)
         {
-            JsonObject params = parameters;
-
-            if (params.HasLabel("passphrase"))
-            {
-                params["passphrase"] = "<passphrase>";
-
-                std::string json;
-                params.ToString(json);
-                LOGINFO( "params=%s", json.c_str() );
-            }
-            else
-                LOGINFOMETHOD();
-
             uint32_t result = wifiConnect.connect(parameters, response);
 
             LOGTRACEMETHODFIN();


### PR DESCRIPTION
Reason for change: removed the redutant parameter checking and logs
Test Procedure: validate with Connect Curl request
Risks: Medium

(cherry picked from commit 7f6b6b353c79ee02923c1313ddd1dfdec519c5ea)

Update WifiManager.cpp

(cherry picked from commit dad6a97f01876e148d0d1a94b67a3be00ffb60ee)
(cherry picked from commit 2c4739a545c783a9dff7c1282e9b740ad2960e6f)