### PR TITLE
RDKTV-17105: WPEFramework Crash in std::terminate

### DIFF
--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -584,11 +584,12 @@ namespace WPEFramework {
             /* we moved every thing to a thread */
             /* only when dcm is getting a DCM_SUCCESS/DCM_ERROR we say
              * Maintenance is started until then we say MAITENANCE_IDLE */
-            if(m_thread.joinable()){
-                     m_thread.join();
-             }
 
             m_thread = std::thread(&MaintenanceManager::task_execution_thread, _instance);
+
+            if(m_thread.joinable()){
+                m_thread.join();
+            }
         }
 
         void MaintenanceManager::_MaintenanceMgrEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
@@ -801,9 +802,6 @@ namespace WPEFramework {
                     }
 
                     LOGINFO("ENDING MAINTENANCE CYCLE");
-                    if(m_thread.joinable()){
-                        m_thread.join();
-                    }
 
                     MaintenanceManager::_instance->onMaintenanceStatusChange(notify_status);
                 }
@@ -1154,6 +1152,10 @@ namespace WPEFramework {
                         }
 
                         m_thread = std::thread(&MaintenanceManager::task_execution_thread, _instance);
+
+			if(m_thread.joinable()){
+                            m_thread.join();
+                        }
 
                         result=true;
                     }


### PR DESCRIPTION
Within Maintenance Manager some thread is joinable and it  hasn't been joined
properly which leads to crash in wpeframework with std::terminate

There should not be any crash with Maintenance Manager