### PR TITLE
XIONE-8959: getConnectedSSID is printed for every 2s causing log rota…

### DIFF
--- a/WifiManager/WifiManager.cpp
+++ b/WifiManager/WifiManager.cpp
@@ -81,8 +81,7 @@ namespace WPEFramework
 
         WifiManager::WifiManager()
         : PluginHost::JSONRPC(),
-          apiVersionNumber(API_VERSION_NUMBER_MAJOR),
-          wifiSignalThreshold(*this)
+          apiVersionNumber(API_VERSION_NUMBER_MAJOR)
         {
             CreateHandler({ 2 });
 


### PR DESCRIPTION
Reason for change: Resolve the rdkservices compilation error in Wifimanager.cpp
Test Procedure: please referred ticket
Risks: Low
Signed-off-by: Thamim  Razith <tabbas651@cable.comcast.com>