### PR TITLE
Revert AMLOGIC-3232:IP - Llama Technical Test – Putting In/Out of Sta…

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -4039,7 +4039,7 @@ namespace WPEFramework {
                     device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
 
                     aPort.getSupportedARCTypes(&types);
-                    if((aPort.isConnected()) && (m_hdmiCecAudioDeviceDetected)) {
+                    if((aPort.isConnected()) && (m_hdmiInAudioDeviceConnected == true)) {
                         LOGINFO("DisplaySettings::setEnableAudioPort Configuring User set Audio mode before starting ARC/eARC Playback...\n");
                         if(aPort.getStereoAuto() == true) {
                             if(types & dsAUDIOARCSUPPORT_eARC) {


### PR DESCRIPTION
…ndby,

audio Auto setting doesn’t really persist
Reason for change: changing the flag m_hdmiCecAudioDeviceDetected to check the audio connected device
Test Procedure: Standby/ON and watch out for the Audio mode on the AVR with auto mode
Risks: low

Signed-off-by: shafi.ahmed@sky.uk <shafi.ahmed@sky.uk>