### PR TITLE
RDKTV-18497 : Static JSONRPC::LinkType crash

### DIFF
--- a/helpers/UtilsSecurityToken.cpp
+++ b/helpers/UtilsSecurityToken.cpp
@@ -146,8 +146,7 @@ std::shared_ptr<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IEleme
     string query = "token=" + token;
 
     Core::SystemInfo::SetEnvironment(_T("THUNDER_ACCESS"), (_T(SERVER_DETAILS)));
-    static std::shared_ptr<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement> > thunderClient = make_shared<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement> >(callsign.c_str(), "",false,query);
-    return thunderClient;
+    return make_shared<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement> >(callsign.c_str(), "",false,query);
 }
 
 void Utils::activatePlugin(const char* callSign)

--- a/helpers/UtilsSecurityToken.h
+++ b/helpers/UtilsSecurityToken.h
@@ -21,6 +21,19 @@
 
 #include <plugins/plugins.h>
 
+
+/**
+ * DO NOT USE THIS.
+ *
+ * Instead, use:
+ * - ThunderInterfaces
+ * - IShell notifications:
+ *      PluginHost::IShell::Register
+ *      PluginHost::IPlugin::INotification
+ * - PluginHost::IShell::Job
+ * - Preconditions
+ */
+
 namespace Utils
 {
     struct SecurityToken


### PR DESCRIPTION
Reason for change: Crash fix.
Test Procedure: Monitor "__cxa_finalize" "~__shared_count".
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>