### PR TITLE
RDKTV-17807: TV show dark start logo about 3 seconds

### DIFF
--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -1481,9 +1481,11 @@ namespace WPEFramework {
                     request["callsign"] = "ResidentApp";
                     request["visible"] = true;
                     int32_t status = getThunderControllerClient("org.rdk.RDKShell.1")->Invoke(0, "setVisibility", request, response);
+		    /*
                     gRdkShellMutex.lock();
                     CompositorController::getLastKeyPress(mLastWakeupKeyCode, mLastWakeupKeyModifiers, mLastWakeupKeyTimestamp);
                     gRdkShellMutex.unlock();
+		    */
                 }
             }
         }


### PR DESCRIPTION
Reason for change: getLastkeypressed called with gRdkShellMutex lock but obtained values not used.
Signed-off-by: Ramkumar Prabaharan <Ramkumar_Prabaharan@comcast.com>
Test Procedure: TBD
Risks: None