### PR TITLE
RDK-35544: HdmiInput thunder plugin changes for ALLM method/event

### DIFF
--- a/HdmiInput/HdmiInput.cpp
+++ b/HdmiInput/HdmiInput.cpp
@@ -42,11 +42,14 @@
 #define HDMIINPUT_METHOD_START_HDMI_INPUT "startHdmiInput"
 #define HDMIINPUT_METHOD_STOP_HDMI_INPUT "stopHdmiInput"
 #define HDMIINPUT_METHOD_SCALE_HDMI_INPUT "setVideoRectangle"
+#define HDMIINPUT_METHOD_SUPPORTED_GAME_FEATURES "getSupportedGameFeatures"
+#define HDMIINPUT_METHOD_GAME_FEATURE_STATUS "getHdmiGameFeatureStatus"
 
 #define HDMIINPUT_EVENT_ON_DEVICES_CHANGED "onDevicesChanged"
 #define HDMIINPUT_EVENT_ON_SIGNAL_CHANGED "onSignalChanged"
 #define HDMIINPUT_EVENT_ON_STATUS_CHANGED "onInputStatusChanged"
 #define HDMIINPUT_EVENT_ON_VIDEO_MODE_UPDATED "videoStreamInfoUpdate"
+#define HDMIINPUT_EVENT_ON_GAME_FEATURE_STATUS_CHANGED "hdmiGameFeatureStatusUpdate"
 
 using namespace std;
 
@@ -84,10 +87,25 @@ namespace WPEFramework
             GetHandler(2)->Register<JsonObject, JsonObject>(HDMIINPUT_METHOD_START_HDMI_INPUT, &HdmiInput::startHdmiInput, this);
             GetHandler(2)->Register<JsonObject, JsonObject>(HDMIINPUT_METHOD_STOP_HDMI_INPUT, &HdmiInput::stopHdmiInput, this);
             GetHandler(2)->Register<JsonObject, JsonObject>(HDMIINPUT_METHOD_SCALE_HDMI_INPUT, &HdmiInput::setVideoRectangleWrapper, this);
+            Register(HDMIINPUT_METHOD_SUPPORTED_GAME_FEATURES, &HdmiInput::getSupportedGameFeatures, this);
+            GetHandler(2)->Register<JsonObject, JsonObject>(HDMIINPUT_METHOD_SUPPORTED_GAME_FEATURES, &HdmiInput::getSupportedGameFeatures, this);
+            Register(HDMIINPUT_METHOD_GAME_FEATURE_STATUS, &HdmiInput::getHdmiGameFeatureStatusWrapper, this);
+            GetHandler(2)->Register<JsonObject, JsonObject>(HDMIINPUT_METHOD_GAME_FEATURE_STATUS, &HdmiInput::getHdmiGameFeatureStatusWrapper, this);
         }
 
         HdmiInput::~HdmiInput()
         {
+        }
+
+        void setResponseArray(JsonObject& response, const char* key, const vector<string>& items)
+        {
+            JsonArray arr;
+            for(auto& i : items) arr.Add(JsonValue(i));
+
+            response[key] = arr;
+
+            string json;
+            response.ToString(json);
         }
 
         void HdmiInput::Deinitialize(PluginHost::IShell* /* service */)
@@ -106,6 +124,7 @@ namespace WPEFramework
 		IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_IN_SIGNAL_STATUS, dsHdmiSignalStatusEventHandler) );
 		IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_IN_STATUS, dsHdmiStatusEventHandler) );
 		IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_IN_VIDEO_MODE_UPDATE, dsHdmiVideoModeEventHandler) );
+		IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_IN_ALLM_STATUS, dsHdmiGameFeatureStatusEventHandler) );
             }
         }
 
@@ -118,6 +137,7 @@ namespace WPEFramework
 		IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_IN_SIGNAL_STATUS) );
 		IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_IN_STATUS) );
 		IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_IN_VIDEO_MODE_UPDATE) );
+		IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_IN_ALLM_STATUS) );
             }
         }
 
@@ -625,6 +645,107 @@ namespace WPEFramework
                 HdmiInput::_instance->hdmiInputVideoModeUpdate(hdmi_in_port, resolution);
 
             }
+        }
+
+        void HdmiInput::dsHdmiGameFeatureStatusEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
+        {
+            if(!HdmiInput::_instance)
+                return;
+
+            if (IARM_BUS_DSMGR_EVENT_HDMI_IN_ALLM_STATUS == eventId)
+            {
+                IARM_Bus_DSMgr_EventData_t *eventData = (IARM_Bus_DSMgr_EventData_t *)data;
+                int hdmi_in_port = eventData->data.hdmi_in_allm_mode.port;
+                bool allm_mode = eventData->data.hdmi_in_allm_mode.allm_mode;
+                LOGWARN("Received IARM_BUS_DSMGR_EVENT_HDMI_IN_ALLM_STATUS  event  port: %d, ALLM Mode: %d", hdmi_in_port,allm_mode);
+
+                HdmiInput::_instance->hdmiInputALLMChange(hdmi_in_port, allm_mode);
+            }
+        }
+
+        void HdmiInput::hdmiInputALLMChange( int port , bool allm_mode)
+        {
+            LOGWARN("hdmiInputALLMChange [%d, %d]", port, allm_mode);
+
+            JsonObject params;
+            params["id"] = port;
+            params["gameFeature"] = "ALLM";
+            params["mode"] = allm_mode;
+
+            sendNotify(HDMIINPUT_EVENT_ON_GAME_FEATURE_STATUS_CHANGED, params);
+            GetHandler(2)->Notify(HDMIINPUT_EVENT_ON_GAME_FEATURE_STATUS_CHANGED, params);
+        }
+
+        uint32_t HdmiInput::getSupportedGameFeatures(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            vector<string> supportedFeatures;
+            try
+            {
+                device::HdmiInput::getInstance().getSupportedGameFeatures (supportedFeatures);
+                for (size_t i = 0; i < supportedFeatures.size(); i++)
+                {
+                    LOGINFO("Supported Game Feature [%d]:  %s\n",i,supportedFeatures.at(i).c_str());
+                }
+            }
+            catch (const device::Exception& err)
+            {
+                LOG_DEVICE_EXCEPTION0();
+            }
+
+            if (supportedFeatures.empty()) {
+                returnResponse(false);
+            }
+            else {
+                setResponseArray(response, "suppoortedGameFeatures", supportedFeatures);
+                returnResponse(true);
+            }
+        }
+
+        uint32_t HdmiInput::getHdmiGameFeatureStatusWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            string sPortId = parameters["portId"].String();
+            string sGameFeature = parameters["gameFeature"].String();
+            int portId = 0;
+
+            LOGINFOMETHOD();
+            returnIfParamNotFound(parameters, "portId");
+            returnIfParamNotFound(parameters, "gameFeature");
+            try {
+                portId = stoi(sPortId);
+            }catch (const device::Exception& err) {
+                LOG_DEVICE_EXCEPTION1(sPortId);
+                returnResponse(false);
+            }
+
+	    if (strcmp (sGameFeature.c_str(), "ALLM") == 0)
+            {
+                bool allm = getHdmiALLMStatus(portId);
+                LOGWARN("HdmiInput::getHdmiGameFeatureStatusWrapper ALLM MODE:%d", allm);
+                response["mode"] = allm;
+            }
+	    else
+	    {
+		LOGWARN("HdmiInput::getHdmiGameFeatureStatusWrapper currunt supported mode: ALLM");
+		returnResponse(false);
+	    }
+            returnResponse(true);
+        }
+
+        bool HdmiInput::getHdmiALLMStatus(int iPort)
+        {
+            bool allm = false;
+
+            try
+            {
+                device::HdmiInput::getInstance().getHdmiALLMStatus (iPort, &allm);
+                LOGWARN("HdmiInput::getHdmiALLMStatus ALLM MODE: %d", allm);
+            }
+            catch (const device::Exception& err)
+            {
+                LOG_DEVICE_EXCEPTION1(std::to_string(iPort));
+            }
+            return allm;
         }
 
         uint32_t HdmiInput::getRawHDMISPDWrapper(const JsonObject& parameters, JsonObject& response)

--- a/HdmiInput/HdmiInput.h
+++ b/HdmiInput/HdmiInput.h
@@ -63,6 +63,8 @@ namespace WPEFramework {
             uint32_t stopHdmiInput(const JsonObject& parameters, JsonObject& response);
 
             uint32_t setVideoRectangleWrapper(const JsonObject& parameters, JsonObject& response);
+            uint32_t getSupportedGameFeatures(const JsonObject& parameters, JsonObject& response);
+            uint32_t getHdmiGameFeatureStatusWrapper(const JsonObject& parameters, JsonObject& response);
             //End methods
 
             JsonArray getHDMIInputDevices();
@@ -72,7 +74,7 @@ namespace WPEFramework {
             std::string getHDMISPD(int iPort);
             int setEdidVersion(int iPort, int iEdidVer);
             int getEdidVersion(int iPort);
-
+            bool getHdmiALLMStatus(int iPort);
 
             bool setVideoRectangle(int x, int y, int width, int height);
 
@@ -87,6 +89,9 @@ namespace WPEFramework {
 
 	    void hdmiInputVideoModeUpdate( int port , dsVideoPortResolution_t resolution);
 	    static void dsHdmiVideoModeEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
+
+            void hdmiInputALLMChange( int port , bool allmMode);
+            static void dsHdmiGameFeatureStatusEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
 
         public:
             HdmiInput();

--- a/HdmiInput/HdmiInput.json
+++ b/HdmiInput/HdmiInput.json
@@ -331,6 +331,63 @@
             "result": {
                 "$ref": "#/definitions/result"
             }
+        },
+        "getSupportedGameFeatures":{
+            "summary": "Returns the list of supported game features.\n \n### Events\n \nNo Events.",
+            "result": {
+                "type": "object",
+                "properties": {
+                    "suppoortedGameFeatures": {
+                        "summary": "The supported game Features",
+                        "type": "string",
+                        "example": "ALLM"
+                    },
+                    "success": {
+                        "$ref": "#/definitions/success"
+                    }
+                },
+                "required": [
+                    "suppoortedGameFeatures",
+                    "success"
+                ]
+            }
+        },
+       "getHdmiGameFeatureStatus":{
+            "summary": "Returns the Game Feature(ALLM) Status.\n \n### Events\n \nNo Events.",
+            "params": {
+                "type":"object",
+                "properties": {
+                    "portId":{
+                        "$ref": "#/definitions/portId"
+                    },
+                     "gameFeature": {
+                        "summary": "Game Feature to which currunt status requested",
+                        "type": "string",
+                        "example": "ALLM"
+                    }
+               },
+                "required": [
+                    "portid",
+		    "gameFeature"
+                ]
+            },
+            "result": {
+                "type": "object",
+                "properties": {
+                    "mode": {
+                        "summary": "The currunt game feature(ALLM) status",
+                        "type": "boolean",
+                        "example": "true"
+                    },
+                    "success": {
+                        "$ref": "#/definitions/success"
+                    }
+                },
+                "required": [
+                    "mode",
+                    "success"
+                ]
+            }
         }
     },
     "events": {
@@ -441,6 +498,32 @@
                     "progressive",
                     "frameRateN",
                     "frameRateD"
+                ]
+            }
+        },
+        "hdmiGameFeatureStatusUpdate": {
+            "summary": "Triggered whenever game feature(ALLM) status changes for an HDMI Input",
+            "params": {
+                "type": "object",
+                "properties": {
+                   "portId": {
+                        "$ref": "#/definitions/portId"
+                    },
+                     "gameFeature": {
+                        "summary": "Game Feature to which currunt status requested",
+                        "type": "string",
+                        "example": "ALLM"
+                    },
+                    "mode": {
+                        "summary": "The currunt game feature(ALLM) status",
+                        "type": "boolean",
+                        "example": "true"
+                    }
+                },
+                "required": [
+                    "portId",
+                    "gameFeature",
+                    "mode"
                 ]
             }
         }

--- a/docs/api/HdmiInputPlugin.md
+++ b/docs/api/HdmiInputPlugin.md
@@ -1,5 +1,5 @@
 <!-- Generated automatically, DO NOT EDIT! -->
-<a name="HdmiInputPlugin"></a>
+<a name="head.HdmiInputPlugin"></a>
 # HdmiInputPlugin
 
 **Version: 2.0**
@@ -10,61 +10,61 @@ A org.rdk.HdmiInput plugin for Thunder framework.
 
 ### Table of Contents
 
-- [Introduction](#Introduction)
-- [Description](#Description)
-- [Configuration](#Configuration)
-- [Methods](#Methods)
-- [Notifications](#Notifications)
+- [Introduction](#head.Introduction)
+- [Description](#head.Description)
+- [Configuration](#head.Configuration)
+- [Methods](#head.Methods)
+- [Notifications](#head.Notifications)
 
-<a name="Introduction"></a>
+<a name="head.Introduction"></a>
 # Introduction
 
-<a name="Scope"></a>
+<a name="head.Scope"></a>
 ## Scope
 
 This document describes purpose and functionality of the org.rdk.HdmiInput plugin. It includes detailed specification about its configuration, methods provided and notifications sent.
 
-<a name="Case_Sensitivity"></a>
+<a name="head.Case_Sensitivity"></a>
 ## Case Sensitivity
 
 All identifiers of the interfaces described in this document are case-sensitive. Thus, unless stated otherwise, all keywords, entities, properties, relations and actions should be treated as such.
 
-<a name="Acronyms,_Abbreviations_and_Terms"></a>
+<a name="head.Acronyms,_Abbreviations_and_Terms"></a>
 ## Acronyms, Abbreviations and Terms
 
 The table below provides and overview of acronyms used in this document and their definitions.
 
 | Acronym | Description |
 | :-------- | :-------- |
-| <a name="API">API</a> | Application Programming Interface |
-| <a name="HTTP">HTTP</a> | Hypertext Transfer Protocol |
-| <a name="JSON">JSON</a> | JavaScript Object Notation; a data interchange format |
-| <a name="JSON-RPC">JSON-RPC</a> | A remote procedure call protocol encoded in JSON |
+| <a name="acronym.API">API</a> | Application Programming Interface |
+| <a name="acronym.HTTP">HTTP</a> | Hypertext Transfer Protocol |
+| <a name="acronym.JSON">JSON</a> | JavaScript Object Notation; a data interchange format |
+| <a name="acronym.JSON-RPC">JSON-RPC</a> | A remote procedure call protocol encoded in JSON |
 
 The table below provides and overview of terms and abbreviations used in this document and their definitions.
 
 | Term | Description |
 | :-------- | :-------- |
-| <a name="callsign">callsign</a> | The name given to an instance of a plugin. One plugin can be instantiated multiple times, but each instance the instance name, callsign, must be unique. |
+| <a name="term.callsign">callsign</a> | The name given to an instance of a plugin. One plugin can be instantiated multiple times, but each instance the instance name, callsign, must be unique. |
 
-<a name="References"></a>
+<a name="head.References"></a>
 ## References
 
 | Ref ID | Description |
 | :-------- | :-------- |
-| <a name="HTTP">[HTTP](http://www.w3.org/Protocols)</a> | HTTP specification |
-| <a name="JSON-RPC">[JSON-RPC](https://www.jsonrpc.org/specification)</a> | JSON-RPC 2.0 specification |
-| <a name="JSON">[JSON](http://www.json.org/)</a> | JSON specification |
-| <a name="Thunder">[Thunder](https://github.com/WebPlatformForEmbedded/Thunder/blob/master/doc/WPE%20-%20API%20-%20WPEFramework.docx)</a> | Thunder API Reference |
+| <a name="ref.HTTP">[HTTP](http://www.w3.org/Protocols)</a> | HTTP specification |
+| <a name="ref.JSON-RPC">[JSON-RPC](https://www.jsonrpc.org/specification)</a> | JSON-RPC 2.0 specification |
+| <a name="ref.JSON">[JSON](http://www.json.org/)</a> | JSON specification |
+| <a name="ref.Thunder">[Thunder](https://github.com/WebPlatformForEmbedded/Thunder/blob/master/doc/WPE%20-%20API%20-%20WPEFramework.docx)</a> | Thunder API Reference |
 
-<a name="Description"></a>
+<a name="head.Description"></a>
 # Description
 
 The `HdmiInput` plugin allows you to control the HDMI Input on a set-top box.
 
-The plugin is designed to be loaded and executed within the Thunder framework. For more information about the framework refer to [[Thunder](#Thunder)].
+The plugin is designed to be loaded and executed within the Thunder framework. For more information about the framework refer to [[Thunder](#ref.Thunder)].
 
-<a name="Configuration"></a>
+<a name="head.Configuration"></a>
 # Configuration
 
 The table below lists configuration options of the plugin.
@@ -76,7 +76,7 @@ The table below lists configuration options of the plugin.
 | locator | string | Library name: *libWPEFrameworkHdmiInput.so* |
 | autostart | boolean | Determines if the plugin shall be started automatically along with the framework |
 
-<a name="Methods"></a>
+<a name="head.Methods"></a>
 # Methods
 
 The following methods are provided by the org.rdk.HdmiInput plugin:
@@ -85,20 +85,22 @@ HdmiInput interface methods:
 
 | Method | Description |
 | :-------- | :-------- |
-| [getHDMIInputDevices](#getHDMIInputDevices) | Returns an array of available HDMI Input ports |
-| [getEdidVersion](#getEdidVersion) | (Version 2) Returns the EDID version |
-| [getHDMISPD](#getHDMISPD) | (Version 2) Returns the Source Data Product Descriptor (SPD) infoFrame packet information for the specified HDMI Input device |
-| [getRawHDMISPD](#getRawHDMISPD) | (Version 2) Returns the Source Data Product Descriptor (SPD) infoFrame packet information for the specified HDMI Input device as raw bits |
-| [readEDID](#readEDID) | Returns the current EDID value |
-| [startHdmiInput](#startHdmiInput) | Activates the specified HDMI Input port as the primary video source |
-| [stopHdmiInput](#stopHdmiInput) | Deactivates the HDMI Input port currently selected as the primary video source |
-| [setEdidVersion](#setEdidVersion) | (Version 2) Sets an HDMI EDID version |
-| [setVideoRectangle](#setVideoRectangle) | Sets an HDMI Input video window |
-| [writeEDID](#writeEDID) | Changes a current EDID value |
+| [getHDMIInputDevices](#method.getHDMIInputDevices) | Returns an array of available HDMI Input ports |
+| [getEdidVersion](#method.getEdidVersion) | (Version 2) Returns the EDID version |
+| [getHDMISPD](#method.getHDMISPD) | (Version 2) Returns the Source Data Product Descriptor (SPD) infoFrame packet information for the specified HDMI Input device |
+| [getRawHDMISPD](#method.getRawHDMISPD) | (Version 2) Returns the Source Data Product Descriptor (SPD) infoFrame packet information for the specified HDMI Input device as raw bits |
+| [readEDID](#method.readEDID) | Returns the current EDID value |
+| [startHdmiInput](#method.startHdmiInput) | Activates the specified HDMI Input port as the primary video source |
+| [stopHdmiInput](#method.stopHdmiInput) | Deactivates the HDMI Input port currently selected as the primary video source |
+| [setEdidVersion](#method.setEdidVersion) | (Version 2) Sets an HDMI EDID version |
+| [setVideoRectangle](#method.setVideoRectangle) | Sets an HDMI Input video window |
+| [writeEDID](#method.writeEDID) | Changes a current EDID value |
+| [getSupportedGameFeatures](#method.getSupportedGameFeatures) | Returns the list of supported game features |
+| [getHdmiGameFeatureStatus](#method.getHdmiGameFeatureStatus) | Returns the Game Feature(ALLM) Status |
 
 
-<a name="getHDMIInputDevices"></a>
-## *getHDMIInputDevices*
+<a name="method.getHDMIInputDevices"></a>
+## *getHDMIInputDevices [<sup>method</sup>](#head.Methods)*
 
 Returns an array of available HDMI Input ports.
  
@@ -153,8 +155,8 @@ This method takes no parameters.
 }
 ```
 
-<a name="getEdidVersion"></a>
-## *getEdidVersion*
+<a name="method.getEdidVersion"></a>
+## *getEdidVersion [<sup>method</sup>](#head.Methods)*
 
 (Version 2) Returns the EDID version.
  
@@ -205,8 +207,8 @@ No Events.
 }
 ```
 
-<a name="getHDMISPD"></a>
-## *getHDMISPD*
+<a name="method.getHDMISPD"></a>
+## *getHDMISPD [<sup>method</sup>](#head.Methods)*
 
 (Version 2) Returns the Source Data Product Descriptor (SPD) infoFrame packet information for the specified HDMI Input device. The SPD infoFrame packet includes vendor name, product description, and source information.
  
@@ -257,8 +259,8 @@ No Events.
 }
 ```
 
-<a name="getRawHDMISPD"></a>
-## *getRawHDMISPD*
+<a name="method.getRawHDMISPD"></a>
+## *getRawHDMISPD [<sup>method</sup>](#head.Methods)*
 
 (Version 2) Returns the Source Data Product Descriptor (SPD) infoFrame packet information for the specified HDMI Input device as raw bits.
  
@@ -309,8 +311,8 @@ No Events.
 }
 ```
 
-<a name="readEDID"></a>
-## *readEDID*
+<a name="method.readEDID"></a>
+## *readEDID [<sup>method</sup>](#head.Methods)*
 
 Returns the current EDID value.
  
@@ -361,8 +363,8 @@ No Events.
 }
 ```
 
-<a name="startHdmiInput"></a>
-## *startHdmiInput*
+<a name="method.startHdmiInput"></a>
+## *startHdmiInput [<sup>method</sup>](#head.Methods)*
 
 Activates the specified HDMI Input port as the primary video source.
  
@@ -372,7 +374,7 @@ Activates the specified HDMI Input port as the primary video source.
 | `onInputStatusChanged` | Triggers the event when HDMI Input source is activated and Input status changes to `started` | 
 | `onSignalChanged` | Triggers the event when HDMI Input signal changes (must be one of the following:noSignal, unstableSignal, notSupportedSignal, stableSignal).
 
-Also see: [onInputStatusChanged](#onInputStatusChanged), [onSignalChanged](#onSignalChanged)
+Also see: [onInputStatusChanged](#event.onInputStatusChanged), [onSignalChanged](#event.onSignalChanged)
 
 ### Parameters
 
@@ -415,8 +417,8 @@ Also see: [onInputStatusChanged](#onInputStatusChanged), [onSignalChanged](#onSi
 }
 ```
 
-<a name="stopHdmiInput"></a>
-## *stopHdmiInput*
+<a name="method.stopHdmiInput"></a>
+## *stopHdmiInput [<sup>method</sup>](#head.Methods)*
 
 Deactivates the HDMI Input port currently selected as the primary video source.
  
@@ -425,7 +427,7 @@ Deactivates the HDMI Input port currently selected as the primary video source.
 | :----------- | :----------- | 
 | `onInputStatusChanged` | Triggers the event when HDMI Input source is deactivated and Input status changes to `stopped`.
 
-Also see: [onInputStatusChanged](#onInputStatusChanged)
+Also see: [onInputStatusChanged](#event.onInputStatusChanged)
 
 ### Parameters
 
@@ -462,8 +464,8 @@ This method takes no parameters.
 }
 ```
 
-<a name="setEdidVersion"></a>
-## *setEdidVersion*
+<a name="method.setEdidVersion"></a>
+## *setEdidVersion [<sup>method</sup>](#head.Methods)*
 
 (Version 2) Sets an HDMI EDID version.
  
@@ -514,8 +516,8 @@ No Events.
 }
 ```
 
-<a name="setVideoRectangle"></a>
-## *setVideoRectangle*
+<a name="method.setVideoRectangle"></a>
+## *setVideoRectangle [<sup>method</sup>](#head.Methods)*
 
 Sets an HDMI Input video window.
  
@@ -570,8 +572,8 @@ No Events.
 }
 ```
 
-<a name="writeEDID"></a>
-## *writeEDID*
+<a name="method.writeEDID"></a>
+## *writeEDID [<sup>method</sup>](#head.Methods)*
 
 Changes a current EDID value.
  
@@ -622,10 +624,110 @@ No Events.
 }
 ```
 
-<a name="Notifications"></a>
+<a name="method.getSupportedGameFeatures"></a>
+## *getSupportedGameFeatures [<sup>method</sup>](#head.Methods)*
+
+Returns the list of supported game features.
+ 
+### Events
+ 
+No Events.
+
+### Parameters
+
+This method takes no parameters.
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.suppoortedGameFeatures | string | The supported game Features |
+| result.success | boolean | Whether the request succeeded |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.HdmiInput.1.getSupportedGameFeatures"
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "suppoortedGameFeatures": "ALLM",
+        "success": true
+    }
+}
+```
+
+<a name="method.getHdmiGameFeatureStatus"></a>
+## *getHdmiGameFeatureStatus [<sup>method</sup>](#head.Methods)*
+
+Returns the Game Feature(ALLM) Status.
+ 
+### Events
+ 
+No Events.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params?.portId | string | <sup>*(optional)*</sup> An ID of an HDMI Input port as returned by the `getHdmiInputDevices` method |
+| params.gameFeature | string | Game Feature to which currunt status requested |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.mode | boolean | The currunt game feature(ALLM) status |
+| result.success | boolean | Whether the request succeeded |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.HdmiInput.1.getHdmiGameFeatureStatus",
+    "params": {
+        "portId": "0",
+        "gameFeature": "ALLM"
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "mode": true,
+        "success": true
+    }
+}
+```
+
+<a name="head.Notifications"></a>
 # Notifications
 
-Notifications are autonomous events, triggered by the internals of the implementation, and broadcasted via JSON-RPC to all registered observers. Refer to [[Thunder](#Thunder)] for information on how to register for a notification.
+Notifications are autonomous events, triggered by the internals of the implementation, and broadcasted via JSON-RPC to all registered observers. Refer to [[Thunder](#ref.Thunder)] for information on how to register for a notification.
 
 The following events are provided by the org.rdk.HdmiInput plugin:
 
@@ -633,14 +735,15 @@ HdmiInput interface events:
 
 | Event | Description |
 | :-------- | :-------- |
-| [onDevicesChanged](#onDevicesChanged) | Triggered whenever a new HDMI device is connected to an HDMI Input |
-| [onInputStatusChanged](#onInputStatusChanged) | Triggered whenever the status changes for an HDMI Input |
-| [onSignalChanged](#onSignalChanged) | Triggered whenever the signal status changes for an HDMI Input |
-| [videoStreamInfoUpdate](#videoStreamInfoUpdate) | Triggered whenever there is an update in HDMI Input video stream info |
+| [onDevicesChanged](#event.onDevicesChanged) | Triggered whenever a new HDMI device is connected to an HDMI Input |
+| [onInputStatusChanged](#event.onInputStatusChanged) | Triggered whenever the status changes for an HDMI Input |
+| [onSignalChanged](#event.onSignalChanged) | Triggered whenever the signal status changes for an HDMI Input |
+| [videoStreamInfoUpdate](#event.videoStreamInfoUpdate) | Triggered whenever there is an update in HDMI Input video stream info |
+| [hdmiGameFeatureStatusUpdate](#event.hdmiGameFeatureStatusUpdate) | Triggered whenever game feature(ALLM) status changes for an HDMI Input |
 
 
-<a name="onDevicesChanged"></a>
-## *onDevicesChanged*
+<a name="event.onDevicesChanged"></a>
+## *onDevicesChanged [<sup>event</sup>](#head.Notifications)*
 
 Triggered whenever a new HDMI device is connected to an HDMI Input.
 
@@ -673,8 +776,8 @@ Triggered whenever a new HDMI device is connected to an HDMI Input.
 }
 ```
 
-<a name="onInputStatusChanged"></a>
-## *onInputStatusChanged*
+<a name="event.onInputStatusChanged"></a>
+## *onInputStatusChanged [<sup>event</sup>](#head.Notifications)*
 
 Triggered whenever the status changes for an HDMI Input.
 
@@ -701,8 +804,8 @@ Triggered whenever the status changes for an HDMI Input.
 }
 ```
 
-<a name="onSignalChanged"></a>
-## *onSignalChanged*
+<a name="event.onSignalChanged"></a>
+## *onSignalChanged [<sup>event</sup>](#head.Notifications)*
 
 Triggered whenever the signal status changes for an HDMI Input.
 
@@ -729,8 +832,8 @@ Triggered whenever the signal status changes for an HDMI Input.
 }
 ```
 
-<a name="videoStreamInfoUpdate"></a>
-## *videoStreamInfoUpdate*
+<a name="event.videoStreamInfoUpdate"></a>
+## *videoStreamInfoUpdate [<sup>event</sup>](#head.Notifications)*
 
 Triggered whenever there is an update in HDMI Input video stream info.
 
@@ -761,6 +864,34 @@ Triggered whenever there is an update in HDMI Input video stream info.
         "progressive": true,
         "frameRateN": 60000,
         "frameRateD": 1001
+    }
+}
+```
+
+<a name="event.hdmiGameFeatureStatusUpdate"></a>
+## *hdmiGameFeatureStatusUpdate [<sup>event</sup>](#head.Notifications)*
+
+Triggered whenever game feature(ALLM) status changes for an HDMI Input.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.portId | string | An ID of an HDMI Input port as returned by the `getHdmiInputDevices` method |
+| params.gameFeature | string | Game Feature to which currunt status requested |
+| params.mode | boolean | The currunt game feature(ALLM) status |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.1.hdmiGameFeatureStatusUpdate",
+    "params": {
+        "portId": "0",
+        "gameFeature": "ALLM",
+        "mode": true
     }
 }
 ```


### PR DESCRIPTION
Reason for change: added code for getSupportedGameFeatures, getHdmiGameFeatureStatus
and the event HdmiGameFeatureStatusUpdate
Test Procedure: available in Jira
Risks: Low
Signed-off-by: Dhivya Ilangovan <dhivya.dilangovan@sky.uk>