### PR TITLE
DELIA-55604: Fix for terminate called without an active exception in …

### DIFF
--- a/HdmiCec/HdmiCec.cpp
+++ b/HdmiCec/HdmiCec.cpp
@@ -195,6 +195,7 @@ namespace WPEFramework
         {
             isDeviceActiveSource = false;
             HdmiCec::_instance->sendActiveSourceEvent();
+            CECDisable();
             HdmiCec::_instance = nullptr;
 
             DeinitializeIARM();


### PR DESCRIPTION
…HDMICEC

Reason for change: Thread join for created updated and poll thread
Test Procedure: Activate and deactivate HDMICEC plugin number of times
Risks: Medium
Signed-off-by: Kumar Santhanam <Kumar_Santhanam@comcast.com>
(cherry picked from commit 591f4d971f74ab4ac2df1dd4a5a43ac8b7bf686e)