### PR TITLE
RDKTV-14660: Remove ARC/eARC HPD signal dependency for audio routing

### DIFF
--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -159,6 +159,7 @@ namespace WPEFramework {
 	    void onSystemAudioModeEventHandler(const JsonObject& parameters);
 	    void onAudioDeviceConnectedStatusEventHandler(const JsonObject& parameters);
 	    void onCecEnabledEventHandler(const JsonObject& parameters);
+            void onAudioDevicePowerStatusEventHandler(const JsonObject& parameters);
             //End events
         public:
             DisplaySettings();
@@ -190,6 +191,7 @@ namespace WPEFramework {
 	    uint32_t subscribeForHdmiCecSinkEvent(const char* eventName);
 	    bool setUpHdmiCecSinkArcRouting (bool arcEnable);
 	    bool requestShortAudioDescriptor();
+            bool requestAudioDevicePowerStatus();
 	    bool sendHdmiCecSinkAudioDevicePowerOn();
 	    bool getHdmiCecSinkCecEnableStatus();
 	    bool getHdmiCecSinkAudioDeviceConnectedStatus();
@@ -220,6 +222,14 @@ namespace WPEFramework {
                 ARC_STATE_ARC_EXIT
             };
 
+            enum {
+                AUDIO_DEVICE_POWER_STATE_UNKNOWN,
+                AUDIO_DEVICE_POWER_STATE_REQUEST,
+                AUDIO_DEVICE_POWER_STATE_STANDBY,
+                AUDIO_DEVICE_POWER_STATE_ON,
+            };
+
+            int m_hdmiInAudioDevicePowerState;
             int m_currentArcRoutingState; 
 
         public:

--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -61,6 +61,7 @@
 #define HDMICECSINK_METHOD_SEND_KEY_PRESS                          "sendKeyPressEvent"
 #define HDMICECSINK_METHOD_SEND_GIVE_AUDIO_STATUS          "sendGetAudioStatusMessage"
 #define HDMICECSINK_METHOD_GET_AUDIO_DEVICE_CONNECTED_STATUS   "getAudioDeviceConnectedStatus"
+#define HDMICECSINK_METHOD_REQUEST_AUDIO_DEVICE_POWER_STATUS   "requestAudioDevicePowerStatus"
 
 #define TEST_ADD 0
 #define HDMICECSINK_REQUEST_MAX_RETRY 				3
@@ -100,6 +101,7 @@ enum {
 	HDMICECSINK_EVENT_REPORT_AUDIO_STATUS,
 	HDMICECSINK_EVENT_AUDIO_DEVICE_CONNECTED_STATUS,
 	HDMICECSINK_EVENT_CEC_ENABLED,
+        HDMICECSINK_EVENT_AUDIO_DEVICE_POWER_STATUS,
 };
 
 static char *eventString[] = {
@@ -119,7 +121,8 @@ static char *eventString[] = {
         "setSystemAudioModeEvent",
         "reportAudioStatusEvent",
 	"reportAudioDeviceConnectedStatus",
-	"reportCecEnabledEvent"
+	"reportCecEnabledEvent",
+        "reportAudioDevicePowerStatus"
 };
 	
 
@@ -381,6 +384,11 @@ namespace WPEFramework
 	   {
 	       HdmiCecSink::_instance->sendDeviceUpdateInfo(header.from.toInt());
 	   }
+
+           if((header.from.toInt() == LogicalAddress::AUDIO_SYSTEM) && (HdmiCecSink::_instance->m_audioDevicePowerStatusRequested)) {
+               HdmiCecSink::_instance->reportAudioDevicePowerStatusInfo(header.from.toInt(), newPowerStatus);
+           }
+
        }
        void HdmiCecSinkProcessor::process (const FeatureAbort &msg, const Header &header)
        {
@@ -499,6 +507,7 @@ namespace WPEFramework
 		   m_currentActiveSource = -1;
 		   m_isHdmiInConnected = false;
 		   hdmiCecAudioDeviceConnected = false;
+                   m_audioDevicePowerStatusRequested = false;
 		   m_pollNextState = POLL_THREAD_STATE_NONE;
 		   m_pollThreadState = POLL_THREAD_STATE_NONE;
 		   dsHdmiInGetNumberOfInputsParam_t hdmiInput;
@@ -527,6 +536,7 @@ namespace WPEFramework
 		   registerMethod(HDMICECSINK_METHOD_SEND_KEY_PRESS,&HdmiCecSink::sendRemoteKeyPressWrapper,this);
 		   registerMethod(HDMICECSINK_METHOD_SEND_GIVE_AUDIO_STATUS,&HdmiCecSink::sendGiveAudioStatusWrapper,this);
 		   registerMethod(HDMICECSINK_METHOD_GET_AUDIO_DEVICE_CONNECTED_STATUS,&HdmiCecSink::getAudioDeviceConnectedStatusWrapper,this);
+                   registerMethod(HDMICECSINK_METHOD_REQUEST_AUDIO_DEVICE_POWER_STATUS,&HdmiCecSink::requestAudioDevicePowerStatusWrapper,this);
            logicalAddressDeviceType = "None";
            logicalAddress = 0xFF;
            m_sendKeyEventThreadExit = false;
@@ -851,13 +861,8 @@ namespace WPEFramework
                         }
 			CheckHdmiInState();
 
-			if ( previousHdmiState != m_isHdmiInConnected )
-			{
-				if ( m_isHdmiInConnected == false )
-				{
-					m_pollNextState = POLL_THREAD_STATE_PING;
-				}
-			}
+          m_pollNextState = POLL_THREAD_STATE_PING;
+          m_ThreadExitCV.notify_one();
           updateArcState();  
           return;
        }
@@ -1021,6 +1026,15 @@ namespace WPEFramework
 	      _instance->smConnection->sendTo(LogicalAddress::AUDIO_SYSTEM,MessageEncoder().encode(GiveAudioStatus()), 100);
 
         }
+        void  HdmiCecSink::reportAudioDevicePowerStatusInfo(const int logicalAddress, const int powerStatus)
+        {
+            JsonObject params;
+            params["powerStatus"] = JsonValue(powerStatus);
+            LOGINFO("Notify DS!!! logicalAddress = %d , Audio device power status = %d \n", logicalAddress, powerStatus);
+            m_audioDevicePowerStatusRequested = false;
+            sendNotify(eventString[HDMICECSINK_EVENT_AUDIO_DEVICE_POWER_STATUS], params);
+        }
+
         void HdmiCecSink::SendStandbyMsgEvent(const int logicalAddress)
         {
             JsonObject params;
@@ -1057,6 +1071,12 @@ namespace WPEFramework
        uint32_t HdmiCecSink::getAudioDeviceConnectedStatusWrapper(const JsonObject& parameters, JsonObject& response)
        {
             response["connected"] = getAudioDeviceConnectedStatus();
+            returnResponse(true);
+       }
+
+       uint32_t HdmiCecSink::requestAudioDevicePowerStatusWrapper(const JsonObject& parameters, JsonObject& response)
+       {
+            requestAudioDevicePowerStatus();
             returnResponse(true);
        }
 
@@ -1819,6 +1839,31 @@ namespace WPEFramework
                     _instance->smConnection->sendTo(LogicalAddress::AUDIO_SYSTEM,MessageEncoder().encode(RequestShortAudioDescriptor(formatid,audioFormatCode,numberofdescriptor)), 200);
 
 		}
+
+                void HdmiCecSink::requestAudioDevicePowerStatus()
+                {
+                        if ( cecEnableStatus != true  )
+                        {
+                             LOGWARN("cec is disabled-> EnableCEC first");
+                             return;
+                        }
+
+                        if(!HdmiCecSink::_instance)
+                                return;
+
+                        if(!(_instance->smConnection))
+                            return;
+                        if ( _instance->m_logicalAddressAllocated == LogicalAddress::UNREGISTERED ){
+                                LOGERR("Logical Address NOT Allocated");
+                                return;
+                        }
+
+                        LOGINFO(" Send GiveDevicePowerStatus Message to Audio system in the network \n");
+                        _instance->smConnection->sendTo(LogicalAddress::AUDIO_SYSTEM, MessageEncoder().encode(GiveDevicePowerStatus()), 500);
+
+			m_audioDevicePowerStatusRequested = true;
+                }
+
 		void HdmiCecSink::sendFeatureAbort(const LogicalAddress logicalAddress, const OpCode feature, const AbortReason reason)
 	        {
 

--- a/HdmiCecSink/HdmiCecSink.h
+++ b/HdmiCecSink/HdmiCecSink.h
@@ -535,11 +535,14 @@ private:
 			void sendFeatureAbort(const LogicalAddress logicalAddress, const OpCode feature, const AbortReason reason);
 			void systemAudioModeRequest();
                         void SendStandbyMsgEvent(const int logicalAddress);
+                        void requestAudioDevicePowerStatus();
+                        void reportAudioDevicePowerStatusInfo(const int logicalAddress, const int powerStatus);
             void Process_ReportAudioStatus_msg(const ReportAudioStatus msg);
             void sendKeyPressEvent(const int logicalAddress, int keyCode);
             void sendKeyReleaseEvent(const int logicalAddress);
 			void sendGiveAudioStatusMsg();
 			int m_numberOfDevices; /* Number of connected devices othethan own device */
+			bool m_audioDevicePowerStatusRequested;
         private:
             // We do not allow this plugin to be copied !!
             HdmiCecSink(const HdmiCecSink&) = delete;
@@ -568,6 +571,7 @@ private:
                         uint32_t sendRemoteKeyPressWrapper(const JsonObject& parameters, JsonObject& response);
 	                uint32_t sendGiveAudioStatusWrapper(const JsonObject& parameters, JsonObject& response);
 			uint32_t getAudioDeviceConnectedStatusWrapper(const JsonObject& parameters, JsonObject& response);
+                        uint32_t requestAudioDevicePowerStatusWrapper(const JsonObject& parameters, JsonObject& response);
                         //End methods
             std::string logicalAddressDeviceType;
             bool cecSettingEnabled;


### PR DESCRIPTION
Reason for change:1) Added support for Audio Device Power
status API in Hdmicecsink & Displaysettings
2) Audio Device power status should be checked by TV once
any audio device connection is detected
3) Audio Routing to rely completely on ARC Initiation &
System audio mode events
4) Remove HPD ON handling from dsHdmiEventHandler and retain
HPD OFF handling
5) Initiate cec device ping immediately on HDMI ARC/eARC
Hotplug
Test Procedure: Refer Ticket
Risks: Medium

Signed-off-by: Deekshit Devadas deekshit.devadasy@sky.uk