### PR TITLE
DELIA-54683: Remove utils where possible

### DIFF
--- a/ActivityMonitor/ActivityMonitor.cpp
+++ b/ActivityMonitor/ActivityMonitor.cpp
@@ -19,7 +19,7 @@
 
 #include "ActivityMonitor.h"
 
-#include "utils.h"
+#include "UtilsJsonRpc.h"
 
 
 #define ACTIVITY_MONITOR_METHOD_GET_APPLICATION_MEMORY_USAGE "getApplicationMemoryUsage"

--- a/ActivityMonitor/ActivityMonitor.h
+++ b/ActivityMonitor/ActivityMonitor.h
@@ -24,7 +24,6 @@
 #include <mutex>
 
 #include "Module.h"
-#include "utils.h"
 
 namespace WPEFramework {
 

--- a/CompositeInput/CMakeLists.txt
+++ b/CompositeInput/CMakeLists.txt
@@ -22,8 +22,7 @@ find_package(${NAMESPACE}Plugins REQUIRED)
 
 add_library(${MODULE_NAME} SHARED
 	CompositeInput.cpp
-        Module.cpp
-        ../helpers/utils.cpp)
+        Module.cpp)
 
 set_target_properties(${MODULE_NAME} PROPERTIES
         CXX_STANDARD 11

--- a/CompositeInput/CompositeInput.cpp
+++ b/CompositeInput/CompositeInput.cpp
@@ -18,7 +18,8 @@
 **/
 
 #include "CompositeInput.h"
-#include "utils.h"
+#include "UtilsJsonRpc.h"
+#include "UtilsIarm.h"
 
 #include "compositeIn.hpp"
 #include "exception.hpp"

--- a/CompositeInput/CompositeInput.h
+++ b/CompositeInput/CompositeInput.h
@@ -22,7 +22,6 @@
 #include "libIBus.h"
 
 #include "Module.h"
-#include "utils.h"
 
 namespace WPEFramework {
 

--- a/ContinueWatching/ContinueWatching.cpp
+++ b/ContinueWatching/ContinueWatching.cpp
@@ -44,6 +44,7 @@
 #include "cJSON.h"
 #include "openssl/sha.h"
 #include "base64.h"
+#include "UtilsJsonRpc.h"
 #define SEC_OBJECTID_CW_NETFLIX_STORAGE_KEY     0x0361000003610001ULL
 #define SEC_OBJECTID_CW_YOUTUBE_STORAGE_KEY     0x0361000003610002ULL
 #define SEC_OBJECTID_CW_HLU_STORAGE_KEY         0x0361000003610003ULL

--- a/ContinueWatching/ContinueWatching.h
+++ b/ContinueWatching/ContinueWatching.h
@@ -41,12 +41,9 @@
 #include <string.h>
 #include <mutex>
 #include "Module.h"
-#include "utils.h"
 #if !defined(DISABLE_SECAPI)
 #include "sec_security_datatype.h"
 #endif
-
-#include "utils.h"
 
 #define CW_LOCAL_FILE  "/opt/continuewatching.json"
 #define NETFLIX_CONTINUEWATCHING_APP_NAME  "netflix"

--- a/ControlService/CMakeLists.txt
+++ b/ControlService/CMakeLists.txt
@@ -24,8 +24,7 @@ add_subdirectory(test)
 
 add_library(${MODULE_NAME} SHARED
         ControlService.cpp
-        Module.cpp
-        ../helpers/utils.cpp)
+        Module.cpp)
 
 set_target_properties(${MODULE_NAME} PROPERTIES
         CXX_STANDARD 11

--- a/ControlService/ControlService.cpp
+++ b/ControlService/ControlService.cpp
@@ -20,7 +20,8 @@
 #include "ControlService.h"
 #include "libIBusDaemon.h"
 
-#include "utils.h"
+#include "UtilsJsonRpc.h"
+#include "UtilsIarm.h"
 
 #include "irMgr.h"
 #include "comcastIrKeyCodes.h"

--- a/ControlService/ControlService.h
+++ b/ControlService/ControlService.h
@@ -20,7 +20,6 @@
 #pragma once
 
 #include "Module.h"
-#include "utils.h"
 #include "libIBus.h"
 
 #include "ctrlm_ipc.h"

--- a/DisplayInfo/CMakeLists.txt
+++ b/DisplayInfo/CMakeLists.txt
@@ -67,8 +67,7 @@ if (USE_DEVICESETTINGS)
         ${DS_LIBRARIES})
     target_sources(${MODULE_NAME}
         PRIVATE
-            DeviceSettings/PlatformImplementation.cpp
-            ../helpers/utils.cpp)
+            DeviceSettings/PlatformImplementation.cpp)
 elseif (NXCLIENT_FOUND AND NEXUS_FOUND)
     target_sources(${MODULE_NAME}
         PRIVATE

--- a/DisplayInfo/DeviceSettings/Broadcom/SoC_abstraction.cpp
+++ b/DisplayInfo/DeviceSettings/Broadcom/SoC_abstraction.cpp
@@ -25,7 +25,8 @@
 #include <sstream>
 #include <algorithm>
 
-#include "utils.h"
+#include "../../Module.h"
+#include "UtilsLogging.h"
 
 #define GRAPHICS_RESOLUTION_LOC 4
 #define WIDTH 0

--- a/DisplayInfo/DeviceSettings/PlatformImplementation.cpp
+++ b/DisplayInfo/DeviceSettings/PlatformImplementation.cpp
@@ -33,7 +33,7 @@
 #include "audioOutputPortConfig.hpp"
 #include "manager.hpp"
 #include "edid-parser.hpp"
-#include "utils.h"
+#include "UtilsIarm.h"
 
 #include "libIBus.h"
 #include "libIBusDaemon.h"

--- a/FireboltMediaPlayer/CMakeLists.txt
+++ b/FireboltMediaPlayer/CMakeLists.txt
@@ -25,7 +25,6 @@ find_package(CompileSettingsDebug CONFIG REQUIRED)
 add_library(${MODULE_NAME} SHARED
     Module.cpp
     FireboltMediaPlayer.cpp
-    ../helpers/utils.cpp
 )
 
 set(MEDIAPLAYERS "AampMediaPlayer")

--- a/FireboltMediaPlayer/FireboltMediaPlayer.cpp
+++ b/FireboltMediaPlayer/FireboltMediaPlayer.cpp
@@ -18,7 +18,7 @@
  **/
 
 #include "FireboltMediaPlayer.h"
-#include "utils.h"
+#include "UtilsJsonRpc.h"
 #include "Module.h"
 
 namespace WPEFramework {

--- a/FireboltMediaPlayer/impl/AampMediaPlayer/AampEventListener.cpp
+++ b/FireboltMediaPlayer/impl/AampMediaPlayer/AampEventListener.cpp
@@ -19,7 +19,7 @@
 
 #include "AampEventListener.h"
 #include "AampMediaStream.h"
-#include "utils.h"
+#include "UtilsLogging.h"
 
 namespace WPEFramework {
 

--- a/FireboltMediaPlayer/impl/AampMediaPlayer/AampMediaPlayer.cpp
+++ b/FireboltMediaPlayer/impl/AampMediaPlayer/AampMediaPlayer.cpp
@@ -20,7 +20,7 @@
 #include "AampMediaPlayer.h"
 #include "AampMediaStream.h"
 
-#include "utils.h"
+#include "UtilsLogging.h"
 
 namespace WPEFramework {
 

--- a/FireboltMediaPlayer/impl/AampMediaPlayer/AampMediaStream.cpp
+++ b/FireboltMediaPlayer/impl/AampMediaPlayer/AampMediaStream.cpp
@@ -19,7 +19,7 @@
 
 #include "AampMediaStream.h"
 
-#include "utils.h"
+#include "UtilsLogging.h"
 
 // Use macros to avoid unnecessary repetition of code. 
 #define ADD_SETTER_INT(name, fn)                                                                                       \

--- a/FrontPanel/CMakeLists.txt
+++ b/FrontPanel/CMakeLists.txt
@@ -24,8 +24,7 @@ add_library(${MODULE_NAME} SHARED
         FrontPanel.cpp
         Module.cpp
         ../helpers/frontpanel.cpp
-        ../helpers/powerstate.cpp
-        ../helpers/utils.cpp)
+        ../helpers/powerstate.cpp)
 
 set_target_properties(${MODULE_NAME} PROPERTIES
         CXX_STANDARD 11

--- a/FrontPanel/FrontPanel.cpp
+++ b/FrontPanel/FrontPanel.cpp
@@ -28,7 +28,8 @@
 #include "libIBus.h"
 #include "rdk/iarmmgrs-hal/pwrMgr.h"
 
-#include "utils.h"
+#include "UtilsJsonRpc.h"
+#include "UtilsIarm.h"
 
 #define SERVICE_NAME "FrontPanelService"
 #define METHOD_FP_SET_BRIGHTNESS "setBrightness"

--- a/FrontPanel/FrontPanel.h
+++ b/FrontPanel/FrontPanel.h
@@ -23,7 +23,7 @@
 
 #include "Module.h"
 
-#include "utils.h"
+#include "libIARM.h"
 
 #include "frontpanel.h"
 

--- a/HdcpProfile/CMakeLists.txt
+++ b/HdcpProfile/CMakeLists.txt
@@ -22,8 +22,7 @@ find_package(${NAMESPACE}Plugins REQUIRED)
 
 add_library(${MODULE_NAME} SHARED
         HdcpProfile.cpp
-        Module.cpp
-        ../helpers/utils.cpp)
+        Module.cpp)
 
 set_target_properties(${MODULE_NAME} PROPERTIES
         CXX_STANDARD 11

--- a/HdcpProfile/HdcpProfile.cpp
+++ b/HdcpProfile/HdcpProfile.cpp
@@ -27,7 +27,8 @@
 #include "manager.hpp"
 #include "host.hpp"
 
-#include "utils.h"
+#include "UtilsJsonRpc.h"
+#include "UtilsIarm.h"
 
 #define HDMI_HOT_PLUG_EVENT_CONNECTED 0
 #define HDMI_HOT_PLUG_EVENT_DISCONNECTED 1

--- a/HdcpProfile/HdcpProfile.h
+++ b/HdcpProfile/HdcpProfile.h
@@ -22,7 +22,6 @@
 #include "libIBus.h"
 
 #include "Module.h"
-#include "utils.h"
 
 namespace WPEFramework {
 

--- a/HdmiInput/CMakeLists.txt
+++ b/HdmiInput/CMakeLists.txt
@@ -22,8 +22,7 @@ find_package(${NAMESPACE}Plugins REQUIRED)
 
 add_library(${MODULE_NAME} SHARED
         HdmiInput.cpp
-        Module.cpp
-        ../helpers/utils.cpp)
+        Module.cpp)
 
 set_target_properties(${MODULE_NAME} PROPERTIES
         CXX_STANDARD 11

--- a/HdmiInput/HdmiInput.cpp
+++ b/HdmiInput/HdmiInput.cpp
@@ -18,7 +18,8 @@
 **/
 
 #include "HdmiInput.h"
-#include "utils.h"
+#include "UtilsJsonRpc.h"
+#include "UtilsIarm.h"
 
 #include "hdmiIn.hpp"
 #include "exception.hpp"

--- a/HdmiInput/HdmiInput.h
+++ b/HdmiInput/HdmiInput.h
@@ -22,7 +22,6 @@
 #include "libIBus.h"
 
 #include "Module.h"
-#include "utils.h"
 #include "dsTypes.h"
 
 namespace WPEFramework {

--- a/LoggingPreferences/CMakeLists.txt
+++ b/LoggingPreferences/CMakeLists.txt
@@ -22,8 +22,7 @@ find_package(${NAMESPACE}Plugins REQUIRED)
 
 add_library(${MODULE_NAME} SHARED
         LoggingPreferences.cpp
-        Module.cpp
-        ../helpers/utils.cpp)
+        Module.cpp)
 
 set_target_properties(${MODULE_NAME} PROPERTIES
         CXX_STANDARD 11

--- a/LoggingPreferences/LoggingPreferences.cpp
+++ b/LoggingPreferences/LoggingPreferences.cpp
@@ -18,6 +18,8 @@
 **/
 
 #include "LoggingPreferences.h"
+#include "UtilsJsonRpc.h"
+#include "UtilsIarm.h"
 #include <sysMgr.h>
 
 using namespace std;

--- a/LoggingPreferences/LoggingPreferences.h
+++ b/LoggingPreferences/LoggingPreferences.h
@@ -23,8 +23,6 @@
 #include "libIBus.h"
 #include "irMgr.h"
 
-#include "utils.h"
-
 namespace WPEFramework {
 
     namespace Plugin {

--- a/MotionDetection/MotionDetection.cpp
+++ b/MotionDetection/MotionDetection.cpp
@@ -23,7 +23,7 @@
 #include "MotionDetection.h"
 #include "tracing/Logging.h"
 #include <syscall.h>
-#include "utils.h"
+#include "UtilsJsonRpc.h"
 
 #define NO_DETECTORS_FOUND    "0"
 #define MOTION_DETECTOR_INDEX "FP_MD"

--- a/MotionDetection/MotionDetection.h
+++ b/MotionDetection/MotionDetection.h
@@ -21,7 +21,6 @@
 
 #include <chrono>
 #include "Module.h"
-#include "utils.h"
 #include "motionDetector.h"
 
 namespace WPEFramework {

--- a/OCIContainer/OCIContainer.cpp
+++ b/OCIContainer/OCIContainer.cpp
@@ -3,6 +3,8 @@
 #include <Dobby/DobbyProxy.h>
 #include <Dobby/IpcService/IpcFactory.h>
 
+#include "UtilsJsonRpc.h"
+
 
 namespace WPEFramework
 {

--- a/OCIContainer/OCIContainer.h
+++ b/OCIContainer/OCIContainer.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "Module.h"
-#include "utils.h"
 
 #include <Dobby/DobbyProtocol.h>
 #include <Dobby/Public/Dobby/IDobbyProxy.h>

--- a/PlayerInfo/CMakeLists.txt
+++ b/PlayerInfo/CMakeLists.txt
@@ -64,8 +64,7 @@ if (GSTREAMER_FOUND)
             ${DS_LIBRARIES})
         target_sources(${MODULE_NAME}
             PRIVATE
-                DeviceSettings/PlatformImplementation.cpp
-                ../helpers/utils.cpp)
+                DeviceSettings/PlatformImplementation.cpp)
     else()
         target_sources(${MODULE_NAME}
             PRIVATE

--- a/PlayerInfo/DeviceSettings/PlatformImplementation.cpp
+++ b/PlayerInfo/DeviceSettings/PlatformImplementation.cpp
@@ -25,7 +25,7 @@
 #include "audioOutputPortType.hpp"
 #include "audioOutputPortConfig.hpp"
 #include "audioOutputPort.hpp"
-#include "utils.h"
+#include "UtilsIarm.h"
 
 #include <gst/gst.h>
 

--- a/RemoteActionMapping/CMakeLists.txt
+++ b/RemoteActionMapping/CMakeLists.txt
@@ -25,8 +25,7 @@ add_subdirectory(test)
 add_library(${MODULE_NAME} SHARED
         RemoteActionMapping.cpp
         RamHelper.cpp
-        Module.cpp
-        ../helpers/utils.cpp)
+        Module.cpp)
 
 set_target_properties(${MODULE_NAME} PROPERTIES
         CXX_STANDARD 11

--- a/RemoteActionMapping/RamHelper.cpp
+++ b/RemoteActionMapping/RamHelper.cpp
@@ -18,7 +18,8 @@
 **/
 
 #include "RamHelper.h"
-#include "utils.h"
+#include "UtilsLogging.h"
+#include "UtilsUnused.h"
 
 // IR-RF Database RF descriptors, needed for all original configurable keys
 // Discrete Power ON/OFF use actual RF keycodes (0x6D, 0x6C), the rest are all XRC ghost codes

--- a/RemoteActionMapping/RamHelper.h
+++ b/RemoteActionMapping/RamHelper.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include "Module.h"
+
 //IARM includes
 #include "libIBus.h"
 

--- a/RemoteActionMapping/RemoteActionMapping.cpp
+++ b/RemoteActionMapping/RemoteActionMapping.cpp
@@ -20,7 +20,9 @@
 #include "RemoteActionMapping.h"
 #include "libIBusDaemon.h"
 
-#include "utils.h"
+#include "UtilsJsonRpc.h"
+#include "UtilsIarm.h"
+#include "UtilsUnused.h"
 #include <exception>
 
 const int supported_ked_keynames[] =

--- a/RemoteActionMapping/RemoteActionMapping.h
+++ b/RemoteActionMapping/RemoteActionMapping.h
@@ -20,7 +20,7 @@
 #pragma once
 
 #include "Module.h"
-#include "utils.h"
+#include "libIARM.h"
 
 #include "RamHelper.h"
 

--- a/StateObserver/CMakeLists.txt
+++ b/StateObserver/CMakeLists.txt
@@ -24,8 +24,7 @@ find_package(${NAMESPACE}Plugins REQUIRED)
 
 add_library(${MODULE_NAME} SHARED
         StateObserver.cpp
-        Module.cpp
-        ../helpers/utils.cpp)
+        Module.cpp)
 
 #add_subdirectory(test)
 

--- a/StateObserver/StateObserver.cpp
+++ b/StateObserver/StateObserver.cpp
@@ -39,6 +39,8 @@
 #include "iarmUtil.h"
 #include "sysMgr.h"
 
+#include "UtilsJsonRpc.h"
+#include "UtilsIarm.h"
 
 #define STATEOBSERVER_MAJOR_VERSION 1
 #define STATEOBSERVER_MINOR_VERSION 0

--- a/StateObserver/StateObserver.h
+++ b/StateObserver/StateObserver.h
@@ -33,9 +33,7 @@
 #include <cjson/cJSON.h>
 
 #include "Module.h"
-#include "libIBus.h"
-#include "utils.h"
-#include "utils.h"
+#include "libIARM.h"
 
 //State Observer Properties
 const string SYSTEM_EXIT_OK    = "com.comcast.exit-ok_key_sequence";

--- a/SystemAudioPlayer/SystemAudioPlayer.h
+++ b/SystemAudioPlayer/SystemAudioPlayer.h
@@ -33,7 +33,6 @@
 
 #include "Module.h"
 #include "tracing/Logging.h"
-#include "utils.h"
 
 #include "SystemAudioPlayerImplementation.h"
 

--- a/SystemAudioPlayer/SystemAudioPlayerImplementation.cpp
+++ b/SystemAudioPlayer/SystemAudioPlayerImplementation.cpp
@@ -21,6 +21,7 @@
 #include <sys/prctl.h>
 #include "impl/Helper.h"
 #include "base64.h"
+#include "UtilsJsonRpc.h"
 
 #define SAP_MAJOR_VERSION 1
 #define SAP_MINOR_VERSION 0

--- a/SystemAudioPlayer/SystemAudioPlayerImplementation.h
+++ b/SystemAudioPlayer/SystemAudioPlayerImplementation.h
@@ -22,7 +22,6 @@
 #include "Module.h"
 #include <interfaces/Ids.h>
 #include "tracing/Logging.h"
-#include "utils.h"
 
 #include "ISystemAudioPlayer.h"
 #include "impl/AudioPlayer.h"

--- a/TextToSpeech/TextToSpeech.h
+++ b/TextToSpeech/TextToSpeech.h
@@ -33,7 +33,6 @@
 
 #include "Module.h"
 #include "tracing/Logging.h"
-#include "utils.h"
 
 #include "TextToSpeechImplementation.h"
 

--- a/TextToSpeech/TextToSpeechImplementation.cpp
+++ b/TextToSpeech/TextToSpeechImplementation.cpp
@@ -19,6 +19,7 @@
 
 #include "TextToSpeechImplementation.h"
 #include <sys/prctl.h>
+#include "UtilsJsonRpc.h"
 
 #define TTS_MAJOR_VERSION 1
 #define TTS_MINOR_VERSION 0

--- a/TextToSpeech/TextToSpeechImplementation.h
+++ b/TextToSpeech/TextToSpeechImplementation.h
@@ -22,7 +22,6 @@
 #include "Module.h"
 #include <interfaces/Ids.h>
 #include "tracing/Logging.h"
-#include "utils.h"
 
 #include "ITextToSpeech.h"
 #include "impl/TTSManager.h"

--- a/TextToSpeech/TextToSpeechJsonRpc.cpp
+++ b/TextToSpeech/TextToSpeechJsonRpc.cpp
@@ -18,6 +18,8 @@
  */
 
 #include "TextToSpeech.h"
+#include "UtilsJsonRpc.h"
+#include "UtilsUnused.h"
 
 namespace WPEFramework {
 namespace Plugin {

--- a/TextToSpeech/impl/TTSCommon.h
+++ b/TextToSpeech/impl/TTSCommon.h
@@ -20,7 +20,7 @@
 #ifndef _TTS_ERRORS_H_
 #define _TTS_ERRORS_H_
 
-#include "utils.h"
+#include "../Module.h"
 #include "logger.h"
 
 namespace TTS {

--- a/Timer/CMakeLists.txt
+++ b/Timer/CMakeLists.txt
@@ -23,8 +23,7 @@ find_package(${NAMESPACE}Plugins REQUIRED)
 add_library(${MODULE_NAME} SHARED
         Timer.cpp
         Module.cpp
-        ../helpers/tptimer.cpp
-        ../helpers/utils.cpp)
+        ../helpers/tptimer.cpp)
 
 set_target_properties(${MODULE_NAME} PROPERTIES
         CXX_STANDARD 11

--- a/Timer/Timer.cpp
+++ b/Timer/Timer.cpp
@@ -25,7 +25,8 @@
 #include "ccec/drivers/CecIARMBusMgr.h"
 #endif
 
-#include "utils.h"
+#include "UtilsJsonRpc.h"
+#include "UtilsIarm.h"
 
 // Methods
 #define TIMER_METHOD_START_TIMER          "startTimer"

--- a/Timer/Timer.h
+++ b/Timer/Timer.h
@@ -22,7 +22,6 @@
 #include <mutex>
 
 #include "Module.h"
-#include "utils.h"
 
 
 #include "tptimer.h"

--- a/UserPreferences/UserPreferences.cpp
+++ b/UserPreferences/UserPreferences.cpp
@@ -18,7 +18,7 @@
 **/
 
 #include "UserPreferences.h"
-#include "utils.h"
+#include "UtilsJsonRpc.h"
 
 #include <glib.h>
 #include <glib/gstdio.h>

--- a/UserPreferences/UserPreferences.h
+++ b/UserPreferences/UserPreferences.h
@@ -20,7 +20,6 @@
 #pragma once
 
 #include "Module.h"
-#include "utils.h"
 
 namespace WPEFramework {
     namespace Plugin {

--- a/VoiceControl/CMakeLists.txt
+++ b/VoiceControl/CMakeLists.txt
@@ -5,8 +5,7 @@ find_package(${NAMESPACE}Plugins REQUIRED)
 
 add_library(${MODULE_NAME} SHARED
         VoiceControl.cpp
-        Module.cpp
-        ../helpers/utils.cpp)
+        Module.cpp)
 
 set_target_properties(${MODULE_NAME} PROPERTIES
         CXX_STANDARD 11

--- a/VoiceControl/VoiceControl.cpp
+++ b/VoiceControl/VoiceControl.cpp
@@ -2,6 +2,8 @@
 #include "VoiceControl.h"
 #include "libIBusDaemon.h"
 #include <stdlib.h>
+#include "UtilsJsonRpc.h"
+#include "UtilsIarm.h"
 
 
 using namespace std;

--- a/VoiceControl/VoiceControl.h
+++ b/VoiceControl/VoiceControl.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "Module.h"
-#include "utils.h"
 #include "libIBus.h"
 
 #include "ctrlm_ipc.h"

--- a/WifiManager/CMakeLists.txt
+++ b/WifiManager/CMakeLists.txt
@@ -28,8 +28,7 @@ add_library(${MODULE_NAME} SHARED
         impl/WifiManagerState.cpp
         impl/WifiManagerConnect.cpp
         impl/WifiManagerScan.cpp
-        impl/WifiManagerEvents.cpp
-        ../helpers/utils.cpp)
+        impl/WifiManagerEvents.cpp)
 
 set_target_properties(${MODULE_NAME} PROPERTIES
         CXX_STANDARD 11

--- a/WifiManager/WifiManager.cpp
+++ b/WifiManager/WifiManager.cpp
@@ -18,7 +18,8 @@
 **/
 
 #include "WifiManager.h"
-#include "utils.h"
+#include "UtilsJsonRpc.h"
+#include "UtilsIarm.h"
 
 #include <vector>
 #include <utility>

--- a/WifiManager/WifiManager.h
+++ b/WifiManager/WifiManager.h
@@ -28,7 +28,6 @@
 #include "impl/WifiManagerSignalThreshold.h"
 #include "impl/WifiManagerScan.h"
 #include "impl/WifiManagerEvents.h"
-#include "utils.h"
 
 namespace WPEFramework {
 

--- a/WifiManager/WifiManagerDefines.h
+++ b/WifiManager/WifiManagerDefines.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include "Module.h"
+
 namespace WPEFramework {
 
     namespace Plugin {

--- a/WifiManager/impl/WifiManagerConnect.cpp
+++ b/WifiManager/impl/WifiManagerConnect.cpp
@@ -21,7 +21,7 @@
 
 #include "wifiSrvMgrIarmIf.h"
 #include "libIBus.h"
-#include "utils.h"
+#include "UtilsJsonRpc.h"
 
 #include <cstring>
 

--- a/WifiManager/impl/WifiManagerEvents.cpp
+++ b/WifiManager/impl/WifiManagerEvents.cpp
@@ -24,7 +24,7 @@
 
 #include "WifiManagerEvents.h"
 #include "../WifiManager.h" // Need access to WifiManager::getInstance so can't use 'WifiManagerInterface.h'
-#include "utils.h"
+#include "UtilsIarm.h"
 
 // RDK
 #include "rdk/iarmbus/libIBus.h"

--- a/WifiManager/impl/WifiManagerScan.cpp
+++ b/WifiManager/impl/WifiManagerScan.cpp
@@ -24,7 +24,8 @@
 
 #include "WifiManagerScan.h"
 #include "../WifiManager.h" // Need access to WifiManager::getInstance so can't use 'WifiManagerInterface.h'
-#include "utils.h"
+#include "UtilsJsonRpc.h"
+#include "UtilsIarm.h"
 
 // RDK
 #include "rdk/iarmbus/libIBus.h"
@@ -33,6 +34,23 @@
 // std
 #include <sstream>
 #include <regex>
+
+namespace Utils {
+std::string formatIARMResult(IARM_Result_t result)
+{
+    switch (result) {
+    case IARM_RESULT_SUCCESS:       return std::string("IARM_RESULT_SUCCESS [success]");
+    case IARM_RESULT_INVALID_PARAM: return std::string("IARM_RESULT_INVALID_PARAM [invalid input parameter]");
+    case IARM_RESULT_INVALID_STATE: return std::string("IARM_RESULT_INVALID_STATE [invalid state encountered]");
+    case IARM_RESULT_IPCCORE_FAIL:  return std::string("IARM_RESULT_IPCORE_FAIL [underlying IPC failure]");
+    case IARM_RESULT_OOM:           return std::string("IARM_RESULT_OOM [out of memory]");
+    default:
+        std::ostringstream tmp;
+        tmp << result << " [unknown IARM_Result_t]";
+        return tmp.str();
+    }
+}
+}
 
 using namespace WPEFramework;
 using namespace WPEFramework::Plugin;

--- a/WifiManager/impl/WifiManagerSignalThreshold.cpp
+++ b/WifiManager/impl/WifiManagerSignalThreshold.cpp
@@ -19,7 +19,7 @@
 
 #include "WifiManagerSignalThreshold.h"
 
-#include "utils.h"
+#include "UtilsJsonRpc.h"
 
 #include <chrono>
 

--- a/WifiManager/impl/WifiManagerState.cpp
+++ b/WifiManager/impl/WifiManagerState.cpp
@@ -22,7 +22,7 @@
 #include "wifiSrvMgrIarmIf.h"
 #include "netsrvmgrIarm.h"
 #include "libIBus.h"
-#include "utils.h"
+#include "UtilsJsonRpc.h"
 
 
 using namespace WPEFramework::Plugin;

--- a/WifiManager/impl/WifiManagerWPS.cpp
+++ b/WifiManager/impl/WifiManagerWPS.cpp
@@ -17,9 +17,9 @@
 * limitations under the License.
 **/
 
-#include "utils.h"
-#include "libIBus.h"
 #include "WifiManagerWPS.h"
+#include "UtilsJsonRpc.h"
+#include "libIBus.h"
 #include "wifiSrvMgrIarmIf.h"
 
 namespace WPEFramework

--- a/XCast/CMakeLists.txt
+++ b/XCast/CMakeLists.txt
@@ -24,8 +24,7 @@ add_library(${MODULE_NAME} SHARED
         XCast.cpp
         Module.cpp
         RtXcastConnector.cpp
-	../helpers/tptimer.cpp
-        ../helpers/utils.cpp)
+	../helpers/tptimer.cpp)
 
 find_package(RFC)
 find_package(IARMBus)

--- a/XCast/RtXcastConnector.cpp
+++ b/XCast/RtXcastConnector.cpp
@@ -18,7 +18,9 @@
  **/
 
 #include "RtXcastConnector.h"
-#include "utils.h"
+#include "Module.h"
+#include "UtilsJsonRpc.h"
+#include "rfcapi.h"
 #include <cjson/cJSON.h>
 
 using namespace std;

--- a/XCast/XCast.cpp
+++ b/XCast/XCast.cpp
@@ -19,7 +19,8 @@
 
 #include "XCast.h"
 #include "tracing/Logging.h"
-#include "utils.h"
+#include "UtilsJsonRpc.h"
+#include "UtilsIarm.h"
 #ifdef RFC_ENABLED
 #include "rfcapi.h"
 #endif //RFC_ENABLED

--- a/XCast/XCast.h
+++ b/XCast/XCast.h
@@ -21,7 +21,6 @@
 
 #include "tptimer.h"
 #include "Module.h"
-#include "utils.h"
 #include "RtNotifier.h"
 #include "libIBus.h"
 #include "libIBusDaemon.h"

--- a/helpers/UtilsIarm.h
+++ b/helpers/UtilsIarm.h
@@ -18,59 +18,45 @@
     } \
 }
 
-namespace Utils
-{
-struct IARM
-{
-    static bool init();
-    static bool isConnected();
+namespace Utils {
+struct IARM {
+    static bool init()
+    {
+        IARM_Result_t res;
+        bool result = false;
 
-    static const char *NAME;
+        if (isConnected()) {
+            LOGINFO("IARM already connected");
+            result = true;
+        } else {
+            res = IARM_Bus_Init(NAME);
+            LOGINFO("IARM_Bus_Init: %d", res);
+            if (res == IARM_RESULT_SUCCESS || res == IARM_RESULT_INVALID_STATE /* already inited or connected */) {
+                res = IARM_Bus_Connect();
+                LOGINFO("IARM_Bus_Connect: %d", res);
+                if (res == IARM_RESULT_SUCCESS || res == IARM_RESULT_INVALID_STATE /* already connected or not inited */) {
+                    result = isConnected();
+                } else {
+                    LOGERR("IARM_Bus_Connect failure: %d", res);
+                }
+            } else {
+                LOGERR("IARM_Bus_Init failure: %d", res);
+            }
+        }
+
+        return result;
+    }
+
+    static bool isConnected()
+    {
+        IARM_Result_t res;
+        int isRegistered = 0;
+        res = IARM_Bus_IsConnected(NAME, &isRegistered);
+        LOGINFO("IARM_Bus_IsConnected: %d (%d)", res, isRegistered);
+
+        return (isRegistered == 1);
+    }
+
+    static constexpr const char* NAME = "Thunder_Plugins";
 };
-
-const char *IARM::NAME = "Thunder_Plugins";
-
-bool IARM::isConnected()
-{
-    IARM_Result_t res;
-    int isRegistered = 0;
-    res = IARM_Bus_IsConnected(NAME, &isRegistered);
-    LOGINFO("IARM_Bus_IsConnected: %d (%d)", res, isRegistered);
-
-    return (isRegistered == 1);
-}
-
-bool IARM::init()
-{
-    IARM_Result_t res;
-    bool result = false;
-
-    if (isConnected()) {
-        LOGINFO("IARM already connected");
-        result = true;
-    }
-    else {
-        res = IARM_Bus_Init(NAME);
-        LOGINFO("IARM_Bus_Init: %d", res);
-        if (res == IARM_RESULT_SUCCESS ||
-            res == IARM_RESULT_INVALID_STATE /* already inited or connected */) {
-
-            res = IARM_Bus_Connect();
-            LOGINFO("IARM_Bus_Connect: %d", res);
-            if (res == IARM_RESULT_SUCCESS ||
-                res == IARM_RESULT_INVALID_STATE /* already connected or not inited */) {
-
-                result = isConnected();
-            }
-            else {
-                LOGERR("IARM_Bus_Connect failure: %d", res);
-            }
-        }
-        else {
-            LOGERR("IARM_Bus_Init failure: %d", res);
-        }
-    }
-
-    return result;
-}
 }

--- a/helpers/UtilsJsonRpc.h
+++ b/helpers/UtilsJsonRpc.h
@@ -22,6 +22,12 @@
         LOGERR("No argument '%s' or it has incorrect type", name); \
         returnResponse(false); \
     }
+#define returnIfBooleanParamNotFound(param, name) \
+    if (!param.HasLabel(name) || param[name].Content() != Core::JSON::Variant::type::BOOLEAN) \
+    { \
+        LOGERR("No argument '%s' or it has incorrect type", name); \
+        returnResponse(false); \
+    }
 #define returnIfNumberParamNotFound(param, name) \
     if (!param.HasLabel(name) || param[name].Content() != Core::JSON::Variant::type::NUMBER) \
     { \
@@ -33,4 +39,28 @@
     params.ToString(json); \
     LOGINFO("Notify %s %s", event, json.c_str()); \
     Notify(event,params); \
+}
+#define getNumberParameter(paramName, param) { \
+    if (Core::JSON::Variant::type::NUMBER == parameters[paramName].Content()) \
+        param = parameters[paramName].Number(); \
+    else \
+        try { param = std::stoi( parameters[paramName].String()); } \
+        catch (...) { param = 0; } \
+}
+#define getNumberParameterObject(parameters, paramName, param) { \
+    if (Core::JSON::Variant::type::NUMBER == parameters[paramName].Content()) \
+        param = parameters[paramName].Number(); \
+    else \
+        try {param = std::stoi( parameters[paramName].String());} \
+        catch (...) { param = 0; } \
+}
+#define getBoolParameter(paramName, param) { \
+    if (Core::JSON::Variant::type::BOOLEAN == parameters[paramName].Content()) \
+        param = parameters[paramName].Boolean(); \
+    else \
+        param = parameters[paramName].String() == "true" || parameters[paramName].String() == "1"; \
+}
+#define getStringParameter(paramName, param) { \
+    if (Core::JSON::Variant::type::STRING == parameters[paramName].Content()) \
+        param = parameters[paramName].String(); \
 }

--- a/helpers/UtilsUnused.h
+++ b/helpers/UtilsUnused.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#define UNUSED(expr)(void)(expr)


### PR DESCRIPTION
Reason for change: Don't build utils.cpp in multiple places.
Optimize by removing utils.h/cpp from 22 plugins.
Exceptions: Bluetooth, DisplaySettings, HdmiCec, HdmiCec_2,
HdmiCecSink, MaintenanceManager, Network, RDKShell,
ScreenCapture, SystemServices, Telemetry, Warehouse.
Test Procedure: It's build optimization, no need to test.
If it builds, it's good to go.
Risks: None
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>