### PR TITLE
RDK-37220: Assertions and fixture optimization

### DIFF
--- a/test/tests/DeviceInfoWebTest.cpp
+++ b/test/tests/DeviceInfoWebTest.cpp
@@ -16,46 +16,36 @@ const string webPrefix = _T("/Service/DeviceInfo");
 const string iarmName = _T("Thunder_Plugins");
 }
 
-class DeviceInfoWebTestFixture : public ::testing::Test {
+class DeviceInfoWebTest : public ::testing::Test {
 protected:
     FactoriesImplementation factoriesImplementation;
-
     IarmBusImplMock iarmBusImplMock;
     ManagerImplMock managerImplMock;
     ServiceMock service;
     Core::Sink<SystemInfo> subSystem;
-
     Core::ProxyType<Plugin::DeviceInfo> plugin;
     PluginHost::IWeb* interface;
 
-    DeviceInfoWebTestFixture()
+    DeviceInfoWebTest()
         : plugin(Core::ProxyType<Plugin::DeviceInfo>::Create())
         , interface(nullptr)
-    {
-        interface = static_cast<PluginHost::IWeb*>(plugin->QueryInterface(PluginHost::IWeb::ID));
-        EXPECT_TRUE(interface != nullptr);
-    }
-    virtual ~DeviceInfoWebTestFixture()
-    {
-        interface->Release();
-    }
-
-    virtual void SetUp()
     {
         PluginHost::IFactories::Assign(&factoriesImplementation);
         IarmBus::getInstance().impl = &iarmBusImplMock;
         device::Manager::getInstance().impl = &managerImplMock;
     }
-
-    virtual void TearDown()
+    virtual ~DeviceInfoWebTest()
     {
         PluginHost::IFactories::Assign(nullptr);
         IarmBus::getInstance().impl = nullptr;
         device::Manager::getInstance().impl = nullptr;
     }
 
-    void Activate()
+    virtual void SetUp()
     {
+        interface = static_cast<PluginHost::IWeb*>(plugin->QueryInterface(PluginHost::IWeb::ID));
+        ASSERT_TRUE(interface != nullptr);
+
         EXPECT_CALL(iarmBusImplMock, IARM_Bus_IsConnected(::testing::_, ::testing::_))
             .Times(1)
             .WillOnce(::testing::Invoke(
@@ -87,27 +77,30 @@ protected:
         EXPECT_EQ(string(""), plugin->Initialize(&service));
     }
 
-    void Deactivate()
+    virtual void TearDown()
     {
+        ASSERT_TRUE(interface != nullptr);
+        interface->Release();
+
         plugin->Deinitialize(&service);
     }
 };
 
-TEST_F(DeviceInfoWebTestFixture, activate_httpGet_deactivate)
+TEST_F(DeviceInfoWebTest, httpGet)
 {
-    Activate();
-
     Web::Request request;
     request.Verb = Web::Request::HTTP_GET;
     request.Path = webPrefix;
 
     auto response = interface->Process(request);
+    ASSERT_TRUE(response.IsValid());
 
     EXPECT_EQ(response->ErrorCode, Web::STATUS_OK);
     EXPECT_EQ(response->Message, "OK");
     EXPECT_EQ(response->ContentType, Web::MIMETypes::MIME_JSON);
 
     auto body = response->Body<Web::JSONBodyType<Plugin::DeviceInfo::Data>>();
+    ASSERT_TRUE(body.IsValid());
 
     string bodyStr;
     body->ToString(bodyStr);
@@ -136,25 +129,23 @@ TEST_F(DeviceInfoWebTestFixture, activate_httpGet_deactivate)
                                                  "\"sockets\":"
                                                  "\\{\"runs\":[0-9]+\\}"
                                                  "\\}"));
-
-    Deactivate();
 }
 
-TEST_F(DeviceInfoWebTestFixture, activate_httpGetAdresses_deactivate)
+TEST_F(DeviceInfoWebTest, httpGetAdresses)
 {
-    Activate();
-
     Web::Request request;
     request.Verb = Web::Request::HTTP_GET;
     request.Path = webPrefix + _T("/Adresses");
 
     auto response = interface->Process(request);
+    ASSERT_TRUE(response.IsValid());
 
     EXPECT_EQ(response->ErrorCode, Web::STATUS_OK);
     EXPECT_EQ(response->Message, "OK");
     EXPECT_EQ(response->ContentType, Web::MIMETypes::MIME_JSON);
 
     auto body = response->Body<Web::JSONBodyType<Plugin::DeviceInfo::Data>>();
+    ASSERT_TRUE(body.IsValid());
 
     string bodyStr;
     body->ToString(bodyStr);
@@ -162,25 +153,23 @@ TEST_F(DeviceInfoWebTestFixture, activate_httpGetAdresses_deactivate)
                                                  "\"addresses\":"
                                                  "\\[(\\{\"name\":\".+\",\"mac\":\".+\",\"ip\":\\[(\".+\"){0,}\\]\\}){0,}\\]"
                                                  "\\}"));
-
-    Deactivate();
 }
 
-TEST_F(DeviceInfoWebTestFixture, activate_httpGetSystem_deactivate)
+TEST_F(DeviceInfoWebTest, httpGetSystem)
 {
-    Activate();
-
     Web::Request request;
     request.Verb = Web::Request::HTTP_GET;
     request.Path = webPrefix + _T("/System");
 
     auto response = interface->Process(request);
+    ASSERT_TRUE(response.IsValid());
 
     EXPECT_EQ(response->ErrorCode, Web::STATUS_OK);
     EXPECT_EQ(response->Message, "OK");
     EXPECT_EQ(response->ContentType, Web::MIMETypes::MIME_JSON);
 
     auto body = response->Body<Web::JSONBodyType<Plugin::DeviceInfo::Data>>();
+    ASSERT_TRUE(body.IsValid());
 
     string bodyStr;
     body->ToString(bodyStr);
@@ -205,25 +194,23 @@ TEST_F(DeviceInfoWebTestFixture, activate_httpGetSystem_deactivate)
                                                  "\"time\":\".+\""
                                                  "\\}"
                                                  "\\}"));
-
-    Deactivate();
 }
 
-TEST_F(DeviceInfoWebTestFixture, activate_httpGetSockets_deactivate)
+TEST_F(DeviceInfoWebTest, httpGetSockets)
 {
-    Activate();
-
     Web::Request request;
     request.Verb = Web::Request::HTTP_GET;
     request.Path = webPrefix + _T("/Sockets");
 
     auto response = interface->Process(request);
+    ASSERT_TRUE(response.IsValid());
 
     EXPECT_EQ(response->ErrorCode, Web::STATUS_OK);
     EXPECT_EQ(response->Message, "OK");
     EXPECT_EQ(response->ContentType, Web::MIMETypes::MIME_JSON);
 
     auto body = response->Body<Web::JSONBodyType<Plugin::DeviceInfo::Data>>();
+    ASSERT_TRUE(body.IsValid());
 
     string bodyStr;
     body->ToString(bodyStr);
@@ -231,6 +218,4 @@ TEST_F(DeviceInfoWebTestFixture, activate_httpGetSockets_deactivate)
                                                  "\"sockets\":"
                                                  "\\{\"runs\":[0-9]+\\}"
                                                  "\\}"));
-
-    Deactivate();
 }

--- a/test/tests/FirmwareVersionTest.cpp
+++ b/test/tests/FirmwareVersionTest.cpp
@@ -4,33 +4,34 @@
 
 using namespace WPEFramework;
 
-class FirmwareVersionTestFixture : public ::testing::Test {
+class FirmwareVersionTest : public ::testing::Test {
 protected:
     Core::ProxyType<Plugin::FirmwareVersion> firmwareVersion;
     Exchange::IFirmwareVersion* interface;
 
-    FirmwareVersionTestFixture()
+    FirmwareVersionTest()
+        : firmwareVersion(Core::ProxyType<Plugin::FirmwareVersion>::Create())
     {
     }
-    virtual ~FirmwareVersionTestFixture()
+    virtual ~FirmwareVersionTest()
     {
     }
 
     virtual void SetUp()
     {
-        firmwareVersion = Core::ProxyType<Plugin::FirmwareVersion>::Create();
         interface = static_cast<Exchange::IFirmwareVersion*>(
             firmwareVersion->QueryInterface(Exchange::IFirmwareVersion::ID));
-        EXPECT_TRUE(interface != nullptr);
+        ASSERT_TRUE(interface != nullptr);
     }
 
     virtual void TearDown()
     {
+        ASSERT_TRUE(interface != nullptr);
         interface->Release();
     }
 };
 
-TEST_F(FirmwareVersionTestFixture, Imagename)
+TEST_F(FirmwareVersionTest, Imagename)
 {
     string imagename;
 
@@ -38,7 +39,7 @@ TEST_F(FirmwareVersionTestFixture, Imagename)
     EXPECT_EQ(imagename, _T("PX051AEI_VBN_2203_sprint_20220331225312sdy_NG"));
 }
 
-TEST_F(FirmwareVersionTestFixture, Sdk)
+TEST_F(FirmwareVersionTest, Sdk)
 {
     string sdk;
 
@@ -46,7 +47,7 @@ TEST_F(FirmwareVersionTestFixture, Sdk)
     EXPECT_EQ(sdk, _T("17.3"));
 }
 
-TEST_F(FirmwareVersionTestFixture, Mediarite)
+TEST_F(FirmwareVersionTest, Mediarite)
 {
     string mediarite;
 
@@ -54,7 +55,7 @@ TEST_F(FirmwareVersionTestFixture, Mediarite)
     EXPECT_EQ(mediarite, _T("8.3.53"));
 }
 
-TEST_F(FirmwareVersionTestFixture, Yocto)
+TEST_F(FirmwareVersionTest, Yocto)
 {
     string yocto;
 


### PR DESCRIPTION
Reason for change: Use ASSERT_* if it doesn’t make sense to
continue when the assertion in question fails.
Optimize fixtures with inheritance.
Remove "Fixture" from fixture names.
Test Procedure: Run Unit Tests.
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>