### PR TITLE
DELIA-54042: Fix dolby_audiomodechanged event only returning STEREO

### DIFF
--- a/PlayerInfo/DeviceSettings/PlatformImplementation.cpp
+++ b/PlayerInfo/DeviceSettings/PlatformImplementation.cpp
@@ -257,7 +257,16 @@ public:
     {
         if(PlayerInfoImplementation::_instance)
         {
-            PlayerInfoImplementation::_instance->audiomodeChanged(STEREO, true);
+            dsAudioStereoMode_t amode = dsAUDIO_STEREO_UNKNOWN;
+            Exchange::Dolby::IOutput::SoundModes mode = UNKNOWN;
+            IARM_Bus_DSMgr_EventData_t *eventData = (IARM_Bus_DSMgr_EventData_t *)data;
+            amode = static_cast<dsAudioStereoMode_t>(eventData->data.Audioport.mode);
+            if (amode == device::AudioStereoMode::kSurround) mode = SURROUND;
+            else if(amode == device::AudioStereoMode::kStereo) mode = STEREO;
+            else if(amode == device::AudioStereoMode::kMono) mode = MONO;
+            else if(amode == device::AudioStereoMode::kPassThru) mode = PASSTHRU;
+            else mode = UNKNOWN;
+            PlayerInfoImplementation::_instance->audiomodeChanged(mode, true);
         }
     }
 


### PR DESCRIPTION
Reason for change: Remove hardcoded STEREO and replaced with correct
implementation to extact audio mode from IARM event
Test Procedure: Check ticket
Risks: None
Signed-off-by: Vinod Jacob <vinod_jacob@comcast.com>