### PR TITLE
REFPLTV-1146 Bring up 64bit support in Rpi4 (for both kernel and user…

### DIFF
--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -1147,7 +1147,7 @@ namespace WPEFramework {
                   if (needsScreenshot)
                   {
                       uint8_t* data = nullptr;
-                      size_t size;
+                      uint32_t size;
                       string screenshotBase64;
                       CompositorController::screenShot(data, size);
                       size_t encodedImageSize = b64_get_encoded_buffer_size(size);


### PR DESCRIPTION
… space).

Reason for change: In RPi4 64bit combatibility typecasting changes
Test Procedure: Build should be successful. rdkservices should build fine.
Risks: Low/None.