### PR TITLE
RDKTV-16239: Able to setGain to invalid values

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -2675,6 +2675,13 @@ namespace WPEFramework {
                 float newGain = 0;
                 try {
                         newGain = stof(sGain);
+<<<<<<< HEAD
+=======
+                         if ((newGain < -2080) || (newGain > 480)) {
+                            LOGERR("Gain value being set to an invalid value newGain: %f \n",newGain);
+                            returnResponse(false);
+                        }
+>>>>>>> 894e248f... Update DisplaySettings.cpp
                 }catch (const device::Exception& err) {
                         LOG_DEVICE_EXCEPTION1(sGain);
                         returnResponse(false);


### PR DESCRIPTION
Reason for change:
Improve efficiency of RDKServices APIs
Test Procedure: None
Risks: Low

Signed-off-by:Hayden Gfeller <Hayden_Gfeller@comcast.com>
origin HEAD:refs/for/2206_sprint