### PR TITLE
RDKTV-17312: eARC AVR no audio on turning on TV

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -409,6 +409,15 @@ namespace WPEFramework {
                                     }
                                     else {
                                         LOGINFO("%s: Connected Device doesn't have ARC/eARC capability... \n", __FUNCTION__);
+                                    //ARC/eARC capability is not recognized even after Audio Device Detection & explicit sendHdmiCecSinkAudioDevicePowerOn
+                                    //Audio device could be in a process of powering on. Trigger Audio device power state request & normal audio routing should resume from onAudioDevicePowerStatusEventHandler
+                                        LOGINFO("Trigger Audio Device Power State Request status ... \n");
+                                        {
+                                           std::lock_guard<std::mutex> lock(m_arcRoutingStateMutex);
+                                           m_hdmiInAudioDevicePowerState = AUDIO_DEVICE_POWER_STATE_REQUEST;
+                                           m_cecArcRoutingThreadRun = true;
+                                           arcRoutingCV.notify_one();
+                                        }
                                     }
                                 }
                                 catch (const device::Exception& err){


### PR DESCRIPTION
Reason for change: Trigger Audio Device Power state
request from initAudioPorts if TV doesn't detect ARC/eARC
capability even after audio device detection &
powering ON the AVR.
This will trigger onAudioDevicePowerStatusEventHandler
which can resume Audio routing
Test Procedure: TV Standby/On test with eARC AVR
Risks: Medium

Signed-off-by: Deekshit Devadas deekshit.devadasy@sky.uk