### PR TITLE
RDK-35268: Configure local storage quota

### DIFF
--- a/WebKitBrowser/WebKitImplementation.cpp
+++ b/WebKitBrowser/WebKitImplementation.cpp
@@ -2151,6 +2151,13 @@ static GSourceFuncs _handlerIntervention =
                 }
                 g_mkdir_with_parents(wpeStoragePath, 0700);
 
+                // Default value suggested by HTML5 spec
+                uint32_t localStorageDatabaseQuotaInBytes = 5 * 1024 * 1024;
+                if (_config.LocalStorageSize.IsSet() == true && _config.LocalStorageSize.Value() != 0) {
+                    localStorageDatabaseQuotaInBytes = _config.LocalStorageSize.Value() * 1024;
+                    TRACE(Trace::Information, (_T("Configured LocalStorage Quota  %u bytes"), localStorageDatabaseQuotaInBytes));
+                }
+
                 gchar* wpeDiskCachePath;
                 if (_config.DiskCacheDir.IsSet() == true && _config.DiskCacheDir.Value().empty() == false) {
                     wpeDiskCachePath = g_build_filename(_config.DiskCacheDir.Value().c_str(), "wpe", "disk-cache", nullptr);
@@ -2159,7 +2166,7 @@ static GSourceFuncs _handlerIntervention =
                 }
                 g_mkdir_with_parents(wpeDiskCachePath, 0700);
 
-                auto* websiteDataManager = webkit_website_data_manager_new("local-storage-directory", wpeStoragePath, "disk-cache-directory", wpeDiskCachePath, nullptr);
+                auto* websiteDataManager = webkit_website_data_manager_new("local-storage-directory", wpeStoragePath, "disk-cache-directory", wpeDiskCachePath, "local-storage-quota", localStorageDatabaseQuotaInBytes, nullptr);
                 g_free(wpeStoragePath);
                 g_free(wpeDiskCachePath);
 


### PR DESCRIPTION
Reason for change: Browser should be able to restrict localstorage limit on certain apps/instances
Test Procedure:  Try the test page attached in the ticket
Risks: None

Signed-off-by: Vivek.A <vivek_arumugam@comcast.com>