### PR TITLE
Set WPE_INIT_VIEW_HEIGHT / WIDTH envs

### DIFF
--- a/WebKitBrowser/WebKitImplementation.cpp
+++ b/WebKitBrowser/WebKitImplementation.cpp
@@ -1864,10 +1864,12 @@ static GSourceFuncs _handlerIntervention =
             Core::SystemInfo::SetEnvironment(_T("WEBKIT_MAXIMUM_FPS"), maxFPS, !environmentOverride);
 
             if (width.empty() == false) {
+                Core::SystemInfo::SetEnvironment(_T("WPE_INIT_VIEW_WIDTH"), width, !environmentOverride);
                 Core::SystemInfo::SetEnvironment(_T("GST_VIRTUAL_DISP_WIDTH"), width, !environmentOverride);
             }
 
             if (height.empty() == false) {
+                Core::SystemInfo::SetEnvironment(_T("WPE_INIT_VIEW_HEIGHT"), height, !environmentOverride);
                 Core::SystemInfo::SetEnvironment(_T("GST_VIRTUAL_DISP_HEIGHT"), height, !environmentOverride);
             }
 


### PR DESCRIPTION
based on plugin config. Envs are used by wpe-backend-rdk