### PR TITLE
DELIA-56519: WPEFramework - undef __DEBUG__ unless passed in CFLAGS

### DIFF
--- a/RDKShell/RDKShell.h
+++ b/RDKShell/RDKShell.h
@@ -370,7 +370,6 @@ namespace WPEFramework {
                   MonitorClients(RDKShell* shell)
                       : mShell(*shell)
                   {
-                      ASSERT(mShell != nullptr);
                   }
                   ~MonitorClients()
                   {


### PR DESCRIPTION
Reason for change: mShell is reference object not a pointer. So cannot be checked for NULL

Test Procedure: Build and verify.
Risks: Low
Signed-off-by:Zameerun Rasheed M S <zexpen@gmail.com>