### PR TITLE
RDK-36267: Improve Efficiency of Network RDKServices APIs

### DIFF
--- a/Network/Network.h
+++ b/Network/Network.h
@@ -21,6 +21,7 @@
 
 #include <cjson/cJSON.h>
 #include <string>
+#include <atomic>
 
 #include "Module.h"
 #include "NetUtils.h"
@@ -32,6 +33,43 @@
 // Define this to use netlink calls (where there may be an alternative method but netlink could provide
 // the information or perform the action required)
 //#define USE_NETLINK
+#define MAX_IP_ADDRESS_LEN 46
+#define NETSRVMGR_INTERFACES_MAX 16
+
+typedef struct {
+    char name[16];
+    char mac[20];
+    unsigned int flags;
+} NetSrvMgr_Interface_t;
+
+typedef struct {
+    unsigned char         size;
+    NetSrvMgr_Interface_t interfaces[NETSRVMGR_INTERFACES_MAX];
+} IARM_BUS_NetSrvMgr_InterfaceList_t;
+
+typedef enum _NetworkManager_GetIPSettings_ErrorCode_t
+{
+  NETWORK_IPADDRESS_ACQUIRED,
+  NETWORK_IPADDRESS_NOTFOUND,
+  NETWORK_NO_ROUTE_INTERFACE,
+  NETWORK_NO_DEFAULT_ROUTE,
+  NETWORK_DNS_NOT_CONFIGURED,
+  NETWORK_INVALID_IPADDRESS,
+} NetworkManager_GetIPSettings_ErrorCode_t;
+
+typedef struct {
+    char interface[16];
+    char ipversion[16];
+    bool autoconfig;
+    char ipaddress[MAX_IP_ADDRESS_LEN];
+    char netmask[MAX_IP_ADDRESS_LEN];
+    char gateway[MAX_IP_ADDRESS_LEN];
+    char dhcpserver[MAX_IP_ADDRESS_LEN];
+    char primarydns[MAX_IP_ADDRESS_LEN];
+    char secondarydns[MAX_IP_ADDRESS_LEN];
+    bool isSupported;
+    NetworkManager_GetIPSettings_ErrorCode_t errCode;
+} IARM_BUS_NetSrvMgr_Iface_Settings_t;
 
 namespace WPEFramework {
     namespace Plugin {
@@ -83,6 +121,7 @@ namespace WPEFramework {
             uint32_t setConnectivityTestEndpoints(const JsonObject& parameters, JsonObject& response);
             uint32_t getPublicIP(const JsonObject& parameters, JsonObject& response);
             uint32_t setStunEndPoint(const JsonObject& parameters, JsonObject& response);
+            bool getIPIARMWrapper(IARM_BUS_NetSrvMgr_Iface_Settings_t& iarmData, const string interface, const string ipversion);
 
             void onInterfaceEnabledStatusChanged(std::string interface, bool enabled);
             void onInterfaceConnectionStatusChanged(std::string interface, bool connected);
@@ -105,7 +144,7 @@ namespace WPEFramework {
 
             JsonObject _doPing(const std::string& guid, const std::string& endPoint, int packets);
             JsonObject _doPingNamedEndpoint(const std::string& guid, const std::string& endpointName, int packets);
-            bool getIPSettingsInternal(const JsonObject& parameters, JsonObject& response,int errCode);
+            bool getIPSettingsInternal(const JsonObject& parameters, JsonObject& response,int& errCode);
             uint32_t setIPSettingsInternal(const JsonObject& parameters, JsonObject& response);
 
         public:
@@ -141,6 +180,22 @@ namespace WPEFramework {
             uint16_t m_stunCacheTimeout;
             bool m_stunSync;
             uint32_t m_apiVersionNumber;
+            std::atomic<bool> m_useIpv4WifiCache;
+            std::atomic<bool> m_useIpv6WifiCache;
+            std::atomic<bool> m_useIpv4EthCache;
+            std::atomic<bool> m_useIpv6EthCache;
+            std::atomic<bool> m_useStbIPCache;
+            string m_stbIpCache;
+            std::atomic<bool> m_useDefInterfaceCache;
+            string m_defInterfaceCache;
+            string m_defIpversionCache;
+            std::atomic<bool> m_useInterfacesCache;
+            IARM_BUS_NetSrvMgr_InterfaceList_t m_interfacesCache;
+
+            IARM_BUS_NetSrvMgr_Iface_Settings_t m_ipv4WifiCache;
+            IARM_BUS_NetSrvMgr_Iface_Settings_t m_ipv6WifiCache;
+            IARM_BUS_NetSrvMgr_Iface_Settings_t m_ipv4EthCache;
+            IARM_BUS_NetSrvMgr_Iface_Settings_t m_ipv6EthCache;
         };
     } // namespace Plugin
 } // namespace WPEFramework


### PR DESCRIPTION
Reason for change: Improves overall performance of clients apps using RDKServices and reduce number of IARM_Bus_Call
Test Procedure: Fetch interface and getipsettings value from netsrvmgr when first call or whenever onInterfaceIPchange event occurs otherwise use cache value for response.
Risks: High
Signed-off-by: Kumar Santhanam Kumar_Santhanam@comcast.com
(cherry picked from commit baae1ae729e2dcea3ed48c06567fa3b77eae8542)