### PR TITLE
RDKTV-19132 : Update SystemServices to call container_setup.sh script…

### DIFF
--- a/SystemServices/CHANGELOG.md
+++ b/SystemServices/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2022-08-24
+### Fixed
+- RDKTV-19132 Update SystemServices to call container_setup.sh script after deleting persistent data
+
 ## [1.0.1]
 ### Fixed
 - Optimize include

--- a/SystemServices/CHANGELOG.md
+++ b/SystemServices/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.2] - 2022-08-24
 ### Fixed
-- RDKTV-19132 Update SystemServices to call container_setup.sh script after deleting persistent data
+- Update SystemServices to call container_setup.sh script after deleting persistent data
 
 ## [1.0.1]
 ### Fixed

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -66,7 +66,7 @@ using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 1
+#define API_VERSION_NUMBER_PATCH 2
 
 #define MAX_REBOOT_DELAY 86400 /* 24Hr = 86400 sec */
 #define TR181_FW_DELAY_REBOOT "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.AutoReboot.fwDelayReboot"

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -4238,6 +4238,11 @@ namespace WPEFramework {
             // Everything is OK
             LOGINFO("Successfully deleted persistent path for '%s' (path = '%s')", callsignOrType.c_str(), persistentPath.c_str());
 
+	    //Calling container_setup.sh along with callsign as container bundle also gets deleted from the persistent path
+            std::string command = "/lib/rdk/container_setup.sh " + callsignOrType;
+            system(command.c_str());
+            LOGINFO("Calling %s \n", command.c_str());
+
             result = true;
 
           } while(false);


### PR DESCRIPTION
… after deleting persistent data

Reason for change : WPEFramework crashes clearing local storage
Test Procedure: Refer Jira
Risks: Low

Signed-off-by: Karthick S <karthick_s@comcast.com>