### PR TITLE
AMLOGIC-3562:TV-59804 Implement amlogic hdmicec

### DIFF
--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -251,7 +251,7 @@ namespace WPEFramework
              LOGINFO("Command: GiveOSDName sending SetOSDName : %s\n",osdName.toString().c_str());
              try
              { 
-                 conn.sendTo(header.from, MessageEncoder().encode(SetOSDName(osdName)));
+                 conn.sendToAsync(header.from, MessageEncoder().encode(SetOSDName(osdName)));
              } 
              catch(...)
              {


### PR DESCRIPTION
 HdmiCecTxAsync functionality
Reason for change: Adding HdmiCecTxAsync functionality
Test Procedure: Build and Verify HdmiCecTxAsync functionality
Risks: Low

Signed-off-by: shafi.ahmed@sky.uk <shafi.ahmed@sky.uk>