### PR TITLE
RDK-37454 : Correct setDeviceVolumeMuteInfo doc

### DIFF
--- a/Bluetooth/Bluetooth.cpp
+++ b/Bluetooth/Bluetooth.cpp
@@ -83,6 +83,7 @@ const string WPEFramework::Plugin::Bluetooth::EVT_PLAYBACK_NEW_TRACK = "onPlayba
 const string WPEFramework::Plugin::Bluetooth::EVT_DEVICE_FOUND = "onDeviceFound";
 const string WPEFramework::Plugin::Bluetooth::EVT_DEVICE_LOST_OR_OUT_OF_RANGE = "onDeviceLost";
 const string WPEFramework::Plugin::Bluetooth::EVT_DEVICE_DISCOVERY_UPDATE = "onDiscoveredDevice";
+const string WPEFramework::Plugin::Bluetooth::EVT_DEVICE_MEDIA_STATUS = "onDeviceMediaStatus";
 
 const string WPEFramework::Plugin::Bluetooth::STATUS_NO_BLUETOOTH_HARDWARE = "NO_BLUETOOTH_HARDWARE";
 const string WPEFramework::Plugin::Bluetooth::STATUS_SOFTWARE_DISABLED = "SOFTWARE_DISABLED";
@@ -117,6 +118,7 @@ const string WPEFramework::Plugin::Bluetooth::CMD_AUDIO_CTRL_VOLUME_UP = "VOLUME
 const string WPEFramework::Plugin::Bluetooth::CMD_AUDIO_CTRL_VOLUME_DOWN = "VOLUME_DOWN";
 const string WPEFramework::Plugin::Bluetooth::CMD_AUDIO_CTRL_MUTE = "AUDIO_MUTE";
 const string WPEFramework::Plugin::Bluetooth::CMD_AUDIO_CTRL_UNMUTE = "AUDIO_UNMUTE";
+const string WPEFramework::Plugin::Bluetooth::CMD_AUDIO_CTRL_UNKNOWN = "CMD_UNKNOWN";
 
 namespace WPEFramework
 {
@@ -1136,6 +1138,33 @@ namespace WPEFramework
                     params["paired"] = eventMsg.m_discoveredDevice.m_isPairedDevice ? true:false;
 
                     eventId = EVT_DEVICE_DISCOVERY_UPDATE;
+                    break;
+
+                case BTRMGR_EVENT_DEVICE_MEDIA_STATUS:
+                    LOGINFO ("Received %s Event from BTRMgr", C_STR(EVT_DEVICE_MEDIA_STATUS));
+                    params["deviceID"] = std::to_string(eventMsg.m_mediaInfo.m_deviceHandle);
+                    params["name"] = string(eventMsg.m_mediaInfo.m_name);
+                    params["deviceType"] = BTRMGR_GetDeviceTypeAsString(eventMsg.m_mediaInfo.m_deviceType);
+                    params["volume"] = std::to_string(eventMsg.m_mediaInfo.m_mediaDevStatus.m_ui8mediaDevVolume);
+                    params["mute"] = eventMsg.m_mediaInfo.m_mediaDevStatus.m_ui8mediaDevMute ? true : false;
+
+                    if (eventMsg.m_mediaInfo.m_mediaDevStatus.m_enmediaCtrlCmd == BTRMGR_MEDIA_CTRL_VOLUMEUP) {
+                        params["command"] = string(CMD_AUDIO_CTRL_VOLUME_UP);
+                    }
+                    else if (eventMsg.m_mediaInfo.m_mediaDevStatus.m_enmediaCtrlCmd == BTRMGR_MEDIA_CTRL_VOLUMEDOWN) {
+                        params["command"] = string(CMD_AUDIO_CTRL_VOLUME_DOWN);
+                    }
+                    else if (eventMsg.m_mediaInfo.m_mediaDevStatus.m_enmediaCtrlCmd == BTRMGR_MEDIA_CTRL_MUTE) {
+                        params["command"] = string(CMD_AUDIO_CTRL_MUTE);
+                    }
+                    else if (eventMsg.m_mediaInfo.m_mediaDevStatus.m_enmediaCtrlCmd == BTRMGR_MEDIA_CTRL_UNMUTE) {
+                        params["command"] = string(CMD_AUDIO_CTRL_UNMUTE);
+                    }
+                    else {
+                        params["command"] = string(CMD_AUDIO_CTRL_UNKNOWN);
+                    }
+
+                    eventId = EVT_DEVICE_MEDIA_STATUS;
                     break;
 
                     // TODO: implement or delete these values from enum

--- a/Bluetooth/Bluetooth.h
+++ b/Bluetooth/Bluetooth.h
@@ -168,6 +168,7 @@ namespace WPEFramework {
             static const string EVT_DEVICE_FOUND;
             static const string EVT_DEVICE_LOST_OR_OUT_OF_RANGE;
             static const string EVT_DEVICE_DISCOVERY_UPDATE;
+            static const string EVT_DEVICE_MEDIA_STATUS;
 
             Bluetooth();
             virtual ~Bluetooth();
@@ -218,6 +219,7 @@ namespace WPEFramework {
             static const string CMD_AUDIO_CTRL_VOLUME_DOWN;
             static const string CMD_AUDIO_CTRL_MUTE;
             static const string CMD_AUDIO_CTRL_UNMUTE;
+            static const string CMD_AUDIO_CTRL_UNKNOWN;
 
             uint32_t m_apiVersionNumber;
             // Assuming that there will be only one threaded call at a time (which is the case for Bluetooth)

--- a/Bluetooth/Bluetooth.json
+++ b/Bluetooth/Bluetooth.json
@@ -221,9 +221,9 @@
             "example":"50"
         },
         "mute": {
-            "summary":"Mute value of the device is either 0 or 1",
+            "summary":"Mute value of the device is either true or false",
             "type": "boolean",
-            "example": "false"
+            "example": false
         }
     },
     "methods": {
@@ -810,23 +810,20 @@
                 "type": "object",
                 "properties": {
                     "volumeInfo": {
-                        "summary":"An array of objects where each object represents a device volume information",
-                        "type": "array",
-                        "items": {
-                            "type":"object",
-                            "properties": {
-                                "volume": {
-                                    "$ref": "#/definitions/volume"
-                                },
-                                "mute": {
-                                    "$ref": "#/definitions/mute"
-                                }
+                        "summary":"An object which represents current device volume and mute information",
+                        "type":"object",
+                        "properties": {
+                            "volume": {
+                                "$ref": "#/definitions/volume"
                             },
-                            "required":[
-                                "volume",
-                                "mute"
-                            ]
-                        }
+                            "mute": {
+                                "$ref": "#/definitions/mute"
+                            }
+                        },
+                        "required":[
+                            "volume",
+                            "mute"
+                        ]
                     },
                     "success":{
                         "$ref": "#/common/success"
@@ -839,7 +836,10 @@
             }
         },
         "setDeviceVolumeMuteInfo": {
-            "summary": "Sets the volume of the connected Bluetooth device ID. \n \n### Event \n\n No Events",
+            "summary": "Sets the volume of the connected Bluetooth device ID.  Triggers `onDeviceMediaStatus` event.\n \n### Events \n| Event | Description | \n| :----------- | :----------- | \n| `MediaAudioControlCommand`: `VOLUME_UP` | Triggers `onDeviceMediaStatus` event once volume of connected given deviceID is increased. | \n| `MediaAudioControlCommand`: `VOLUME_DOWN` | Triggers `onDeviceMediaStatus` event once volume of connected given deviceID is decreased. | \n| `MediaAudioControlCommand`: `MUTE` | Triggers `onDeviceMediaStatus` event when connected given deviceID is muted. | \n| `MediaAudioControlCommand`: `UNMUTE` | Triggers `onDeviceMediaStatus` event when connected given deviceID is unmuted. | \n| `MediaAudioControlCommand`: `CMD_UNKNOWN` | Triggers `onDeviceMediaStatus` event when unknown key is pressed on connected given deviceID. |",
+            "events": [
+                "onDeviceMediaStatus"
+            ],
             "params": {
                 "type":"object",
                 "properties": {
@@ -853,7 +853,9 @@
                         "$ref": "#/definitions/volume"
                     },
                     "mute": {
-                        "$ref": "#/definitions/mute"
+                        "summary":"Mute value of the device is either 1 or 0",
+                        "type": "string",
+                        "example": "1"
                     }
                 },
                 "required": [
@@ -1272,6 +1274,40 @@
                     "deviceType",
                     "rawDeviceType",
                     "lastConnectedState"
+                ]
+            }
+        },
+        "onDeviceMediaStatus":{
+            "summary": "Triggered when any change occurs to Device Media like volume or mute. Supported Audio Media Control commands are:  \n* `MUTE` - BT audio device muted using remote or external BT device.  \n* `UNMUTE` - BT audio device unmuted using remote or external BT device.  \n* `VOLUME_UP` - BT audio device volume increased using remote or external BT device.  \n* `VOLUME_DOWN`- BT audio device volume decreased using remote or external BT device. \n* `CMD_UNKNOWN`- Unknown Media control other than MUTE, UNMUTE, VOLUME_UP, VOLUME_DOWN was performed on external BT device. ",
+            "params": {
+                "type":"object",
+                "properties": {
+                    "deviceID": {
+                        "$ref": "#/definitions/deviceID"
+                    },
+                    "name": {
+                        "$ref": "#/definitions/name"
+                    },
+                    "deviceType": {
+                        "$ref": "#/definitions/deviceType"
+                    },
+                    "volume": {
+                        "$ref": "#/definitions/volume"
+                    },
+                    "mute": {
+                        "$ref": "#/definitions/mute"
+                    },
+                    "command": {
+                        "$ref": "#/definitions/command"
+                    }
+                },
+                "required": [
+                    "deviceID",
+                    "name",
+                    "deviceType",
+                    "volume",
+                    "mute",
+                    "command"
                 ]
             }
         }

--- a/Bluetooth/README.md
+++ b/Bluetooth/README.md
@@ -26,6 +26,8 @@ curl --header "Content-Type: application/json" --request POST --data '{"jsonrpc"
 curl --header "Content-Type: application/json" --request POST --data '{"jsonrpc":"2.0", "id":"3", "method":"org.rdk.Bluetooth.1.getAudioInfo", "params": {"deviceID": "256168644324480"}}' http://127.0.0.1:9998/jsonrpc
 curl --header "Content-Type: application/json" --request POST --data '{"jsonrpc":"2.0", "id":"3", "method":"org.rdk.Bluetooth.1.sendAudioPlaybackCommand", "params": {"deviceID": "256168644324480", "command": "PLAY"}}' http://127.0.0.1:9998/jsonrpc
 curl --header "Content-Type: application/json" --request POST --data '{"jsonrpc":"2.0","id": "3", "method":"org.rdk.Bluetooth.1.respondToEvent", "params": {"deviceID": "256168644324480", "eventType": "onPairingRequest", "responseValue": "ACCEPTED"}}' http://127.0.0.1:9998/jsonrpc
+curl --header "Content-Type: application/json" --request POST --data '{"jsonrpc":"2.0", "id":"3", "method":"org.rdk.Bluetooth.1.setDeviceVolumeMuteInfo", "params": {"deviceID": "256168644324480", "profile": "WEARABLE HEADSET", "volume": "255", "mute": "1"}}' http://127.0.0.1:9998/jsonrpc
+curl --header "Content-Type: application/json" --request POST --data '{"jsonrpc":"2.0", "id":"3", "method":"org.rdk.Bluetooth.1.getDeviceVolumeMuteInfo", "params": {"deviceID": "256168644324480", "profile": "WEARABLE HEADSET"}}' http://127.0.0.1:9998/jsonrpc
 ```
 
 ## Responses:
@@ -92,6 +94,12 @@ sendAudioPlaybackCommand:
 
 respondToEvent:
 {"jsonrpc":"2.0","id":3,"result":{"success":true}}
+
+setDeviceVolumeMuteInfo:
+{"jsonrpc":"2.0","id":3,"result":{"success":true}}
+
+getDeviceVolumeMuteInfo:
+{"jsonrpc":"2.0","id":3,"result":{"volumeInfo":{"volume":"255","mute":false},"success":true}}
 ```
 
 ## Events
@@ -107,6 +115,7 @@ onPlaybackNewTrack
 onDeviceFound
 onDeviceLost
 onDiscoveredDevice
+onDeviceMediaStatus
 ```
 
 ## Full Reference


### PR DESCRIPTION
Reason for change: setDeviceVolumeMuteInfo uses 1 or 0 as arguments,
but currently documented as true or false. Fix the doc as
application developers are confused by this inconsistency

Test Procedure: Ensure that generated documentation is consistent
with the implementation of Bluetooth Plugin
Platforms to test - None

Risks: Medium

Signed-off-by: Chandresh Pitty <Chandresh_Pitty@cable.comcast.com>
(cherry picked from commit 186bc7f6b721f5f412d0d3ecf72e0f481e0d0e64)

RDK-37453, RDK-37454 : Emit Media Status volume/mute changes for AVRCP

Reason for change: Expose Media statue volume/mute events to
clients of BTRMgr

Events to be triggered for Remote controlled volume change as
well as Bluetooth device volume changes

Test Procedure: Volume/Mute control using External BT device
Platforms to test - Llama/HiSense/Platco/Element

Risks: Medium

Signed-off-by: Chandresh Pitty <Chandresh_Pitty@cable.comcast.com>
(cherry picked from commit f9d5b1f36402bd66f28693c1f2efe7383e9133bd)
(cherry picked from commit 581a08dfd772fbfc6e7c57543ec3eabcebe44ce5)