### PR TITLE
RDKTV-16239: [TDK]Able to setGain for Invalid values

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -2657,6 +2657,10 @@ namespace WPEFramework {
                 float newGain = 0;
                 try {
                         newGain = stof(sGain);
+                         if ((newGain < -2080) || (newGain > 480)) {
+                            LOGERR("Gain (value = " + sGain + ") being set to an invalid value \n");
+                            returnResponse(false);
+                        }
                 }catch (const device::Exception& err) {
                         LOG_DEVICE_EXCEPTION1(sGain);
                         returnResponse(false);

--- a/DisplaySettings/DisplaySettings.json
+++ b/DisplaySettings/DisplaySettings.json
@@ -98,7 +98,7 @@
             "example": 0
         },
         "gain": {
-            "summary": "Value between 0 and 100, where 0 means no gain and 100 means maximum gain",
+            "summary": "Value between -2080 and 480, where -2080 means no gain and 480 means maximum gain",
             "type": "number",
             "example": "10.000000"
         },

--- a/DisplaySettings/DisplaySettings.json
+++ b/DisplaySettings/DisplaySettings.json
@@ -98,7 +98,7 @@
             "example": 0
         },
         "gain": {
-            "summary": "Value between -2080 and 480, where -2080 means no gain and 480 means maximum gain",
+            "summary": "Value between -2080 and 480, where -2080 means negative gain and 480 means maximum gain",
             "type": "number",
             "example": "10.000000"
         },


### PR DESCRIPTION
Reason for change:
Changing the thunder setGain function to check the bounds of the value being updated to make sure it is within bounds.
Also updating the setGain documentation to match the bounds in ds setGain function.
Test Procedure: None
Risks: Low

Signed-off-by:Hayden Gfeller <Hayden_Gfeller@comcast.com>