### PR TITLE
LLAMA-5857: Network standbyMode info printed every 10sec

### DIFF
--- a/SystemServices/System.json
+++ b/SystemServices/System.json
@@ -1977,6 +1977,22 @@
                 ]
             }
         },
+        "onNetworkStandbyModeChanged":{
+            "summary": "Triggered when the network standby mode setting changed",
+            "params": {
+                "type" :"object",
+                "properties": {
+                    "nwStandby": {
+                        "summary": "Network standby mode",
+                        "type": "boolean",
+                        "example": true
+                    }
+                },
+                "required": [
+                    "nwStandby",
+                ]
+            }
+        },
         "onTemperatureThresholdChanged":{
             "summary": "Triggered when the device temperature changes beyond the `WARN` or `MAX` limits (see `setTemperatureThresholds`). Not supported on all devices.",
             "params": {

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -711,10 +711,13 @@ namespace WPEFramework {
             sendNotify(EVT_ONREBOOTREQUEST, params);
         }
 
-        void SystemServices::onNetorkModeChanged(bool betworkStandbyMode)
+        void SystemServices::onNetorkModeChanged(bool bNetworkStandbyMode)
         {
-            m_networkStandbyMode = betworkStandbyMode;
+            m_networkStandbyMode = bNetworkStandbyMode;
             m_networkStandbyModeValid = true;
+            JsonObject params;
+            params["nwStandby"] = bNetworkStandbyMode;
+            sendNotify(EVT_ONNETWORKSTANDBYMODECHANGED , params);
         }
 
         /**

--- a/SystemServices/SystemServices.h
+++ b/SystemServices/SystemServices.h
@@ -49,6 +49,7 @@
 #define EVT_ONSYSTEMSAMPLEEVENT           "onSampleEvent"
 #define EVT_ONSYSTEMPOWERSTATECHANGED     "onSystemPowerStateChanged"
 #define EVT_ONSYSTEMMODECHANGED           "onSystemModeChanged"
+#define EVT_ONNETWORKSTANDBYMODECHANGED   "onNetworkStandbyModeChanged"
 #define EVT_ONFIRMWAREUPDATEINFORECEIVED  "onFirmwareUpdateInfoReceived"
 #define EVT_ONFIRMWAREUPDATESTATECHANGED  "onFirmwareUpdateStateChange"
 #define EVT_ONTEMPERATURETHRESHOLDCHANGED "onTemperatureThresholdChanged"


### PR DESCRIPTION
Reason for change: Provided notification event to app.
Test Procedure: refer jira.
Risks: Low

Signed-off-by: apatel859 <amit_patel5@comcast.com>