### PR TITLE
LLAMA-6599:Box stuck at skylogo after multiple reboot

### DIFF
--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -3196,13 +3196,18 @@ namespace WPEFramework
        
       void HdmiCecSink::getHdmiArcPortID()
       {
-         int portId = -1;
-         device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort("HDMI_ARC0");
-         aPort.getHdmiArcPortId(&portId);
-         if(portId >= 0) {
-              HdmiArcPortID = portId;
-              LOGWARN("HDMI ARC port ID hdmiArcPortId=%d\n",HdmiArcPortID);
-         } 
+         int err;
+         dsGetHDMIARCPortIdParam_t param;
+         err = IARM_Bus_Call(IARM_BUS_DSMGR_NAME,
+                            (char *)IARM_BUS_DSMGR_API_dsGetHDMIARCPortId,
+                            (void *)&param,
+                            sizeof(param));
+          if (IARM_RESULT_SUCCESS == err)
+          {
+             LOGINFO("HDMI ARC port ID HdmiArcPortID=[%d] \n", param.portId);
+             HdmiArcPortID = param.portId;
+          }
+
       }
 
     } // namespace Plugin


### PR DESCRIPTION
Reason for change: Audio port waqs not intialized and
it was invoking with corrupted pointer
Test Procedure:  As per Jira
Risks:  Low

Signed-off-by: shafi.ahmed@sky.uk <shafi.ahmed@sky.uk>