### PR TITLE
LLAMA-7026: [SAP] Avoid crash when secure connection is trying to be …

### DIFF
--- a/SystemAudioPlayer/impl/AudioPlayer.cpp
+++ b/SystemAudioPlayer/impl/AudioPlayer.cpp
@@ -502,6 +502,12 @@ void AudioPlayer::wsConnectionStatus(WSStatus status)
         case DISCONNECTED:  break;
         case NETWORKERROR: 
         {
+            if (webClient == nullptr)
+            {
+                SAPLOG_INFO("Secured connection to %s interrupted.", m_url.c_str());
+                break;
+            }
+
             if (webClient->getConnectionType() == impl::ConnectionType::Secured)
             {
                 SAPLOG_WARNING("Secured connection to %s failed. Retrying with unsecured.", m_url.c_str());


### PR DESCRIPTION
…established

Reason for change: SAP crashes when stop is called during secure connection handshake.
Test Procedure: Start SAP and stop it within 5s time interval to interupt secure
                connection if client does not support it.
Risks: Small

Signed-off-by: sebastian.kowalewski@sky.uk