### PR TITLE
RDKTV-18719: WpeFramework crash with shared_count display settings

### DIFF
--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -210,6 +210,7 @@ namespace WPEFramework {
 
 	    std::shared_ptr<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>> getHdmiCecSinkPlugin();
 	    std::shared_ptr<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement> > m_client;
+	    std::vector<std::string> m_clientRegisteredEventNames;
 	    std::shared_ptr<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>> getSystemPlugin();
 	    uint32_t subscribeForHdmiCecSinkEvent(const char* eventName);
 	    bool setUpHdmiCecSinkArcRouting (bool arcEnable);


### PR DESCRIPTION
Reason for change: Fixed Display Settings distractor.
Test Procedure: refer jira.
Risks: Medium

Signed-off-by: apatel859 <amit_patel5@comcast.com>