### PR TITLE
DELIA-55782: Inconsistent response header for getIPSettings

### DIFF
--- a/Network/Network.cpp
+++ b/Network/Network.cpp
@@ -1030,7 +1030,7 @@ namespace WPEFramework
                          response["interface"] = InternalResponse["interface"];
                          response["ipversion"] = InternalResponse["ipversion"];
                          response["autoconfig"] = InternalResponse["autoconfig"];
-                         response["ipaddress"] = InternalResponse["ipaddr"];
+                         response["ipaddr"] = InternalResponse["ipaddr"];
                          response["netmask"] = InternalResponse["netmask"];
                          response["gateway"] = InternalResponse["gateway"];
                          response["primarydns"] = InternalResponse["primarydns"];


### PR DESCRIPTION
Reason for change: Added ipaddress in response header
Test Procedure: Verify in Xi6 , Platco , SkyXione devices
Risks: Low
Signed-off-by: Thamim Razith <tabbas651@cable.comcast.com>
(cherry picked from commit 41222733d0206ee9c5355ebf105a6d84adadd877)