### PR TITLE
RDK-34568: Expand AVInput RDK Service to include HDMIInput and Compos…

### DIFF
--- a/AVInput/AVInput.cpp
+++ b/AVInput/AVInput.cpp
@@ -18,193 +18,1160 @@
 **/
 
 #include "AVInput.h"
-
 #include "dsMgr.h"
 #include "hdmiIn.hpp"
-
+#include "compositeIn.hpp"
 #include "UtilsJsonRpc.h"
 #include "UtilsIarm.h"
+#include "exception.hpp"
+#include "dsUtl.h"
+#include "dsError.h"
+#include <vector>
+#include <algorithm>
+
+#define HDMI 0
+#define COMPOSITE 1
+#define AV_HOT_PLUG_EVENT_CONNECTED 0
+#define AV_HOT_PLUG_EVENT_DISCONNECTED 1
+#define AVINPUT_METHOD_NUMBER_OF_INPUTS "numberOfInputs"
+#define AVINPUT_METHOD_GET_INPUT_DEVICES "getInputDevices"
+#define AVINPUT_METHOD_WRITE_EDID "writeEDID"
+#define AVINPUT_METHOD_READ_EDID "readEDID"
+#define AVINPUT_METHOD_READ_RAWSPD "getRawSPD"
+#define AVINPUT_METHOD_READ_SPD "getSPD"
+#define AVINPUT_METHOD_SET_EDID_VERSION "setEdidVersion"
+#define AVINPUT_METHOD_GET_EDID_VERSION "getEdidVersion"
+#define AVINPUT_METHOD_START_INPUT "startInput"
+#define AVINPUT_METHOD_STOP_INPUT "stopInput"
+#define AVINPUT_METHOD_SCALE_INPUT "setVideoRectangle"
+#define AVINPUT_METHOD_CURRENT_VIDEO_MODE "currentVideoMode"
+#define AVINPUT_METHOD_CONTENT_PROTECTED "contentProtected"
+#define AVINPUT_METHOD_SUPPORTED_GAME_FEATURES "getSupportedGameFeatures"
+#define AVINPUT_METHOD_GAME_FEATURE_STATUS "getGameFeatureStatus"
+
+#define AVINPUT_EVENT_ON_DEVICES_CHANGED "onDevicesChanged"
+#define AVINPUT_EVENT_ON_SIGNAL_CHANGED "onSignalChanged"
+#define AVINPUT_EVENT_ON_STATUS_CHANGED "onInputStatusChanged"
+#define AVINPUT_EVENT_ON_VIDEO_MODE_UPDATED "videoStreamInfoUpdate"
+#define AVINPUT_EVENT_ON_GAME_FEATURE_STATUS_CHANGED "gameFeatureStatusUpdate"
+
+using namespace std;
+int getTypeOfInput(string sType)
+{
+    int iType = -1;
+    if (strcmp (sType.c_str(), "HDMI") == 0)
+        iType = HDMI;
+    else if (strcmp (sType.c_str(), "COMPOSITE") ==0)
+        iType = COMPOSITE;
+    else
+        throw "Invalide type of INPUT, please specify HDMI/COMPOSITE";
+    return iType;
+}
 
 namespace WPEFramework {
-namespace Plugin {
-
-namespace {
-void dsHdmiEventHandler(const char *, IARM_EventId_t eventId, void *, size_t)
-{
-    if ((IARM_BUS_DSMGR_EVENT_HDMI_IN_HOTPLUG == eventId) &&
-        (AVInput::_instance != nullptr)) {
-        try {
-            int num = device::HdmiInput::getInstance().getNumberOfInputs();
-            if (num > 0) {
-                for (int i = 0; i < num; i++) {
-                    if (device::HdmiInput::getInstance().isPortConnected(i)) {
-                        AVInput::_instance->event_onAVInputActive(i);
+    namespace Plugin {
+        namespace {
+            void dsHdmiEventHandler(const char *, IARM_EventId_t eventId, void *, size_t)
+            {
+                if ((IARM_BUS_DSMGR_EVENT_HDMI_IN_HOTPLUG == eventId) &&
+                    (AVInput::_instance != nullptr)) {
+                    try {
+                        int num = device::HdmiInput::getInstance().getNumberOfInputs();
+                        if (num > 0) {
+                            for (int i = 0; i < num; i++) {
+                                if (device::HdmiInput::getInstance().isPortConnected(i)) {
+                                    AVInput::_instance->event_onAVInputActive(i);
+                                }
+                                else {
+                                    AVInput::_instance->event_onAVInputInactive(i);
+                                }
+                            }
+                        }
                     }
-                    else {
-                        AVInput::_instance->event_onAVInputInactive(i);
+                    catch (...) {
+                        LOGERR("Exception caught");
                     }
                 }
             }
         }
-        catch (...) {
-            LOGERR("Exception caught");
+
+        SERVICE_REGISTRATION(AVInput, 1, 0);
+
+        AVInput* AVInput::_instance = nullptr;
+
+        AVInput::AVInput()
+            : PluginHost::JSONRPC()
+        {
+            RegisterAll();
         }
-    }
-}
-}
 
-SERVICE_REGISTRATION(AVInput, 1, 0);
+        AVInput::~AVInput()
+        {
+            UnregisterAll();
+        }
 
-AVInput* AVInput::_instance = nullptr;
+        const string AVInput::Initialize(PluginHost::IShell * /* service */)
+        {
+            AVInput::_instance = this;
+            InitializeIARM();
 
-AVInput::AVInput()
-    : PluginHost::JSONRPC()
-{
-    RegisterAll();
-}
+            return (string());
+        }
 
-AVInput::~AVInput()
-{
-    UnregisterAll();
-}
+        void AVInput::Deinitialize(PluginHost::IShell * /* service */)
+        {
+            DeinitializeIARM();
+            AVInput::_instance = nullptr;
+        }
 
-const string AVInput::Initialize(PluginHost::IShell * /* service */)
-{
-    AVInput::_instance = this;
-    InitializeIARM();
+        string AVInput::Information() const
+        {
+            return (string());
+        }
 
-    return (string());
-}
+        void AVInput::InitializeIARM()
+        {
+            if (Utils::IARM::init()) {
+                IARM_Result_t res;
+                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_IN_HOTPLUG, dsAVEventHandler) );
+                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_IN_SIGNAL_STATUS, dsAVSignalStatusEventHandler) );
+                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_IN_STATUS, dsAVStatusEventHandler) );
+                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_IN_VIDEO_MODE_UPDATE, dsAVVideoModeEventHandler) );
+				IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_IN_ALLM_STATUS, dsAVGameFeatureStatusEventHandler) );
+                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_COMPOSITE_IN_HOTPLUG, dsAVEventHandler) );
+                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_COMPOSITE_IN_SIGNAL_STATUS, dsAVSignalStatusEventHandler) );
+                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_COMPOSITE_IN_STATUS, dsAVStatusEventHandler) );
+            }
+        }
 
-void AVInput::Deinitialize(PluginHost::IShell * /* service */)
-{
-    DeinitializeIARM();
-    AVInput::_instance = nullptr;
-}
+        void AVInput::DeinitializeIARM()
+        {
+            if (Utils::IARM::isConnected()) {
+                IARM_Result_t res;
+                IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_IN_HOTPLUG) );
+                IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_IN_SIGNAL_STATUS) );
+                IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_IN_STATUS) );
+                IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_IN_VIDEO_MODE_UPDATE) );
+				IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_IN_ALLM_STATUS) );
+                IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_COMPOSITE_IN_HOTPLUG) );
+                IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_COMPOSITE_IN_SIGNAL_STATUS) );
+                IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_COMPOSITE_IN_STATUS) );
+            }
+        }
 
-string AVInput::Information() const
-{
-    return (string());
-}
+        void AVInput::RegisterAll()
+        {
+            Register<JsonObject, JsonObject>(_T(AVINPUT_METHOD_NUMBER_OF_INPUTS), &AVInput::endpoint_numberOfInputs, this);
+            Register<JsonObject, JsonObject>(_T(AVINPUT_METHOD_CURRENT_VIDEO_MODE), &AVInput::endpoint_currentVideoMode, this);
+            Register<JsonObject, JsonObject>(_T(AVINPUT_METHOD_CONTENT_PROTECTED), &AVInput::endpoint_contentProtected, this);
+            Register<JsonObject, JsonObject>(_T(AVINPUT_METHOD_GET_INPUT_DEVICES), &AVInput::getInputDevicesWrapper, this);
+            Register<JsonObject, JsonObject>(_T(AVINPUT_METHOD_WRITE_EDID), &AVInput::writeEDIDWrapper, this);
+            Register<JsonObject, JsonObject>(_T(AVINPUT_METHOD_READ_EDID), &AVInput::readEDIDWrapper, this);
+            Register<JsonObject, JsonObject>(_T(AVINPUT_METHOD_READ_RAWSPD), &AVInput::getRawSPDWrapper, this);
+            Register<JsonObject, JsonObject>(_T(AVINPUT_METHOD_READ_SPD), &AVInput::getSPDWrapper, this);
+            Register<JsonObject, JsonObject>(_T(AVINPUT_METHOD_SET_EDID_VERSION), &AVInput::setEdidVersionWrapper, this);
+            Register<JsonObject, JsonObject>(_T(AVINPUT_METHOD_GET_EDID_VERSION), &AVInput::getEdidVersionWrapper, this);
+            Register<JsonObject, JsonObject>(_T(AVINPUT_METHOD_START_INPUT), &AVInput::startInput, this);
+            Register<JsonObject, JsonObject>(_T(AVINPUT_METHOD_STOP_INPUT), &AVInput::stopInput, this);
+            Register<JsonObject, JsonObject>(_T(AVINPUT_METHOD_SCALE_INPUT), &AVInput::setVideoRectangleWrapper, this);
+			Register<JsonObject, JsonObject>(_T(AVINPUT_METHOD_SUPPORTED_GAME_FEATURES), &AVInput::getSupportedGameFeatures, this);
+			Register<JsonObject, JsonObject>(_T(AVINPUT_METHOD_GAME_FEATURE_STATUS), &AVInput::getGameFeatureStatusWrapper, this);
+        }
 
-void AVInput::InitializeIARM()
-{
-    if (Utils::IARM::init()) {
-        IARM_Result_t res;
-        IARM_CHECK(IARM_Bus_RegisterEventHandler(
-            IARM_BUS_DSMGR_NAME,
-            IARM_BUS_DSMGR_EVENT_HDMI_IN_HOTPLUG,
-            dsHdmiEventHandler));
-    }
-}
+        void AVInput::UnregisterAll()
+        {
+            Unregister(_T(AVINPUT_METHOD_NUMBER_OF_INPUTS));
+            Unregister(_T(AVINPUT_METHOD_CURRENT_VIDEO_MODE));
+            Unregister(_T(AVINPUT_METHOD_CONTENT_PROTECTED));
+        	Unregister(_T(AVINPUT_METHOD_GET_INPUT_DEVICES));
+        	Unregister(_T(AVINPUT_METHOD_WRITE_EDID));
+        	Unregister(_T(AVINPUT_METHOD_READ_EDID));
+        	Unregister(_T(AVINPUT_METHOD_READ_RAWSPD));
+        	Unregister(_T(AVINPUT_METHOD_READ_SPD));
+        	Unregister(_T(AVINPUT_METHOD_SET_EDID_VERSION));
+        	Unregister(_T(AVINPUT_METHOD_GET_EDID_VERSION));
+        	Unregister(_T(AVINPUT_METHOD_START_INPUT));
+        	Unregister(_T(AVINPUT_METHOD_STOP_INPUT));
+        	Unregister(_T(AVINPUT_METHOD_SCALE_INPUT));
+        	Unregister(_T(AVINPUT_METHOD_SUPPORTED_GAME_FEATURES));
+        	Unregister(_T(AVINPUT_METHOD_GAME_FEATURE_STATUS));			
+        }
 
-void AVInput::DeinitializeIARM()
-{
-    if (Utils::IARM::isConnected()) {
-        IARM_Result_t res;
-        IARM_CHECK(IARM_Bus_UnRegisterEventHandler(
-            IARM_BUS_DSMGR_NAME,
-            IARM_BUS_DSMGR_EVENT_HDMI_IN_HOTPLUG));
-    }
-}
+        void setResponseArray(JsonObject& response, const char* key, const vector<string>& items)
+        {
+            JsonArray arr;
+            for(auto& i : items) arr.Add(JsonValue(i));
 
-void AVInput::RegisterAll()
-{
-    Register<JsonObject, JsonObject>(_T("numberOfInputs"), &AVInput::endpoint_numberOfInputs, this);
-    Register<JsonObject, JsonObject>(_T("currentVideoMode"), &AVInput::endpoint_currentVideoMode, this);
-    Register<JsonObject, JsonObject>(_T("contentProtected"), &AVInput::endpoint_contentProtected, this);
-}
+            response[key] = arr;
 
-void AVInput::UnregisterAll()
-{
-    Unregister(_T("numberOfInputs"));
-    Unregister(_T("currentVideoMode"));
-    Unregister(_T("contentProtected"));
-}
+            string json;
+            response.ToString(json);
+        }
 
-uint32_t AVInput::endpoint_numberOfInputs(const JsonObject &parameters, JsonObject &response)
-{
-    LOGINFOMETHOD();
+        uint32_t AVInput::endpoint_numberOfInputs(const JsonObject &parameters, JsonObject &response)
+        {
+            LOGINFOMETHOD();
 
-    bool success = false;
+            bool success = false;
 
-    auto result = numberOfInputs(success);
-    if (success) {
-        response[_T("numberOfInputs")] = result;
-    }
+            auto result = numberOfInputs(success);
+            if (success) {
+                response[_T("numberOfInputs")] = result;
+            }
 
-    returnResponse(success);
-}
+            returnResponse(success);
+        }
 
-uint32_t AVInput::endpoint_currentVideoMode(const JsonObject &parameters, JsonObject &response)
-{
-    LOGINFOMETHOD();
+        uint32_t AVInput::endpoint_currentVideoMode(const JsonObject &parameters, JsonObject &response)
+        {
+            LOGINFOMETHOD();
 
-    bool success = false;
+            bool success = false;
 
-    auto result = currentVideoMode(success);
-    if (success) {
-        response[_T("currentVideoMode")] = result;
-    }
+            auto result = currentVideoMode(success);
+            if (success) {
+                response[_T("currentVideoMode")] = result;
+            }
 
-    returnResponse(success);
-}
+            returnResponse(success);
+        }
 
-uint32_t AVInput::endpoint_contentProtected(const JsonObject &parameters, JsonObject &response)
-{
-    LOGINFOMETHOD();
+        uint32_t AVInput::endpoint_contentProtected(const JsonObject &parameters, JsonObject &response)
+        {
+            LOGINFOMETHOD();
 
-    // "Ths is the way it's done in Service Manager"
-    response[_T("isContentProtected")] = true;
+            // "Ths is the way it's done in Service Manager"
+            response[_T("isContentProtected")] = true;
 
-    returnResponse(true);
-}
+            returnResponse(true);
+        }
 
-void AVInput::event_onAVInputActive(int id)
-{
-    JsonObject params;
-    params[_T("url")] = "avin://input" + std::to_string(id);
-    sendNotify(_T("onAVInputActive"), params);
-}
+        void AVInput::event_onAVInputActive(int id)
+        {
+            JsonObject params;
+            params[_T("url")] = "avin://input" + std::to_string(id);
+            sendNotify(_T("onAVInputActive"), params);
+        }
 
-void AVInput::event_onAVInputInactive(int id)
-{
-    JsonObject params;
-    params[_T("url")] = "avin://input" + std::to_string(id);
-    sendNotify(_T("onAVInputInactive"), params);
-}
+        void AVInput::event_onAVInputInactive(int id)
+        {
+            JsonObject params;
+            params[_T("url")] = "avin://input" + std::to_string(id);
+            sendNotify(_T("onAVInputInactive"), params);
+        }
 
-int AVInput::numberOfInputs(bool &success)
-{
-    int result = 0;
+        int AVInput::numberOfInputs(bool &success)
+        {
+            int result = 0;
 
-    try {
-        result = device::HdmiInput::getInstance().getNumberOfInputs();
-        success = true;
-    }
-    catch (...) {
-        LOGERR("Exception caught");
-        success = false;
-    }
+            try {
+                result = device::HdmiInput::getInstance().getNumberOfInputs();
+                success = true;
+            }
+            catch (...) {
+                LOGERR("Exception caught");
+                success = false;
+            }
 
-    return result;
-}
+            return result;
+        }
 
-string AVInput::currentVideoMode(bool &success)
-{
-    string result;
+        string AVInput::currentVideoMode(bool &success)
+        {
+            string result;
 
-    try {
-        result = device::HdmiInput::getInstance().getCurrentVideoMode();
-        success = true;
-    }
-    catch (...) {
-        LOGERR("Exception caught");
-        success = false;
-    }
+            try {
+                result = device::HdmiInput::getInstance().getCurrentVideoMode();
+                success = true;
+            }
+            catch (...) {
+                LOGERR("Exception caught");
+                success = false;
+            }
 
-    return result;
-}
+            return result;
+        }
 
-} // namespace Plugin
+        uint32_t AVInput::startInput(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+
+            string sPortId = parameters["portId"].String();
+            string sType = parameters["typeOfInput"].String();
+            int portId = 0;
+            int iType = 0;
+            bool success = true;
+
+            returnIfParamNotFound(parameters, "portId");
+            returnIfParamNotFound(parameters, "typeOfInput");
+            try {
+                portId = stoi(sPortId);
+                iType = getTypeOfInput (sType);
+            }catch (...) {
+                LOGWARN("Invalid Arguments");
+                response["message"] = "Invalid Arguments";
+                returnResponse(false);
+            }
+
+            try
+            {
+                if (iType == HDMI) {
+                    device::HdmiInput::getInstance().selectPort(portId);
+            }
+                else if(iType == COMPOSITE) {
+                    device::CompositeInput::getInstance().selectPort(portId);
+                }
+            }
+            catch (const device::Exception& err) {
+                LOG_DEVICE_EXCEPTION1(sPortId);
+                success = false;
+            }
+            returnResponse(success);
+        }
+
+        uint32_t AVInput::stopInput(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+
+            returnIfParamNotFound(parameters, "typeOfInput");
+            string sType = parameters["typeOfInput"].String();
+            bool success = true;
+            int iType = 0;
+            try {
+                iType = getTypeOfInput (sType);
+            }catch (...) {
+                LOGWARN("Invalid Arguments");
+                response["message"] = "Invalid Arguments";
+                returnResponse(false);
+            }
+
+            try
+            {
+                if (iType == HDMI) {
+                    device::HdmiInput::getInstance().selectPort(-1);
+                }
+                else if (iType == COMPOSITE) {
+                    device::CompositeInput::getInstance().selectPort(-1);
+                }
+            }
+            catch (const device::Exception& err) {
+                LOGWARN("AVInputService::stopInput Failed");
+                success = false;
+            }
+            returnResponse(success);
+        }
+
+        uint32_t AVInput::setVideoRectangleWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+
+            bool result = true;
+            if (!parameters.HasLabel("x") && !parameters.HasLabel("y")) {
+                result = false;
+                response["message"] = "please specif coordinates (x,y)";
+            }
+
+            if (!parameters.HasLabel("w") && !parameters.HasLabel("h")) {
+                result = false;
+                response["message"] = "please specify window width and height (w,h)";
+            }
+
+            if (!parameters.HasLabel("typeOfInput")) {
+                result = false;
+                response["message"] = "please specify type of input HDMI/COMPOSITE";
+            }
+
+            if (result) {
+                int x = 0;
+                int y = 0;
+                int w = 0;
+                int h = 0;
+                int t = 0;
+                string sType;
+
+                try {
+                    if (parameters.HasLabel("x")) {
+                        x = std::stoi(parameters["x"].String());
+                    }
+                    if (parameters.HasLabel("y")) {
+                        y = std::stoi(parameters["y"].String());
+                    }
+                    if (parameters.HasLabel("w")) {
+                        w = std::stoi(parameters["w"].String());
+                    }
+                    if (parameters.HasLabel("h")) {
+                        h = std::stoi(parameters["h"].String());
+                    }
+                    if (parameters.HasLabel("typeOfInput")) {
+                        sType = parameters["typeOfInput"].String();
+                        t = getTypeOfInput (sType);
+                    }
+                }
+                catch (...) {
+                    LOGWARN("Invalid Arguments");
+                    response["message"] = "Invalid Arguments";
+                    returnResponse(false);
+                }
+
+                result = setVideoRectangle(x, y, w, h, t);
+                if (false == result) {
+                    LOGWARN("AVInputService::setVideoRectangle Failed");
+                    response["message"] = "failed to set scale";
+                }
+            }
+            returnResponse(result);
+        }
+
+        bool AVInput::setVideoRectangle(int x, int y, int width, int height, int type)
+        {
+            bool ret = true;
+
+            try
+            {
+                if (type == HDMI) {
+                    device::HdmiInput::getInstance().scaleVideo(x, y, width, height);
+                }
+                else {
+                    device::CompositeInput::getInstance().scaleVideo(x, y, width, height);
+                }
+            }
+            catch (const device::Exception& err) {
+                ret = false;
+            }
+
+            return ret;
+        }
+
+        uint32_t AVInput::getInputDevicesWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+
+            if (parameters.HasLabel("typeOfInput")) {
+                string sType = parameters["typeOfInput"].String();
+                int iType = 0;
+                try {
+                    iType = getTypeOfInput (sType);
+                }catch (...) {
+                    LOGWARN("Invalid Arguments");
+                    response["message"] = "Invalid Arguments";
+                    returnResponse(false);
+                }
+                response["devices"] = getInputDevices(iType);
+            }
+            else {
+                JsonArray listHdmi = getInputDevices(HDMI);
+                JsonArray listComposite = getInputDevices(COMPOSITE);
+                for (int i = 0; i < listComposite.Length(); i++) {
+                    listHdmi.Add(listComposite.Get(i));
+                }
+            response["devices"] = listHdmi;
+            }
+            returnResponse(true);
+        }
+
+        uint32_t AVInput::writeEDIDWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+
+            int deviceId;
+            std::string message;
+
+            if (parameters.HasLabel("deviceId") && parameters.HasLabel("message")) {
+                getNumberParameter("deviceId", deviceId);
+                message = parameters["message"].String();
+            }
+            else {
+                LOGWARN("Required parameters are not passed");
+                returnResponse(false);
+            }
+
+            writeEDID(deviceId, message);
+            returnResponse(true);
+
+        }
+
+        uint32_t AVInput::readEDIDWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+
+            string sPortId = parameters.HasLabel("deviceId") ? parameters["deviceId"].String() : "0";;
+            int portId = 0;
+            try {
+                portId = stoi(sPortId);
+            }catch (const device::Exception& err) {
+                LOG_DEVICE_EXCEPTION1(sPortId);
+                returnResponse(false);
+            }
+
+            string edid = readEDID (portId);
+            response["EDID"] = edid;
+            if (edid.empty()) {
+                returnResponse(false);
+            }
+            else {
+                returnResponse(true);
+            }
+        }
+
+        JsonArray AVInput::getInputDevices(int iType)
+        {
+            JsonArray list;
+            try
+            {
+                int num;
+                if (iType == HDMI) {
+                    num = device::HdmiInput::getInstance().getNumberOfInputs();
+                }
+                else if (iType == COMPOSITE) {
+                    num = device::CompositeInput::getInstance().getNumberOfInputs();
+                }
+                if (num > 0) {
+                    int i = 0;
+                    for (i = 0; i < num; i++) {
+                        //Input ID is aleays 0-indexed, continuous number starting 0
+                        JsonObject hash;
+                        hash["id"] = i;
+                        std::stringstream locator;
+                        if (iType == HDMI) {
+                            locator << "hdmiin://localhost/deviceid/" << i;
+                            hash["connected"] = device::HdmiInput::getInstance().isPortConnected(i) ? "true" : "false";
+                        }
+                        else if (iType == COMPOSITE) {
+                            locator << "cvbsin://localhost/deviceid/" << i;
+                            hash["connected"] = device::CompositeInput::getInstance().isPortConnected(i) ? "true" : "false";
+                        }
+                        hash["locator"] = locator.str();
+                        LOGWARN("AVInputService::getInputDevices id %d, locator=[%s], connected=[%s]", i, hash["locator"].String().c_str(), hash["connected"].String().c_str());
+                        list.Add(hash);
+                    }
+                }
+            }
+            catch (const std::exception e) {
+                LOGWARN("AVInputService::getInputDevices Failed");
+            }
+            return list;
+        }
+
+        void AVInput::writeEDID(int deviceId, std::string message)
+        {
+        }
+
+        std::string AVInput::readEDID(int iPort)
+        {
+            vector<uint8_t> edidVec({'u','n','k','n','o','w','n' });
+            string edidbase64 = "";
+            try {
+                vector<uint8_t> edidVec2;
+                device::HdmiInput::getInstance().getEDIDBytesInfo (iPort, edidVec2);
+                edidVec = edidVec2;//edidVec must be "unknown" unless we successfully get to this line
+
+                //convert to base64
+                uint16_t size = min(edidVec.size(), (size_t)numeric_limits<uint16_t>::max());
+
+                LOGWARN("AVInput::readEDID size:%d edidVec.size:%d", size, edidVec.size());
+                if(edidVec.size() > (size_t)numeric_limits<uint16_t>::max()) {
+                    LOGERR("Size too large to use ToString base64 wpe api");
+                    return edidbase64;
+                }
+                Core::ToString((uint8_t*)&edidVec[0], size, true, edidbase64);
+            }
+            catch (const device::Exception& err) {
+                LOG_DEVICE_EXCEPTION1(std::to_string(iPort));
+            }
+            return edidbase64;
+        }
+
+        /**
+         * @brief This function is used to translate HDMI/COMPOSITE input hotplug to 
+         * deviceChanged event.
+         *
+         * @param[in] input Number of input port integer.
+         * @param[in] connection status of input port integer.
+         */
+        void AVInput::AVInputHotplug( int input , int connect, int type)
+        {
+            LOGWARN("AVInputHotplug [%d, %d, %d]", input, connect, type);
+
+            JsonObject params;
+            params["devices"] = getInputDevices(type);
+            sendNotify(AVINPUT_EVENT_ON_DEVICES_CHANGED, params);
+        }
+
+        /**
+         * @brief This function is used to translate HDMI/COMPOSITE input signal change to
+         * signalChanged event.
+         *
+         * @param[in] port HDMI/COMPOSITE In port id.
+         * @param[in] signalStatus signal status of HDMI/COMPOSITE In port.
+         */
+        void AVInput::AVInputSignalChange( int port , int signalStatus, int type)
+        {
+            LOGWARN("AVInputSignalStatus [%d, %d, %d]", port, signalStatus, type);
+
+            JsonObject params;
+            params["id"] = port;
+            std::stringstream locator;
+            if (type == HDMI) {
+                locator << "hdmiin://localhost/deviceid/" << port;
+            }
+            else {
+                locator << "cvbsin://localhost/deviceid/" << port;
+            }
+            params["locator"] = locator.str();
+            /* values of dsHdmiInSignalStatus_t and dsCompInSignalStatus_t are same
+           Hence used only HDMI macro for case statement */
+            switch (signalStatus) {
+                case dsHDMI_IN_SIGNAL_STATUS_NOSIGNAL:
+                    params["signalStatus"] = "noSignal";
+                    break;
+
+                case dsHDMI_IN_SIGNAL_STATUS_UNSTABLE:
+                    params["signalStatus"] = "unstableSignal";
+                    break;
+
+                case dsHDMI_IN_SIGNAL_STATUS_NOTSUPPORTED:
+                    params["signalStatus"] = "notSupportedSignal";
+                    break;
+
+                case dsHDMI_IN_SIGNAL_STATUS_STABLE:
+                    params["signalStatus"] = "stableSignal";
+                    break;
+
+                default:
+                    params["signalStatus"] = "none";
+                    break;
+            }
+            sendNotify(AVINPUT_EVENT_ON_SIGNAL_CHANGED, params);
+        }
+
+        /**
+         * @brief This function is used to translate HDMI/COMPOSITE input status change to
+         * inputStatusChanged event.
+         *
+         * @param[in] port HDMI/COMPOSITE In port id.
+         * @param[bool] isPresented HDMI/COMPOSITE In presentation started/stopped.
+         */
+        void AVInput::AVInputStatusChange( int port , bool isPresented, int type)
+        {
+            LOGWARN("avInputStatus [%d, %d, %d]", port, isPresented, type);
+
+            JsonObject params;
+            params["id"] = port;
+            std::stringstream locator;
+            if (type == HDMI) {
+                locator << "hdmiin://localhost/deviceid/" << port;
+            }
+            else if (type == COMPOSITE) {
+                locator << "cvbsin://localhost/deviceid/" << port;
+            }
+            params["locator"] = locator.str();
+
+            if(isPresented) {
+                params["status"] = "started";
+            }
+            else {
+                params["status"] = "stopped";
+            }
+            sendNotify(AVINPUT_EVENT_ON_STATUS_CHANGED, params);
+        }
+
+        /**
+         * @brief This function is used to translate HDMI input video mode change to
+         * videoStreamInfoUpdate event.
+         *
+         * @param[in] port HDMI In port id.
+         * @param[dsVideoPortResolution_t] video resolution data
+         */
+        void AVInput::AVInputVideoModeUpdate( int port , dsVideoPortResolution_t resolution)
+        {
+            LOGWARN("AVInputVideoModeUpdate [%d]", port);
+
+            JsonObject params;
+            params["id"] = port;
+            std::stringstream locator;
+            locator << "hdmiin://localhost/deviceid/" << port;
+            params["locator"] = locator.str();
+
+            switch(resolution.pixelResolution) {
+                case dsVIDEO_PIXELRES_720x480:
+                    params["width"] = 720;
+                    params["height"] = 480;
+                    break;
+
+                case dsVIDEO_PIXELRES_720x576:
+                    params["width"] = 720;
+                    params["height"] = 576;
+                    break;
+
+                case dsVIDEO_PIXELRES_1280x720:
+                    params["width"] = 1280;
+                    params["height"] = 720;
+                    break;
+
+                case dsVIDEO_PIXELRES_1920x1080:
+                    params["width"] = 1920;
+                    params["height"] = 1080;
+                    break;
+
+                case dsVIDEO_PIXELRES_3840x2160:
+                    params["width"] = 3840;
+                    params["height"] = 2160;
+                    break;
+
+                case dsVIDEO_PIXELRES_4096x2160:
+                    params["width"] = 4096;
+                    params["height"] = 2160;
+                    break;
+
+                default:
+                    params["width"] = 1920;
+                    params["height"] = 1080;
+                    break;
+            }
+
+            params["progressive"] = (!resolution.interlaced);
+
+            switch(resolution.frameRate) {
+                case dsVIDEO_FRAMERATE_24:
+                    params["frameRateN"] = 24000;
+                    params["frameRateD"] = 1000;
+                    break;
+
+                case dsVIDEO_FRAMERATE_25:
+                    params["frameRateN"] = 25000;
+                    params["frameRateD"] = 1000;
+                    break;
+
+                case dsVIDEO_FRAMERATE_30:
+                    params["frameRateN"] = 30000;
+                    params["frameRateD"] = 1000;
+                    break;
+
+                case dsVIDEO_FRAMERATE_50:
+                    params["frameRateN"] = 50000;
+                    params["frameRateD"] = 1000;
+                    break;
+
+                case dsVIDEO_FRAMERATE_60:
+                    params["frameRateN"] = 60000;
+                    params["frameRateD"] = 1000;
+                    break;
+
+                case dsVIDEO_FRAMERATE_23dot98:
+                    params["frameRateN"] = 24000;
+                    params["frameRateD"] = 1001;
+                    break;
+
+                case dsVIDEO_FRAMERATE_29dot97:
+                    params["frameRateN"] = 30000;
+                    params["frameRateD"] = 1001;
+                    break;
+
+                case dsVIDEO_FRAMERATE_59dot94:
+                    params["frameRateN"] = 60000;
+                    params["frameRateD"] = 1001;
+                    break;
+
+                default:
+                    params["frameRateN"] = 60000;
+                    params["frameRateD"] = 1000;
+                    break;
+            }
+
+            sendNotify(AVINPUT_EVENT_ON_VIDEO_MODE_UPDATED, params);
+        }
+
+        void AVInput::dsAVEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
+        {
+            if(!AVInput::_instance)
+                return;
+
+            IARM_Bus_DSMgr_EventData_t *eventData = (IARM_Bus_DSMgr_EventData_t *)data;
+            if (IARM_BUS_DSMGR_EVENT_HDMI_IN_HOTPLUG == eventId) {
+                int hdmiin_hotplug_port = eventData->data.hdmi_in_connect.port;
+                int hdmiin_hotplug_conn = eventData->data.hdmi_in_connect.isPortConnected;
+                LOGWARN("Received IARM_BUS_DSMGR_EVENT_HDMI_IN_HOTPLUG  event data:%d", hdmiin_hotplug_port);
+                AVInput::_instance->AVInputHotplug(hdmiin_hotplug_port, hdmiin_hotplug_conn ? AV_HOT_PLUG_EVENT_CONNECTED : AV_HOT_PLUG_EVENT_DISCONNECTED, HDMI);
+            }
+            else if (IARM_BUS_DSMGR_EVENT_COMPOSITE_IN_HOTPLUG == eventId) {
+                int compositein_hotplug_port = eventData->data.composite_in_connect.port;
+                int compositein_hotplug_conn = eventData->data.composite_in_connect.isPortConnected;
+                LOGWARN("Received IARM_BUS_DSMGR_EVENT_COMPOSITE_IN_HOTPLUG  event data:%d", compositein_hotplug_port);
+                AVInput::_instance->AVInputHotplug(compositein_hotplug_port, compositein_hotplug_conn ? AV_HOT_PLUG_EVENT_CONNECTED : AV_HOT_PLUG_EVENT_DISCONNECTED, COMPOSITE);
+            }
+        }
+
+        void AVInput::dsAVSignalStatusEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
+        {
+            if(!AVInput::_instance)
+                return;
+            IARM_Bus_DSMgr_EventData_t *eventData = (IARM_Bus_DSMgr_EventData_t *)data;
+            if (IARM_BUS_DSMGR_EVENT_HDMI_IN_SIGNAL_STATUS == eventId) {
+                int hdmi_in_port = eventData->data.hdmi_in_sig_status.port;
+                int hdmi_in_signal_status = eventData->data.hdmi_in_sig_status.status;
+                LOGWARN("Received IARM_BUS_DSMGR_EVENT_HDMI_IN_SIGNAL_STATUS  event  port: %d, signal status: %d", hdmi_in_port,hdmi_in_signal_status);
+                AVInput::_instance->AVInputSignalChange(hdmi_in_port, hdmi_in_signal_status, HDMI);
+            }
+            else if (IARM_BUS_DSMGR_EVENT_COMPOSITE_IN_SIGNAL_STATUS == eventId) {
+                int composite_in_port = eventData->data.composite_in_sig_status.port;
+                int composite_in_signal_status = eventData->data.composite_in_sig_status.status;
+                LOGWARN("Received IARM_BUS_DSMGR_EVENT_COMPOSITE_IN_SIGNAL_STATUS  event  port: %d, signal status: %d", composite_in_port,composite_in_signal_status);
+                AVInput::_instance->AVInputSignalChange(composite_in_port, composite_in_signal_status, COMPOSITE);
+            }
+        }
+
+        void AVInput::dsAVStatusEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
+        {
+            if(!AVInput::_instance)
+                return;
+            IARM_Bus_DSMgr_EventData_t *eventData = (IARM_Bus_DSMgr_EventData_t *)data;
+            if (IARM_BUS_DSMGR_EVENT_HDMI_IN_STATUS == eventId) {
+                int hdmi_in_port = eventData->data.hdmi_in_status.port;
+                bool hdmi_in_status = eventData->data.hdmi_in_status.isPresented;
+                LOGWARN("Received IARM_BUS_DSMGR_EVENT_HDMI_IN_STATUS  event  port: %d, started: %d", hdmi_in_port,hdmi_in_status);
+                AVInput::_instance->AVInputStatusChange(hdmi_in_port, hdmi_in_status, HDMI);
+            }
+            else if (IARM_BUS_DSMGR_EVENT_COMPOSITE_IN_STATUS == eventId) {
+                int composite_in_port = eventData->data.composite_in_status.port;
+                bool composite_in_status = eventData->data.composite_in_status.isPresented;
+                LOGWARN("Received IARM_BUS_DSMGR_EVENT_COMPOSITE_IN_STATUS  event  port: %d, started: %d", composite_in_port,composite_in_status);
+                AVInput::_instance->AVInputStatusChange(composite_in_port, composite_in_status, COMPOSITE);
+            }
+        }
+
+        void AVInput::dsAVVideoModeEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
+        {
+            if(!AVInput::_instance)
+                return;
+
+            if (IARM_BUS_DSMGR_EVENT_HDMI_IN_VIDEO_MODE_UPDATE == eventId) {
+                IARM_Bus_DSMgr_EventData_t *eventData = (IARM_Bus_DSMgr_EventData_t *)data;
+                int hdmi_in_port = eventData->data.hdmi_in_video_mode.port;
+                dsVideoPortResolution_t resolution;
+                resolution.pixelResolution =  eventData->data.hdmi_in_video_mode.resolution.pixelResolution;
+                resolution.interlaced =  eventData->data.hdmi_in_video_mode.resolution.interlaced;
+                resolution.frameRate =  eventData->data.hdmi_in_video_mode.resolution.frameRate;
+                LOGWARN("Received IARM_BUS_DSMGR_EVENT_HDMI_IN_VIDEO_MODE_UPDATE  event  port: %d, pixelResolution: %d, interlaced : %d, frameRate: %d \n", hdmi_in_port,resolution.pixelResolution, resolution.interlaced, resolution.frameRate);
+                AVInput::_instance->AVInputVideoModeUpdate(hdmi_in_port, resolution);
+            }
+        }
+
+        void AVInput::dsAVGameFeatureStatusEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
+        {
+            if(!AVInput::_instance)
+                return;
+
+            if (IARM_BUS_DSMGR_EVENT_HDMI_IN_ALLM_STATUS == eventId)
+            {
+                IARM_Bus_DSMgr_EventData_t *eventData = (IARM_Bus_DSMgr_EventData_t *)data;
+                int hdmi_in_port = eventData->data.hdmi_in_allm_mode.port;
+                bool allm_mode = eventData->data.hdmi_in_allm_mode.allm_mode;
+                LOGWARN("Received IARM_BUS_DSMGR_EVENT_HDMI_IN_ALLM_STATUS  event  port: %d, ALLM Mode: %d", hdmi_in_port,allm_mode);
+
+                AVInput::_instance->AVInputALLMChange(hdmi_in_port, allm_mode);
+            }
+        }
+
+        void AVInput::AVInputALLMChange( int port , bool allm_mode)
+        {
+            JsonObject params;
+            params["id"] = port;
+            params["gameFeature"] = "ALLM";
+            params["mode"] = allm_mode;
+
+            sendNotify(AVINPUT_EVENT_ON_GAME_FEATURE_STATUS_CHANGED, params);
+            GetHandler(2)->Notify(AVINPUT_EVENT_ON_GAME_FEATURE_STATUS_CHANGED, params);
+        }
+
+        uint32_t AVInput::getSupportedGameFeatures(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            vector<string> supportedFeatures;
+            try
+            {
+                device::HdmiInput::getInstance().getSupportedGameFeatures (supportedFeatures);
+                for (size_t i = 0; i < supportedFeatures.size(); i++)
+                {
+                    LOGINFO("Supported Game Feature [%d]:  %s\n",i,supportedFeatures.at(i).c_str());
+                }
+            }
+            catch (const device::Exception& err)
+            {
+                LOG_DEVICE_EXCEPTION0();
+            }
+
+            if (supportedFeatures.empty()) {
+                returnResponse(false);
+            }
+            else {
+                setResponseArray(response, "suppoortedGameFeatures", supportedFeatures);
+                returnResponse(true);
+            }
+        }
+
+        uint32_t AVInput::getGameFeatureStatusWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            string sPortId = parameters["portId"].String();
+            string sGameFeature = parameters["gameFeature"].String();
+            int portId = 0;
+
+            LOGINFOMETHOD();
+            returnIfParamNotFound(parameters, "portId");
+            returnIfParamNotFound(parameters, "gameFeature");
+            try {
+                portId = stoi(sPortId);
+            }catch (const device::Exception& err) {
+                LOG_DEVICE_EXCEPTION1(sPortId);
+                returnResponse(false);
+            }
+
+	        if (strcmp (sGameFeature.c_str(), "ALLM") == 0)
+            {
+                bool allm = getALLMStatus(portId);
+                LOGWARN("AVInput::getGameFeatureStatusWrapper ALLM MODE:%d", allm);
+                response["mode"] = allm;
+            }
+	        else
+	        {
+		        LOGWARN("AVInput::getGameFeatureStatusWrapper Mode is not supported. Supported mode: ALLM");
+		        response["message"] = "Mode is not supported. Supported mode: ALLM";
+		        returnResponse(false);
+	        }
+            returnResponse(true);
+        }
+
+        bool AVInput::getALLMStatus(int iPort)
+        {
+            bool allm = false;
+
+            try
+            {
+                device::HdmiInput::getInstance().getHdmiALLMStatus (iPort, &allm);
+                LOGWARN("AVInput::getALLMStatus ALLM MODE: %d", allm);
+            }
+            catch (const device::Exception& err)
+            {
+                LOG_DEVICE_EXCEPTION1(std::to_string(iPort));
+            }
+            return allm;
+        }
+
+        uint32_t AVInput::getRawSPDWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            returnIfParamNotFound(parameters, "portId");
+
+            string sPortId = parameters["portId"].String();
+            int portId = 0;
+            try {
+                portId = stoi(sPortId);
+            }catch (const device::Exception& err) {
+                LOG_DEVICE_EXCEPTION1(sPortId);
+                returnResponse(false);
+            }
+
+            string spdInfo = getRawSPD (portId);
+            response["HDMISPD"] = spdInfo;
+            if (spdInfo.empty()) {
+                returnResponse(false);
+            }
+            else {
+                returnResponse(true);
+            }
+        }
+
+        uint32_t AVInput::getSPDWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            returnIfParamNotFound(parameters, "portId");
+
+            string sPortId = parameters["portId"].String();
+            int portId = 0;
+            try {
+                portId = stoi(sPortId);
+            }catch (const device::Exception& err) {
+                LOG_DEVICE_EXCEPTION1(sPortId);
+                returnResponse(false);
+            }
+
+            string spdInfo = getSPD (portId);
+            response["HDMISPD"] = spdInfo;
+            if (spdInfo.empty()) {
+                returnResponse(false);
+            }
+            else {
+                returnResponse(true);
+            }
+        }
+
+        std::string AVInput::getRawSPD(int iPort)
+        {
+            LOGINFO("AVInput::getSPDInfo");
+            vector<uint8_t> spdVect({'u','n','k','n','o','w','n' });
+            std::string spdbase64 = "";
+            try {
+                LOGWARN("AVInput::getSPDInfo");
+                vector<uint8_t> spdVect2;
+                device::HdmiInput::getInstance().getHDMISPDInfo(iPort, spdVect2);
+                spdVect = spdVect2;//edidVec must be "unknown" unless we successfully get to this line
+
+                //convert to base64
+                uint16_t size = min(spdVect.size(), (size_t)numeric_limits<uint16_t>::max());
+
+                LOGWARN("AVInput::getSPD size:%d spdVec.size:%d", size, spdVect.size());
+
+                if(spdVect.size() > (size_t)numeric_limits<uint16_t>::max()) {
+                    LOGERR("Size too large to use ToString base64 wpe api");
+                    return spdbase64;
+                }
+
+                LOGINFO("------------getSPD: ");
+                for (int itr =0; itr < spdVect.size(); itr++) {
+                    LOGINFO("%02X ", spdVect[itr]);
+                }
+                Core::ToString((uint8_t*)&spdVect[0], size, false, spdbase64);
+            }
+            catch (const device::Exception& err) {
+                LOG_DEVICE_EXCEPTION1(std::to_string(iPort));
+            }
+            return spdbase64;
+        }
+
+        std::string AVInput::getSPD(int iPort)
+        {
+            LOGINFO("AVInput::getSPDInfo");
+            vector<uint8_t> spdVect({'u','n','k','n','o','w','n' });
+            std::string spdbase64 = "";
+            try {
+                LOGWARN("AVInput::getSPDInfo");
+                vector<uint8_t> spdVect2;
+                device::HdmiInput::getInstance().getHDMISPDInfo(iPort, spdVect2);
+                spdVect = spdVect2;//edidVec must be "unknown" unless we successfully get to this line
+
+                //convert to base64
+                uint16_t size = min(spdVect.size(), (size_t)numeric_limits<uint16_t>::max());
+
+                LOGWARN("AVInput::getSPD size:%d spdVec.size:%d", size, spdVect.size());
+
+                if(spdVect.size() > (size_t)numeric_limits<uint16_t>::max()) {
+                    LOGERR("Size too large to use ToString base64 wpe api");
+                    return spdbase64;
+                }
+
+                LOGINFO("------------getSPD: ");
+                for (int itr =0; itr < spdVect.size(); itr++) {
+                  LOGINFO("%02X ", spdVect[itr]);
+                }
+                if (spdVect.size() > 0) {
+                    struct dsSpd_infoframe_st pre;
+                    memcpy(&pre,spdVect.data(),sizeof(struct dsSpd_infoframe_st));
+
+                    char str[200] = {0};
+                    sprintf(str, "Packet Type:%02X,Version:%u,Length:%u,vendor name:%s,product des:%s,source info:%02X"
+,pre.pkttype,pre    .version,pre.length,pre.vendor_name,pre.product_des,pre.source_info);
+                    spdbase64 = str;
+                }
+            }
+            catch (const device::Exception& err) {
+                LOG_DEVICE_EXCEPTION1(std::to_string(iPort));
+            }
+            return spdbase64;
+        }
+
+        uint32_t AVInput::setEdidVersionWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            int portId = 0;
+
+            LOGINFOMETHOD();
+            returnIfParamNotFound(parameters, "portId");
+            returnIfParamNotFound(parameters, "edidVersion");
+            string sPortId = parameters["portId"].String();
+            string sVersion = parameters["edidVersion"].String();
+            try {
+                portId = stoi(sPortId);
+            }catch (const device::Exception& err) {
+                LOG_DEVICE_EXCEPTION1(sPortId);
+                returnResponse(false);
+            }
+
+            int edidVer = -1;
+            if (strcmp (sVersion.c_str(), "HDMI1.4") == 0) {
+                edidVer = HDMI_EDID_VER_14;
+            }
+            else if (strcmp (sVersion.c_str(), "HDMI2.0") == 0) {
+                edidVer = HDMI_EDID_VER_20;
+            }
+
+            if (edidVer < 0) {
+                returnResponse(false);
+            }
+            bool result = setEdidVersion (portId, edidVer);
+            if (result == false) {
+                returnResponse(false);
+            }
+            else {
+                returnResponse(true);
+            }
+        }
+
+        int AVInput::setEdidVersion(int iPort, int iEdidVer)
+        {
+            bool ret = true;
+            try {
+                device::HdmiInput::getInstance().setEdidVersion (iPort, iEdidVer);
+                LOGWARN("AVInput::setEdidVersion EDID Version:%d", iEdidVer);
+            }
+            catch (const device::Exception& err) {
+                LOG_DEVICE_EXCEPTION1(std::to_string(iPort));
+                ret = false;
+            }
+            return ret;
+        }
+
+        uint32_t AVInput::getEdidVersionWrapper(const JsonObject& parameters, JsonObject& response)
+        {
+            string sPortId = parameters["portId"].String();
+            int portId = 0;
+
+            LOGINFOMETHOD();
+            returnIfParamNotFound(parameters, "portId");
+            try {
+                portId = stoi(sPortId);
+            }catch (const device::Exception& err) {
+                LOG_DEVICE_EXCEPTION1(sPortId);
+                returnResponse(false);
+            }
+
+            int edidVer = getEdidVersion (portId);
+            switch (edidVer) {
+                case HDMI_EDID_VER_14:
+                    response["edidVersion"] = "HDMI1.4";
+                    break;
+                case HDMI_EDID_VER_20:
+                    response["edidVersion"] = "HDMI2.0";
+                    break;
+            }
+
+            if (edidVer < 0) {
+                returnResponse(false);
+            }
+            else {
+                returnResponse(true);
+            }
+        }
+
+        int AVInput::getEdidVersion(int iPort)
+        {
+            int edidVersion = -1;
+
+            try {
+                device::HdmiInput::getInstance().getEdidVersion (iPort, &edidVersion);
+                LOGWARN("AVInput::getEdidVersion EDID Version:%d", &edidVersion);
+            }
+            catch (const device::Exception& err) {
+                LOG_DEVICE_EXCEPTION1(std::to_string(iPort));
+            }
+            return edidVersion;
+        }
+    } // namespace Plugin
 } // namespace WPEFramework

--- a/AVInput/AVInput.h
+++ b/AVInput/AVInput.h
@@ -20,6 +20,16 @@
 #pragma once
 
 #include "Module.h"
+#include "libIBus.h"
+#include "dsTypes.h"
+
+#define getNumberParameter(paramName, param) { \
+	    if (Core::JSON::Variant::type::NUMBER == parameters[paramName].Content()) \
+	        param = parameters[paramName].Number(); \
+	    else \
+	        try { param = std::stoi( parameters[paramName].String()); } \
+	        catch (...) { param = 0; } \
+}
 
 namespace WPEFramework {
 namespace Plugin {
@@ -64,6 +74,46 @@ protected:
 private:
     static int numberOfInputs(bool &success);
     static string currentVideoMode(bool &success);
+
+    //Begin methods
+    uint32_t getInputDevicesWrapper(const JsonObject& parameters, JsonObject& response);
+    uint32_t writeEDIDWrapper(const JsonObject& parameters, JsonObject& response);
+    uint32_t readEDIDWrapper(const JsonObject& parameters, JsonObject& response);
+    uint32_t getRawSPDWrapper(const JsonObject& parameters, JsonObject& response);
+    uint32_t getSPDWrapper(const JsonObject& parameters, JsonObject& response);
+    uint32_t setEdidVersionWrapper(const JsonObject& parameters, JsonObject& response);
+    uint32_t getEdidVersionWrapper(const JsonObject& parameters, JsonObject& response);
+    uint32_t startInput(const JsonObject& parameters, JsonObject& response);
+    uint32_t stopInput(const JsonObject& parameters, JsonObject& response);
+    uint32_t setVideoRectangleWrapper(const JsonObject& parameters, JsonObject& response);
+    uint32_t getSupportedGameFeatures(const JsonObject& parameters, JsonObject& response);
+    uint32_t getGameFeatureStatusWrapper(const JsonObject& parameters, JsonObject& response);
+    //End methods
+
+    JsonArray getInputDevices(int iType);
+    void writeEDID(int deviceId, std::string message);
+    std::string readEDID(int iPort);
+    std::string getRawSPD(int iPort);
+    std::string getSPD(int iPort);
+    int setEdidVersion(int iPort, int iEdidVer);
+    int getEdidVersion(int iPort);
+    bool setVideoRectangle(int x, int y, int width, int height, int type);
+    bool getALLMStatus(int iPort);
+	
+    void AVInputHotplug(int input , int connect, int type);
+    static void dsAVEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
+
+    void AVInputSignalChange( int port , int signalStatus, int type);
+    static void dsAVSignalStatusEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
+
+    void AVInputStatusChange( int port , bool isPresented, int type);
+    static void dsAVStatusEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
+
+    void AVInputVideoModeUpdate( int port , dsVideoPortResolution_t resolution);
+    static void dsAVVideoModeEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
+
+    void AVInputALLMChange( int port , bool allmMode);
+    static void dsAVGameFeatureStatusEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
 
 public:
     static AVInput* _instance;

--- a/AVInput/AVInput.json
+++ b/AVInput/AVInput.json
@@ -4,9 +4,57 @@
     "info": {
         "title": "AVInput API",
         "class": "AVInput", 
-        "description": "The `AVInput` API facilitates interactions with the Parker STB HDMI input. The HDMI input is presented by using a `VideoResource` whose url starts with `avin:`. For example: `avin://input1`."
+        "description": "The `AVInput` plugin allows you to control the HDMI and Composite Inputs on a TV box."
     },
     "definitions": {
+		"devices":{
+            "summary": "An object [] that describes each HDMI/Composite Input port",
+            "type":"array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "$ref": "#/definitions/id"
+                    },
+                    "locator": {
+                        "$ref": "#/definitions/locator"
+                    },
+                    "connected": {
+                        "$ref": "#/definitions/connected"
+                    }
+                },
+                "required": [
+                    "id",
+                    "locator",
+                    "connected"
+                ]
+            }
+        },
+        "id": {
+            "summary": "The port identifier for the HDMI/Composite Input",
+            "type": "number",
+            "example": 0
+        },
+        "locator": {
+            "summary": "A URL corresponding to the HDMI/Composite Input port",
+            "type": "string",
+            "example": "hdmiin://localhost/deviceid/0"
+        },
+        "connected": {
+            "summary": "Whether a device is currently connected to this HDMI/Composite Input port",
+            "type": "boolean",
+            "example": true
+        },
+        "portId":{
+            "summary": "An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method",
+            "type": "string",
+            "example": "0"
+        },
+		"typeOfInput":{
+            "summary": "The type of Input - HDMI/COMPOSITE",
+            "type": "string",
+            "example": "HDMI"
+        },
         "result": {
             "type":"object",
             "properties": {
@@ -25,6 +73,293 @@
         }
     },
     "methods": {
+        "getInputDevices": {
+            "summary": "Returns an array of available HDMI/Composite Input ports.\n \n### Events\n \nNo Events.",
+            "result": {
+                "type": "object",
+                "properties": {
+                    "devices": {
+                        "$ref": "#/definitions/devices"
+                    },
+                    "success": {
+                        "$ref": "#/definitions/success"
+                    },
+					"typeOfInput": {
+						"$ref": "#/definitions/typeOfInput"
+                    }
+                },
+                "required": [
+                    "devices",
+                    "success"
+                ]
+            }
+        },
+        "getEdidVersion":{
+            "summary": "(Version 2) Returns the EDID version.\n \n### Events\n \nNo Events.",
+            "params": {
+                "type":"object",
+                "properties": {
+                    "portId":{
+                        "$ref": "#/definitions/portId"
+                    }
+                },
+                "required": [
+                    "portid"
+                ]
+            },
+            "result": {
+                "type": "object",
+                "properties": {
+                    "edidVersion": {
+                        "summary": "The EDID version",
+                        "type": "string",
+                        "example": "HDMI2.0"
+                    },
+                    "success": {
+                        "$ref": "#/definitions/success"
+                    }
+                },
+                "required": [
+                    "edidVersion",
+                    "success"
+                ]
+            }
+        },
+        "getSPD": {
+            "summary": "(Version 2) Returns the Source Data Product Descriptor (SPD) infoFrame packet information for the specified HDMI Input device. The SPD infoFrame packet includes vendor name, product description, and source information.\n \n### Events\n \nNo Events.",
+            "params": {
+                "type":"object",
+                "properties": {
+                    "portId":{
+                        "$ref": "#/definitions/portId"
+                    }
+                },
+                "required": [
+                    "portid"
+                ]
+            },
+            "result": {
+                "type": "object",
+                "properties": {
+                    "HDMISPD": {
+                        "summary": "The SPD information",
+                        "type": "string",
+                        "example": ""
+                    },
+                    "success": {
+                        "$ref": "#/definitions/success"
+                    }
+                },
+                "required": [
+                    "HDMISPD",
+                    "success"
+                ]
+            }
+        },
+        "getRawSPD":{
+            "summary": "(Version 2) Returns the Source Data Product Descriptor (SPD) infoFrame packet information for the specified HDMI Input device as raw bits.\n \n### Events\n \nNo Events.",
+            "params": {
+                "type":"object",
+                "properties": {
+                    "portId":{
+                        "$ref": "#/definitions/portId"
+                    }
+                },
+                "required": [
+                    "portId"
+                ]
+            },
+            "result": {
+                "type": "object",
+                "properties": {
+                    "HDMISPD": {
+                        "summary": "The SPD information as raw bits",
+                        "type": "string",
+                        "example": ""
+                    },
+                    "success": {
+                        "$ref": "#/definitions/success"
+                    }
+                },
+                "required": [
+                    "HDMISPD",
+                    "success"
+                ]
+            }
+        },
+        "readEDID":{
+            "summary": "Returns the current EDID value.\n \n### Events\n \nNo Events.",
+            "params": {
+                "type":"object",
+                "properties": {
+                    "deviceId": {
+                        "$ref": "#/definitions/id"
+                    }
+                },
+                "required": [
+                    "deviceId"
+                ]
+            },
+            "result": {
+                "type": "object",
+                "properties": {
+                    "EDID": {
+                        "summary": "The EDID Value",
+                        "type": "string",
+                        "example": ""
+                    },
+                    "success": {
+                        "$ref": "#/definitions/success"
+                    }
+                },
+                "required": [
+                    "EDID",
+                    "success"
+                ]
+            }
+        },
+        "startInput": {
+            "summary": "Activates the specified HDMI/Composite Input port as the primary video source.\n \n### Events \n| Event | Description | \n| :----------- | :----------- | \n| `onInputStatusChanged` | Triggers the event when HDMI/Composite Input source is activated and Input status changes to `started` | \n| `onSignalChanged` | Triggers the event when HDMI/Composite Input signal changes (must be one of the following:noSignal, unstableSignal, notSupportedSignal, stableSignal)",
+            "events": [
+                "onInputStatusChanged",
+                "onSignalChanged"
+            ],
+            "params": {
+                "type":"object",
+                "properties": {
+                    "portId":{
+                        "$ref": "#/definitions/portId"
+                    },
+					"typeOfInput":{
+                        "$ref": "#/definitions/typeOfInput"
+                    }
+                },
+                "required": [
+                    "portid",
+					"typeOfInput"
+                ]
+            },
+            "result": {
+                "$ref": "#/definitions/result"
+            }
+        },
+        "stopInput": {
+            "summary": "Deactivates the HDMI/Composite Input port currently selected as the primary video source.\n \n### Events \n| Event | Description | \n| :----------- | :----------- | \n| `onInputStatusChanged` | Triggers the event when HDMI/Composite Input source is deactivated and Input status changes to `stopped`",
+            "events": [
+                "onInputStatusChanged"
+            ],
+            "params": {
+                "type":"object",
+                "properties": {
+					"typeOfInput":{
+                        "$ref": "#/definitions/typeOfInput"
+                    }
+                },
+                "required": [
+					"typeOfInput"
+                ]
+            },
+            "result": {
+                "type": "object",
+                "properties": {
+                    "success": {
+                        "$ref": "#/definitions/success"
+                    }
+                },
+                "required": [
+                    "success"
+                ]
+            }            
+        },
+        "setEdidVersion": {
+            "summary": "(Version 2) Sets an HDMI EDID version.\n \n### Events\n \nNo Events.",
+            "params": {
+                "type":"object",
+                "properties": {
+                    "portId":{
+                        "$ref": "#/definitions/portId"
+                    },
+                    "edidVersion":{
+                        "summary": "The EDID version",
+                        "type": "string",
+                        "example": "HDMI2.0"
+                    }
+                },
+                "required": [
+                    "portId",
+                    "edidVersion"
+                ]
+            },
+            "result": {
+                "$ref": "#/definitions/result"
+            }
+        },
+        "setVideoRectangle": {
+            "summary": "Sets an HDMI/Composite Input video window.\n \n### Events\n \nNo Events.",
+            "params": {
+                "type":"object",
+                "properties": {
+                    "x":{
+                        "summary": "The x-coordinate of the video rectangle",
+                        "type": "integer",
+                        "example": 0
+                    },
+                    "y":{
+                        "summary": "The y-coordinate of the video rectangle",
+                        "type": "integer",
+                        "example": 0
+                    },
+                    "w":{
+                        "summary": "The width of the video rectangle",
+                        "type": "integer",
+                        "example": 1920
+                    },
+                    "h":{
+                        "summary": "The height of the video rectangle",
+                        "type": "integer",
+                        "example": 1080
+                    },
+					"typeOfInput":{
+                        "$ref": "#/definitions/typeOfInput"
+                    }
+                },
+                "required": [
+                    "x",
+                    "y",
+                    "w",
+                    "h",
+                    "typeOfInput"
+				]
+            },
+            "result": {
+                "$ref": "#/definitions/result"
+            }
+        },
+        "writeEDID": {
+            "summary": "Changes a current EDID value.\n \n### Events\n \nNo Events.",
+            "params": {
+                "type":"object",
+                "properties": {
+                    "deviceId":{
+                        "summary": "The ID of an input device for which the EDID should be changed",
+                        "type": "number",
+                        "example": 0
+                    },
+                    "message":{
+                        "summary": "A new EDID value",
+                        "type": "string",
+                        "example": "EDID"
+                    }
+                },
+                "required": [
+                    "deviceId",
+                    "message"
+                ]
+            },
+            "result": {
+                "$ref": "#/definitions/result"
+            }
+        },
         "contentProtected": {
             "summary": "Returns `true` if the content coming in the HDMI input is protected; otherwise, it returns `false`. If the content is protected, then it is only presented if the component and composite outputs of the box are disabled.",
             "params": {
@@ -111,9 +446,176 @@
                     "success"
                 ]
             }
+        },
+       "getSupportedGameFeatures":{
+            "summary": "Returns the list of supported game features.\n \n### Events\n \nNo Events.",
+            "result": {
+                "type": "object",
+                "properties": {
+                    "supportedGameFeatures": {
+                        "summary": "The supported game Features",
+                        "type": "string",
+                        "example": "ALLM"
+                    },
+                    "success": {
+                        "$ref": "#/definitions/success"
+                    }
+                },
+                "required": [
+                    "supportedGameFeatures",
+                    "success"
+                ]
+            }
+        },
+       "getGameFeatureStatus":{
+            "summary": "Returns the Game Feature Status. For example: ALLM\n \n### Events\n \nNo Events.",
+            "params": {
+                "type":"object",
+                "properties": {
+                    "portId":{
+                        "$ref": "#/definitions/portId"
+                    },
+                     "gameFeature": {
+                        "summary": "Game Feature to which current status requested",
+                        "type": "string",
+                        "example": "ALLM"
+                    }
+               },
+                "required": [
+                    "portid",
+		    "gameFeature"
+                ]
+            },
+            "result": {
+                "type": "object",
+                "properties": {
+                    "mode": {
+                        "summary": "The current game feature status. Mode is required only for ALLM. Need to add support for future game features",
+                        "type": "boolean",
+                        "example": "true"
+                    },
+                    "success": {
+                        "$ref": "#/definitions/success"
+                    }
+                },
+                "required": [
+                    "mode",
+                    "success"
+                ]
+            }
         }
     },
     "events": {
+        "onDevicesChanged": {
+            "summary": "Triggered whenever a new HDMI/Composite device is connected to an HDMI/Composite Input",
+            "params": {
+                "type":"object",
+                "properties": {
+                    "devices":{
+                        "$ref": "#/definitions/devices"
+                    }
+                },
+                "required": [
+                    "devices"
+                ]
+            }
+        },
+        "onInputStatusChanged": {
+            "summary": "Triggered whenever the status changes for an HDMI/Composite Input",
+            "params": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "$ref": "#/definitions/id"
+                    },
+                    "locator": {
+                        "$ref": "#/definitions/locator"
+                    },
+                    "status": {
+                        "summary": "Status of the HDMI/Composite Input. Valid values are `started` or `stopped`.",
+                        "type": "string",
+                        "example": "started"
+                    }
+                },
+                "required": [
+                    "id",
+                    "locator",
+                    "status"
+                ]
+            }
+        },
+        "onSignalChanged": {
+            "summary": "Triggered whenever the signal status changes for an HDMI/Composite Input",
+            "params": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "$ref": "#/definitions/id"
+                    },
+                    "locator": {
+                        "$ref": "#/definitions/locator"
+                    },
+                    "signalStatus": {
+                        "summary": "Signal Status of the HDMI/Composite Input. Valid values are `noSignal`, `unstableSignal`, `notSupportedSignal`, `stableSignal`.",
+                        "type": "string",
+                        "example": "stableSignal"
+                    }
+                },
+                "required": [
+                    "id",
+                    "locator",
+                    "signalStatus"
+                ]                
+            }
+        },
+        "videoStreamInfoUpdate": {
+            "summary": "Triggered whenever there is an update in HDMI Input video stream info",
+            "params": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "$ref": "#/definitions/id"
+                    },
+                    "locator": {
+                        "$ref": "#/definitions/locator"
+                    },
+                    "width": {
+                        "summary": "Width of the Video Stream",
+                        "type": "integer",
+                        "example": 3840
+                    },
+                    "height": {
+                        "summary": "Height of the Video Stream",
+                        "type": "integer",
+                        "example": 2160
+                    },
+                    "progressive": {
+                        "summary": "Whether the streaming video is progressive or not?",
+                        "type": "boolean",
+                        "example": "true"
+                    },
+                    "frameRateN": {
+                        "summary": "FrameRate Numerator",
+                        "type": "integer",
+                        "example": 60000
+                    },
+                    "frameRateD": {
+                        "summary": "FrameRate Denomirator",
+                        "type": "integer",
+                        "example": 1001
+                    }
+                },
+                "required": [
+                    "id",
+                    "locator",
+                    "width",
+                    "height",
+                    "progressive",
+                    "frameRateN",
+                    "frameRateD"
+                ]
+            }
+        },
         "onAVInputActive":{
             "summary": "Triggered when an active device is connected to an AVInput port",
             "params": {
@@ -145,6 +647,32 @@
                     "url"
                 ]
                 
+            }
+        },
+        "AVGameFeatureStatusUpdate": {
+            "summary": "Triggered whenever game feature(ALLM) status changes for an HDMI Input",
+            "params": {
+                "type": "object",
+                "properties": {
+                   "portId": {
+                        "$ref": "#/definitions/portId"
+                    },
+                     "gameFeature": {
+                        "summary": "Game Feature to which current status requested",
+                        "type": "string",
+                        "example": "ALLM"
+                    },
+                    "mode": {
+                        "summary": "The current game feature status. Mode is required only for ALLM. Need to add support for future game features",
+                        "type": "boolean",
+                        "example": "true"
+                    }
+                },
+                "required": [
+                    "portId",
+                    "gameFeature",
+                    "mode"
+                ]
             }
         }
     }

--- a/AVInput/AVInputPlugin.json
+++ b/AVInput/AVInputPlugin.json
@@ -5,7 +5,7 @@
       "callsign": "org.rdk.AVInput",
       "locator": "libWPEFrameworkAVInput.so",
       "status": "production",
-      "description": "The `AVInput` plugin facilitates interactions with the Parker STB HDMI input. The HDMI input is presented by using a `VideoResource` whose URL starts with `avin:`. For example: `avin://input1`.",
+      "description": "The `AVInput` plugin allows you to control the Hdmi and Composite input source on a device",
       "version": "1.0"
     },
     "interface": {

--- a/docs/api/AVInputPlugin.md
+++ b/docs/api/AVInputPlugin.md
@@ -1,70 +1,70 @@
 <!-- Generated automatically, DO NOT EDIT! -->
-<a name="AVInput_Plugin"></a>
+<a name="head.AVInput_Plugin"></a>
 # AVInput Plugin
 
 **Version: 1.0**
 
 **Status: :black_circle::black_circle::black_circle:**
 
-A org.rdk.AVInput plugin for Thunder framework.
+org.rdk.AVInput plugin for Thunder framework.
 
 ### Table of Contents
 
-- [Introduction](#Introduction)
-- [Description](#Description)
-- [Configuration](#Configuration)
-- [Methods](#Methods)
-- [Notifications](#Notifications)
+- [Introduction](#head.Introduction)
+- [Description](#head.Description)
+- [Configuration](#head.Configuration)
+- [Methods](#head.Methods)
+- [Notifications](#head.Notifications)
 
-<a name="Introduction"></a>
+<a name="head.Introduction"></a>
 # Introduction
 
-<a name="Scope"></a>
+<a name="head.Scope"></a>
 ## Scope
 
 This document describes purpose and functionality of the org.rdk.AVInput plugin. It includes detailed specification about its configuration, methods provided and notifications sent.
 
-<a name="Case_Sensitivity"></a>
+<a name="head.Case_Sensitivity"></a>
 ## Case Sensitivity
 
 All identifiers of the interfaces described in this document are case-sensitive. Thus, unless stated otherwise, all keywords, entities, properties, relations and actions should be treated as such.
 
-<a name="Acronyms,_Abbreviations_and_Terms"></a>
+<a name="head.Acronyms,_Abbreviations_and_Terms"></a>
 ## Acronyms, Abbreviations and Terms
 
 The table below provides and overview of acronyms used in this document and their definitions.
 
 | Acronym | Description |
 | :-------- | :-------- |
-| <a name="API">API</a> | Application Programming Interface |
-| <a name="HTTP">HTTP</a> | Hypertext Transfer Protocol |
-| <a name="JSON">JSON</a> | JavaScript Object Notation; a data interchange format |
-| <a name="JSON-RPC">JSON-RPC</a> | A remote procedure call protocol encoded in JSON |
+| <a name="acronym.API">API</a> | Application Programming Interface |
+| <a name="acronym.HTTP">HTTP</a> | Hypertext Transfer Protocol |
+| <a name="acronym.JSON">JSON</a> | JavaScript Object Notation; a data interchange format |
+| <a name="acronym.JSON-RPC">JSON-RPC</a> | A remote procedure call protocol encoded in JSON |
 
 The table below provides and overview of terms and abbreviations used in this document and their definitions.
 
 | Term | Description |
 | :-------- | :-------- |
-| <a name="callsign">callsign</a> | The name given to an instance of a plugin. One plugin can be instantiated multiple times, but each instance the instance name, callsign, must be unique. |
+| <a name="term.callsign">callsign</a> | The name given to an instance of a plugin. One plugin can be instantiated multiple times, but each instance the instance name, callsign, must be unique. |
 
-<a name="References"></a>
+<a name="head.References"></a>
 ## References
 
 | Ref ID | Description |
 | :-------- | :-------- |
-| <a name="HTTP">[HTTP](http://www.w3.org/Protocols)</a> | HTTP specification |
-| <a name="JSON-RPC">[JSON-RPC](https://www.jsonrpc.org/specification)</a> | JSON-RPC 2.0 specification |
-| <a name="JSON">[JSON](http://www.json.org/)</a> | JSON specification |
-| <a name="Thunder">[Thunder](https://github.com/WebPlatformForEmbedded/Thunder/blob/master/doc/WPE%20-%20API%20-%20WPEFramework.docx)</a> | Thunder API Reference |
+| <a name="ref.HTTP">[HTTP](http://www.w3.org/Protocols)</a> | HTTP specification |
+| <a name="ref.JSON-RPC">[JSON-RPC](https://www.jsonrpc.org/specification)</a> | JSON-RPC 2.0 specification |
+| <a name="ref.JSON">[JSON](http://www.json.org/)</a> | JSON specification |
+| <a name="ref.Thunder">[Thunder](https://github.com/WebPlatformForEmbedded/Thunder/blob/master/doc/WPE%20-%20API%20-%20WPEFramework.docx)</a> | Thunder API Reference |
 
-<a name="Description"></a>
+<a name="head.Description"></a>
 # Description
 
-The `AVInput` plugin facilitates interactions with the Parker STB HDMI input. The HDMI input is presented by using a `VideoResource` whose URL starts with `avin:`. For example: `avin://input1`.
+The `AVInput` plugin allows you to control the Hdmi and Composite input source on a device.
 
-The plugin is designed to be loaded and executed within the Thunder framework. For more information about the framework refer to [[Thunder](#Thunder)].
+The plugin is designed to be loaded and executed within the Thunder framework. For more information about the framework refer to [[Thunder](#ref.Thunder)].
 
-<a name="Configuration"></a>
+<a name="head.Configuration"></a>
 # Configuration
 
 The table below lists configuration options of the plugin.
@@ -76,7 +76,7 @@ The table below lists configuration options of the plugin.
 | locator | string | Library name: *libWPEFrameworkAVInput.so* |
 | autostart | boolean | Determines if the plugin shall be started automatically along with the framework |
 
-<a name="Methods"></a>
+<a name="head.Methods"></a>
 # Methods
 
 The following methods are provided by the org.rdk.AVInput plugin:
@@ -85,13 +85,562 @@ AVInput interface methods:
 
 | Method | Description |
 | :-------- | :-------- |
-| [contentProtected](#contentProtected) | Returns `true` if the content coming in the HDMI input is protected; otherwise, it returns `false` |
-| [currentVideoMode](#currentVideoMode) | Returns a string encoding the video mode being supplied by the device currently attached to the HDMI input |
-| [numberOfInputs](#numberOfInputs) | Returns an integer that specifies the number of available inputs |
+| [getInputDevices](#method.getInputDevices) | Returns an array of available HDMI/Composite Input ports |
+| [getEdidVersion](#method.getEdidVersion) | (Version 2) Returns the EDID version |
+| [getSPD](#method.getSPD) | (Version 2) Returns the Source Data Product Descriptor (SPD) infoFrame packet information for the specified HDMI Input device |
+| [getRawSPD](#method.getRawSPD) | (Version 2) Returns the Source Data Product Descriptor (SPD) infoFrame packet information for the specified HDMI Input device as raw bits |
+| [readEDID](#method.readEDID) | Returns the current EDID value |
+| [startInput](#method.startInput) | Activates the specified HDMI/Composite Input port as the primary video source |
+| [stopInput](#method.stopInput) | Deactivates the HDMI/Composite Input port currently selected as the primary video source |
+| [setEdidVersion](#method.setEdidVersion) | (Version 2) Sets an HDMI EDID version |
+| [setVideoRectangle](#method.setVideoRectangle) | Sets an HDMI/Composite Input video window |
+| [writeEDID](#method.writeEDID) | Changes a current EDID value |
+| [contentProtected](#method.contentProtected) | Returns `true` if the content coming in the HDMI input is protected; otherwise, it returns `false` |
+| [currentVideoMode](#method.currentVideoMode) | Returns a string encoding the video mode being supplied by the device currently attached to the HDMI input |
+| [numberOfInputs](#method.numberOfInputs) | Returns an integer that specifies the number of available inputs |
+| [getSupportedGameFeatures](#method.getSupportedGameFeatures) | Returns the list of supported game features |
+| [getGameFeatureStatus](#method.getGameFeatureStatus) | Returns the Game Feature Status |
 
 
-<a name="contentProtected"></a>
-## *contentProtected*
+<a name="method.getInputDevices"></a>
+## *getInputDevices [<sup>method</sup>](#head.Methods)*
+
+Returns an array of available HDMI/Composite Input ports.
+ 
+### Events
+ 
+No Events.
+
+### Parameters
+
+This method takes no parameters.
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.devices | array | An object [] that describes each HDMI/Composite Input port |
+| result.devices[#] | object |  |
+| result.devices[#].id | number | The port identifier for the HDMI/Composite Input |
+| result.devices[#].locator | string | A URL corresponding to the HDMI/Composite Input port |
+| result.devices[#].connected | boolean | Whether a device is currently connected to this HDMI/Composite Input port |
+| result.success | boolean | Whether the request succeeded |
+| result?.typeOfInput | string | <sup>*(optional)*</sup> The type of Input - HDMI/COMPOSITE |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.AVInput.1.getInputDevices"
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "devices": [
+            {
+                "id": 0,
+                "locator": "hdmiin://localhost/deviceid/0",
+                "connected": true
+            }
+        ],
+        "success": true,
+        "typeOfInput": "HDMI"
+    }
+}
+```
+
+<a name="method.getEdidVersion"></a>
+## *getEdidVersion [<sup>method</sup>](#head.Methods)*
+
+(Version 2) Returns the EDID version.
+ 
+### Events
+ 
+No Events.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params?.portId | string | <sup>*(optional)*</sup> An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.edidVersion | string | The EDID version |
+| result.success | boolean | Whether the request succeeded |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.AVInput.1.getEdidVersion",
+    "params": {
+        "portId": "0"
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "edidVersion": "HDMI2.0",
+        "success": true
+    }
+}
+```
+
+<a name="method.getSPD"></a>
+## *getSPD [<sup>method</sup>](#head.Methods)*
+
+(Version 2) Returns the Source Data Product Descriptor (SPD) infoFrame packet information for the specified HDMI Input device. The SPD infoFrame packet includes vendor name, product description, and source information.
+ 
+### Events
+ 
+No Events.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params?.portId | string | <sup>*(optional)*</sup> An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.HDMISPD | string | The SPD information |
+| result.success | boolean | Whether the request succeeded |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.AVInput.1.getSPD",
+    "params": {
+        "portId": "0"
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "HDMISPD": "...",
+        "success": true
+    }
+}
+```
+
+<a name="method.getRawSPD"></a>
+## *getRawSPD [<sup>method</sup>](#head.Methods)*
+
+(Version 2) Returns the Source Data Product Descriptor (SPD) infoFrame packet information for the specified HDMI Input device as raw bits.
+ 
+### Events
+ 
+No Events.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.portId | string | An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.HDMISPD | string | The SPD information as raw bits |
+| result.success | boolean | Whether the request succeeded |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.AVInput.1.getRawSPD",
+    "params": {
+        "portId": "0"
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "HDMISPD": "...",
+        "success": true
+    }
+}
+```
+
+<a name="method.readEDID"></a>
+## *readEDID [<sup>method</sup>](#head.Methods)*
+
+Returns the current EDID value.
+ 
+### Events
+ 
+No Events.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.deviceId | number | The port identifier for the HDMI/Composite Input |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.EDID | string | The EDID Value |
+| result.success | boolean | Whether the request succeeded |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.AVInput.1.readEDID",
+    "params": {
+        "deviceId": 0
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "EDID": "...",
+        "success": true
+    }
+}
+```
+
+<a name="method.startInput"></a>
+## *startInput [<sup>method</sup>](#head.Methods)*
+
+Activates the specified HDMI/Composite Input port as the primary video source.
+ 
+### Events 
+| Event | Description | 
+| :----------- | :----------- | 
+| `onInputStatusChanged` | Triggers the event when HDMI/Composite Input source is activated and Input status changes to `started` | 
+| `onSignalChanged` | Triggers the event when HDMI/Composite Input signal changes (must be one of the following:noSignal, unstableSignal, notSupportedSignal, stableSignal).
+
+Also see: [onInputStatusChanged](#event.onInputStatusChanged), [onSignalChanged](#event.onSignalChanged)
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params?.portId | string | <sup>*(optional)*</sup> An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method |
+| params.typeOfInput | string | The type of Input - HDMI/COMPOSITE |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.success | boolean | Whether the request succeeded |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.AVInput.1.startInput",
+    "params": {
+        "portId": "0",
+        "typeOfInput": "HDMI"
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "success": true
+    }
+}
+```
+
+<a name="method.stopInput"></a>
+## *stopInput [<sup>method</sup>](#head.Methods)*
+
+Deactivates the HDMI/Composite Input port currently selected as the primary video source.
+ 
+### Events 
+| Event | Description | 
+| :----------- | :----------- | 
+| `onInputStatusChanged` | Triggers the event when HDMI/Composite Input source is deactivated and Input status changes to `stopped`.
+
+Also see: [onInputStatusChanged](#event.onInputStatusChanged)
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.typeOfInput | string | The type of Input - HDMI/COMPOSITE |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.success | boolean | Whether the request succeeded |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.AVInput.1.stopInput",
+    "params": {
+        "typeOfInput": "HDMI"
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "success": true
+    }
+}
+```
+
+<a name="method.setEdidVersion"></a>
+## *setEdidVersion [<sup>method</sup>](#head.Methods)*
+
+(Version 2) Sets an HDMI EDID version.
+ 
+### Events
+ 
+No Events.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.portId | string | An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method |
+| params.edidVersion | string | The EDID version |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.success | boolean | Whether the request succeeded |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.AVInput.1.setEdidVersion",
+    "params": {
+        "portId": "0",
+        "edidVersion": "HDMI2.0"
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "success": true
+    }
+}
+```
+
+<a name="method.setVideoRectangle"></a>
+## *setVideoRectangle [<sup>method</sup>](#head.Methods)*
+
+Sets an HDMI/Composite Input video window.
+ 
+### Events
+ 
+No Events.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.x | integer | The x-coordinate of the video rectangle |
+| params.y | integer | The y-coordinate of the video rectangle |
+| params.w | integer | The width of the video rectangle |
+| params.h | integer | The height of the video rectangle |
+| params.typeOfInput | string | The type of Input - HDMI/COMPOSITE |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.success | boolean | Whether the request succeeded |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.AVInput.1.setVideoRectangle",
+    "params": {
+        "x": 0,
+        "y": 0,
+        "w": 1920,
+        "h": 1080,
+        "typeOfInput": "HDMI"
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "success": true
+    }
+}
+```
+
+<a name="method.writeEDID"></a>
+## *writeEDID [<sup>method</sup>](#head.Methods)*
+
+Changes a current EDID value.
+ 
+### Events
+ 
+No Events.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.deviceId | number | The ID of an input device for which the EDID should be changed |
+| params.message | string | A new EDID value |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.success | boolean | Whether the request succeeded |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.AVInput.1.writeEDID",
+    "params": {
+        "deviceId": 0,
+        "message": "EDID"
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "success": true
+    }
+}
+```
+
+<a name="method.contentProtected"></a>
+## *contentProtected [<sup>method</sup>](#head.Methods)*
 
 Returns `true` if the content coming in the HDMI input is protected; otherwise, it returns `false`. If the content is protected, then it is only presented if the component and composite outputs of the box are disabled.
 
@@ -135,8 +684,8 @@ Returns `true` if the content coming in the HDMI input is protected; otherwise, 
 }
 ```
 
-<a name="currentVideoMode"></a>
-## *currentVideoMode*
+<a name="method.currentVideoMode"></a>
+## *currentVideoMode [<sup>method</sup>](#head.Methods)*
 
 Returns a string encoding the video mode being supplied by the device currently attached to the HDMI input. The format of the string is the same format used for the `resolutionName` parameter of the XRE `setResolution` messages. HDMI input is presentable if its resolution is less than or equal to the current Parker display resolution. 
  
@@ -186,8 +735,8 @@ Returns a string encoding the video mode being supplied by the device currently 
 }
 ```
 
-<a name="numberOfInputs"></a>
-## *numberOfInputs*
+<a name="method.numberOfInputs"></a>
+## *numberOfInputs [<sup>method</sup>](#head.Methods)*
 
 Returns an integer that specifies the number of available inputs. For example, a value of `2` indicates that there are two available inputs that can be selected using `avin://input0` and `avin://input1`. 
  
@@ -237,10 +786,110 @@ Returns an integer that specifies the number of available inputs. For example, a
 }
 ```
 
-<a name="Notifications"></a>
+<a name="method.getSupportedGameFeatures"></a>
+## *getSupportedGameFeatures [<sup>method</sup>](#head.Methods)*
+
+Returns the list of supported game features.
+ 
+### Events
+ 
+No Events.
+
+### Parameters
+
+This method takes no parameters.
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.supportedGameFeatures | string | The supported game Features |
+| result.success | boolean | Whether the request succeeded |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.AVInput.1.getSupportedGameFeatures"
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "supportedGameFeatures": "ALLM",
+        "success": true
+    }
+}
+```
+
+<a name="method.getGameFeatureStatus"></a>
+## *getGameFeatureStatus [<sup>method</sup>](#head.Methods)*
+
+Returns the Game Feature Status. For example: ALLM
+ 
+### Events
+ 
+No Events.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params?.portId | string | <sup>*(optional)*</sup> An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method |
+| params.gameFeature | string | Game Feature to which current status requested |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.mode | boolean | The current game feature status. Mode is required only for ALLM. Need to add support for future game features |
+| result.success | boolean | Whether the request succeeded |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.AVInput.1.getGameFeatureStatus",
+    "params": {
+        "portId": "0",
+        "gameFeature": "ALLM"
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "mode": true,
+        "success": true
+    }
+}
+```
+
+<a name="head.Notifications"></a>
 # Notifications
 
-Notifications are autonomous events, triggered by the internals of the implementation, and broadcasted via JSON-RPC to all registered observers. Refer to [[Thunder](#Thunder)] for information on how to register for a notification.
+Notifications are autonomous events, triggered by the internals of the implementation, and broadcasted via JSON-RPC to all registered observers. Refer to [[Thunder](#ref.Thunder)] for information on how to register for a notification.
 
 The following events are provided by the org.rdk.AVInput plugin:
 
@@ -248,12 +897,143 @@ AVInput interface events:
 
 | Event | Description |
 | :-------- | :-------- |
-| [onAVInputActive](#onAVInputActive) | Triggered when an active device is connected to an AVInput port |
-| [onAVInputInActive](#onAVInputInActive) | Triggered when an active device is disconnected from an AVInput port or when the device becomes inactive |
+| [onDevicesChanged](#event.onDevicesChanged) | Triggered whenever a new HDMI/Composite device is connected to an HDMI/Composite Input |
+| [onInputStatusChanged](#event.onInputStatusChanged) | Triggered whenever the status changes for an HDMI/Composite Input |
+| [onSignalChanged](#event.onSignalChanged) | Triggered whenever the signal status changes for an HDMI/Composite Input |
+| [videoStreamInfoUpdate](#event.videoStreamInfoUpdate) | Triggered whenever there is an update in HDMI Input video stream info |
+| [onAVInputActive](#event.onAVInputActive) | Triggered when an active device is connected to an AVInput port |
+| [onAVInputInActive](#event.onAVInputInActive) | Triggered when an active device is disconnected from an AVInput port or when the device becomes inactive |
+| [AVGameFeatureStatusUpdate](#event.AVGameFeatureStatusUpdate) | Triggered whenever game feature(ALLM) status changes for an HDMI Input |
 
 
-<a name="onAVInputActive"></a>
-## *onAVInputActive*
+<a name="event.onDevicesChanged"></a>
+## *onDevicesChanged [<sup>event</sup>](#head.Notifications)*
+
+Triggered whenever a new HDMI/Composite device is connected to an HDMI/Composite Input.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.devices | array | An object [] that describes each HDMI/Composite Input port |
+| params.devices[#] | object |  |
+| params.devices[#].id | number | The port identifier for the HDMI/Composite Input |
+| params.devices[#].locator | string | A URL corresponding to the HDMI/Composite Input port |
+| params.devices[#].connected | boolean | Whether a device is currently connected to this HDMI/Composite Input port |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.1.onDevicesChanged",
+    "params": {
+        "devices": [
+            {
+                "id": 0,
+                "locator": "hdmiin://localhost/deviceid/0",
+                "connected": true
+            }
+        ]
+    }
+}
+```
+
+<a name="event.onInputStatusChanged"></a>
+## *onInputStatusChanged [<sup>event</sup>](#head.Notifications)*
+
+Triggered whenever the status changes for an HDMI/Composite Input.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.id | number | The port identifier for the HDMI/Composite Input |
+| params.locator | string | A URL corresponding to the HDMI/Composite Input port |
+| params.status | string | Status of the HDMI/Composite Input. Valid values are `started` or `stopped` |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.1.onInputStatusChanged",
+    "params": {
+        "id": 0,
+        "locator": "hdmiin://localhost/deviceid/0",
+        "status": "started"
+    }
+}
+```
+
+<a name="event.onSignalChanged"></a>
+## *onSignalChanged [<sup>event</sup>](#head.Notifications)*
+
+Triggered whenever the signal status changes for an HDMI/Composite Input.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.id | number | The port identifier for the HDMI/Composite Input |
+| params.locator | string | A URL corresponding to the HDMI/Composite Input port |
+| params.signalStatus | string | Signal Status of the HDMI/Composite Input. Valid values are `noSignal`, `unstableSignal`, `notSupportedSignal`, `stableSignal` |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.1.onSignalChanged",
+    "params": {
+        "id": 0,
+        "locator": "hdmiin://localhost/deviceid/0",
+        "signalStatus": "stableSignal"
+    }
+}
+```
+
+<a name="event.videoStreamInfoUpdate"></a>
+## *videoStreamInfoUpdate [<sup>event</sup>](#head.Notifications)*
+
+Triggered whenever there is an update in HDMI Input video stream info.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.id | number | The port identifier for the HDMI/Composite Input |
+| params.locator | string | A URL corresponding to the HDMI/Composite Input port |
+| params.width | integer | Width of the Video Stream |
+| params.height | integer | Height of the Video Stream |
+| params.progressive | boolean | Whether the streaming video is progressive or not? |
+| params.frameRateN | integer | FrameRate Numerator |
+| params.frameRateD | integer | FrameRate Denomirator |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.1.videoStreamInfoUpdate",
+    "params": {
+        "id": 0,
+        "locator": "hdmiin://localhost/deviceid/0",
+        "width": 3840,
+        "height": 2160,
+        "progressive": true,
+        "frameRateN": 60000,
+        "frameRateD": 1001
+    }
+}
+```
+
+<a name="event.onAVInputActive"></a>
+## *onAVInputActive [<sup>event</sup>](#head.Notifications)*
 
 Triggered when an active device is connected to an AVInput port.
 
@@ -276,8 +1056,8 @@ Triggered when an active device is connected to an AVInput port.
 }
 ```
 
-<a name="onAVInputInActive"></a>
-## *onAVInputInActive*
+<a name="event.onAVInputInActive"></a>
+## *onAVInputInActive [<sup>event</sup>](#head.Notifications)*
 
 Triggered when an active device is disconnected from an AVInput port or when the device becomes inactive.
 
@@ -296,6 +1076,34 @@ Triggered when an active device is disconnected from an AVInput port or when the
     "method": "client.events.1.onAVInputInActive",
     "params": {
         "url": "avin://input0"
+    }
+}
+```
+
+<a name="event.AVGameFeatureStatusUpdate"></a>
+## *AVGameFeatureStatusUpdate [<sup>event</sup>](#head.Notifications)*
+
+Triggered whenever game feature(ALLM) status changes for an HDMI Input.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.portId | string | An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method |
+| params.gameFeature | string | Game Feature to which current status requested |
+| params.mode | boolean | The current game feature status. Mode is required only for ALLM. Need to add support for future game features |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.1.AVGameFeatureStatusUpdate",
+    "params": {
+        "portId": "0",
+        "gameFeature": "ALLM",
+        "mode": true
     }
 }
 ```


### PR DESCRIPTION
…iteInput APIs

Reason for change: Combine HdmiInput and CompositeInput Plugins into AVInput
Test Procedure: sanity testases on HDMI and COMPOSITE inputs
Risks: Low
Signed-off-by: Dhivya Ilangovan <dhivya.dilangovan@sky.uk>