### PR TITLE
RDK-37454 : Correct setDeviceVolumeMuteInfo doc

### DIFF
--- a/Bluetooth/Bluetooth.json
+++ b/Bluetooth/Bluetooth.json
@@ -221,9 +221,9 @@
             "example":"50"
         },
         "mute": {
-            "summary":"Mute value of the device is either 0 or 1",
+            "summary":"Mute value of the device is either true or false",
             "type": "boolean",
-            "example": "false"
+            "example": false
         }
     },
     "methods": {
@@ -853,7 +853,9 @@
                         "$ref": "#/definitions/volume"
                     },
                     "mute": {
-                        "$ref": "#/definitions/mute"
+                        "summary":"Mute value of the device is either 1 or 0",
+                        "type": "string",
+                        "example": "1"
                     }
                 },
                 "required": [

--- a/Bluetooth/README.md
+++ b/Bluetooth/README.md
@@ -26,7 +26,7 @@ curl --header "Content-Type: application/json" --request POST --data '{"jsonrpc"
 curl --header "Content-Type: application/json" --request POST --data '{"jsonrpc":"2.0", "id":"3", "method":"org.rdk.Bluetooth.1.getAudioInfo", "params": {"deviceID": "256168644324480"}}' http://127.0.0.1:9998/jsonrpc
 curl --header "Content-Type: application/json" --request POST --data '{"jsonrpc":"2.0", "id":"3", "method":"org.rdk.Bluetooth.1.sendAudioPlaybackCommand", "params": {"deviceID": "256168644324480", "command": "PLAY"}}' http://127.0.0.1:9998/jsonrpc
 curl --header "Content-Type: application/json" --request POST --data '{"jsonrpc":"2.0","id": "3", "method":"org.rdk.Bluetooth.1.respondToEvent", "params": {"deviceID": "256168644324480", "eventType": "onPairingRequest", "responseValue": "ACCEPTED"}}' http://127.0.0.1:9998/jsonrpc
-curl --header "Content-Type: application/json" --request POST --data '{"jsonrpc":"2.0", "id":"3", "method":"org.rdk.Bluetooth.1.setDeviceVolumeMuteInfo", "params": {"deviceID": "256168644324480", "profile": "WEARABLE HEADSET", "volume": "255", "mute": "false"}}' http://127.0.0.1:9998/jsonrpc
+curl --header "Content-Type: application/json" --request POST --data '{"jsonrpc":"2.0", "id":"3", "method":"org.rdk.Bluetooth.1.setDeviceVolumeMuteInfo", "params": {"deviceID": "256168644324480", "profile": "WEARABLE HEADSET", "volume": "255", "mute": "1"}}' http://127.0.0.1:9998/jsonrpc
 curl --header "Content-Type: application/json" --request POST --data '{"jsonrpc":"2.0", "id":"3", "method":"org.rdk.Bluetooth.1.getDeviceVolumeMuteInfo", "params": {"deviceID": "256168644324480", "profile": "WEARABLE HEADSET"}}' http://127.0.0.1:9998/jsonrpc
 ```
 


### PR DESCRIPTION
Reason for change: setDeviceVolumeMuteInfo uses 1 or 0 as arguments,
but currently documented as true or false. Fix the doc as
application developers are confused by this inconsistency

Test Procedure: Ensure that generated documentation is consistent
with the implementation of Bluetooth Plugin
Platforms to test - None

Risks: Medium

Signed-off-by: Chandresh Pitty <Chandresh_Pitty@cable.comcast.com>