### PR TITLE
RDKCOM-3277 RDKDEV-343 - SecurityAgent: token generated is always the same

### DIFF
--- a/SecurityAgent/TokenFactory.h
+++ b/SecurityAgent/TokenFactory.h
@@ -33,6 +33,7 @@ private:
   JWTFactory &operator=(const JWTFactory &) = delete;
   JWTFactory() {
     #ifndef ENABLE_SECAPI
+    WPEFramework::Crypto::Reseed();
     for (uint8_t index = 0; index < sizeof(_secretKey); index++) {
       WPEFramework::Crypto::Random(_secretKey[index]);
     }


### PR DESCRIPTION
While testing it was observed the token generated is always the same for
a given payload across the devices. This was caused since the secret we
use for crating the token is always the same. The secret is supposed to
be random, the implementation uses random() and rand() methods based on
the platform to get the token. The random numbers thus generated depends
on the seed that we are using. The original implementation was using the
default seed.
To get a better random numbers we need to set the seed value properly.
This commit is for fixing this by setting a seed before using the
`random` function. This could be easy done using `WPEFramework::Crypto::Reseed()`.