### PR TITLE
RDKTV-16902 Modify the Storemode URL format to file based

### DIFF
--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -82,7 +82,7 @@ using namespace std;
 #define REGEX_UNALLOWABLE_INPUT "[^[:alnum:]_-]{1}"
 
 #define STORE_DEMO_FILE "/opt/persistent/store-mode-video/videoFile.mp4"
-#define STORE_DEMO_LINK "http://127.0.0.1:50050/store-mode-video/videoFile.mp4"
+#define STORE_DEMO_LINK "file:///opt/persistent/store-mode-video/videoFile.mp4"
 
 #define RFC_CALLERID           "SystemServices"
 


### PR DESCRIPTION
Currently the videoFile.mp4 is hosted by lighttpd which is deadlock situation in 2GB platform devices.

Lighttpd on our video CPE is configured to only act as light http server to support lightweight http get/post requests.
Even the modules that are enabled are very limited and none of the streaming options are enabled.

The current attempt seems to be using the http get option for file download as input for streaming is not appropriate.
So we should go with file:/// url format for storemode video playback.
Signed-off-by: nganes961 <nambirajan_ganesan@comcast.com>