### PR TITLE
RDKTV-16239: Able to setGain to invalid values

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -2651,13 +2651,10 @@ namespace WPEFramework {
                 float newGain = 0;
                 try {
                         newGain = stof(sGain);
-<<<<<<< HEAD
-=======
-                         if ((newGain < -2080) || (newGain > 480)) {
+                        if ((newGain < -2080) || (newGain > 480)) {
                             LOGERR("Gain value being set to an invalid value newGain: %f \n",newGain);
                             returnResponse(false);
                         }
->>>>>>> 894e248f... Update DisplaySettings.cpp
                 }catch (const device::Exception& err) {
                         LOG_DEVICE_EXCEPTION1(sGain);
                         returnResponse(false);

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -2651,6 +2651,13 @@ namespace WPEFramework {
                 float newGain = 0;
                 try {
                         newGain = stof(sGain);
+<<<<<<< HEAD
+=======
+                         if ((newGain < -2080) || (newGain > 480)) {
+                            LOGERR("Gain value being set to an invalid value newGain: %f \n",newGain);
+                            returnResponse(false);
+                        }
+>>>>>>> 894e248f... Update DisplaySettings.cpp
                 }catch (const device::Exception& err) {
                         LOG_DEVICE_EXCEPTION1(sGain);
                         returnResponse(false);

--- a/DisplaySettings/DisplaySettings.json
+++ b/DisplaySettings/DisplaySettings.json
@@ -98,7 +98,7 @@
             "example": 0
         },
         "gain": {
-            "summary": "Value between 0 and 100, where 0 means no gain and 100 means maximum gain",
+            "summary": "Value between -2080 and 480, where -2080 means negative gain and 480 means maximum gain",
             "type": "number",
             "example": "10.000000"
         },


### PR DESCRIPTION
RDKTV-16239: Able to setGain to invalid values

Reason for change:
Improve efficiency of RDKServices APIs
Test Procedure: None
Risks: Low

Signed-off-by:Hayden Gfeller <Hayden_Gfeller@comcast.com>
origin HEAD:refs/for/2206_sprint