### PR TITLE
REFPLTV-1319: RDK Services Ethernet connection.

### DIFF
--- a/Network/Network.cpp
+++ b/Network/Network.cpp
@@ -1404,6 +1404,8 @@ namespace WPEFramework
             m_useIpv6EthCache = false;
             m_defIpversionCache = "";
             m_defInterfaceCache = m_netUtils.getInterfaceDescription(newInterface);
+            m_defaultInterface = ""; /* REFPLTV-1319 : Resetting when there is switch in interface, to get new value in getDefaultInterface() */
+            m_gatewayInterface = "";
             sendNotify("onDefaultInterfaceChanged", params);
             GetHandler(2)->Notify("onDefaultInterfaceChanged", params);
         }


### PR DESCRIPTION
Reason for change: Resetting defaultInterface value at change in Interface event.

Test Procedure: Set the default interface to ETHERNET and check if getDefaultInterface gets correct value.

Risks: Low

Signed-off-by: avadla226 <Anil_Vadla@comcast.com>