### PR TITLE
RDK-30982: Handling pwrmgr2 in DisplaySettings

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -39,6 +39,7 @@
 #include "dsDisplay.h"
 #include "rdk/iarmmgrs-hal/pwrMgr.h"
 #include "pwrMgr.h"
+#include "dsRpc.h"
 
 #include "tr181api.h"
 


### PR DESCRIPTION
Reason for change: Calling IARM call based on RFC.
Test Procedure: Refer JIRA
Risks: Low
Signed-off-by: Akhil Baby Sarada akhil_sarada@comcast.com