### PR TITLE
RDK-34768 - API docs for ignoring EDID resolution

### DIFF
--- a/DisplaySettings/DisplaySettings.json
+++ b/DisplaySettings/DisplaySettings.json
@@ -1737,6 +1737,12 @@
                         "summary":"Persists the resolution",
                         "type": "boolean",
                         "example": true
+                    },
+                    "ignoreEdid": {
+                        "summary": "Ignore the supported resolutions as transmitted by the connected TV EDID",
+                        "type": "boolean",
+                        "default": false,
+                        "example": true
                     }
                 },
                 "required": [

--- a/docs/api/DisplaySettingsPlugin.md
+++ b/docs/api/DisplaySettingsPlugin.md
@@ -2960,6 +2960,7 @@ Also see: [resolutionPreChange](#resolutionPreChange), [resolutionChanged](#reso
 | params.videoDisplay | string | Video display port name. The default port is `HDMI0` if no port is specified |
 | params.resolution | string | Video display resolution |
 | params?.persist | boolean | <sup>*(optional)*</sup> Persists the resolution |
+| params?.ignoreEdid | boolean | <sup>*(optional)*</sup> Ignore the supported resolutions as transmitted by the connected TV EDID |
 
 ### Result
 
@@ -2980,7 +2981,8 @@ Also see: [resolutionPreChange](#resolutionPreChange), [resolutionChanged](#reso
     "params": {
         "videoDisplay": "HDMI0",
         "resolution": "1080p",
-        "persist": true
+        "persist": true,
+        "ignoreEdid": true
     }
 }
 ```


### PR DESCRIPTION
(cherry picked from commit a82765d89ed23294d38eeb3fa16ddedf00c1b175)

[RDK-36392](https://ccp.sys.comcast.net/browse/RDK-36392) Thunder API documentation: Display Settings: setCurrentResolution: ignoreEdid argument is not documented

As reported by Andrew Bennett