### PR TITLE
RDKTV-18035: Audio did not switch to e-ARC when it was switched ON

### DIFF
--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -78,6 +78,8 @@
 #define SAD_FMT_CODE_AC3 2
 #define SAD_FMT_CODE_ENHANCED_AC3 10
 
+#define IN_TRANSITION_STANDBY_TO_ON 2
+
 enum {
 	DEVICE_POWER_STATE_ON = 0,
 	DEVICE_POWER_STATE_OFF = 1
@@ -387,7 +389,9 @@ namespace WPEFramework
 	   }
 
            if((header.from.toInt() == LogicalAddress::AUDIO_SYSTEM) && (HdmiCecSink::_instance->m_audioDevicePowerStatusRequested)) {
-               HdmiCecSink::_instance->reportAudioDevicePowerStatusInfo(header.from.toInt(), newPowerStatus);
+	       if (newPowerStatus != IN_TRANSITION_STANDBY_TO_ON) {
+                   HdmiCecSink::_instance->reportAudioDevicePowerStatusInfo(header.from.toInt(), newPowerStatus);
+	       }
            }
 
        }


### PR DESCRIPTION
Reason for change: Ignore the power state in transtion stnadby to on from AVR
Test Procedure: As in ticket
Risks: Low

Signed-off-by: shashank.kumar@sky.uk <shashank.kumar@sky.uk>