### PR TITLE
RDKTV-18587: Observed stopMaintenance Crash with MM

### DIFF
--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -1165,14 +1165,14 @@ namespace WPEFramework {
         uint32_t MaintenanceManager::stopMaintenance(const JsonObject& parameters,
                 JsonObject& response){
 
+                bool result=false;
                 if( checkAbortFlag() ) {
-                    bool result=false;
                     result=stopMaintenanceTasks();
-                    returnResponse(result);
                 }
                 else {
                     LOGINFO("Failed to initiate stopMaintenance, RFC is set as False\n");
                 }
+                returnResponse(result);
         }
 
         bool MaintenanceManager::stopMaintenanceTasks(){


### PR DESCRIPTION
stopMaintenance Api is not returning anything when stopMaintenance
RFC is disabled which is causing this crash since it receives empty
output from server.