### PR TITLE
DELIA-56623: Remove multiple time prints same log in wifi manager plu…

### DIFF
--- a/WifiManager/WifiManager.cpp
+++ b/WifiManager/WifiManager.cpp
@@ -151,11 +151,8 @@ namespace WPEFramework
 
         uint32_t WifiManager::getCurrentState(const JsonObject &parameters, JsonObject &response)
         {
-            LOGINFOMETHOD();
-
             uint32_t result = wifiState.getCurrentState(parameters, response);
 
-            LOGTRACEMETHODFIN();
             return result;
         }
 
@@ -181,21 +178,15 @@ namespace WPEFramework
 
         uint32_t WifiManager::getConnectedSSID(const JsonObject &parameters, JsonObject &response)
         {
-            LOGINFOMETHOD();
-
             uint32_t result = wifiState.getConnectedSSID(parameters, response);
 
-            LOGTRACEMETHODFIN();
             return result;
         }
 
         uint32_t WifiManager::setEnabled(const JsonObject &parameters, JsonObject &response)
         {
-            LOGINFOMETHOD();
-
             uint32_t result = wifiState.setEnabled(parameters, response);
 
-            LOGTRACEMETHODFIN();
             return result;
         }
 
@@ -219,111 +210,78 @@ namespace WPEFramework
 
         uint32_t WifiManager::initiateWPSPairing(const JsonObject &parameters, JsonObject &response)
         {
-            LOGINFOMETHOD();
-
             uint32_t result = wifiWPS.initiateWPSPairing(parameters, response);
 
-            LOGTRACEMETHODFIN();
             return result;
         }
 
         uint32_t WifiManager::initiateWPSPairing2(const JsonObject &parameters, JsonObject &response)
         {
-            LOGINFOMETHOD();
-
             uint32_t result = wifiWPS.initiateWPSPairing2(parameters, response);
 
-            LOGTRACEMETHODFIN();
             return result;
         }
 
         uint32_t WifiManager::cancelWPSPairing(const JsonObject &parameters, JsonObject &response)
         {
-            LOGINFOMETHOD();
-
             uint32_t result = wifiWPS.cancelWPSPairing(parameters, response);
 
-            LOGTRACEMETHODFIN();
             return result;
         }
 
         uint32_t WifiManager::saveSSID(const JsonObject &parameters, JsonObject &response)
         {
-            LOGINFOMETHOD();
-
             uint32_t result = wifiWPS.saveSSID(parameters, response);
 
-            LOGTRACEMETHODFIN();
             return result;
         }
 
         uint32_t WifiManager::clearSSID(const JsonObject &parameters, JsonObject &response)
         {
-            LOGINFOMETHOD();
-
             uint32_t result = wifiWPS.clearSSID(parameters, response);
 
-            LOGTRACEMETHODFIN();
             return result;
         }
 
         uint32_t WifiManager::getPairedSSID(const JsonObject &parameters, JsonObject &response)
         {
-            LOGINFOMETHOD();
-
             uint32_t result = wifiWPS.getPairedSSID(parameters, response);
 
-            LOGTRACEMETHODFIN();
             return result;
         }
 
         uint32_t WifiManager::getPairedSSIDInfo(const JsonObject &parameters, JsonObject &response)
         {
-            LOGINFOMETHOD();
-
             uint32_t result = wifiWPS.getPairedSSIDInfo(parameters, response);
 
-            LOGTRACEMETHODFIN();
             return result;
         }
 
         uint32_t WifiManager::isPaired(const JsonObject &parameters, JsonObject &response)
         {
-            LOGINFOMETHOD();
-
             uint32_t result = wifiWPS.isPaired(parameters, response);
 
-            LOGTRACEMETHODFIN();
             return result;
         }
 
         uint32_t WifiManager::setSignalThresholdChangeEnabled(const JsonObject &parameters, JsonObject &response)
         {
-            LOGINFOMETHOD();
-
             uint32_t result = wifiSignalThreshold.setSignalThresholdChangeEnabled(parameters, response);
 
-            LOGTRACEMETHODFIN();
             return result;
         }
 
         uint32_t WifiManager::isSignalThresholdChangeEnabled(const JsonObject &parameters, JsonObject &response) const
         {
-            LOGINFOMETHOD();
-
             uint32_t result = wifiSignalThreshold.isSignalThresholdChangeEnabled(parameters, response);
 
-            LOGTRACEMETHODFIN();
             return result;
         }
 
         uint32_t WifiManager::getSupportedSecurityModes(const JsonObject &parameters, JsonObject &response)
         {
-            LOGINFOMETHOD();
-
             uint32_t result = wifiState.getSupportedSecurityModes(parameters, response);
 
-            LOGTRACEMETHODFIN();
             return result;
         }
 


### PR DESCRIPTION
…gin (#2864)

* XIONE-8959:  Remove multiple time prints same log in wifi manager plugin

Reason for change: Printed for every 2s causing log rotation in wpeframework.log
Test Procedure:
Risks: Medium
Signed-off-by: Kumar Santhanam <Kumar_Santhanam@comcast.com>
(cherry picked from commit 3f03c2d47b25f9f834d61e8890089fd94d36a858)

Co-authored-by: Karunakaran A <48997923+karuna2git@users.noreply.github.com>
(cherry picked from commit 0fad2084575ae8fc75ed0dd7c11a46cbd095aab6)