### PR TITLE
RDKTV-15642: Avoid deadlock in Monitor

### DIFF
--- a/Monitor/Monitor.h
+++ b/Monitor/Monitor.h
@@ -774,7 +774,7 @@ namespace Plugin {
                             // Moreover it's the only only which now becomes active. This means probing
                             // has to be activated as well since it was stopped at point the last observee
                             // turned inactive
-                            _job.Submit();
+                            _job.Schedule(Core::Time::Now());
 
                             TRACE(Trace::Information, (_T("Starting to probe as active observee appeared.")));
                         }
@@ -801,7 +801,13 @@ namespace Plugin {
                                 _service->Notify(message);
                                 _parent.event_action(service->Callsign(), "Activate", "Automatic");
                                 TRACE(Trace::Error, (_T("Restarting %s again because we detected it misbehaved."), service->Callsign().c_str()));
-                                Core::IWorkerPool::Instance().Submit(PluginHost::IShell::Job::Create(service, PluginHost::IShell::ACTIVATED, PluginHost::IShell::AUTOMATIC));
+
+                                Core::IWorkerPool::Instance().Schedule(
+                                    Core::Time::Now(),
+                                    PluginHost::IShell::Job::Create(
+                                        service,
+                                        PluginHost::IShell::ACTIVATED,
+                                        PluginHost::IShell::AUTOMATIC));
                             }
                         }
                     }


### PR DESCRIPTION
Reason for change: ThreadPool::Submit blocks if no slots.
If server locks were acquired (like for StateChange)
and all other threads depend on them then it's a deadlock.

Test Procedure: Test Monitor plugin.
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>
(cherry picked from commit f32daa7ce882044fed9b449154d704944dd4ea03)