### PR TITLE
RDKTV-13125: WPEFramework timeout during shutdown in Maintenance cleanup

### DIFF
--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -274,7 +274,7 @@ namespace WPEFramework {
             // Unsolicited part comes here
             if (UNSOLICITED_MAINTENANCE == g_maintenance_type && internetConnectStatus){
                 LOGINFO("---------------UNSOLICITED_MAINTENANCE--------------");
-                for( i = 0; i < tasks.size(); i++) {
+                for( i = 0; i < tasks.size() && !m_abort_flag; i++) {
                     LOGINFO("waiting to unlock.. [%d/%d]",i,tasks.size());
                     task_thread.wait(lck);
                     LOGINFO("EL: Lock acquired.waiting to unlock...");
@@ -287,13 +287,6 @@ namespace WPEFramework {
                         LOGINFO("Starting Script (USM) :  %s \n", cmd.c_str());
                         system(cmd.c_str());
                     }
-                    else {
-                        LOGINFO("EL: Abort flag set to true.");
-                        LOGINFO("EL: Unlocking all the tasks. calling notify_all()");
-                        task_thread.notify_all();
-                        LOGINFO("EL: Unlocked all the active tasks. hence exiting from for loop");
-                        break;
-		    }
                 }
             }
             /* Here in Solicited, we start with RFC so no
@@ -307,7 +300,7 @@ namespace WPEFramework {
                 LOGINFO("Starting Script (SM) :  %s \n", cmd.c_str());
                 system(cmd.c_str());
                 cmd="";
-                for( i = 1; i < tasks.size(); i++){
+                for( i = 1; i < tasks.size() && !m_abort_flag; i++){
                     LOGINFO("Waiting to unlock.. [%d/%d]",i,tasks.size());
                     task_thread.wait(lck);
                     cmd = tasks[i];
@@ -830,10 +823,10 @@ namespace WPEFramework {
                 MaintenanceManager::_instance = nullptr;
             }
 
-            m_abort_flag = true;
+            //m_abort_flag = true;
 		
             /* unlock if the task is still waiting */
-            //task_thread.notify_all();
+            task_thread.notify_all();
             LOGINFO("EL:checking if thread is joinable");
             if(m_thread.joinable()){
                 LOGINFO("EL:thread is joinable");

--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -822,6 +822,7 @@ namespace WPEFramework {
                 MaintenanceManager::_instance = nullptr;
             }
 
+            m_abort_flag = true;
             task_thread.notify_all();
             if(m_thread.joinable()){
                 m_thread.join();

--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -821,7 +821,6 @@ namespace WPEFramework {
                 IARM_CHECK(IARM_Bus_UnRegisterEventHandler(IARM_BUS_MAINTENANCE_MGR_NAME, IARM_BUS_DCM_NEW_START_TIME_EVENT));
                 MaintenanceManager::_instance = nullptr;
             }
-		
             m_abort_flag = true;
             task_thread.notify_all();
             if(m_thread.joinable()){

--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -821,7 +821,7 @@ namespace WPEFramework {
                 IARM_CHECK(IARM_Bus_UnRegisterEventHandler(IARM_BUS_MAINTENANCE_MGR_NAME, IARM_BUS_DCM_NEW_START_TIME_EVENT));
                 MaintenanceManager::_instance = nullptr;
             }
-		
+
             m_abort_flag = true;
             task_thread.notify_all();
             if(m_thread.joinable()){

--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -277,7 +277,6 @@ namespace WPEFramework {
                 for( i = 0; i < tasks.size() && !m_abort_flag; i++) {
                     LOGINFO("waiting to unlock.. [%d/%d]",i,tasks.size());
                     task_thread.wait(lck);
-                    LOGINFO("EL: Lock acquired.waiting to unlock...");
                     cmd = tasks[i];
                     cmd += " &";
                     cmd += "\0";
@@ -823,15 +822,9 @@ namespace WPEFramework {
                 MaintenanceManager::_instance = nullptr;
             }
 
-            //m_abort_flag = true;
-		
-            /* unlock if the task is still waiting */
             task_thread.notify_all();
-            LOGINFO("EL:checking if thread is joinable");
             if(m_thread.joinable()){
-                LOGINFO("EL:thread is joinable");
                 m_thread.join();
-                LOGINFO("EL: successfully executed join()");
             }
         }
 #endif /* defined(USE_IARMBUS) || defined(USE_IARM_BUS) */

--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -1144,7 +1144,7 @@ namespace WPEFramework {
                 if ( MAINTENANCE_STARTED == m_notify_status  ){
 
                     // Set the condition flag m_abort_flag to true
-                    m_abort_flag = true;
+                    //m_abort_flag = true;
 
                     auto task_status_DCM=m_task_map.find("/lib/rdk/StartDCM_maintaince.sh");
                     auto task_status_RFC=m_task_map.find(task_names_foreground[0].c_str());
@@ -1212,6 +1212,7 @@ namespace WPEFramework {
                 else {
                     LOGERR("Failed to stopMaintenance without starting maintenance \n");
                 }
+                m_abort_flag = true;
                 task_thread.notify_all();
                 if(m_thread.joinable()){
                     m_thread.join();

--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -824,7 +824,9 @@ namespace WPEFramework {
 
             m_abort_flag = true;
             task_thread.notify_all();
+            LOGINFO("EL: Checking thread is joinable");
             if(m_thread.joinable()){
+                LOGINFO("EL: thread is joinable. Executing join");
                 m_thread.join();
             }
         }

--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -823,6 +823,10 @@ namespace WPEFramework {
                 IARM_CHECK(IARM_Bus_UnRegisterEventHandler(IARM_BUS_MAINTENANCE_MGR_NAME, IARM_BUS_MAINTENANCEMGR_EVENT_UPDATE));
                 IARM_CHECK(IARM_Bus_UnRegisterEventHandler(IARM_BUS_MAINTENANCE_MGR_NAME, IARM_BUS_DCM_NEW_START_TIME_EVENT));
                 MaintenanceManager::_instance = nullptr;
+		    
+                if(m_thread.joinable()){
+                    m_thread.join();
+                }
             }
         }
 #endif /* defined(USE_IARMBUS) || defined(USE_IARM_BUS) */

--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -821,12 +821,6 @@ namespace WPEFramework {
                 IARM_CHECK(IARM_Bus_UnRegisterEventHandler(IARM_BUS_MAINTENANCE_MGR_NAME, IARM_BUS_DCM_NEW_START_TIME_EVENT));
                 MaintenanceManager::_instance = nullptr;
             }
-
-            m_abort_flag = true;
-            task_thread.notify_all();
-            if(m_thread.joinable()){
-                m_thread.join();
-            }
         }
 #endif /* defined(USE_IARMBUS) || defined(USE_IARM_BUS) */
 
@@ -1218,6 +1212,10 @@ namespace WPEFramework {
                 else {
                     LOGERR("Failed to stopMaintenance without starting maintenance \n");
                 }
+                task_thread.notify_all();
+                if(m_thread.joinable()){
+                    m_thread.join();
+		}
                 m_statusMutex.unlock();
             }
             else {

--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -823,7 +823,8 @@ namespace WPEFramework {
             }
 
             m_abort_flag = true;
-            LOGINFO("EL: Unlocking all the threads");
+		
+            /* unlock if the task is still waiting */
             task_thread.notify_all();
             if(m_thread.joinable()){
                 m_thread.join();

--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -1212,7 +1212,7 @@ namespace WPEFramework {
                 else {
                     LOGERR("Failed to stopMaintenance without starting maintenance \n");
                 }
-                task_thread.notify_all();
+                task_thread.notify_one();
 		    
                 if(m_thread.joinable()){
                     m_thread.join();

--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -509,6 +509,7 @@ namespace WPEFramework {
         void MaintenanceManager::Deinitialize(PluginHost::IShell*)
         {
 #if defined(USE_IARMBUS) || defined(USE_IARM_BUS)
+            stopMaintenanceTasks();
             DeinitializeIARM();
 #endif /* defined(USE_IARMBUS) || defined(USE_IARM_BUS) */
         }
@@ -821,6 +822,7 @@ namespace WPEFramework {
                 MaintenanceManager::_instance = nullptr;
             }
 
+            task_thread.notify_all();
             if(m_thread.joinable()){
                 m_thread.join();
             }
@@ -1123,6 +1125,12 @@ namespace WPEFramework {
         uint32_t MaintenanceManager::stopMaintenance(const JsonObject& parameters,
                 JsonObject& response){
 
+		bool result=false;
+		result=stopMaintenanceTasks();
+		returnResponse(result);
+	}
+
+        bool MaintenanceManager::stopMaintenanceTasks(){
             pid_t pid_num=-1;
 
             int k_ret=EINVAL;
@@ -1214,7 +1222,7 @@ namespace WPEFramework {
             else {
                 LOGERR("Failed to initiate stopMaintenance, RFC is set as False \n");
             }
-            returnResponse(result);
+            return result;
         }
 
         bool MaintenanceManager::checkAbortFlag(){

--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -286,9 +286,6 @@ namespace WPEFramework {
                         LOGINFO("Starting Script (USM) :  %s \n", cmd.c_str());
                         system(cmd.c_str());
                     }
-                    else {
-                        break;
-		    }
                 }
             }
             /* Here in Solicited, we start with RFC so no
@@ -824,6 +821,12 @@ namespace WPEFramework {
                 IARM_CHECK(IARM_Bus_UnRegisterEventHandler(IARM_BUS_MAINTENANCE_MGR_NAME, IARM_BUS_DCM_NEW_START_TIME_EVENT));
                 MaintenanceManager::_instance = nullptr;
             }
+		
+            m_abort_flag = true;
+            task_thread.notify_all();
+            if(m_thread.joinable()){
+                m_thread.join();
+            }
         }
 #endif /* defined(USE_IARMBUS) || defined(USE_IARM_BUS) */
 
@@ -1215,11 +1218,6 @@ namespace WPEFramework {
                 else {
                     LOGERR("Failed to stopMaintenance without starting maintenance \n");
                 }
-                //m_abort_flag = true;
-                //task_thread.notify_all();
-                if(m_thread.joinable()){
-                   m_thread.join();
-		}
                 m_statusMutex.unlock();
             }
             else {

--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -821,11 +821,6 @@ namespace WPEFramework {
                 IARM_CHECK(IARM_Bus_UnRegisterEventHandler(IARM_BUS_MAINTENANCE_MGR_NAME, IARM_BUS_DCM_NEW_START_TIME_EVENT));
                 MaintenanceManager::_instance = nullptr;
             }
-
-            task_thread.notify_all();
-            if(m_thread.joinable()){
-                m_thread.join();
-            }
         }
 #endif /* defined(USE_IARMBUS) || defined(USE_IARM_BUS) */
 
@@ -1216,6 +1211,11 @@ namespace WPEFramework {
                 }
                 else {
                     LOGERR("Failed to stopMaintenance without starting maintenance \n");
+                }
+                task_thread.notify_all();
+		    
+                if(m_thread.joinable()){
+                    m_thread.join();
                 }
                 m_statusMutex.unlock();
             }

--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -826,9 +826,9 @@ namespace WPEFramework {
                 MaintenanceManager::_instance = nullptr;
             }
 
-            m_abort_flag = true;
+            //m_abort_flag = true;
             LOGINFO("EL: Notifiying all");
-            task_thread.notify_all();
+            //task_thread.notify_all();
             LOGINFO("EL: Checking thread is joinable");
             if(m_thread.joinable()){
                 LOGINFO("EL: thread is joinable. Executing join");

--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -823,10 +823,6 @@ namespace WPEFramework {
                 IARM_CHECK(IARM_Bus_UnRegisterEventHandler(IARM_BUS_MAINTENANCE_MGR_NAME, IARM_BUS_MAINTENANCEMGR_EVENT_UPDATE));
                 IARM_CHECK(IARM_Bus_UnRegisterEventHandler(IARM_BUS_MAINTENANCE_MGR_NAME, IARM_BUS_DCM_NEW_START_TIME_EVENT));
                 MaintenanceManager::_instance = nullptr;
-		    
-                if(m_thread.joinable()){
-                    m_thread.join();
-                }
             }
         }
 #endif /* defined(USE_IARMBUS) || defined(USE_IARM_BUS) */
@@ -1221,9 +1217,9 @@ namespace WPEFramework {
                 }
                 //m_abort_flag = true;
                 //task_thread.notify_all();
-                //if(m_thread.joinable()){
-                  //  m_thread.join();
-		//}
+                if(m_thread.joinable()){
+                   m_thread.join();
+		}
                 m_statusMutex.unlock();
             }
             else {

--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -286,10 +286,6 @@ namespace WPEFramework {
                         LOGINFO("Starting Script (USM) :  %s \n", cmd.c_str());
                         system(cmd.c_str());
                     }
-                    //else {
-                      //  LOGINFO("Inside else. Executing break");
-                       // break;
-                    //}
                 }
             }
             /* Here in Solicited, we start with RFC so no
@@ -827,11 +823,8 @@ namespace WPEFramework {
             }
 
             m_abort_flag = true;
-            LOGINFO("EL: Notifiying all");
             task_thread.notify_all();
-            LOGINFO("EL: Checking thread is joinable");
             if(m_thread.joinable()){
-                LOGINFO("EL: thread is joinable. Executing join");
                 m_thread.join();
             }
         }

--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -286,6 +286,9 @@ namespace WPEFramework {
                         LOGINFO("Starting Script (USM) :  %s \n", cmd.c_str());
                         system(cmd.c_str());
                     }
+                    else {
+                        break;
+		    }
                 }
             }
             /* Here in Solicited, we start with RFC so no
@@ -1144,7 +1147,7 @@ namespace WPEFramework {
                 if ( MAINTENANCE_STARTED == m_notify_status  ){
 
                     // Set the condition flag m_abort_flag to true
-                    //m_abort_flag = true;
+                    m_abort_flag = true;
 
                     auto task_status_DCM=m_task_map.find("/lib/rdk/StartDCM_maintaince.sh");
                     auto task_status_RFC=m_task_map.find(task_names_foreground[0].c_str());
@@ -1212,11 +1215,11 @@ namespace WPEFramework {
                 else {
                     LOGERR("Failed to stopMaintenance without starting maintenance \n");
                 }
-                m_abort_flag = true;
-                task_thread.notify_all();
-                if(m_thread.joinable()){
-                    m_thread.join();
-		}
+                //m_abort_flag = true;
+                //task_thread.notify_all();
+                //if(m_thread.joinable()){
+                  //  m_thread.join();
+		//}
                 m_statusMutex.unlock();
             }
             else {

--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -823,10 +823,9 @@ namespace WPEFramework {
             }
 
             m_abort_flag = true;
+            LOGINFO("EL: Unlocking all the threads");
             task_thread.notify_all();
-            LOGINFO("EL: Checking thread is joinable");
             if(m_thread.joinable()){
-                LOGINFO("EL: thread is joinable. Executing join");
                 m_thread.join();
             }
         }

--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -277,6 +277,7 @@ namespace WPEFramework {
                 for( i = 0; i < tasks.size(); i++) {
                     LOGINFO("waiting to unlock.. [%d/%d]",i,tasks.size());
                     task_thread.wait(lck);
+                    LOGINFO("EL: Lock acquired.waiting to unlock...");
                     cmd = tasks[i];
                     cmd += " &";
                     cmd += "\0";
@@ -286,6 +287,13 @@ namespace WPEFramework {
                         LOGINFO("Starting Script (USM) :  %s \n", cmd.c_str());
                         system(cmd.c_str());
                     }
+                    else {
+                        LOGINFO("EL: Abort flag set to true.");
+                        LOGINFO("EL: Unlocking all the tasks. calling notify_all()");
+                        task_thread.notify_all();
+                        LOGINFO("EL: Unlocked all the active tasks. hence exiting from for loop");
+                        break;
+		    }
                 }
             }
             /* Here in Solicited, we start with RFC so no
@@ -825,9 +833,12 @@ namespace WPEFramework {
             m_abort_flag = true;
 		
             /* unlock if the task is still waiting */
-            task_thread.notify_all();
+            //task_thread.notify_all();
+            LOGINFO("EL:checking if thread is joinable");
             if(m_thread.joinable()){
+                LOGINFO("EL:thread is joinable");
                 m_thread.join();
+                LOGINFO("EL: successfully executed join()");
             }
         }
 #endif /* defined(USE_IARMBUS) || defined(USE_IARM_BUS) */

--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -286,6 +286,10 @@ namespace WPEFramework {
                         LOGINFO("Starting Script (USM) :  %s \n", cmd.c_str());
                         system(cmd.c_str());
                     }
+                    else {
+                        LOGINFO("Inside else. Executing break");
+                        break;
+                    }
                 }
             }
             /* Here in Solicited, we start with RFC so no
@@ -823,8 +827,11 @@ namespace WPEFramework {
             }
 
             m_abort_flag = true;
+            LOGINFO("EL: Notifiying all");
             task_thread.notify_all();
+            LOGINFO("EL: Checking thread is joinable");
             if(m_thread.joinable()){
+                LOGINFO("EL: thread is joinable. Executing join");
                 m_thread.join();
             }
         }

--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -286,10 +286,10 @@ namespace WPEFramework {
                         LOGINFO("Starting Script (USM) :  %s \n", cmd.c_str());
                         system(cmd.c_str());
                     }
-                    else {
-                        LOGINFO("Inside else. Executing break");
-                        break;
-                    }
+                    //else {
+                      //  LOGINFO("Inside else. Executing break");
+                       // break;
+                    //}
                 }
             }
             /* Here in Solicited, we start with RFC so no
@@ -826,9 +826,9 @@ namespace WPEFramework {
                 MaintenanceManager::_instance = nullptr;
             }
 
-            //m_abort_flag = true;
+            m_abort_flag = true;
             LOGINFO("EL: Notifiying all");
-            //task_thread.notify_all();
+            task_thread.notify_all();
             LOGINFO("EL: Checking thread is joinable");
             if(m_thread.joinable()){
                 LOGINFO("EL: thread is joinable. Executing join");

--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -821,6 +821,7 @@ namespace WPEFramework {
                 IARM_CHECK(IARM_Bus_UnRegisterEventHandler(IARM_BUS_MAINTENANCE_MGR_NAME, IARM_BUS_DCM_NEW_START_TIME_EVENT));
                 MaintenanceManager::_instance = nullptr;
             }
+		
             m_abort_flag = true;
             task_thread.notify_all();
             if(m_thread.joinable()){

--- a/MaintenanceManager/MaintenanceManager.h
+++ b/MaintenanceManager/MaintenanceManager.h
@@ -150,6 +150,7 @@ namespace WPEFramework {
                 void maintenanceManagerOnBootup();
                 bool checkAutoRebootFlag();
                 bool checkAbortFlag();
+                bool stopMaintenanceTasks();
                 bool checkNetwork();
                 bool getActivatedStatus(bool &skipFirmwareCheck);
                 const string checkActivatedStatus(void);


### PR DESCRIPTION
RDKTV-13125: WPEFramework timeout during shutdown in Maintenance cleanup

Graceful exit is not happening with maintenace manager when we stop wpeframework.
It got stuck with deInitialize method as it locks until a conditional variable is notified/
Hence unlocked the tasks if it is still waiting.

Verify maintenance manager is exiting gracefully when maintenance is in progress