### PR TITLE
RDKDEV-310: Monitor: Add changes for monitoring additional plugins

### DIFF
--- a/Monitor/Monitor.config
+++ b/Monitor/Monitor.config
@@ -203,3 +203,53 @@ if(PLUGIN_MONITOR_WEBKITBROWSER_RESIDENT_APP)
     map_append(${configuration} observables ___array___)
     map_append(${configuration} observables ${RESIDENT_APP_MONITOR_CONFIG})
 endif()
+
+if(PLUGIN_MONITOR_INSTANCES_LIST)
+
+    # 'PLUGIN_MONITOR_INSTANCES_LIST' contains a semi-colon (';') separated list of Monitor observable
+    # instances. In turn, each instance is a comma (',') separated list defining an observable instance
+    # element ("callsign,memory,memorylimit,operational,window,limit"), where:
+    # - "callsign": The callsign/name of the plugin to be monitored.
+    # - "memory": Interval in seconds used for checking the plugin's memory usage.
+    #    If 0, means don't check memory.
+    # - "memorylimit": Value in KiB above which memory usage is considered excessive.
+    #    Ignored if "memory" is zero.
+    # - "operational": Interval in seconds used for checking plugin's operational state.
+    # - "window": Interval in seconds considered for callsign restart throttling.
+    # - "limit": Maximum number of times the plugin can be restarted within the "window" time.
+    # More details of the parameters is available at https://github.com/rdkcentral/rdkservices/tree/sprint/2101/Monitor/doc
+
+    map_append(${configuration} observables ___array___)
+    foreach(instance ${PLUGIN_MONITOR_INSTANCES_LIST})
+        string(REPLACE "," ";" instance_conf ${instance})
+
+        set(instance_conf_list_required_length 6)
+        list(LENGTH instance_conf instance_conf_list_length)
+        if (NOT instance_conf_list_length EQUAL instance_conf_list_required_length)
+            message(FATAL_ERROR "Instance conf '${instance}': Must have ${instance_conf_list_required_length} entries 'callsign,memory,memorylimit,operational,window,limit', but only has ${instance_conf_list_length} entries")
+        endif()
+
+        list(GET instance_conf 0 name)
+        list(GET instance_conf 1 memory)
+        list(GET instance_conf 2 memorylimit)
+        list(GET instance_conf 3 operational)
+        list(GET instance_conf 4 window)
+        list(GET instance_conf 5 limit)
+
+        map()
+            kv(callsign ${name})
+            if(NOT "${memory}" STREQUAL "0")
+                kv(memory ${memory})
+                kv(memorylimit ${memorylimit})
+            endif()
+            kv(operational ${operational})
+            key(restart)
+            map()
+                kv(window ${window})
+                kv(limit ${limit})
+            end()
+        end()
+        ans(monitor_conf)
+        map_append(${configuration} observables ${monitor_conf})
+    endforeach()
+endif()


### PR DESCRIPTION
This commit brings in the changes to monitor the plugins configured
in 'PLUGIN_MONITOR_INSTANCES_LIST'.
'PLUGIN_MONITOR_INSTANCES_LIST' contains a semi-colon (';') separated
list of Monitor observable instances.
Each instance, in turn, is a comma (',') separated list defining an observable
instance elements ("callsign,memory,memorylimit,operational,window,limit").

(cherry picked from commit da0183e4a6912c2bbec381eb806172837567ef90)