### PR TITLE
RDK-36049: Get DHCP Server address of my network interface

### DIFF
--- a/Network/Network.cpp
+++ b/Network/Network.cpp
@@ -1034,7 +1034,7 @@ namespace WPEFramework
                          std::string sIPVersion = InternalResponse["ipversion"].String();
                          response["autoconfig"] = InternalResponse["autoconfig"];
                          std::string sAutoconfig =  InternalResponse["autoconfig"].String();
-                         if (!sAutoconfig.compare("true") && !(sIPVersion.compare("IPv4")))
+                         if (!(strcasecmp(sAutoconfig.c_str(), "true")) && !(strcasecmp(sIPVersion.c_str(), "IPv4")))
                              response["dhcpserver"] = InternalResponse["dhcpserver"];
                          response["ipaddress"] = InternalResponse["ipaddr"];
                          response["netmask"] = InternalResponse["netmask"];


### PR DESCRIPTION
Reason for change: To get DHCP ServerIP Address even ipversion case sensitive test cases also.
Test Procedure: As RDK Developer, I must be able to get DHCP Server address of my network interface.
                This DHCP Server address will be used to pass it to DVB-CI+ implementation.
Risks: High
Signed-off-by: Kumar Santhanam <Kumar_Santhanam@comcast.com>