### PR TITLE
RDK-36360: Separate SearchAndDiscovery from WPE app (2205_sprint)

### DIFF
--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -3391,7 +3391,7 @@ namespace WPEFramework {
                 }
 
                 // One RFC controls all WPE-based apps
-                if (!type.empty() && (type == "HtmlApp" || type == "LightningApp" || type == "SearchAndDiscoveryApp" ))
+                if (!type.empty() && (type == "HtmlApp" || type == "LightningApp"))
                 {
 #ifdef RFC_ENABLED
                     RFC_ParamData_t param;
@@ -3420,6 +3420,37 @@ namespace WPEFramework {
                     std::cout << "rfc is disabled and unable to check for " << type << " container mode " << std::endl;
 #endif
                 }
+
+                if (!type.empty() && type == "SearchAndDiscoveryApp" )
+                {
+#ifdef RFC_ENABLED
+                    RFC_ParamData_t param;
+                    if (Utils::getRFCConfig("Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.Dobby.SAD.Enable", param))
+                    {
+                        JsonObject root;
+                        if (strncasecmp(param.value, "true", 4) == 0)
+                        {
+                            std::cout << "dobby SAD rfc true - launching " << type << " in container mode " << std::endl;
+                            root = configSet["root"].Object();
+                            root["mode"] = JsonValue("Container");
+                        }
+                        else
+                        {
+                            std::cout << "dobby SAD rfc false - launching " << type << " in out-of-process mode " << std::endl;
+                            root = configSet["root"].Object();
+                            root["outofprocess"] = JsonValue(true);
+                        }
+                        configSet["root"] = root;
+                    }
+                    else
+                    {
+                        std::cout << "reading dobby SAD rfc failed - launching " << type << " in default mode" << std::endl;
+                    }
+#else
+                    std::cout << "rfc is disabled and unable to check for " << type << " container mode " << std::endl;
+#endif
+                }
+
                 status = thunderController->Set<JsonObject>(RDKSHELL_THUNDER_TIMEOUT, method.c_str(), configSet);
 
                 std::cout << "set status: " << status << std::endl;


### PR DESCRIPTION
Reason for change: Search and discovery should be separate from WPE apps
Test Procedure: Should be able to enable/disable the Feature.Dobby.SAD.Enable
    RFC flag, and run separately from WPE apps.
Risks: Low

Signed-off-by: Marcin Koczwara <marcin.koczwara@consult.red>

This is cherry pick of https://github.com/rdkcentral/rdkservices/pull/2499 into 2205_sprint branch.