### PR TITLE
RDKTV-17901: [eARC]eARC AVR doesn’t work after set parameter “HDMI-CEC”

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -4845,6 +4845,25 @@ namespace WPEFramework {
 		isCecEnabled = true;
 	      } else{
 		isCecEnabled = false;
+		try
+                    {
+                        if(m_hdmiInAudioDeviceConnected ==  true) {
+                            m_hdmiInAudioDeviceConnected = false;
+                            connectedAudioPortUpdated(dsAUDIOPORT_TYPE_HDMI_ARC, false);
+
+                            device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort("HDMI_ARC0");
+                            LOGINFO("cec Disabled: Disable ARC\n");
+                            aPort.enableARC(dsAUDIOARCSUPPORT_ARC, false);
+                            m_arcAudioEnabled = false;
+                        }
+                        else {
+                            LOGINFO("Skip Disable ARC and not notifying the UI as  m_hdmiInAudioDeviceConnected = false\n");
+                        }
+                    }
+                    catch (const device::Exception& err)
+                    {
+                        LOG_DEVICE_EXCEPTION1(string("HDMI_ARC0"));
+                    }
 	      }
 
               LOGINFO("updated isCecEnabled [%d] ... \n", isCecEnabled);


### PR DESCRIPTION
Reason for change: Audio routes to eArc on cec off where as it should be on TV speakers
Test Procedure: check ticket
Risks: Low

Signed-off-by: shashank.kumar@sky.uk <shashank.kumar@sky.uk>