### PR TITLE
LLAMA-5540: Fix and patch WPEFramework debug builds.

### DIFF
--- a/RDKShell/RDKShell.h
+++ b/RDKShell/RDKShell.h
@@ -360,7 +360,6 @@ namespace WPEFramework {
                   MonitorClients(RDKShell* shell)
                       : mShell(*shell)
                   {
-                      ASSERT(mShell != nullptr);
                   }
                   ~MonitorClients()
                   {


### PR DESCRIPTION
Reason for change: Remove wrong assert for non pointer object
Test Procedure: build in debug mode
Risks: Low

Signed-off-by: mateusz.adamski <mateusz.adamski2@sky.uk>