### PR TITLE
RDK-36049: Get DHCP Server address of my network interface

### DIFF
--- a/Network/Network.cpp
+++ b/Network/Network.cpp
@@ -97,6 +97,7 @@ typedef struct {
     char ipaddress[MAX_IP_ADDRESS_LEN];
     char netmask[MAX_IP_ADDRESS_LEN];
     char gateway[MAX_IP_ADDRESS_LEN];
+    char dhcpserver[MAX_IP_ADDRESS_LEN];
     char primarydns[MAX_IP_ADDRESS_LEN];
     char secondarydns[MAX_IP_ADDRESS_LEN];
     bool isSupported;
@@ -1029,7 +1030,11 @@ namespace WPEFramework
                      {
                          response["interface"] = InternalResponse["interface"];
                          response["ipversion"] = InternalResponse["ipversion"];
+                         std::string sIPVersion = InternalResponse["ipversion"].String();
                          response["autoconfig"] = InternalResponse["autoconfig"];
+                         std::string sAutoconfig = InternalResponse["autoconfig"].String();
+                         if (!(strcasecmp(sAutoconfig.c_str(), "true")) && !(strcasecmp(sIPVersion.c_str(), "IPv4")))
+                             response["dhcpserver"] = InternalResponse["dhcpserver"];
                          response["ipaddr"] = InternalResponse["ipaddr"];
                          response["netmask"] = InternalResponse["netmask"];
                          response["gateway"] = InternalResponse["gateway"];
@@ -1070,6 +1075,7 @@ namespace WPEFramework
                 response["autoconfig"] = iarmData.autoconfig;
                 response["ipaddr"] = string(iarmData.ipaddress,MAX_IP_ADDRESS_LEN - 1);
                 response["netmask"] = string(iarmData.netmask,MAX_IP_ADDRESS_LEN - 1);
+                response["dhcpserver"] = string(iarmData.dhcpserver,MAX_IP_ADDRESS_LEN - 1);
                 response["gateway"] = string(iarmData.gateway,MAX_IP_ADDRESS_LEN - 1);
                 response["primarydns"] = string(iarmData.primarydns,MAX_IP_ADDRESS_LEN - 1);
                 response["secondarydns"] = string(iarmData.secondarydns,MAX_IP_ADDRESS_LEN - 1);

--- a/Network/Network.json
+++ b/Network/Network.json
@@ -32,6 +32,11 @@
             "type": "boolean",
             "example": true
         },
+        "dhcpserver": {
+            "summary": "The DHCP Server address",
+            "type": "string",
+            "example": "192.168.1.1"
+        },
         "ipaddr": {
             "summary": "The IP address",
             "type": "string",
@@ -268,6 +273,9 @@
                     },
                     "autoconfig": {
                         "$ref": "#/definitions/autoconfig"
+                    },
+                    "dhcpserver": {
+                        "$ref": "#/definitions/dhcpserver"
                     },
                     "ipaddr": {
                         "$ref": "#/definitions/ipaddr"

--- a/docs/api/NetworkPlugin.md
+++ b/docs/api/NetworkPlugin.md
@@ -235,6 +235,7 @@ Gets the IP setting for the given interface.
 | result.interface | string | An interface, such as `ETHERNET` or `WIFI`, depending upon availability of the given interface in `getInterfaces` |
 | result.ipversion | string | either IPv4 or IPv6 |
 | result.autoconfig | boolean | `true` if DHCP is used, `false` if IP is configured manually |
+| result.dhcpserver | string | The DHCP Server address |
 | result.ipaddr | string | The IP address |
 | result.netmask | string | The network mask address |
 | result.gateway | string | The gateway address |
@@ -268,6 +269,7 @@ Gets the IP setting for the given interface.
         "interface": "WIFI",
         "ipversion": "IPv4",
         "autoconfig": true,
+        "dhcpserver": "192.168.1.1",
         "ipaddr": "192.168.1.101",
         "netmask": "255.255.255.0",
         "gateway": "192.168.1.1",


### PR DESCRIPTION
Reason for change: To get DHCP ServerIP Address
Test Procedure: As RDK Developer, I must be able to get DHCP Server address of my network interface.
                This DHCP Server address will be used to pass it to DVB-CI+ implementation.
Risks: High
Signed-off-by: Kumar Santhanam <Kumar_Santhanam@comcast.com>