### PR TITLE
RDK-35648: Override HDMI Color Depth

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -241,6 +241,10 @@ namespace WPEFramework {
 	    registerMethod("setSurroundVirtualizer", &DisplaySettings::setSurroundVirtualizer2, this, {2});
             registerMethod("getVideoFormat", &DisplaySettings::getVideoFormat, this);
 
+            registerMethod("setPreferredColorDepth", &DisplaySettings::setPreferredColorDepth, this);
+            registerMethod("getPreferredColorDepth", &DisplaySettings::getPreferredColorDepth, this);
+            registerMethod("getColorDepthCapabilities", &DisplaySettings::getColorDepthCapabilities, this);
+
 	    m_subscribed = false; //HdmiCecSink event subscription
 	    m_hdmiInAudioDeviceConnected = false;
         m_arcAudioEnabled = false;
@@ -3680,6 +3684,109 @@ namespace WPEFramework {
             returnResponse(success);
         }
 
+        uint32_t DisplaySettings::getPreferredColorDepth(const JsonObject& parameters, JsonObject& response)
+        {   //sample servicemanager response:{"colorDepth":"10 Bit","success":true}
+            LOGINFOMETHOD();
+            std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+            string videoDisplay = parameters.HasLabel("videoDisplay") ? parameters["videoDisplay"].String() : strVideoPort;
+            bool persist = parameters.HasLabel("persist") ? parameters["persist"].Boolean() : true;
+
+            bool success = true;
+            try
+            {
+                device::VideoOutputPort &vPort = device::Host::getInstance().getVideoOutputPort(videoDisplay);
+                unsigned int colorDepth = vPort.getPreferredColorDepth(persist);
+		switch (colorDepth) {
+			case dsDISPLAY_COLORDEPTH_8BIT:
+				response["colorDepth"] = "8 Bit";
+				break;
+			case dsDISPLAY_COLORDEPTH_10BIT:
+				response["colorDepth"] = "10 Bit";
+				break;
+			case dsDISPLAY_COLORDEPTH_12BIT:
+				response["colorDepth"] = "12 Bit";
+				break;
+			case dsDISPLAY_COLORDEPTH_AUTO:
+				response["colorDepth"] = "Auto";
+				break;
+			default :
+				success = false;
+				break;
+		}
+            }
+            catch(const device::Exception& err)
+            {
+                LOG_DEVICE_EXCEPTION1(videoDisplay);
+                success = false;
+            }
+            returnResponse(success);
+        }
+
+        uint32_t DisplaySettings::setPreferredColorDepth(const JsonObject& parameters, JsonObject& response)
+        {   //sample servicemanager response: {"success":true}
+            LOGINFOMETHOD();
+            returnIfParamNotFound(parameters, "videoDisplay");
+            returnIfParamNotFound(parameters, "colorDepth");
+
+            string videoDisplay = parameters["videoDisplay"].String();
+            string strColorDepth = parameters["colorDepth"].String();
+
+            bool persist = parameters.HasLabel("persist") ? parameters["persist"].Boolean() : true;
+
+            bool success = true;
+            try
+            {
+                dsDisplayColorDepth_t colorDepth = dsDISPLAY_COLORDEPTH_UNKNOWN;
+                device::VideoOutputPort &vPort = device::Host::getInstance().getVideoOutputPort(videoDisplay);
+		if (0==strncmp(strColorDepth.c_str(), "8 Bit", 5)){
+                        colorDepth = dsDISPLAY_COLORDEPTH_8BIT;
+		} else if (0==strncmp(strColorDepth.c_str(), "10 Bit", 6)){
+                        colorDepth = dsDISPLAY_COLORDEPTH_10BIT;
+		} else if (0==strncmp(strColorDepth.c_str(), "12 Bit", 6)){
+                        colorDepth = dsDISPLAY_COLORDEPTH_12BIT;
+		} else if (0==strncmp(strColorDepth.c_str(), "Auto", 4)){
+                        colorDepth = dsDISPLAY_COLORDEPTH_AUTO;
+		} else {
+			//UNKNOWN color depth
+			LOGERR("UNKNOWN color depth: %s", strColorDepth.c_str());
+			success = false;
+		}
+                if (dsDISPLAY_COLORDEPTH_UNKNOWN!=colorDepth) {
+                    vPort.setPreferredColorDepth(colorDepth, persist);
+                }
+            }
+            catch (const device::Exception& err)
+            {
+                LOG_DEVICE_EXCEPTION2(videoDisplay, strColorDepth);
+                success = false;
+            }
+            returnResponse(success);
+        }
+
+        uint32_t DisplaySettings::getColorDepthCapabilities(const JsonObject& parameters, JsonObject& response)
+        {   //sample servicemanager response:{"success":true,"capabilities":["8 Bit","10 Bit","12 Bit","Auto"]}
+            LOGINFOMETHOD();
+            std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
+            string videoDisplay = parameters.HasLabel("videoDisplay") ? parameters["videoDisplay"].String() : strVideoPort;
+            vector<string> colorDepthCapabilities;
+            try
+            {
+                unsigned int capabilities = 0;
+                device::VideoOutputPort &vPort = device::Host::getInstance().getVideoOutputPort(videoDisplay);
+                vPort.getColorDepthCapabilities(&capabilities);
+                if(!capabilities) colorDepthCapabilities.emplace_back("none");
+                if(capabilities & dsDISPLAY_COLORDEPTH_8BIT)colorDepthCapabilities.emplace_back("8 Bit");
+                if(capabilities & dsDISPLAY_COLORDEPTH_10BIT)colorDepthCapabilities.emplace_back("10 Bit");
+                if(capabilities & dsDISPLAY_COLORDEPTH_12BIT)colorDepthCapabilities.emplace_back("12 Bit");
+                if(capabilities & dsDISPLAY_COLORDEPTH_AUTO)colorDepthCapabilities.emplace_back("Auto");
+            }
+            catch(const device::Exception& err)
+            {
+                LOG_DEVICE_EXCEPTION1(videoDisplay);
+            }
+            setResponseArray(response, "capabilities", colorDepthCapabilities);
+            returnResponse(true);
+        }
 
         bool DisplaySettings::setUpHdmiCecSinkArcRouting (bool arcEnable)
         {

--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -148,6 +148,11 @@ namespace WPEFramework {
             uint32_t resetVolumeLeveller(const JsonObject& parameters, JsonObject& response);
             uint32_t getVideoFormat(const JsonObject& parameters, JsonObject& response);
             uint32_t setMS12ProfileSettingsOverride(const JsonObject& parameters, JsonObject& response);
+
+            uint32_t setPreferredColorDepth(const JsonObject& parameters, JsonObject& response);
+            uint32_t getPreferredColorDepth(const JsonObject& parameters, JsonObject& response);
+            uint32_t getColorDepthCapabilities(const JsonObject& parameters, JsonObject& response);
+
             void InitAudioPorts();
             void AudioPortsReInitialize();
             static void initAudioPortsWorker(void);

--- a/DisplaySettings/DisplaySettings.json
+++ b/DisplaySettings/DisplaySettings.json
@@ -176,6 +176,11 @@
             "type": "string",
             "example": "FULL"
         },
+        "colordepth": {
+            "summary": "Video display colordepth. Possible values: `8 Bit`,`10 Bit`,`12 Bit`,`Auto`",
+            "type": "string",
+            "example": "12 Bit"
+        },
         "result": {
             "type":"object",
             "properties": {
@@ -2243,8 +2248,84 @@
             "result": {
                 "$ref": "#/definitions/result"
             }
+        },
+        "getColorDepthCapabilities": {
+            "summary": "Returns supported STB color depth capabilities.\n \n### Event \n\n No Events.",
+            "result": {
+                "type":"object",
+                "properties": {
+                    "getColorDepthCapabilities": {
+                        "summary": "A string array of supported STB color depth capabilities",
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "example": "8 Bit"
+                        }
+                    },
+                    "success": {
+                        "$ref": "#/definitions/success"
+                    }
+                },
+                "required": [
+                    "success"
+                ]
+            }
+        },
+        "getPreferredColorDepth":{
+            "summary": "Returns the current color depth on the selected video display port.\n \n### Event \n\n No Events.",
+            "params": {
+                "type":"object",
+                "properties": {
+                    "videoDisplay": {
+                        "$ref": "#/definitions/videoDisplay"
+                    }
+                },
+                "required":[
+                    " "
+                ]
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "resolution": {
+                        "$ref": "#/definitions/colordepth"
+                    },
+                    "success": {
+                        "$ref": "#/definitions/success"
+                    }
+                },
+                "required": [
+                    "success"
+                ]
+            }
+        },
+        "setPreferredColorDepth":{
+            "summary": "Sets the current color depth for the videoDisplay.\n",
+            "params": {
+                "type": "object",
+                "properties": {
+                    "videoDisplay": {
+                        "$ref": "#/definitions/videoDisplay"
+                    },
+                    "resolution": {
+                        "$ref": "#/definitions/colordepth"
+                    },
+                    "persist": {
+                        "summary":"Persists the color depth",
+                        "type": "boolean",
+                        "example": true
+                    }
+                },
+                "required": [
+                    "videoDisplay",
+                    "colorDepth"
+                ]
+            },
+            "result": {
+                "$ref": "#/definitions/result"
+            }
         }
-    },    
+    },
     "events": {
         "activeInputChanged":{
             "summary": "Triggered on active input change (RxSense)",


### PR DESCRIPTION
Reason for change:
Override HDMI Color Depth
Test Procedure: None
Risks: Low

Change-Id: I9e18de182d516d65b1f794163c238621a08212ed
Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>