### PR TITLE
RDK-36464 : Improve Efficiency of WiFiManager RDKServices APIs phase-3

### DIFF
--- a/WifiManager/WifiManager.h
+++ b/WifiManager/WifiManager.h
@@ -56,10 +56,10 @@ namespace WPEFramework {
 
             //Begin methods
             virtual uint32_t getQuirks(const JsonObject& parameters, JsonObject& response) const override;
-            virtual uint32_t getCurrentState(const JsonObject& parameters, JsonObject& response) const override;
+            virtual uint32_t getCurrentState(const JsonObject& parameters, JsonObject& response) override;
             virtual uint32_t startScan(const JsonObject& parameters, JsonObject& response) const override;
             virtual uint32_t stopScan(const JsonObject& parameters, JsonObject& response) override;
-            virtual uint32_t getConnectedSSID(const JsonObject& parameters, JsonObject& response) const override;
+            virtual uint32_t getConnectedSSID(const JsonObject& parameters, JsonObject& response) override;
             virtual uint32_t setEnabled(const JsonObject& parameters, JsonObject& response) override;
             virtual uint32_t connect(const JsonObject& parameters, JsonObject& response) override;
             virtual uint32_t disconnect(const JsonObject& parameters, JsonObject& response) override;
@@ -68,9 +68,9 @@ namespace WPEFramework {
             virtual uint32_t cancelWPSPairing(const JsonObject& parameters, JsonObject& response) override;
             virtual uint32_t saveSSID(const JsonObject& parameters, JsonObject& response) override;
             virtual uint32_t clearSSID(const JsonObject& parameters, JsonObject& response) override;
-            virtual uint32_t getPairedSSID(const JsonObject& parameters, JsonObject& response) const override;
-            virtual uint32_t getPairedSSIDInfo(const JsonObject& parameters, JsonObject& response) const override;
-            virtual uint32_t isPaired(const JsonObject& parameters, JsonObject& response) const override;
+            virtual uint32_t getPairedSSID(const JsonObject& parameters, JsonObject& response) override;
+            virtual uint32_t getPairedSSIDInfo(const JsonObject& parameters, JsonObject& response) override;
+            virtual uint32_t isPaired(const JsonObject& parameters, JsonObject& response) override;
             virtual uint32_t setSignalThresholdChangeEnabled(const JsonObject& parameters, JsonObject& response) override;
             virtual uint32_t isSignalThresholdChangeEnabled(const JsonObject& parameters, JsonObject& response) const;
             virtual uint32_t getSupportedSecurityModes(const JsonObject& parameters, JsonObject& response) override;

--- a/WifiManager/WifiManagerInterface.h
+++ b/WifiManager/WifiManagerInterface.h
@@ -30,10 +30,10 @@ namespace WPEFramework {
             virtual ~WifiManagerInterface() {}
             //Begin methods
             virtual uint32_t getQuirks(const JsonObject& parameters, JsonObject& response) const = 0;
-            virtual uint32_t getCurrentState(const JsonObject& parameters, JsonObject& response) const = 0;
+            virtual uint32_t getCurrentState(const JsonObject& parameters, JsonObject& response) = 0;
             virtual uint32_t startScan(const JsonObject& parameters, JsonObject& response) const = 0;
             virtual uint32_t stopScan(const JsonObject& parameters, JsonObject& response) = 0;
-            virtual uint32_t getConnectedSSID(const JsonObject& parameters, JsonObject& response) const = 0;
+            virtual uint32_t getConnectedSSID(const JsonObject& parameters, JsonObject& response) = 0;
             virtual uint32_t setEnabled(const JsonObject& parameters, JsonObject& response) = 0;
             virtual uint32_t connect(const JsonObject& parameters, JsonObject& response) = 0;
             virtual uint32_t disconnect(const JsonObject& parameters, JsonObject& response) = 0;
@@ -42,9 +42,9 @@ namespace WPEFramework {
             virtual uint32_t cancelWPSPairing(const JsonObject& parameters, JsonObject& response) = 0;
             virtual uint32_t saveSSID(const JsonObject& parameters, JsonObject& response) = 0;
             virtual uint32_t clearSSID(const JsonObject& parameters, JsonObject& response) = 0;
-            virtual uint32_t getPairedSSID(const JsonObject& parameters, JsonObject& response) const = 0;
-            virtual uint32_t getPairedSSIDInfo(const JsonObject& parameters, JsonObject& response) const = 0;
-            virtual uint32_t isPaired(const JsonObject& parameters, JsonObject& response) const = 0;
+            virtual uint32_t getPairedSSID(const JsonObject& parameters, JsonObject& response) = 0;
+            virtual uint32_t getPairedSSIDInfo(const JsonObject& parameters, JsonObject& response) = 0;
+            virtual uint32_t isPaired(const JsonObject& parameters, JsonObject& response) = 0;
             virtual uint32_t setSignalThresholdChangeEnabled(const JsonObject& parameters, JsonObject& response) = 0;
             virtual uint32_t isSignalThresholdChangeEnabled(const JsonObject& parameters, JsonObject& response) const = 0;
             virtual uint32_t getSupportedSecurityModes(const JsonObject& parameters, JsonObject& response) = 0;

--- a/WifiManager/impl/WifiManagerState.cpp
+++ b/WifiManager/impl/WifiManagerState.cpp
@@ -24,6 +24,9 @@
 #include "libIBus.h"
 #include "UtilsJsonRpc.h"
 
+#define BUFFER_SIZE 512
+#define Command1 "wpa_cli status"
+#define Command2 "wpa_cli signal_poll"
 
 using namespace WPEFramework::Plugin;
 using namespace std;
@@ -41,51 +44,244 @@ namespace {
         }
         return WifiState::FAILED;
     }
+
+    SsidSecurity getSecurityModeValue(std::string str)
+    {
+        if(!str.compare("NET_WIFI_SECURITY_NONE"))
+            return SsidSecurity::NET_WIFI_SECURITY_NONE;
+        else if(!str.compare("NET_WIFI_SECURITY_WEP_64"))
+            return SsidSecurity::NET_WIFI_SECURITY_WEP_64;
+        else if(!str.compare("NET_WIFI_SECURITY_WEP_128"))
+            return SsidSecurity::NET_WIFI_SECURITY_WEP_128;
+        else if(!str.compare("NET_WIFI_SECURITY_WPA_PSK_TKIP"))
+            return SsidSecurity::NET_WIFI_SECURITY_WPA_PSK_TKIP;
+        else if(!str.compare("NET_WIFI_SECURITY_WPA_PSK_AES"))
+            return SsidSecurity::NET_WIFI_SECURITY_WPA_PSK_AES;
+        else if(!str.compare("NET_WIFI_SECURITY_WPA2_PSK_TKIP"))
+            return SsidSecurity::NET_WIFI_SECURITY_WPA2_PSK_TKIP;
+        else if(!str.compare("NET_WIFI_SECURITY_WPA2_PSK_AES"))
+            return SsidSecurity::NET_WIFI_SECURITY_WPA2_PSK_AES;
+        else if(!str.compare("NET_WIFI_SECURITY_WPA_ENTERPRISE_TKIP"))
+            return SsidSecurity::NET_WIFI_SECURITY_WPA_ENTERPRISE_TKIP;
+        else if(!str.compare("NET_WIFI_SECURITY_WPA_ENTERPRISE_AES"))
+            return SsidSecurity::NET_WIFI_SECURITY_WPA_ENTERPRISE_AES;
+        else if(!str.compare("NET_WIFI_SECURITY_WPA2_ENTERPRISE_TKIP"))
+            return SsidSecurity::NET_WIFI_SECURITY_WPA2_ENTERPRISE_TKIP;
+        else if(!str.compare("NET_WIFI_SECURITY_WPA2_PSK_AES"))
+            return SsidSecurity::NET_WIFI_SECURITY_WPA2_PSK_AES;
+        else if(!str.compare("NET_WIFI_SECURITY_WPA_WPA2_PSK"))
+            return SsidSecurity::NET_WIFI_SECURITY_WPA_WPA2_PSK;
+        else if(!str.compare("NET_WIFI_SECURITY_WPA_WPA2_ENTERPRISE"))
+            return SsidSecurity::NET_WIFI_SECURITY_WPA_WPA2_ENTERPRISE;
+        else if(!str.compare("NET_WIFI_SECURITY_WPA3_PSK_AES"))
+            return SsidSecurity::NET_WIFI_SECURITY_WPA3_PSK_AES;
+        else if(!str.compare("NET_WIFI_SECURITY_WPA3_SAE"))
+            return SsidSecurity::NET_WIFI_SECURITY_WPA3_SAE;
+        else
+            return SsidSecurity::NET_WIFI_SECURITY_NOT_SUPPORTED;
+    }
 }
 
-uint32_t WifiManagerState::getCurrentState(const JsonObject &parameters, JsonObject &response) const
+WifiManagerState::WifiManagerState()
+{
+    m_useWifiStateCache = false;
+    m_wifiStateCache = WifiState::FAILED;
+    m_useWifiConnectedCache = false;
+    m_ConnectedSSIDCache = "";
+    m_ConnectedBSSIDCache = "";
+    m_ConnectedSecurityModeCache = 0;
+}
+
+WifiManagerState::~WifiManagerState()
+{
+}
+
+
+void WifiManagerState::setWifiStateCache(bool value,WifiState Cstate)
+{
+    m_useWifiStateCache = value;
+    m_wifiStateCache = Cstate;
+}
+
+void WifiManagerState::resetWifiStateConnectedCache(bool value)
+{
+    m_useWifiConnectedCache = value;
+}
+
+uint32_t WifiManagerState::getCurrentState(const JsonObject &parameters, JsonObject &response)
 {
     LOGINFOMETHOD();
     IARM_Result_t retVal = IARM_RESULT_SUCCESS;
     IARM_Bus_WiFiSrvMgr_Param_t param;
-    WiFiStatusCode_t wifiStatusCode = (WiFiStatusCode_t)-1;
 
     memset(&param, 0, sizeof(param));
 
-    retVal = IARM_Bus_Call(IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_WIFI_MGR_API_getCurrentState, (void *)&param, sizeof(param));
-
-    if(retVal == IARM_RESULT_SUCCESS)
+    if (!m_useWifiStateCache)
     {
-        wifiStatusCode = param.data.wifiStatus;
+        if(IARM_RESULT_SUCCESS == IARM_Bus_Call(IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_WIFI_MGR_API_getCurrentState, (void *)&param, sizeof(param)))
+        {
+            setWifiStateCache(true,(to_wifi_state(param.data.wifiStatus)));
+        }
     }
-
-    response["state"] = static_cast<int>(to_wifi_state(wifiStatusCode));
+    response["state"] = static_cast<int>(m_wifiStateCache);
     returnResponse(retVal == IARM_RESULT_SUCCESS);
 }
 
-uint32_t WifiManagerState::getConnectedSSID(const JsonObject &parameters, JsonObject &response) const
+std::map<std::string, std::string> WifiManagerState::retrieveValues(const char *command, char *output_buffer, size_t output_buffer_size)
+{
+    std::string key, value;
+    std::map<std::string, std::string> MyMap;
+
+    FILE *fp = popen(command, "r");
+    if (!fp)
+    {
+        LOGERR("Failed in getting output from command %s \n",command);
+    }
+    while(fgets(output_buffer, output_buffer_size, fp) != NULL)
+    {
+        std::istringstream mystream(output_buffer);
+        if(std::getline(std::getline(mystream, key, '=') >> std::ws, value))
+            MyMap[key] = value;
+    }
+    pclose(fp);
+
+    return MyMap;
+}
+
+uint32_t WifiManagerState::getConnectedSSID(const JsonObject &parameters, JsonObject &response)
 {
     LOGINFOMETHOD();
-    IARM_Result_t retVal = IARM_RESULT_SUCCESS;
-    IARM_Bus_WiFiSrvMgr_Param_t param;
+    WiFiConnectedSSIDInfo_t param;
+    char buff[BUFFER_SIZE] = {'\0'};
+    int phyrate, noise, rssi,freq,avgRssi;
+    bool result = false;
+    std::string security_mode = "";
+    std::string auth = "";
+    std::string encryption = "";
+    std::string wifi_wpa_state = "";
 
-    memset(&param, 0, sizeof(param));
+    memset(&param, '\0', sizeof(param));
 
-    retVal = IARM_Bus_Call(IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_WIFI_MGR_API_getConnectedSSID, (void *)&param, sizeof(param));
-
-    if(retVal == IARM_RESULT_SUCCESS)
+    if(!m_useWifiConnectedCache)
     {
-        auto &connectedSsid = param.data.getConnectedSSID;
-        response["ssid"] = string(connectedSsid.ssid);
-        response["bssid"] = string(connectedSsid.bssid);
-        response["rate"] = to_string(connectedSsid.rate);
-        response["noise"] = to_string(connectedSsid.noise);
-        response["security"] = to_string(connectedSsid.securityMode);
-        response["signalStrength"] = to_string(connectedSsid.signalStrength);
-        response["frequency"] = to_string(((float)connectedSsid.frequency)/1000);
+        auto list = WifiManagerState::retrieveValues(Command1, buff, sizeof (buff));
+
+        if (!list.empty())
+        {
+            for(auto it = list.cbegin(); it != list.cend(); ++it)
+            {
+                if (it->first == "wpa_state")
+                {
+                    wifi_wpa_state = it->second;
+                }
+                else if (it->first == "ssid")
+                {
+                    m_ConnectedSSIDCache = it->second;
+                }
+                else if (it->first == "bssid")
+                {
+                    m_ConnectedBSSIDCache = it->second;
+                }
+                else if (it->first == "pairwise_cipher")
+                {
+                    encryption = it->second.c_str();
+                    if(!encryption.compare("TKIP"))
+                    {
+                        encryption.clear();
+                        encryption = "_TKIP";
+                    }
+                    if(!encryption.compare("CCMP"))
+                    {
+                        encryption.clear();
+                        encryption = "_AES";
+                    }
+                }
+                else if (it->first == "key_mgmt")
+                {
+                    auth = it->second.c_str();
+                    std::replace( auth.begin(), auth.end(), '-', '_');
+                }
+            }
+            /* if Wifi is Disconnected ,getConnectedSSID api response becomes zero and empty string */
+            if(wifi_wpa_state != "COMPLETED")
+            {
+                result = true;
+                response["ssid"] = "";
+                response["bssid"] = "";
+                response["rate"] = to_string(param.rate);
+                response["noise"] = to_string(param.noise);
+                response["security"] = m_ConnectedSecurityModeCache;
+                response["signalStrength"] = to_string(param.signalStrength);
+                response["frequency"] = to_string(((float)param.frequency)/1000);
+
+                returnResponse(result);
+             }
+             else
+             {
+                 if (auth.empty())
+                     security_mode = "NET_WIFI_SECURITY_NONE";
+                 else
+                     security_mode = "NET_WIFI_SECURITY_" + auth + encryption;
+
+                 m_ConnectedSecurityModeCache = static_cast<int>(getSecurityModeValue(security_mode));
+                 result = true;
+                 m_useWifiConnectedCache = true;
+             }
+        }
+        else
+        {
+            LOGERR("Command failed to execute:%s\n",Command1);
+            result = false;
+        }
     }
 
-    returnResponse(retVal == IARM_RESULT_SUCCESS);
+    auto clist = WifiManagerState::retrieveValues(Command2, buff, sizeof (buff));
+
+    if (!clist.empty())
+    {
+        for(auto it = clist.cbegin(); it != clist.cend(); ++it)
+        {
+            if (it->first == "LINKSPEED") // phyRate
+            {
+                phyrate = atoi(it->second.c_str());
+                param.rate = phyrate;
+            }
+            else if (it->first == "RSSI")
+            {
+                rssi = atoi(it->second.c_str());
+                param.signalStrength  = rssi;
+            }
+            else if (it->first == "NOISE")
+            {
+                noise = atoi(it->second.c_str());
+                param.noise  = noise;
+            }
+            else if (it->first == "FREQUENCY")
+            {
+                freq = atoi(it->second.c_str());
+                param.frequency  = freq;
+            }
+        }
+        result = true;
+    }
+    else
+    {
+        LOGERR("Command failed to execute:%s\n",Command2);
+        result = false;
+    }
+
+    if(result == true)
+    {
+        response["ssid"] = m_ConnectedSSIDCache;
+        response["bssid"] = m_ConnectedBSSIDCache;
+        response["rate"] = to_string(param.rate);
+        response["noise"] = to_string(param.noise);
+        response["security"] = m_ConnectedSecurityModeCache;
+        response["signalStrength"] = to_string(param.signalStrength);
+        response["frequency"] = to_string(((float)param.frequency)/1000);
+    }
+
+    returnResponse(result);
 }
 
 uint32_t WifiManagerState::setEnabled(const JsonObject &parameters, JsonObject &response)

--- a/WifiManager/impl/WifiManagerState.h
+++ b/WifiManager/impl/WifiManagerState.h
@@ -26,15 +26,27 @@ namespace WPEFramework {
     namespace Plugin {
         class WifiManagerState {
         public:
-            WifiManagerState() = default;
-            virtual ~WifiManagerState() = default;
+            WifiManagerState();
+            virtual ~WifiManagerState();
             WifiManagerState(const WifiManagerState&) = delete;
             WifiManagerState& operator=(const WifiManagerState&) = delete;
 
-            uint32_t getCurrentState(const JsonObject& parameters, JsonObject& response) const;
-            uint32_t getConnectedSSID(const JsonObject& parameters, JsonObject& response) const;
+            uint32_t getCurrentState(const JsonObject& parameters, JsonObject& response);
+            uint32_t getConnectedSSID(const JsonObject& parameters, JsonObject& response);
             uint32_t setEnabled(const JsonObject& parameters, JsonObject& response);
             uint32_t getSupportedSecurityModes(const JsonObject& parameters, JsonObject& response);
+            void setWifiStateCache(bool value,WifiState state);
+            void resetWifiStateConnectedCache(bool value);
+
+            std::atomic<bool> m_useWifiStateCache;
+            WifiState m_wifiStateCache;
+            std::atomic<bool> m_useWifiConnectedCache;
+            std::string m_ConnectedSSIDCache;
+            std::string m_ConnectedBSSIDCache;
+            int m_ConnectedSecurityModeCache;
+
+	private:
+	    std::map<std::string, std::string> retrieveValues(const char *, char *, size_t );
         };
     }
 }

--- a/WifiManager/impl/WifiManagerWPS.cpp
+++ b/WifiManager/impl/WifiManagerWPS.cpp
@@ -28,10 +28,18 @@ namespace WPEFramework
     {
         WifiManagerWPS::WifiManagerWPS()
         {
+            m_useCachePairedSSID = false;
+            m_cachePairedSSID = "";
+            m_cachePairedBSSID = "";
         }
 
         WifiManagerWPS::~WifiManagerWPS()
         {
+        }
+
+        void WifiManagerWPS::updateWifiWPSCache(bool value)
+        {
+            m_useCachePairedSSID = value;
         }
 
         uint32_t WifiManagerWPS::initiateWPSPairing(const JsonObject &parameters, JsonObject &response)
@@ -161,52 +169,87 @@ namespace WPEFramework
             returnResponse(true);
         }
 
-        uint32_t WifiManagerWPS::getPairedSSID(const JsonObject &parameters, JsonObject &response) const
+        uint32_t WifiManagerWPS::getPairedSSID(const JsonObject &parameters, JsonObject &response)
         {
             LOGINFOMETHOD();
             IARM_Bus_WiFiSrvMgr_Param_t param;
             memset(&param, 0, sizeof(param));
+            bool result = false;
 
-            IARM_Result_t retVal = IARM_Bus_Call(IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_WIFI_MGR_API_getPairedSSID, (void *)&param, sizeof(param));
-            if (retVal == IARM_RESULT_SUCCESS)
+            if (m_useCachePairedSSID)
             {
-                response["ssid"] = string(param.data.getPairedSSID.ssid, SSID_SIZE);
+                response["ssid"] = m_cachePairedSSID;
+                result = true;
             }
-            LOGINFO("[%s] : retVal:%d", IARM_BUS_WIFI_MGR_API_getPairedSSID, retVal);
+            else if (IARM_RESULT_SUCCESS == IARM_Bus_Call(IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_WIFI_MGR_API_getPairedSSIDInfo, (void *)&param, sizeof(param)))
+            {
+                response["ssid"] = m_cachePairedSSID = string(param.data.getPairedSSIDInfo.ssid, SSID_SIZE);
+                m_cachePairedBSSID = string(param.data.getPairedSSIDInfo.bssid, BSSID_BUFF);
+                m_useCachePairedSSID = true;
+                result = true;
+            }
+            else
+            {
+                LOGWARN ("Call to %s for %s failed", IARM_BUS_NM_SRV_MGR_NAME, __FUNCTION__);
+                result = false;
+            }
 
-            returnResponse(retVal == IARM_RESULT_SUCCESS);
+            returnResponse(result);
         }
 
-        uint32_t WifiManagerWPS::getPairedSSIDInfo(const JsonObject &parameters, JsonObject &response) const
+        uint32_t WifiManagerWPS::getPairedSSIDInfo(const JsonObject &parameters, JsonObject &response)
         {
             LOGINFOMETHOD();
             IARM_Bus_WiFiSrvMgr_Param_t param;
             memset(&param, 0, sizeof(param));
+            bool result = false;
 
-            IARM_Result_t retVal = IARM_Bus_Call(IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_WIFI_MGR_API_getPairedSSIDInfo, (void *)&param, sizeof(param));
-            if (retVal == IARM_RESULT_SUCCESS)
+            if (m_useCachePairedSSID)
             {
-                response["ssid"] = string(param.data.getPairedSSIDInfo.ssid, SSID_SIZE);
-                response["bssid"] = string(param.data.getPairedSSIDInfo.bssid, BSSID_BUFF);
+                response["ssid"] = m_cachePairedSSID;
+                response["bssid"] = m_cachePairedBSSID;
+                result = true;
             }
-            LOGINFO("[%s] : retVal:%d", IARM_BUS_WIFI_MGR_API_getPairedSSIDInfo, retVal);
+            else if (IARM_RESULT_SUCCESS == IARM_Bus_Call(IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_WIFI_MGR_API_getPairedSSIDInfo, (void *)&param, sizeof(param)))
+            {
+                response["ssid"] = m_cachePairedSSID = string(param.data.getPairedSSIDInfo.ssid, SSID_SIZE);
+                response["bssid"] = m_cachePairedBSSID = string(param.data.getPairedSSIDInfo.bssid, BSSID_BUFF);
+                m_useCachePairedSSID = true;
+                result = true;
+            }
+            else
+            {
+                LOGWARN ("Call to %s for %s failed", IARM_BUS_NM_SRV_MGR_NAME, __FUNCTION__);
+                result = false;
+            }
 
-            returnResponse(retVal == IARM_RESULT_SUCCESS);
+            returnResponse(result);
         }
 
-        uint32_t WifiManagerWPS::isPaired(const JsonObject &parameters, JsonObject &response) const
+        uint32_t WifiManagerWPS::isPaired(const JsonObject &parameters, JsonObject &response)
         {
             LOGINFOMETHOD();
-            bool paired = false;
-
             IARM_Bus_WiFiSrvMgr_Param_t param;
             memset(&param, 0, sizeof(param));
+            int ssid_len = 0;
 
-            IARM_Result_t retVal = IARM_Bus_Call(IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_WIFI_MGR_API_isPaired, (void *)&param, sizeof(param));
-            paired = (retVal == IARM_RESULT_SUCCESS) && param.data.isPaired;
-            LOGINFO("[%s] : retVal:%d paired:%d", IARM_BUS_WIFI_MGR_API_isPaired, retVal, param.data.isPaired);
+            if (m_useCachePairedSSID)
+            {
+                ssid_len = strlen(m_cachePairedSSID.c_str());
+            }
+            else if (IARM_RESULT_SUCCESS == IARM_Bus_Call(IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_WIFI_MGR_API_getPairedSSIDInfo, (void *)&param, sizeof(param)))
+            {
+                m_cachePairedSSID = string(param.data.getPairedSSIDInfo.ssid, SSID_SIZE);
+                m_cachePairedBSSID = string(param.data.getPairedSSIDInfo.bssid, BSSID_BUFF);
+                ssid_len = strlen(m_cachePairedSSID.c_str());
+                m_useCachePairedSSID = true;
+            }
+            else
+            {
+                LOGWARN ("Call to %s for %s failed", IARM_BUS_NM_SRV_MGR_NAME, __FUNCTION__);
+            }
 
-            response["result"] = (paired ? 0 : 1);
+            response["result"] = (ssid_len) ? 0 : 1;
             returnResponse(true);
         }
     } // namespace Plugin

--- a/WifiManager/impl/WifiManagerWPS.h
+++ b/WifiManager/impl/WifiManagerWPS.h
@@ -37,9 +37,14 @@ namespace WPEFramework {
             uint32_t cancelWPSPairing(const JsonObject& parameters, JsonObject& response);
             uint32_t saveSSID (const JsonObject& parameters, JsonObject& response);
             uint32_t clearSSID(const JsonObject& parameters, JsonObject& response);
-            uint32_t getPairedSSID(const JsonObject& parameters, JsonObject& response) const;
-            uint32_t getPairedSSIDInfo(const JsonObject& parameters, JsonObject& response) const;
-            uint32_t isPaired(const JsonObject& parameters, JsonObject& response) const;
+            uint32_t getPairedSSID(const JsonObject& parameters, JsonObject& response);
+            uint32_t getPairedSSIDInfo(const JsonObject& parameters, JsonObject& response);
+            uint32_t isPaired(const JsonObject& parameters, JsonObject& response);
+            void updateWifiWPSCache(bool value);
+
+            std::atomic<bool> m_useCachePairedSSID;
+            std::string m_cachePairedSSID;
+            std::string m_cachePairedBSSID;
         };
     } // namespace Plugin
 } // namespace WPEFramework


### PR DESCRIPTION
Reason for change:  Improves overall performance of clients apps using RDKServices and reduce number of IARM_Bus_Call
Test Procedure:please referred ticket
Risks: Medium
Signed-off-by: Thamim Razith <tabbas651@cable.comcast.com>
(cherry picked from commit 251138c2610c9cc04abe145388dc8f359e48cb56)

RDK-36464 : Improve Efficiency of WiFiManager RDKServices APIs phase-3 (#2822)

* RDK-36464 : Improve Efficiency of WiFiManager RDKServices APIs phase-3

Reason for change: Improves overall performance of clients apps using RDKServices and reduce number of IARM_Bus_Call
Test Procedure:please referred ticket
Risks: Medium
Signed-off-by: Thamim Razith tabbas651@cable.comcast.com

* Update WifiManagerState.cpp

Co-authored-by: Karunakaran A <48997923+karuna2git@users.noreply.github.com>
(cherry picked from commit a1dff9884a4261f01958e413285dcec1c502ff3f)

RDK-36464 : Improve Efficiency of WiFiManager RDKServices APIs phase-3 (#2839)

Reason for change: Based on wpa_state update the getConnected api response
Test Procedure:please referred ticket
Risks: Medium
Signed-off-by: Thamim Razith tabbas651@cable.comcast.com
(cherry picked from commit b4cbf4f084f3cff3d32dfa3948c37dcd2c4bb574)