### PR TITLE
RDKTV-18517: Crash in rtRemoteServer::findObject

### DIFF
--- a/XCast/CHANGELOG.md
+++ b/XCast/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2022-08-16
+### Added
+- Added fix to stop retry timer when distruct xcast plugin.
+
 ## [1.0.0] - 2022-05-11
 ### Added
 - Add CHANGELOG

--- a/XCast/XCast.cpp
+++ b/XCast/XCast.cpp
@@ -67,7 +67,7 @@ using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 0
+#define API_VERSION_NUMBER_PATCH 1
 
 namespace WPEFramework {
 
@@ -158,11 +158,6 @@ void XCast::DeinitializeIARM()
      Unregister(METHOD_GET_FRIENDLYNAME);
      Unregister(METHOD_SET_FRIENDLYNAME);
 
-     DeinitializeIARM();
-     if ( m_locateCastTimer.isActive())
-     {
-         m_locateCastTimer.stop();
-     }
 }
 void XCast::powerModeChange(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
 {
@@ -185,7 +180,7 @@ void XCast::powerModeChange(const char *owner, IARM_EventId_t eventId, void *dat
 
 const string XCast::Initialize(PluginHost::IShell* /* service */)
 {
-    LOGINFO("Activate plugin.");
+    LOGINFO("XCast:: Initialize  plugin called \n");
     _rtConnector  = RtXcastConnector::getInstance();
     _rtConnector->setService(this);
     if (XCast::isCastEnabled)
@@ -207,10 +202,16 @@ const string XCast::Initialize(PluginHost::IShell* /* service */)
 
 void XCast::Deinitialize(PluginHost::IShell* /* service */)
 {
+    LOGINFO("XCast::Deinitialize  called \n ");
+    if ( m_locateCastTimer.isActive())
+    {
+        m_locateCastTimer.stop();
+    }
     if( XCast::isCastEnabled){
         _rtConnector->enableCastService(m_friendlyName,false);
         _rtConnector->shutdown();
     }
+    DeinitializeIARM();
 }
 
 string XCast::Information() const


### PR DESCRIPTION
Reason for change:  stop retry timer when distruct xcast plugin
Test Procedure: refer jira.
Risks: Medium

Signed-off-by: apatel859 <amit_patel5@comcast.com>