### PR TITLE
RDK-34729: New APIs to DeviceInfo

### DIFF
--- a/DeviceInfo/CMakeLists.txt
+++ b/DeviceInfo/CMakeLists.txt
@@ -19,7 +19,9 @@ set(PLUGIN_NAME DeviceInfo)
 set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
 
 find_package(${NAMESPACE}Plugins REQUIRED)
+find_package(${NAMESPACE}Definitions REQUIRED)
 find_package(CompileSettingsDebug CONFIG REQUIRED)
+find_package(RFC REQUIRED)
 
 add_library(${MODULE_NAME} SHARED
     DeviceInfo.cpp
@@ -30,10 +32,15 @@ set_target_properties(${MODULE_NAME} PROPERTIES
         CXX_STANDARD 11
         CXX_STANDARD_REQUIRED YES)
 
+target_include_directories(${MODULE_NAME} PRIVATE
+        ${RFC_INCLUDE_DIRS})
+
 target_link_libraries(${MODULE_NAME} 
     PRIVATE
         CompileSettingsDebug::CompileSettingsDebug
-        ${NAMESPACE}Plugins::${NAMESPACE}Plugins)
+        ${NAMESPACE}Plugins::${NAMESPACE}Plugins
+        ${NAMESPACE}Definitions::${NAMESPACE}Definitions
+        ${RFC_LIBRARIES})
 
 install(TARGETS ${MODULE_NAME} 
     DESTINATION lib/${STORAGE_DIRECTORY}/plugins)

--- a/DeviceInfo/DeviceInfo.h
+++ b/DeviceInfo/DeviceInfo.h
@@ -27,6 +27,12 @@ namespace WPEFramework {
 namespace Plugin {
 
     class DeviceInfo : public PluginHost::IPlugin, public PluginHost::IWeb, public PluginHost::JSONRPC {
+    private:
+        typedef Core::JSON::EnumType<JsonData::DeviceInfo::DistributoridData::DistributoridType> DistributoridJsonEnum;
+        typedef Core::JSON::EnumType<JsonData::DeviceInfo::DevicetypeData::DevicetypeType> DevicetypeJsonEnum;
+        typedef Core::JSON::EnumType<JsonData::DeviceInfo::MakeData::MakeType> MakeJsonEnum;
+        typedef Core::JSON::EnumType<JsonData::DeviceInfo::ModelidData::SkuType> SkuJsonEnum;
+
     public:
         class Data : public Core::JSON::Container {
         public:
@@ -38,6 +44,19 @@ namespace Plugin {
                 Add(_T("addresses"), &Addresses);
                 Add(_T("systeminfo"), &SystemInfo);
                 Add(_T("sockets"), &Sockets);
+                Add(_T("firmwareversion"), &FirmwareVersion);
+                Add(_T("serialnumber"), &SerialNumber);
+                Add(_T("sku"), &Sku);
+                Add(_T("make"), &Make);
+                Add(_T("model"), &Model);
+                Add(_T("devicetype"), &DeviceType);
+                Add(_T("distributorid"), &DistributorId);
+                Add(_T("estbmac"), &EstbMac);
+                Add(_T("wifimac"), &WifiMac);
+                Add(_T("bluetoothmac"), &BluetoothMac);
+                Add(_T("mocamac"), &MocaMac);
+                Add(_T("ethmac"), &EthMac);
+                Add(_T("rf4cemac"), &Rf4ceMac);
             }
 
             virtual ~Data()
@@ -48,27 +67,24 @@ namespace Plugin {
             Core::JSON::ArrayType<JsonData::DeviceInfo::AddressesData> Addresses;
             JsonData::DeviceInfo::SysteminfoData SystemInfo;
             JsonData::DeviceInfo::SocketinfoData Sockets;
+            JsonData::DeviceInfo::FirmwareversionData FirmwareVersion;
+            Core::JSON::String SerialNumber;
+            SkuJsonEnum Sku;
+            MakeJsonEnum Make;
+            Core::JSON::String Model;
+            DevicetypeJsonEnum DeviceType;
+            DistributoridJsonEnum DistributorId;
+            Core::JSON::String EstbMac;
+            Core::JSON::String WifiMac;
+            Core::JSON::String BluetoothMac;
+            Core::JSON::String MocaMac;
+            Core::JSON::String EthMac;
+            Core::JSON::String Rf4ceMac;
         };
 
     private:
         DeviceInfo(const DeviceInfo&) = delete;
         DeviceInfo& operator=(const DeviceInfo&) = delete;
-
-        uint32_t addresses(const Core::JSON::String& parameters, Core::JSON::ArrayType<JsonData::DeviceInfo::AddressesData>& response)
-        {
-            AddressInfo(response);
-            return (Core::ERROR_NONE);
-        }
-        uint32_t system(const Core::JSON::String& parameters, JsonData::DeviceInfo::SysteminfoData& response)
-        {
-            SysInfo(response);
-            return (Core::ERROR_NONE);
-        }
-        uint32_t sockets(const Core::JSON::String& parameters, JsonData::DeviceInfo::SocketinfoData& response)
-        {
-            SocketPortInfo(response);
-            return (Core::ERROR_NONE);
-        }
 
     public:
         DeviceInfo()
@@ -76,7 +92,6 @@ namespace Plugin {
             , _service(nullptr)
             , _subSystem(nullptr)
             , _systemId()
-            , _deviceId()
         {
             RegisterAll();
         }
@@ -108,21 +123,46 @@ namespace Plugin {
         // JsonRpc
         void RegisterAll();
         void UnregisterAll();
+
         uint32_t get_systeminfo(JsonData::DeviceInfo::SysteminfoData& response) const;
         uint32_t get_addresses(Core::JSON::ArrayType<JsonData::DeviceInfo::AddressesData>& response) const;
         uint32_t get_socketinfo(JsonData::DeviceInfo::SocketinfoData& response) const;
+        uint32_t get_firmwareversion(JsonData::DeviceInfo::FirmwareversionData& response) const;
+        uint32_t get_serialnumber(JsonData::DeviceInfo::SerialnumberData& response) const;
+        uint32_t get_modelid(JsonData::DeviceInfo::ModelidData& response) const;
+        uint32_t get_make(JsonData::DeviceInfo::MakeData& response) const;
+        uint32_t get_modelname(JsonData::DeviceInfo::ModelnameData& response) const;
+        uint32_t get_devicetype(JsonData::DeviceInfo::DevicetypeData& response) const;
+        uint32_t get_distributorid(JsonData::DeviceInfo::DistributoridData& response) const;
+        uint32_t get_estbmac(JsonData::DeviceInfo::EstbmacData& response) const;
+        uint32_t get_wifimac(JsonData::DeviceInfo::WifimacData& response) const;
+        uint32_t get_bluetoothmac(JsonData::DeviceInfo::BluetoothmacData& response) const;
+        uint32_t get_mocamac(JsonData::DeviceInfo::MocamacData& response) const;
+        uint32_t get_ethmac(JsonData::DeviceInfo::EthmacData& response) const;
+        uint32_t get_rf4cemac(JsonData::DeviceInfo::Rf4cemacData& response) const;
 
         void SysInfo(JsonData::DeviceInfo::SysteminfoData& systemInfo) const;
         void AddressInfo(Core::JSON::ArrayType<JsonData::DeviceInfo::AddressesData>& addressInfo) const;
         void SocketPortInfo(JsonData::DeviceInfo::SocketinfoData& socketPortInfo) const;
-        string GetDeviceId() const;
+        void FirmwareVersion(JsonData::DeviceInfo::FirmwareversionData& firmwareVersion) const;
+        void SerialNumber(Core::JSON::String& serialNumber) const;
+        void Sku(SkuJsonEnum& sku) const;
+        void Make(MakeJsonEnum& make) const;
+        void Model(Core::JSON::String& model) const;
+        void DeviceType(DevicetypeJsonEnum& deviceType) const;
+        void DistributorId(DistributoridJsonEnum& distributorId) const;
+        void EstbMac(Core::JSON::String& estbMac) const;
+        void WifiMac(Core::JSON::String& wifiMac) const;
+        void BluetoothMac(Core::JSON::String& bluetoothMac) const;
+        void MocaMac(Core::JSON::String& mocaMac) const;
+        void EthMac(Core::JSON::String& ethMac) const;
+        void Rf4ceMac(Core::JSON::String& rf4ceMac) const;
 
     private:
         uint8_t _skipURL;
         PluginHost::IShell* _service;
         PluginHost::ISubSystem* _subSystem;
         string _systemId;
-        mutable string _deviceId;
     };
 
 } // namespace Plugin

--- a/DeviceInfo/DeviceInfoJsonRpc.cpp
+++ b/DeviceInfo/DeviceInfoJsonRpc.cpp
@@ -33,6 +33,19 @@ namespace Plugin {
         Property<SysteminfoData>(_T("systeminfo"), &DeviceInfo::get_systeminfo, nullptr, this);
         Property<Core::JSON::ArrayType<AddressesData>>(_T("addresses"), &DeviceInfo::get_addresses, nullptr, this);
         Property<SocketinfoData>(_T("socketinfo"), &DeviceInfo::get_socketinfo, nullptr, this);
+        Property<FirmwareversionData>(_T("firmwareversion"), &DeviceInfo::get_firmwareversion, nullptr, this);
+        Property<SerialnumberData>(_T("serialnumber"), &DeviceInfo::get_serialnumber, nullptr, this);
+        Property<ModelidData>(_T("modelid"), &DeviceInfo::get_modelid, nullptr, this);
+        Property<MakeData>(_T("make"), &DeviceInfo::get_make, nullptr, this);
+        Property<ModelnameData>(_T("modelname"), &DeviceInfo::get_modelname, nullptr, this);
+        Property<DevicetypeData>(_T("devicetype"), &DeviceInfo::get_devicetype, nullptr, this);
+        Property<DistributoridData>(_T("distributorid"), &DeviceInfo::get_distributorid, nullptr, this);
+        Property<EstbmacData>(_T("estbmac"), &DeviceInfo::get_estbmac, nullptr, this);
+        Property<WifimacData>(_T("wifimac"), &DeviceInfo::get_wifimac, nullptr, this);
+        Property<BluetoothmacData>(_T("bluetoothmac"), &DeviceInfo::get_bluetoothmac, nullptr, this);
+        Property<MocamacData>(_T("mocamac"), &DeviceInfo::get_mocamac, nullptr, this);
+        Property<EthmacData>(_T("ethmac"), &DeviceInfo::get_ethmac, nullptr, this);
+        Property<Rf4cemacData>(_T("rf4cemac"), &DeviceInfo::get_rf4cemac, nullptr, this);
     }
 
     void DeviceInfo::UnregisterAll()
@@ -40,6 +53,19 @@ namespace Plugin {
         Unregister(_T("socketinfo"));
         Unregister(_T("addresses"));
         Unregister(_T("systeminfo"));
+        Unregister(_T("firmwareversion"));
+        Unregister(_T("serialnumber"));
+        Unregister(_T("modelid"));
+        Unregister(_T("make"));
+        Unregister(_T("modelname"));
+        Unregister(_T("devicetype"));
+        Unregister(_T("distributorid"));
+        Unregister(_T("estbmac"));
+        Unregister(_T("wifimac"));
+        Unregister(_T("bluetoothmac"));
+        Unregister(_T("mocamac"));
+        Unregister(_T("ethmac"));
+        Unregister(_T("rf4cemac"));
     }
 
     // API implementation
@@ -72,7 +98,123 @@ namespace Plugin {
         return Core::ERROR_NONE;
     }
 
+    // Property: firmwareversion - Versions maintained in version.txt
+    // Return codes:
+    //  - ERROR_NONE: Success
+    uint32_t DeviceInfo::get_firmwareversion(JsonData::DeviceInfo::FirmwareversionData& response) const
+    {
+        FirmwareVersion(response);
+        return Core::ERROR_NONE;
+    }
+
+    // Property: serialnumber - Serial number set by manufacturer
+    // Return codes:
+    //  - ERROR_NONE: Success
+    uint32_t DeviceInfo::get_serialnumber(JsonData::DeviceInfo::SerialnumberData& response) const
+    {
+        SerialNumber(response.Serialnumber);
+        return Core::ERROR_NONE;
+    }
+
+    // Property: modelid - Device model number or SKU
+    // Return codes:
+    //  - ERROR_NONE: Success
+    uint32_t DeviceInfo::get_modelid(JsonData::DeviceInfo::ModelidData& response) const
+    {
+        Sku(response.Sku);
+        return Core::ERROR_NONE;
+    }
+
+    // Property: make - Device manufacturer
+    // Return codes:
+    //  - ERROR_NONE: Success
+    uint32_t DeviceInfo::get_make(JsonData::DeviceInfo::MakeData& response) const
+    {
+        Make(response.Make);
+        return Core::ERROR_NONE;
+    }
+
+    // Property: modelname - Friendly device model name
+    // Return codes:
+    //  - ERROR_NONE: Success
+    uint32_t DeviceInfo::get_modelname(JsonData::DeviceInfo::ModelnameData& response) const
+    {
+        Model(response.Model);
+        return Core::ERROR_NONE;
+    }
+
+    // Property: devicetype - Device type
+    // Return codes:
+    //  - ERROR_NONE: Success
+    uint32_t DeviceInfo::get_devicetype(JsonData::DeviceInfo::DevicetypeData& response) const
+    {
+        DeviceType(response.Devicetype);
+        return Core::ERROR_NONE;
+    }
+
+    // Property: distributorid - Partner ID or distributor ID for device
+    // Return codes:
+    //  - ERROR_NONE: Success
+    uint32_t DeviceInfo::get_distributorid(JsonData::DeviceInfo::DistributoridData& response) const
+    {
+        DistributorId(response.Distributorid);
+        return Core::ERROR_NONE;
+    }
+
+    // Property: estbmac - Embedded set-top box MAC address
+    // Return codes:
+    //  - ERROR_NONE: Success
+    uint32_t DeviceInfo::get_estbmac(JsonData::DeviceInfo::EstbmacData& response) const
+    {
+        EstbMac(response.Estbmac);
+        return Core::ERROR_NONE;
+    }
+
+    // Property: wifimac - Wifi MAC address
+    // Return codes:
+    //  - ERROR_NONE: Success
+    uint32_t DeviceInfo::get_wifimac(JsonData::DeviceInfo::WifimacData& response) const
+    {
+        WifiMac(response.Wifimac);
+        return Core::ERROR_NONE;
+    }
+
+    // Property: bluetoothmac - Bluetooth MAC address
+    // Return codes:
+    //  - ERROR_NONE: Success
+    uint32_t DeviceInfo::get_bluetoothmac(JsonData::DeviceInfo::BluetoothmacData& response) const
+    {
+        BluetoothMac(response.Bluetoothmac);
+        return Core::ERROR_NONE;
+    }
+
+    // Property: mocamac - MOCA MAC address
+    // Return codes:
+    //  - ERROR_NONE: Success
+    uint32_t DeviceInfo::get_mocamac(JsonData::DeviceInfo::MocamacData& response) const
+    {
+        MocaMac(response.Mocamac);
+        return Core::ERROR_NONE;
+    }
+
+    // Property: ethmac - Ethernet MAC address
+    // Return codes:
+    //  - ERROR_NONE: Success
+    uint32_t DeviceInfo::get_ethmac(JsonData::DeviceInfo::EthmacData& response) const
+    {
+        EthMac(response.Ethmac);
+        return Core::ERROR_NONE;
+    }
+
+    // Property: rf4cemac - Rf4ce MAC address
+    // Return codes:
+    //  - ERROR_NONE: Success
+    uint32_t DeviceInfo::get_rf4cemac(JsonData::DeviceInfo::Rf4cemacData& response) const
+    {
+        Rf4ceMac(response.Rf4cemac);
+        return Core::ERROR_NONE;
+    }
+
 } // namespace Plugin
 
 }
-

--- a/DeviceInfo/Module.h
+++ b/DeviceInfo/Module.h
@@ -25,6 +25,7 @@
 #endif
 
 #include <plugins/plugins.h>
+#include <interfaces/definitions.h>
 
 #undef EXTERNAL
 #define EXTERNAL


### PR DESCRIPTION
Reason for change: Add properties as below.
- firmwareversion ->
  - string imagename
  - string sdk
  - string mediarite
  - enum yocto
- serialnumber -> string serialnumber
- modelid -> enum sku
- make -> enum make
- modelname -> string model
- devicetype -> enum devicetype
- distributorid -> enum distributorid
- estbmac -> string estbmac
- wifimac -> string wifimac
- bluetoothmac -> string bluetoothmac
- mocamac -> string mocamac
- ethmac -> string ethmac
- rf4cemac -> string rf4cemac

Test Procedure: Test DeviceInfo RDK Service.
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>