### PR TITLE
 REFPLTV-1400 DisplaySettings - resolutionPreChange event is not gett…

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -1275,7 +1275,10 @@ namespace WPEFramework {
             bool isIgnoreEdidArg = parameters.HasLabel("ignoreEdid");
             bool isIgnoreEdid = isIgnoreEdidArg ? parameters["ignoreEdid"].Boolean() : false;
             if (!isIgnoreEdidArg) LOGINFO("isIgnoreEdid: false"); else LOGINFO("isIgnoreEdid: %d", isIgnoreEdid);
-
+	    if(DisplaySettings::_instance)
+            {
+                DisplaySettings::_instance->resolutionPreChange();
+            }
             bool success = true;
             try
             {


### PR DESCRIPTION
…ing triggered on changing the current resolution Reason for change :RdK Plugin requeirement. Affected Area: Resolution change scenario Features to test: Sanity on Resolution change related scenaos Analysis: On setCurrentResolution call the preChangeNotification was not called