### PR TITLE
RDKTV-17105: WPEFramework Crash in std::terminate

### DIFF
--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -494,6 +494,9 @@ namespace WPEFramework {
 
         MaintenanceManager::~MaintenanceManager()
         {
+            if(m_thread.joinable()){
+                m_thread.join();
+            }
             MaintenanceManager::_instance = nullptr;
         }
 


### PR DESCRIPTION
Within Maintenance Manager some thread is joinable and it hasn't been joined
properly which leads to crash in wpeframework with std::terminate. Hence
joining the thread inside the destructor

There should not be any crash with Maintenance Manager