### PR TITLE
RDKTV-19132:- Update SystemServices  to call container_setup.sh script after deleting persistent data

### DIFF
--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -4255,6 +4255,11 @@ namespace WPEFramework {
             // Everything is OK
             LOGINFO("Successfully deleted persistent path for '%s' (path = '%s')", callsignOrType.c_str(), persistentPath.c_str());
 
+            //Calling container_setup.sh along with callsign as container bundle also gets deleted from the persistent path
+            std::string command = "/lib/rdk/container_setup.sh " + callsignOrType;
+            system(command.c_str());
+            LOGINFO("Calling %s \n", command.c_str());
+
             result = true;
 
           } while(false);


### PR DESCRIPTION
Calling container_setup.sh along with callsign as container bundle also gets deleted from the persistent path