### PR TITLE
Revert LLAMA-6059: Audio interruption on HDMI ARC

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -4089,13 +4089,8 @@ namespace WPEFramework {
 			       // For certain ARC devices, we get ARC initiate message even when ARC device is in standby
 			       // Wake up the device always before audio routing
 			       sendHdmiCecSinkAudioDevicePowerOn();
-			       if(m_arcAudioEnabled == false) {
-                                   aPort.enableARC(dsAUDIOARCSUPPORT_ARC, true);
-                                   m_arcAudioEnabled = true;
-			       }
-			       else {
-			           LOGINFO("ARC is already enabled. Value of m_arcAudioEnabled is %d: \n", m_arcAudioEnabled);
-			       }
+                               aPort.enableARC(dsAUDIOARCSUPPORT_ARC, true);
+                               m_arcAudioEnabled = true;
 			   }
 			   else {
                                LOGINFO("%s: Disable ARC \n",__FUNCTION__);
@@ -4448,11 +4443,9 @@ namespace WPEFramework {
                         }
 
                         if(aPortConfig["HDMI_ARC"].Boolean()) {
-                            if(m_arcAudioEnabled == false) {
-			        LOGINFO("onARCInitiationEventHandler: Enable ARC\n");
-                                aPort.enableARC(dsAUDIOARCSUPPORT_ARC, true);
-                                m_arcAudioEnabled = true;
-			    }
+                            LOGINFO("onARCInitiationEventHandler: Enable ARC\n");
+                            aPort.enableARC(dsAUDIOARCSUPPORT_ARC, true);
+                            m_arcAudioEnabled = true;
                         }
                         else {
                            LOGINFO("onARCInitiationEventHandler: HDMI_ARC0 Port not enabled. Skip Audio Routing !!!\n");


### PR DESCRIPTION
Reason for change: Added a condition to check if ARC is enabled
Test Procedure: Refer ticket
Risks: Low

Signed-off-by: shafi.ahmed@sky.uk <shafi.ahmed@sky.uk>