### PR TITLE
RDKTV-18791, LLAMA-7438, LLAMA-7431: std::terminate crash with MM in

### DIFF
--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -1143,6 +1143,12 @@ namespace WPEFramework {
                         /* we set this to false */
                         g_is_critical_maintenance="false";
 
+                        /* if there is any active thread, join it before executing the tasks from startMaintenance
+                        * especially when device is in offline mode*/
+                        if(m_thread.joinable()){
+                            m_thread.join();
+                        }
+
                         m_thread = std::thread(&MaintenanceManager::task_execution_thread, _instance);
 
                         result=true;


### PR DESCRIPTION
…startMaintenance API

Joined the thread before executing tasks from startMaintenance API.
Whenever device has no internet connectvity, unsolicitated maintenance
was performed and thread was not yet joined. so whenever we invoke
startMaintenance API, it is better to do join before creating m_thread.