### PR TITLE
XIONE-8959: getConnectedSSID is printed for every 2s causing log rota…

### DIFF
--- a/WifiManager/WifiManager.cpp
+++ b/WifiManager/WifiManager.cpp
@@ -65,8 +65,7 @@ namespace WPEFramework
 
         WifiManager::WifiManager()
         : PluginHost::JSONRPC(),
-          apiVersionNumber(API_VERSION_NUMBER_MAJOR),
-          wifiSignalThreshold(*this)
+          apiVersionNumber(API_VERSION_NUMBER_MAJOR)
         {
             CreateHandler({ 2 });
 
@@ -162,7 +161,32 @@ namespace WPEFramework
 
         uint32_t WifiManager::getConnectedSSID(const JsonObject &parameters, JsonObject &response)
         {
-            uint32_t result = wifiState.getConnectedSSID(parameters, response);
+            bool result = false;
+
+            if(getConnectedSSID2(parameters, response))
+            {
+                result = true;
+            }
+            else
+            {
+                LOGWARN("getConnectedSSID2 Call get failed,ret value:%d\n",result);
+            }
+
+            returnResponse(result);
+        }
+
+        bool WifiManager::getConnectedSSID2(const JsonObject &parameters, JsonObject &response)
+        {
+            bool result = false;
+
+            if(wifiState.getConnectedSSID(parameters, response))
+            {
+                result = true;
+            }
+            else
+            {
+                LOGWARN("getConnectedSSID Call get failed,ret value:%d\n",result);
+            }
 
             return result;
         }

--- a/WifiManager/WifiManager.h
+++ b/WifiManager/WifiManager.h
@@ -97,6 +97,7 @@ namespace WPEFramework {
 
             uint32_t getApiVersionNumber() const {return apiVersionNumber;};
             void setApiVersionNumber(uint32_t apiVersion) {apiVersionNumber = apiVersion;};
+            bool getConnectedSSID2(const JsonObject &parameters, JsonObject &response);
 
             //Internal methods
             static WifiManager& getInstance();

--- a/WifiManager/impl/WifiManagerSignalThreshold.cpp
+++ b/WifiManager/impl/WifiManagerSignalThreshold.cpp
@@ -18,7 +18,7 @@
 **/
 
 #include "WifiManagerSignalThreshold.h"
-
+#include "../WifiManager.h" // Need access to WifiManager::getInstance so can't use 'WifiManagerInterface.h'
 #include "UtilsJsonRpc.h"
 
 #include <chrono>
@@ -30,9 +30,9 @@ namespace {
     const float signalStrengthThresholdGood = -60.0f;
     const float signalStrengthThresholdFair = -67.0f;
 
-    void getSignalData(WifiManagerInterface &wifiManager, float &signalStrengthOut, std::string &strengthOut) {
+    void getSignalData(float &signalStrengthOut, std::string &strengthOut) {
         JsonObject response;
-        wifiManager.getConnectedSSID(JsonObject(), response);
+        WifiManager::getInstance().getConnectedSSID2(JsonObject(), response);
 
         signalStrengthOut = 0.0f;
         if (response.HasLabel("signalStrength")) {
@@ -58,9 +58,8 @@ namespace {
     }
 }
 
-WifiManagerSignalThreshold::WifiManagerSignalThreshold(WifiManagerInterface &wifiManager):
+WifiManagerSignalThreshold::WifiManagerSignalThreshold():
     changeEnabled(false),
-    wifiManager(wifiManager),
     running(false)
 {
 }
@@ -110,7 +109,7 @@ void WifiManagerSignalThreshold::setSignalThresholdChangeEnabled(bool enabled, i
     JsonObject parameters, response;
     WifiState state;
 
-    uint32_t result = wifiManager.getCurrentState(parameters, response);
+    uint32_t result = WifiManager::getInstance().getCurrentState(parameters, response);
     if (result != 0)
     {
         LOGINFO("wifiManager.getCurrentState result = %d", result);
@@ -152,13 +151,13 @@ void WifiManagerSignalThreshold::loop(int interval)
         std::string strength;
         if (running)
         {
-            getSignalData(wifiManager, signalStrength, strength);
+            getSignalData(signalStrength, strength);
 
 
             if (strength != lastStrength)
             {
                 LOGINFO("Triggering onWifiSignalThresholdChanged notification");
-                wifiManager.onWifiSignalThresholdChanged(signalStrength, strength);
+                WifiManager::getInstance().onWifiSignalThresholdChanged(signalStrength, strength);
                 lastStrength = strength;
             }
         }

--- a/WifiManager/impl/WifiManagerSignalThreshold.h
+++ b/WifiManager/impl/WifiManagerSignalThreshold.h
@@ -21,7 +21,6 @@
 
 #include "../Module.h"
 #include "../WifiManagerDefines.h"
-#include "../WifiManagerInterface.h"
 
 #include <atomic>
 #include <condition_variable>
@@ -41,7 +40,7 @@ namespace WPEFramework {
             // As the onWifiSignalTresholdChanged event is signalled periodically,
             // it has to be handled with an additional thread.
         public:
-            WifiManagerSignalThreshold(WifiManagerInterface &wifiManager);
+            WifiManagerSignalThreshold();
             virtual ~WifiManagerSignalThreshold();
             WifiManagerSignalThreshold(const WifiManagerSignalThreshold&) = delete;
             WifiManagerSignalThreshold& operator=(const WifiManagerSignalThreshold&) = delete;
@@ -63,7 +62,6 @@ namespace WPEFramework {
             std::atomic<bool> changeEnabled;
             std::mutex cv_mutex;
             std::condition_variable cv;
-            WifiManagerInterface &wifiManager;
             bool running;
         };
     }

--- a/WifiManager/impl/WifiManagerState.cpp
+++ b/WifiManager/impl/WifiManagerState.cpp
@@ -148,9 +148,8 @@ std::map<std::string, std::string> WifiManagerState::retrieveValues(const char *
     return MyMap;
 }
 
-uint32_t WifiManagerState::getConnectedSSID(const JsonObject &parameters, JsonObject &response)
+bool WifiManagerState::getConnectedSSID(const JsonObject &parameters, JsonObject &response)
 {
-    LOGINFOMETHOD();
     WiFiConnectedSSIDInfo_t param;
     char buff[BUFFER_SIZE] = {'\0'};
     int phyrate, noise, rssi,freq,avgRssi;
@@ -214,7 +213,7 @@ uint32_t WifiManagerState::getConnectedSSID(const JsonObject &parameters, JsonOb
                 response["signalStrength"] = to_string(param.signalStrength);
                 response["frequency"] = to_string(((float)param.frequency)/1000);
 
-                returnResponse(result);
+                return result;
              }
              else
              {
@@ -281,7 +280,7 @@ uint32_t WifiManagerState::getConnectedSSID(const JsonObject &parameters, JsonOb
         response["frequency"] = to_string(((float)param.frequency)/1000);
     }
 
-    returnResponse(result);
+    return result;
 }
 
 uint32_t WifiManagerState::setEnabled(const JsonObject &parameters, JsonObject &response)

--- a/WifiManager/impl/WifiManagerState.h
+++ b/WifiManager/impl/WifiManagerState.h
@@ -32,7 +32,7 @@ namespace WPEFramework {
             WifiManagerState& operator=(const WifiManagerState&) = delete;
 
             uint32_t getCurrentState(const JsonObject& parameters, JsonObject& response);
-            uint32_t getConnectedSSID(const JsonObject& parameters, JsonObject& response);
+            bool getConnectedSSID(const JsonObject& parameters, JsonObject& response);
             uint32_t setEnabled(const JsonObject& parameters, JsonObject& response);
             uint32_t getSupportedSecurityModes(const JsonObject& parameters, JsonObject& response);
             void setWifiStateCache(bool value,WifiState state);


### PR DESCRIPTION
…tion in wpeframework.log (#2898)

Reason for change: Printed for every 2s causing log rotation in wpeframework.log
Test Procedure: please referred ticket
Risks: Low
Signed-off-by: Thamim  Razith <tabbas651@cable.comcast.com>
(cherry picked from commit c8d7d26e5182817f16b8df7d990292535f15ab1e)

XIONE-8959: getConnectedSSID is printed for every 2s causing log rotation (#2900)

Reason for change: Resolve the rdkservices compilation error
Test Procedure: please referred ticket
Risks: Low
Signed-off-by: Thamim  Razith <tabbas651@cable.comcast.com>
(cherry picked from commit 70fa362a92a619ff4c9fe14b4e8db4cc5ffc8807)