### PR TITLE
RDK-36464 : Improve Efficiency of WiFiManager RDKServices APIs phase-3

### DIFF
--- a/WifiManager/impl/WifiManagerState.h
+++ b/WifiManager/impl/WifiManagerState.h
@@ -41,9 +41,9 @@ namespace WPEFramework {
             std::atomic<bool> m_useWifiStateCache;
             WifiState m_wifiStateCache;
             std::atomic<bool> m_useWifiConnectedCache;
-            std::string m_ConnectedSSIDCache = "";
-            std::string m_ConnectedBSSIDCache = "";
-            int m_ConnectedSecurityModeCache = 0;
+            std::string m_ConnectedSSIDCache;
+            std::string m_ConnectedBSSIDCache;
+            int m_ConnectedSecurityModeCache;
 
 	private:
 	    std::map<std::string, std::string> retrieveValues(const char *, char *, size_t );


### PR DESCRIPTION
Reason for change: Based on wpa_state update the getConnected api response
Test Procedure:please referred ticket
Risks: Medium
Signed-off-by: Thamim Razith tabbas651@cable.comcast.com