### PR TITLE
RDKTV-18414: VG not announcing activate URL properly

### DIFF
--- a/TextToSpeech/impl/TTSURLConstructer.cpp
+++ b/TextToSpeech/impl/TTSURLConstructer.cpp
@@ -123,13 +123,13 @@ std::string TTSURLConstructer::constructURL(TTSConfiguration &config,std::string
     return tts_request;
 }
 
-void TTSURLConstructer::replaceIfIsolated(std::string& text, const std::string& search, const std::string& replace) {
+void TTSURLConstructer::replaceIfIsolated(std::string& text, const std::string& search, const std::string& replace, bool skipIsolationCheck) {
     size_t pos = 0;
     while ((pos = text.find(search, pos)) != std::string::npos) {
         bool punctBefore = (pos == 0 || std::ispunct(text[pos-1]) || std::isspace(text[pos-1]));
         bool punctAfter = (pos+1 == text.length() || std::ispunct(text[pos+1]) || std::isspace(text[pos+1]));
 
-        if(punctBefore && punctAfter) {
+        if((punctBefore && punctAfter) || skipIsolationCheck) {
             text.replace(pos, search.length(), replace);
             pos += replace.length();
         } else {
@@ -183,6 +183,7 @@ void TTSURLConstructer::curlSanitize(std::string &sanitizedString) {
 void TTSURLConstructer::sanitizeString(const std::string &input, std::string &sanitizedString) {
     sanitizedString = input;
 
+    replaceIfIsolated(sanitizedString, "://", " colon slash slash ", true);
     replaceIfIsolated(sanitizedString, "$", "dollar");
     replaceIfIsolated(sanitizedString, "#", "pound");
     replaceIfIsolated(sanitizedString, "&", "and");

--- a/TextToSpeech/impl/TTSURLConstructer.h
+++ b/TextToSpeech/impl/TTSURLConstructer.h
@@ -19,7 +19,7 @@ class TTSURLConstructer
    void sanitizeString(const std::string &input, std::string &sanitizedString);
    bool isSilentPunctuation(const char c);
    void replaceSuccesivePunctuation(std::string& subject);
-   void replaceIfIsolated(std::string& subject, const std::string& search, const std::string& replace);
+   void replaceIfIsolated(std::string& subject, const std::string& search, const std::string& replace, bool skipIsolationCheck = false);
    void curlSanitize(std::string &url);
 
    private:


### PR DESCRIPTION
Reason for change: The replaceIfIsolated() will replace "/" with "or"
if the text have a punction character before or after it. Due to this
the URL scheme "://" will change into ":or/" which affecting the output
of TTS.
To solve the issue if the text contains "://" then it replace by
" colon slash slash " using ReplaceIfIsolated() Fn. And also a bool variable
is added as the default parameter for ReplaceIfIsolated() Fn.

Test Procedure: check the output of TTS with diffrent URL.

Risks: LOW

Signed-off-by: Aravind MP <aravind.m@tataelxsi.co.in>