### PR TITLE
RDK-37567: Fixing errors in json files

### DIFF
--- a/Messenger/MessengerPlugin.json
+++ b/Messenger/MessengerPlugin.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/rdkcentral/rdkservices/main/Tools/json_generator/schemas/plugin.schema.json",
     "info": {
-        "title": "Messenger Plugin"
+        "title": "Messenger Plugin",
         "callsign": "Messenger",
         "locator": "libWPEFrameworkMessenger.so",
         "status": "alpha",

--- a/OpenCDMi/OpenCDMiPlugin.json
+++ b/OpenCDMi/OpenCDMiPlugin.json
@@ -5,7 +5,7 @@
         "callsign": "OCDM",
         "locator": "libWPEFrameworkOCDM.so",
         "status": "production",
-        "description": "The `OpenCDMi` plugin allows you view Open Content Decryption Module (OCDM) properties",
+        "description": "The `OpenCDMi` plugin allows you view Open Content Decryption Module (OCDM) properties"
     },
     "configuration": {
         "summary": "Configuration for the OpenCDMi plugin",

--- a/RDKShell/RDKShellPlugin.json
+++ b/RDKShell/RDKShellPlugin.json
@@ -5,7 +5,7 @@
       "callsign": "org.rdk.RDKShell",
       "locator": "libWPEFrameworkRDKShell.so",
       "status": "production",
-      "description": "The `RDKShell` plugin controls the management of composition, layout, Z order, and key handling.",
+      "description": "The `RDKShell` plugin controls the management of composition, layout, Z order, and key handling."
     },
     "interface": {
       "$ref": "RDKShell.json#"


### PR DESCRIPTION
"RDK-37567: Fixing errors in json files"

**Reason for change**: The below three json files have improper structure, as a result of which md file generation is getting failed in RDK Documentation. 
         1.Messenger\MessengerPlugin.json
         2.OpenCDMi\OpenCDMiPlugin.json
         3.RDKShell\RDKShellPlugin.json
**Risks**: Create None
**Signed-off-by**: Rekha Jayaram "[Rekha_Jayaram3@comcast.com](mailto:Rekha_Jayaram3@comcast.com)"

**Jira link** : https://ccp.sys.comcast.net/browse/RDK-37567