### PR TITLE
RDKTV-18719: WpeFramework crash with shared_count display settings

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -287,7 +287,25 @@ namespace WPEFramework {
 
         DisplaySettings::~DisplaySettings()
         {
-            LOGINFO("dtor");
+            LOGINFO("dtor  ");
+            {
+                LOGINFO("de-init timer and subscribbed event if not done as pert of Deinitialize fundtion ");
+                lock_guard<mutex> lck(m_callMutex);
+                if ( m_timer.isActive()) {
+                    m_timer.stop();
+                }
+
+                if ( m_AudioDeviceDetectTimer.isActive()) {
+                    m_AudioDeviceDetectTimer.stop();
+                }
+                for (std::string eventName : m_clientRegisteredEventNames) {
+                    m_client->Unsubscribe(1000, _T(eventName));
+                    LOGINFO("Unsubscribing event %s", eventName.c_str());
+                }
+                m_clientRegisteredEventNames.clear();
+                m_client.reset();
+                LOGINFO("reset m_client :%d  ", m_client.use_count());
+            }
         }
 
         void DisplaySettings::AudioPortsReInitialize()
@@ -3930,8 +3948,8 @@ namespace WPEFramework {
             bool success = true;
 
             if (Utils::isPluginActivated(HDMICECSINK_CALLSIGN)) {
-                auto hdmiCecSinkPlugin = getHdmiCecSinkPlugin();
-                if (!hdmiCecSinkPlugin) {
+                getHdmiCecSinkPlugin();
+                if (!m_client) {
                     LOGERR("HdmiCecSink Initialisation failed\n");
                 }
                 else {
@@ -3945,7 +3963,7 @@ namespace WPEFramework {
                     }
 
                     LOGINFO("ARC Routing - %d \n", arcEnable);
-                    hdmiCecSinkPlugin->Invoke<JsonObject, JsonObject>(2000, "setupARCRouting", param, hdmiCecSinkResult);
+                    m_client->Invoke<JsonObject, JsonObject>(2000, "setupARCRouting", param, hdmiCecSinkResult);
                     if (!hdmiCecSinkResult["success"].Boolean()) {
 			success = false;
                         LOGERR("HdmiCecSink Plugin returned error\n");
@@ -3966,15 +3984,15 @@ namespace WPEFramework {
 	    bool cecEnable = false;
 
             if (Utils::isPluginActivated(HDMICECSINK_CALLSIGN)) {
-                auto hdmiCecSinkPlugin = getHdmiCecSinkPlugin();
-                if (!hdmiCecSinkPlugin) {
+                getHdmiCecSinkPlugin();
+                if (!m_client) {
                     LOGERR("HdmiCecSink Initialisation failed\n");
                 }
                 else {
                     JsonObject hdmiCecSinkResult;
                     JsonObject param;
 
-                    hdmiCecSinkPlugin->Invoke<JsonObject, JsonObject>(2000, "getEnabled", param, hdmiCecSinkResult);
+                    m_client->Invoke<JsonObject, JsonObject>(2000, "getEnabled", param, hdmiCecSinkResult);
 
 		    cecEnable = hdmiCecSinkResult["enabled"].Boolean();
 		    LOGINFO("get-cecEnabled [%d]\n",cecEnable);
@@ -3998,15 +4016,15 @@ namespace WPEFramework {
             bool hdmiAudioDeviceDetected = false;
 
             if (Utils::isPluginActivated(HDMICECSINK_CALLSIGN)) {
-                auto hdmiCecSinkPlugin = getHdmiCecSinkPlugin();
-                if (!hdmiCecSinkPlugin) {
+                getHdmiCecSinkPlugin();
+                if (!m_client) {
                     LOGERR("HdmiCecSink Initialisation failed\n");
                 }
                 else {
                     JsonObject hdmiCecSinkResult;
                     JsonObject param;
 
-                    hdmiCecSinkPlugin->Invoke<JsonObject, JsonObject>(2000, "getAudioDeviceConnectedStatus", param, hdmiCecSinkResult);
+                    m_client->Invoke<JsonObject, JsonObject>(2000, "getAudioDeviceConnectedStatus", param, hdmiCecSinkResult);
 
                     hdmiAudioDeviceDetected = hdmiCecSinkResult["connected"].Boolean();
                     LOGINFO("getAudioDeviceConnectedStatus [%d]\n",hdmiAudioDeviceDetected);
@@ -4029,8 +4047,8 @@ namespace WPEFramework {
             bool success = true;
 
             if (Utils::isPluginActivated(HDMICECSINK_CALLSIGN)) {
-                auto hdmiCecSinkPlugin = getHdmiCecSinkPlugin();
-                if (!hdmiCecSinkPlugin) {
+                getHdmiCecSinkPlugin();
+                if (!m_client) {
                     LOGERR("HdmiCecSink Initialisation failed\n");
                 }
                 else {
@@ -4038,7 +4056,7 @@ namespace WPEFramework {
                     JsonObject param;
 
                     LOGINFO("%s: Send Audio Device Power On !!!\n");
-                    hdmiCecSinkPlugin->Invoke<JsonObject, JsonObject>(2000, "sendAudioDevicePowerOnMessage", param, hdmiCecSinkResult);
+                    m_client->Invoke<JsonObject, JsonObject>(2000, "sendAudioDevicePowerOnMessage", param, hdmiCecSinkResult);
                     if (!hdmiCecSinkResult["success"].Boolean()) {
                         success = false;
                         LOGERR("HdmiCecSink Plugin returned error\n");
@@ -4058,8 +4076,8 @@ namespace WPEFramework {
             bool success = true;
 
             if (Utils::isPluginActivated(HDMICECSINK_CALLSIGN)) {
-                auto hdmiCecSinkPlugin = getHdmiCecSinkPlugin();
-                if (!hdmiCecSinkPlugin) {
+                getHdmiCecSinkPlugin();
+                if (!m_client) {
                     LOGERR("HdmiCecSink plugin not accessible\n");
                 }
                 else {
@@ -4067,7 +4085,7 @@ namespace WPEFramework {
                     JsonObject param;
 
                     LOGINFO("Requesting Short Audio Descriptor \n");
-                    hdmiCecSinkPlugin->Invoke<JsonObject, JsonObject>(2000, "requestShortAudioDescriptor", param, hdmiCecSinkResult);
+                    m_client->Invoke<JsonObject, JsonObject>(2000, "requestShortAudioDescriptor", param, hdmiCecSinkResult);
                     if (!hdmiCecSinkResult["success"].Boolean()) {
                         success = false;
                         LOGERR("HdmiCecSink Plugin returned error\n");
@@ -4087,8 +4105,8 @@ namespace WPEFramework {
             bool success = true;
 
             if (Utils::isPluginActivated(HDMICECSINK_CALLSIGN)) {
-                auto hdmiCecSinkPlugin = getHdmiCecSinkPlugin();
-                if (!hdmiCecSinkPlugin) {
+                getHdmiCecSinkPlugin();
+                if (!m_client) {
                     LOGERR("HdmiCecSink plugin not accessible\n");
                 }
                 else {
@@ -4096,7 +4114,7 @@ namespace WPEFramework {
                     JsonObject param;
 
                     LOGINFO("Requesting Audio Device power Status \n");
-                    hdmiCecSinkPlugin->Invoke<JsonObject, JsonObject>(2000, "requestAudioDevicePowerStatus", param, hdmiCecSinkResult);
+                    m_client->Invoke<JsonObject, JsonObject>(2000, "requestAudioDevicePowerStatus", param, hdmiCecSinkResult);
                     if (!hdmiCecSinkResult["success"].Boolean()) {
                         success = false;
                         LOGERR("HdmiCecSink Plugin returned error\n");
@@ -4298,17 +4316,16 @@ namespace WPEFramework {
 
 
         // Thunder plugins communication
-        std::shared_ptr<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>> DisplaySettings::getHdmiCecSinkPlugin()
+        void DisplaySettings::getHdmiCecSinkPlugin()
         {
-            Core::SystemInfo::SetEnvironment(_T("THUNDER_ACCESS"), (_T("127.0.0.1:9998")));
-            return make_shared<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>>("org.rdk.HdmiCecSink.1", "");
+            if(m_client == NULL)
+            { 
+                Core::SystemInfo::SetEnvironment(_T("THUNDER_ACCESS"), (_T("127.0.0.1:9998")));
+                m_client =  make_shared<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>>("org.rdk.HdmiCecSink.1", "");
+                LOGINFO("DisplaySettings getHdmiCecSinkPlugin init m_client count: %d  \n",m_client.use_count());
+            }
         }
 
-        std::shared_ptr<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>> DisplaySettings::getSystemPlugin()
-        {
-            Core::SystemInfo::SetEnvironment(_T("THUNDER_ACCESS"), (_T("127.0.0.1:9998")));
-            return make_shared<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>>("org.rdk.System.1", "");
-        }
 
         IARM_Bus_PWRMgr_PowerState_t DisplaySettings::getSystemPowerState()
         {
@@ -4494,7 +4511,7 @@ namespace WPEFramework {
             LOGINFO("Attempting to subscribe for event: %s\n", eventName);
             Core::SystemInfo::SetEnvironment(_T("THUNDER_ACCESS"), (_T(SERVER_DETAILS)));
             if (nullptr == m_client) {
-                m_client = make_shared<WPEFramework::JSONRPC::LinkType<Core::JSON::IElement>>(_T(HDMICECSINK_CALLSIGN_VER), (_T(HDMICECSINK_CALLSIGN_VER)));
+                getHdmiCecSinkPlugin();
                 if (nullptr == m_client) {
                     LOGERR("JSONRPC: %s: client initialization failed", HDMICECSINK_CALLSIGN_VER);
                     err = Core::ERROR_UNAVAILABLE;

--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -209,10 +209,9 @@ namespace WPEFramework {
             bool checkPortName(std::string& name) const;
             IARM_Bus_PWRMgr_PowerState_t getSystemPowerState();
 
-	    std::shared_ptr<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>> getHdmiCecSinkPlugin();
+	    void getHdmiCecSinkPlugin();
 	    std::shared_ptr<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement> > m_client;
 	    std::vector<std::string> m_clientRegisteredEventNames;
-	    std::shared_ptr<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>> getSystemPlugin();
 	    uint32_t subscribeForHdmiCecSinkEvent(const char* eventName);
 	    bool setUpHdmiCecSinkArcRouting (bool arcEnable);
 	    bool requestShortAudioDescriptor();


### PR DESCRIPTION
Reason for change: Fixed Display Settings distractor.
Test Procedure: refer jira.
Risks: Medium

Signed-off-by: apatel859 <amit_patel5@comcast.com>