### PR TITLE
XIONE-8959:  Remove multiple time prints same log in wifi manager plugin

### DIFF
--- a/WifiManager/WifiManager.cpp
+++ b/WifiManager/WifiManager.cpp
@@ -178,7 +178,32 @@ namespace WPEFramework
 
         uint32_t WifiManager::getConnectedSSID(const JsonObject &parameters, JsonObject &response)
         {
-            uint32_t result = wifiState.getConnectedSSID(parameters, response);
+            bool result = false;
+
+            if(getConnectedSSID2(parameters, response))
+            {
+                result = true;
+            }
+            else
+            {
+                LOGWARN("getConnectedSSID2 Call get failed,ret value:%d\n",result);
+            }
+
+            returnResponse(result);
+        }
+
+        bool WifiManager::getConnectedSSID2(const JsonObject &parameters, JsonObject &response)
+        {
+            bool result = false;
+
+            if(wifiState.getConnectedSSID(parameters, response))
+            {
+                result = true;
+            }
+            else
+            {
+                LOGWARN("getConnectedSSID Call get failed,ret value:%d\n",result);
+            }
 
             return result;
         }

--- a/WifiManager/WifiManager.cpp
+++ b/WifiManager/WifiManager.cpp
@@ -151,11 +151,8 @@ namespace WPEFramework
 
         uint32_t WifiManager::getCurrentState(const JsonObject &parameters, JsonObject &response)
         {
-            LOGINFOMETHOD();
-
             uint32_t result = wifiState.getCurrentState(parameters, response);
 
-            LOGTRACEMETHODFIN();
             return result;
         }
 
@@ -181,21 +178,15 @@ namespace WPEFramework
 
         uint32_t WifiManager::getConnectedSSID(const JsonObject &parameters, JsonObject &response)
         {
-            LOGINFOMETHOD();
-
             uint32_t result = wifiState.getConnectedSSID(parameters, response);
 
-            LOGTRACEMETHODFIN();
             return result;
         }
 
         uint32_t WifiManager::setEnabled(const JsonObject &parameters, JsonObject &response)
         {
-            LOGINFOMETHOD();
-
             uint32_t result = wifiState.setEnabled(parameters, response);
 
-            LOGTRACEMETHODFIN();
             return result;
         }
 
@@ -219,111 +210,78 @@ namespace WPEFramework
 
         uint32_t WifiManager::initiateWPSPairing(const JsonObject &parameters, JsonObject &response)
         {
-            LOGINFOMETHOD();
-
             uint32_t result = wifiWPS.initiateWPSPairing(parameters, response);
 
-            LOGTRACEMETHODFIN();
             return result;
         }
 
         uint32_t WifiManager::initiateWPSPairing2(const JsonObject &parameters, JsonObject &response)
         {
-            LOGINFOMETHOD();
-
             uint32_t result = wifiWPS.initiateWPSPairing2(parameters, response);
 
-            LOGTRACEMETHODFIN();
             return result;
         }
 
         uint32_t WifiManager::cancelWPSPairing(const JsonObject &parameters, JsonObject &response)
         {
-            LOGINFOMETHOD();
-
             uint32_t result = wifiWPS.cancelWPSPairing(parameters, response);
 
-            LOGTRACEMETHODFIN();
             return result;
         }
 
         uint32_t WifiManager::saveSSID(const JsonObject &parameters, JsonObject &response)
         {
-            LOGINFOMETHOD();
-
             uint32_t result = wifiWPS.saveSSID(parameters, response);
 
-            LOGTRACEMETHODFIN();
             return result;
         }
 
         uint32_t WifiManager::clearSSID(const JsonObject &parameters, JsonObject &response)
         {
-            LOGINFOMETHOD();
-
             uint32_t result = wifiWPS.clearSSID(parameters, response);
 
-            LOGTRACEMETHODFIN();
             return result;
         }
 
         uint32_t WifiManager::getPairedSSID(const JsonObject &parameters, JsonObject &response)
         {
-            LOGINFOMETHOD();
-
             uint32_t result = wifiWPS.getPairedSSID(parameters, response);
 
-            LOGTRACEMETHODFIN();
             return result;
         }
 
         uint32_t WifiManager::getPairedSSIDInfo(const JsonObject &parameters, JsonObject &response)
         {
-            LOGINFOMETHOD();
-
             uint32_t result = wifiWPS.getPairedSSIDInfo(parameters, response);
 
-            LOGTRACEMETHODFIN();
             return result;
         }
 
         uint32_t WifiManager::isPaired(const JsonObject &parameters, JsonObject &response)
         {
-            LOGINFOMETHOD();
-
             uint32_t result = wifiWPS.isPaired(parameters, response);
 
-            LOGTRACEMETHODFIN();
             return result;
         }
 
         uint32_t WifiManager::setSignalThresholdChangeEnabled(const JsonObject &parameters, JsonObject &response)
         {
-            LOGINFOMETHOD();
-
             uint32_t result = wifiSignalThreshold.setSignalThresholdChangeEnabled(parameters, response);
 
-            LOGTRACEMETHODFIN();
             return result;
         }
 
         uint32_t WifiManager::isSignalThresholdChangeEnabled(const JsonObject &parameters, JsonObject &response) const
         {
-            LOGINFOMETHOD();
-
             uint32_t result = wifiSignalThreshold.isSignalThresholdChangeEnabled(parameters, response);
 
-            LOGTRACEMETHODFIN();
             return result;
         }
 
         uint32_t WifiManager::getSupportedSecurityModes(const JsonObject &parameters, JsonObject &response)
         {
-            LOGINFOMETHOD();
-
             uint32_t result = wifiState.getSupportedSecurityModes(parameters, response);
 
-            LOGTRACEMETHODFIN();
             return result;
         }
 

--- a/WifiManager/WifiManager.h
+++ b/WifiManager/WifiManager.h
@@ -94,6 +94,7 @@ namespace WPEFramework {
 
             uint32_t getApiVersionNumber() const {return apiVersionNumber;};
             void setApiVersionNumber(uint32_t apiVersion) {apiVersionNumber = apiVersion;};
+            bool getConnectedSSID2(const JsonObject &parameters, JsonObject &response);
 
             //Internal methods
             static WifiManager& getInstance();

--- a/WifiManager/impl/WifiManagerSignalThreshold.cpp
+++ b/WifiManager/impl/WifiManagerSignalThreshold.cpp
@@ -18,7 +18,7 @@
 **/
 
 #include "WifiManagerSignalThreshold.h"
-
+#include "../WifiManager.h" // Need access to WifiManager::getInstance so can't use 'WifiManagerInterface.h'
 #include "UtilsJsonRpc.h"
 
 #include <chrono>
@@ -30,9 +30,9 @@ namespace {
     const float signalStrengthThresholdGood = -60.0f;
     const float signalStrengthThresholdFair = -67.0f;
 
-    void getSignalData(WifiManagerInterface &wifiManager, float &signalStrengthOut, std::string &strengthOut) {
+    void getSignalData(float &signalStrengthOut, std::string &strengthOut) {
         JsonObject response;
-        wifiManager.getConnectedSSID(JsonObject(), response);
+        WifiManager::getInstance().getConnectedSSID2(JsonObject(), response);
 
         signalStrengthOut = 0.0f;
         if (response.HasLabel("signalStrength")) {
@@ -58,9 +58,8 @@ namespace {
     }
 }
 
-WifiManagerSignalThreshold::WifiManagerSignalThreshold(WifiManagerInterface &wifiManager):
+WifiManagerSignalThreshold::WifiManagerSignalThreshold():
     changeEnabled(false),
-    wifiManager(wifiManager),
     running(false)
 {
 }
@@ -110,7 +109,7 @@ void WifiManagerSignalThreshold::setSignalThresholdChangeEnabled(bool enabled, i
     JsonObject parameters, response;
     WifiState state;
 
-    uint32_t result = wifiManager.getCurrentState(parameters, response);
+    uint32_t result = WifiManager::getInstance().getCurrentState(parameters, response);
     if (result != 0)
     {
         LOGINFO("wifiManager.getCurrentState result = %d", result);
@@ -152,13 +151,13 @@ void WifiManagerSignalThreshold::loop(int interval)
         std::string strength;
         if (running)
         {
-            getSignalData(wifiManager, signalStrength, strength);
+            getSignalData(signalStrength, strength);
 
 
             if (strength != lastStrength)
             {
                 LOGINFO("Triggering onWifiSignalThresholdChanged notification");
-                wifiManager.onWifiSignalThresholdChanged(signalStrength, strength);
+                WifiManager::getInstance().onWifiSignalThresholdChanged(signalStrength, strength);
                 lastStrength = strength;
             }
         }

--- a/WifiManager/impl/WifiManagerSignalThreshold.h
+++ b/WifiManager/impl/WifiManagerSignalThreshold.h
@@ -21,7 +21,6 @@
 
 #include "../Module.h"
 #include "../WifiManagerDefines.h"
-#include "../WifiManagerInterface.h"
 
 #include <atomic>
 #include <condition_variable>
@@ -41,7 +40,7 @@ namespace WPEFramework {
             // As the onWifiSignalTresholdChanged event is signalled periodically,
             // it has to be handled with an additional thread.
         public:
-            WifiManagerSignalThreshold(WifiManagerInterface &wifiManager);
+            WifiManagerSignalThreshold();
             virtual ~WifiManagerSignalThreshold();
             WifiManagerSignalThreshold(const WifiManagerSignalThreshold&) = delete;
             WifiManagerSignalThreshold& operator=(const WifiManagerSignalThreshold&) = delete;
@@ -63,7 +62,6 @@ namespace WPEFramework {
             std::atomic<bool> changeEnabled;
             std::mutex cv_mutex;
             std::condition_variable cv;
-            WifiManagerInterface &wifiManager;
             bool running;
         };
     }

--- a/WifiManager/impl/WifiManagerState.cpp
+++ b/WifiManager/impl/WifiManagerState.cpp
@@ -148,9 +148,8 @@ std::map<std::string, std::string> WifiManagerState::retrieveValues(const char *
     return MyMap;
 }
 
-uint32_t WifiManagerState::getConnectedSSID(const JsonObject &parameters, JsonObject &response)
+bool WifiManagerState::getConnectedSSID(const JsonObject &parameters, JsonObject &response)
 {
-    LOGINFOMETHOD();
     WiFiConnectedSSIDInfo_t param;
     char buff[BUFFER_SIZE] = {'\0'};
     int phyrate, noise, rssi,freq,avgRssi;
@@ -281,7 +280,7 @@ uint32_t WifiManagerState::getConnectedSSID(const JsonObject &parameters, JsonOb
         response["frequency"] = to_string(((float)param.frequency)/1000);
     }
 
-    returnResponse(result);
+    return result;
 }
 
 uint32_t WifiManagerState::setEnabled(const JsonObject &parameters, JsonObject &response)

--- a/WifiManager/impl/WifiManagerState.h
+++ b/WifiManager/impl/WifiManagerState.h
@@ -32,7 +32,7 @@ namespace WPEFramework {
             WifiManagerState& operator=(const WifiManagerState&) = delete;
 
             uint32_t getCurrentState(const JsonObject& parameters, JsonObject& response);
-            uint32_t getConnectedSSID(const JsonObject& parameters, JsonObject& response);
+            bool getConnectedSSID(const JsonObject& parameters, JsonObject& response);
             uint32_t setEnabled(const JsonObject& parameters, JsonObject& response);
             uint32_t getSupportedSecurityModes(const JsonObject& parameters, JsonObject& response);
             void setWifiStateCache(bool value,WifiState state);


### PR DESCRIPTION
[DELIA-56623: Remove multiple time prints same log in wifi manager plu…](https://github.com/rdkcentral/rdkservices/commit/f182ef8d8148f0445039040e34d1002ead807f8b) 

…gin (https://github.com/rdkcentral/rdkservices/pull/2864)

* XIONE-8959:  Remove multiple time prints same log in wifi manager plugin

Reason for change: Printed for every 2s causing log rotation in wpeframework.log
Test Procedure:
Risks: Medium
Signed-off-by: Kumar Santhanam <Kumar_Santhanam@comcast.com>
(cherry picked from commit https://github.com/rdkcentral/rdkservices/commit/3f03c2d47b25f9f834d61e8890089fd94d36a858)

Co-authored-by: Karunakaran A <48997923+karuna2git@users.noreply.github.com>
(cherry picked from commit https://github.com/rdkcentral/rdkservices/commit/0fad2084575ae8fc75ed0dd7c11a46cbd095aab6)