### PR TITLE
LLAMA-6533:Flickering observed while tuning on the Panel/xbox

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -4093,9 +4093,14 @@ namespace WPEFramework {
 
                     if(types & dsAUDIOARCSUPPORT_eARC) {
                         if(pEnable) {
-                            LOGINFO("DisplaySettings::setEnableAudioPort Enable eARC !!!");
-                            aPort.enableARC(dsAUDIOARCSUPPORT_eARC, true);
-                            m_arcAudioEnabled = true;
+                            if(m_arcAudioEnabled == false) {
+				LOGINFO("DisplaySettings::setEnableAudioPort Enable eARC !!!");
+                                aPort.enableARC(dsAUDIOARCSUPPORT_eARC, true);
+                                m_arcAudioEnabled = true;
+			    }
+			    else {
+				LOGINFO("eARC is already enabled. Value of m_arcAudioEnabled is %d: \n", m_arcAudioEnabled);
+			    }
                         }
                         else{
                             LOGINFO("DisplaySettings::setEnableAudioPort Disable eARC !!!");


### PR DESCRIPTION
Reason for change: Enable eARC happening twice. Restricting Enable eARC if it is already Done
Test Procedure: Build and Verify.
Risks: Low
Signed-off-by: bp-tdora114 [dautapankumar.dora@sky.uk](mailto:dautapankumar.dora@sky.uk)