### PR TITLE
RDKTV-17965: Fix LocationService hang

### DIFF
--- a/test/tests/LocationSyncTest.cpp
+++ b/test/tests/LocationSyncTest.cpp
@@ -21,6 +21,7 @@
 
 #include "LocationSync.h"
 
+#include "FactoriesImplementation.h"
 #include "ServiceMock.h"
 #include "source/SystemInfo.h"
 #include "source/WorkerPoolImplementation.h"
@@ -29,26 +30,32 @@ using namespace WPEFramework;
 
 namespace {
 const string webPrefix = _T("/Service/LocationSync");
-const unsigned int waitRetries = 2000;
-const unsigned int waitInterval = 100;
 }
 
 class LocationSyncTestFixture : public ::testing::Test {
 protected:
     Core::ProxyType<WorkerPoolImplementation> workerPool;
+    FactoriesImplementation factoriesImplementation;
+
+    ServiceMock service;
     Core::Sink<SystemInfo> subSystem;
+
     Core::ProxyType<Plugin::LocationSync> plugin;
     Core::JSONRPC::Handler& handler;
+
     Core::JSONRPC::Connection connection;
-    ServiceMock service;
+    Core::JSONRPC::Message message;
     string response;
+
+    Core::Event locationchange;
 
     LocationSyncTestFixture()
         : workerPool(Core::ProxyType<WorkerPoolImplementation>::Create(
-            2, Core::Thread::DefaultStackSize(), 16))
+            5, Core::Thread::DefaultStackSize(), 16))
         , plugin(Core::ProxyType<Plugin::LocationSync>::Create())
         , handler(*plugin)
         , connection(1, 0)
+        , locationchange(false, true)
     {
     }
     virtual ~LocationSyncTestFixture()
@@ -57,8 +64,8 @@ protected:
 
     virtual void SetUp()
     {
+        PluginHost::IFactories::Assign(&factoriesImplementation);
         Core::IWorkerPool::Assign(&(*workerPool));
-
         workerPool->Run();
     }
 
@@ -68,10 +75,17 @@ protected:
 
         Core::IWorkerPool::Assign(nullptr);
         workerPool.Release();
+        PluginHost::IFactories::Assign(nullptr);
     }
 };
 
-TEST_F(LocationSyncTestFixture, probeTest)
+TEST_F(LocationSyncTestFixture, registeredMethods)
+{
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("sync")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("location")));
+}
+
+TEST_F(LocationSyncTestFixture, location)
 {
     EXPECT_CALL(service, ConfigLine())
         .Times(1)
@@ -80,11 +94,9 @@ TEST_F(LocationSyncTestFixture, probeTest)
                                     "  \"retries\":20,\n"
                                     "  \"source\":\"http://jsonip.metrological.com/?maf=true\"\n"
                                     " }"));
-
     EXPECT_CALL(service, WebPrefix())
         .Times(1)
         .WillOnce(::testing::Return(webPrefix));
-
     EXPECT_CALL(service, SubSystems())
         .Times(2)
         .WillRepeatedly(::testing::Invoke(
@@ -93,38 +105,153 @@ TEST_F(LocationSyncTestFixture, probeTest)
                 result->AddRef();
                 return result;
             }));
-
     ON_CALL(service, Version())
         .WillByDefault(::testing::Return(string()));
+    EXPECT_CALL(service, Submit(::testing::_, ::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Invoke(
+            [&](const uint32_t, const Core::ProxyType<Core::JSON::IElement>& json) {
+                string text;
+                EXPECT_TRUE(json->ToString(text));
+                EXPECT_EQ(text, string(_T("{"
+                                          "\"jsonrpc\":\"2.0\","
+                                          "\"method\":\"LocationSync.locationchange\","
+                                          "\"params\":\"\""
+                                          "}")));
 
-    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("sync")));
-    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("location")));
+                locationchange.SetEvent();
+
+                return Core::ERROR_NONE;
+            }));
+
+    auto dispatcher = static_cast<PluginHost::IDispatcher*>(
+        plugin->QueryInterface(PluginHost::IDispatcher::ID));
+    EXPECT_TRUE(dispatcher != nullptr);
+    dispatcher->Activate(&service);
+    handler.Subscribe(0, _T("locationchange"), _T("LocationSync"), message);
 
     EXPECT_EQ(string(""), plugin->Initialize(&service));
 
-    EXPECT_EQ(Core::ERROR_INPROGRESS, handler.Invoke(connection, _T("sync"), _T("{}"), response));
-    EXPECT_EQ(response,
-        _T(""));
-
-    Core::Event wait(false, true);
-    for (unsigned int i = 0; ((subSystem.Get(PluginHost::ISubSystem::LOCATION) == nullptr) && (i < waitRetries)); i++) {
-        wait.Lock(waitInterval);
-    }
+    EXPECT_EQ(Core::ERROR_NONE, locationchange.Lock(100000)); // 100s
 
     EXPECT_TRUE(subSystem.Get(PluginHost::ISubSystem::LOCATION) != nullptr);
     EXPECT_TRUE(subSystem.Get(PluginHost::ISubSystem::INTERNET) != nullptr);
 
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("location"), _T(""), response));
-    EXPECT_TRUE(response.empty() == false);
+    EXPECT_THAT(response, ::testing::MatchesRegex("\\{"
+                                                  "\"city\":\".*\","
+                                                  "\"country\":\".*\","
+                                                  "\"region\":\".*\","
+                                                  "\"timezone\":\".+\","
+                                                  "\"publicip\":\".+\""
+                                                  "\\}"));
 
-    JsonObject params;
+    handler.Unsubscribe(0, _T("locationchange"), _T("LocationSync"), message);
+    dispatcher->Deactivate();
+    dispatcher->Release();
+    plugin->Deinitialize(&service);
+}
 
-    EXPECT_TRUE(params.FromString(response));
-    EXPECT_TRUE(params.HasLabel("city"));
-    EXPECT_TRUE(params.HasLabel("country"));
-    EXPECT_TRUE(params.HasLabel("region"));
-    EXPECT_TRUE(params.HasLabel("timezone"));
-    EXPECT_TRUE(params.HasLabel("publicip"));
+TEST_F(LocationSyncTestFixture, inProgress)
+{
+    EXPECT_CALL(service, ConfigLine())
+        .Times(1)
+        .WillOnce(::testing::Return("{\n"
+                                    "  \"interval\":10,\n"
+                                    "  \"retries\":20,\n"
+                                    "  \"source\":\"http://jsonip.metrological.com/?maf=true\"\n"
+                                    " }"));
+    EXPECT_CALL(service, WebPrefix())
+        .Times(1)
+        .WillOnce(::testing::Return(webPrefix));
+    ON_CALL(service, SubSystems())
+        .WillByDefault(::testing::Invoke(
+            [&]() {
+                PluginHost::ISubSystem* result = (&subSystem);
+                result->AddRef();
+                return result;
+            }));
+    ON_CALL(service, Version())
+        .WillByDefault(::testing::Return(string()));
 
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+
+    EXPECT_EQ(Core::ERROR_INPROGRESS, handler.Invoke(connection, _T("sync"), _T("{}"), response));
+
+    plugin->Deinitialize(&service);
+}
+
+TEST_F(LocationSyncTestFixture, urlIncorrect)
+{
+    EXPECT_CALL(service, ConfigLine())
+        .Times(1)
+        .WillOnce(::testing::Return("{\n"
+                                    "  \"interval\":10,\n"
+                                    "  \"retries\":20,\n"
+                                    "  \"source\":\"http://0.0.0.0\"\n"
+                                    " }"));
+    ON_CALL(service, Version())
+        .WillByDefault(::testing::Return(string()));
+
+    EXPECT_EQ(string("URL for retrieving location is incorrect !!!"), plugin->Initialize(&service));
+}
+
+TEST_F(LocationSyncTestFixture, hostUnreachable)
+{
+    EXPECT_CALL(service, ConfigLine())
+        .Times(1)
+        .WillOnce(::testing::Return("{\n"
+                                    "  \"interval\":1,\n"
+                                    "  \"retries\":1,\n"
+                                    "  \"source\":\"http://jsonip.metrological.com:1234/?maf=true\"\n"
+                                    " }"));
+    EXPECT_CALL(service, WebPrefix())
+        .Times(1)
+        .WillOnce(::testing::Return(webPrefix));
+    EXPECT_CALL(service, SubSystems())
+        .Times(2)
+        .WillOnce(::testing::Invoke(
+            [&]() {
+                PluginHost::ISubSystem* result = (&subSystem);
+                result->AddRef();
+
+                locationchange.SetEvent();
+
+                return result;
+            }))
+        .WillOnce(::testing::Invoke(
+            [&]() {
+                PluginHost::ISubSystem* result = (&subSystem);
+                result->AddRef();
+                return result;
+            }));
+    ON_CALL(service, Version())
+        .WillByDefault(::testing::Return(string()));
+
+    auto dispatcher = static_cast<PluginHost::IDispatcher*>(
+        plugin->QueryInterface(PluginHost::IDispatcher::ID));
+    EXPECT_TRUE(dispatcher != nullptr);
+    dispatcher->Activate(&service);
+    handler.Subscribe(0, _T("locationchange"), _T("LocationSync"), message);
+
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+
+    EXPECT_EQ(Core::ERROR_NONE, locationchange.Lock(100000)); // 100s
+
+    EXPECT_TRUE(subSystem.Get(PluginHost::ISubSystem::LOCATION) != nullptr);
+    EXPECT_TRUE(subSystem.Get(PluginHost::ISubSystem::INTERNET) != nullptr);
+
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("location"), _T(""), response));
+    EXPECT_THAT(response, ::testing::MatchesRegex("\\{"
+                                                  "\"city\":\"\","
+                                                  "\"country\":\"\","
+                                                  "\"region\":\"\","
+                                                  "\"timezone\":\"\","
+                                                  "\"publicip\":\"\""
+                                                  "\\}"));
+
+    handler.Unsubscribe(0, _T("locationchange"), _T("LocationSync"), message);
+    dispatcher->Deactivate();
+    dispatcher->Release();
     plugin->Deinitialize(&service);
 }


### PR DESCRIPTION
Reason for change: Do not rely on system time when scheduling.
Test Procedure: Unknown.
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>