### PR TITLE
RDKTV-17058:  While performing FTUE device is not connecting to Wifi

### DIFF
--- a/Network/Network.cpp
+++ b/Network/Network.cpp
@@ -1344,6 +1344,15 @@ namespace WPEFramework
             JsonObject params;
             params["interface"] = m_netUtils.getInterfaceDescription(interface);
             params["status"] = string (connected ? "CONNECTED" : "DISCONNECTED");
+            m_useInterfacesCache = false;
+            m_useStbIPCache = false;
+            m_useDefInterfaceCache = false;
+            m_useIpv4WifiCache = false;
+            m_useIpv6WifiCache = false;
+            m_useIpv4EthCache = false;
+            m_useIpv6EthCache = false;
+            m_defIpversionCache = "";
+            m_defInterfaceCache = "";
             sendNotify("onConnectionStatusChanged", params);
             GetHandler(2)->Notify("onConnectionStatusChanged", params);
         }


### PR DESCRIPTION
Reason for change:
While performing FTUE device is not connecting to Wifi always lands in "Choose Different Network" Screen.
Fix above issue: Resetting cache value when onInterfaceConnectionStatusChanged event triggers.
Test Procedure: Perform FTUE.
Risks: High
Signed-off-by: Kumar Santhanam <Kumar_Santhanam@comcast.com>