### PR TITLE
DELIA-55782: Inconsistent response header for getIPSettings

### DIFF
--- a/Network/Network.cpp
+++ b/Network/Network.cpp
@@ -1036,7 +1036,7 @@ namespace WPEFramework
                          std::string sAutoconfig =  InternalResponse["autoconfig"].String();
                          if (!(strcasecmp(sAutoconfig.c_str(), "true")) && !(strcasecmp(sIPVersion.c_str(), "IPv4")))
                              response["dhcpserver"] = InternalResponse["dhcpserver"];
-                         response["ipaddress"] = InternalResponse["ipaddr"];
+                         response["ipaddr"] = InternalResponse["ipaddr"];
                          response["netmask"] = InternalResponse["netmask"];
                          response["gateway"] = InternalResponse["gateway"];
                          response["primarydns"] = InternalResponse["primarydns"];


### PR DESCRIPTION
Reason for change: Added ipaddress in response header
Test Procedure: Verify in Xi6 , Platco , SkyXione devices
Risks: Low
Signed-off-by: Thamim Razith <tabbas651@cable.comcast.com>