### PR TITLE
LLAMA-7165: Possible crash fix

### DIFF
--- a/SystemAudioPlayer/SystemAudioPlayerImplementation.cpp
+++ b/SystemAudioPlayer/SystemAudioPlayerImplementation.cpp
@@ -57,7 +57,7 @@ namespace Plugin {
 
     uint32_t SystemAudioPlayerImplementation::Configure(PluginHost::IShell* service)
     {
-     
+        return Core::ERROR_NONE;
     }
 
     void SystemAudioPlayerImplementation::Register(Exchange::ISystemAudioPlayer::INotification* sink)
@@ -418,6 +418,8 @@ namespace Plugin {
         _adminLock.Lock();
 
         _adminLock.Unlock();
+
+        return Core::ERROR_NONE;
     }
 
     impl::SecurityParameters SystemAudioPlayerImplementation::extractSecurityParams(const JsonObject& params) const

--- a/SystemAudioPlayer/impl/AudioPlayer.cpp
+++ b/SystemAudioPlayer/impl/AudioPlayer.cpp
@@ -487,7 +487,7 @@ gboolean AudioPlayer::PushDataAppSrc()
         buffer->deleteBuffer();
 	delete buffer;        
     }
-   
+    return TRUE;
 }
 
 void AudioPlayer::wsConnectionStatus(WSStatus status)


### PR DESCRIPTION
Reason for change: Missing return statements (undefined behavior).
Test Procedure: SystemAudioPlay activates in DFL llama build.
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>