### PR TITLE
RDKTV-18791, LLAMA-7438, LLAMA-7431: std::terminate crash with MM in …

### DIFF
--- a/MaintenanceManager/CHANGELOG.md
+++ b/MaintenanceManager/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2022-08-12
+### Fixed
+- Fixed std::terminate crash in Maintenance Manager with startMaintenance API.
+
 ## [1.0.1] - 2022-08-12
 ### Fixed
 - Fixed std::terminate crash in Maintenance Manager with stopMaintenance API.

--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -67,7 +67,7 @@ using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 1
+#define API_VERSION_NUMBER_PATCH 2
 #define SERVER_DETAILS  "127.0.0.1:9998"
 
 
@@ -1158,6 +1158,12 @@ namespace WPEFramework {
 
                         /* we set this to false */
                         g_is_critical_maintenance="false";
+
+                        /* if there is any active thread, join it before executing the tasks from startMaintenance
+                        * especially when device is in offline mode*/
+                        if(m_thread.joinable()){
+                            m_thread.join();
+                        }
 
                         m_thread = std::thread(&MaintenanceManager::task_execution_thread, _instance);
 


### PR DESCRIPTION
…startMaintenance API

Joined the thread before executing tasks from startMaintenance API.
Whenever device has no internet connectvity, unsolicitated maintenance
was performed and thread was not yet joined. so whenever we invoke
startMaintenance API, it is better to do join before creating m_thread.