### PR TITLE
Add RustAdapter (#2892)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,6 +324,10 @@ if(PLUGIN_LINEARPLAYBACKCONTROL)
     add_subdirectory(LinearPlaybackControl)
 endif()
 
+if(PLUGIN_RUSTADAPTER)
+    add_subdirectory(RustAdapter)
+endif()
+
 if(RDK_SERVICES_TEST)
     add_subdirectory(Tests)
 endif()

--- a/RustAdapter/CMakeLists.txt
+++ b/RustAdapter/CMakeLists.txt
@@ -1,0 +1,45 @@
+# If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2022 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set(PLUGIN_NAME RustAdapter)
+set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
+
+find_package(${NAMESPACE}Plugins REQUIRED)
+find_package(CompileSettingsDebug CONFIG REQUIRED)
+
+if (WITH_RPC_CONTEXT)
+  set(CMAKE_CXX_FLAGS "-DJSON_RPC_CONTEXT ${CMAKE_CXX_FLAGS}")
+endif()
+
+add_library(${MODULE_NAME} SHARED
+    RustAdapter.cpp
+    LocalPlugin.cpp
+    RemotePlugin.cpp
+    SocketServer.cpp    
+    Module.cpp)
+
+set_target_properties(${MODULE_NAME} PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED YES)
+
+target_link_libraries(${MODULE_NAME} PRIVATE
+    CompileSettingsDebug::CompileSettingsDebug
+    ${NAMESPACE}Plugins::${NAMESPACE}Plugins)
+
+
+install(TARGETS ${MODULE_NAME} 
+    DESTINATION lib/${STORAGE_DIRECTORY}/plugins)

--- a/RustAdapter/LocalPlugin.cpp
+++ b/RustAdapter/LocalPlugin.cpp
@@ -1,0 +1,290 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "RustAdapter.h"
+#include "LocalPlugin.h"
+#include "Logger.h"
+#include <plugins/Channel.h>
+#include <sstream>
+
+namespace WPEFramework {
+namespace Plugin {
+namespace Rust {
+  struct RequestContext {
+    uint32_t    channel_id;
+    const char *auth_token;
+  };
+
+  struct PluginContext {
+    uint32_t id;
+    std::function<void (uint32_t channel_id, const char *json_res)> send_to;
+  };
+
+
+} } }
+
+namespace {
+  std::atomic_int ctx_next_id = {1};
+  std::vector< WPEFramework::Plugin::Rust::PluginContext * > ctx_array;
+
+  // this function is passed into Rust as a pointer
+  extern "C" void wpe_send_to(uint32_t channel_id, const char *json, uint32_t ctx_id)
+  {
+    for (WPEFramework::Plugin::Rust::PluginContext *ctx : ctx_array) {
+      if (ctx->id == ctx_id) {
+        ctx->send_to(channel_id, json);
+        break;
+      }
+    }
+  }
+
+  std::vector<string> get_library_search_paths()
+  {
+    std::vector<string> paths  = {};
+
+    char *ld_paths = getenv("LD_LIBRARY_PATH");
+    if (ld_paths) {
+      ld_paths = strdup(ld_paths);
+
+      char *p = nullptr;
+      char *saveptr = nullptr;
+      while ((p = strtok_r(ld_paths, ":", &saveptr)) != nullptr) {
+        paths.push_back(string(p));
+        ld_paths = nullptr;
+      }
+      free(ld_paths);
+    }
+    return paths;
+  }
+
+  inline string to_string(const WPEFramework::Core::JSONRPC::Message &m)
+  {
+    string s;
+    m.ToString(s);
+    return s;
+  }
+
+  bool file_exists(const string &path)
+  {
+    struct stat statbuf = {};
+    return stat(path.c_str(), &statbuf) != -1;
+  }
+
+  void *find_rust_plugin(const string &fname)
+  {
+    void *lib = nullptr;
+    if (file_exists(fname)) {
+      LOGDBG("Loading library from:%s\n", fname.c_str());
+      lib = dlopen(fname.c_str(), RTLD_LAZY);
+      if (!lib)
+        LOGERR("Failed to load %s. %s", fname.c_str(), dlerror());
+    }
+    else {
+      //MARKR is this needed because dlopen docs says it searches LD_LIBRARY_PATH paths by default
+      for (const string &path : get_library_search_paths()) {
+        string full_path = path + "/" + fname;
+        if (file_exists(full_path)) {
+          LOGDBG("Loading library from:%s\n", full_path.c_str());
+          lib = dlopen(full_path.c_str(), RTLD_LAZY);
+          if (!lib)
+            LOGERR("Failed to load %s. %s", full_path.c_str(), dlerror());
+          break;
+        }
+      }
+    }
+    return lib;
+  }
+}
+
+WPEFramework::Plugin::Rust::LocalPlugin::LocalPlugin(const RustAdapter::Config &config)
+  : m_rust_plugin_create(nullptr)
+  , m_rust_plugin_destroy(nullptr)
+  , m_rust_plugin_init(nullptr)
+  , m_rust_plugin_invoke(nullptr)
+  , m_rust_plugin_on_client_connect(nullptr)
+  , m_rust_plugin_on_client_disconnect(nullptr)
+  , m_refcount(1)
+  , m_rust_plugin(nullptr)
+  , m_rust_plugin_lib(nullptr)
+  , m_service(nullptr)
+  , m_config(config)
+{
+}
+
+const string
+WPEFramework::Plugin::Rust::LocalPlugin::Initialize(PluginHost::IShell *shell)
+{
+  m_service = shell;
+  m_auth_token = RustAdapter::GetAuthToken(shell, shell->Callsign());
+
+  std::string lib_name = RustAdapter::GetLibraryPathOrName(m_config.LibName.Value(), shell->Callsign());
+
+  m_rust_plugin_lib = find_rust_plugin(lib_name);
+  if (!m_rust_plugin_lib) {
+    std::stringstream buff;
+    buff << "cannot find ";
+    buff << lib_name;
+    return buff.str();
+  }
+
+  //
+  // TODO: we should compile libWPEFrameworkRust.so into libWPEFrameworkRust.a
+  // and link it with libthunder_rs.so. In that case, we probably won't have to 
+  // dynamically bind all the functions
+  //
+  m_rust_plugin_create = (RustPlugin_Create) dlsym(m_rust_plugin_lib, "wpe_rust_plugin_create");
+  m_rust_plugin_init = (RustPlugin_Init) dlsym(m_rust_plugin_lib, "wpe_rust_plugin_init");
+  m_rust_plugin_destroy = (RustPlugin_Destroy) dlsym(m_rust_plugin_lib, "wpe_rust_plugin_destroy");
+  m_rust_plugin_invoke = (RustPlugin_Invoke) dlsym(m_rust_plugin_lib, "wpe_rust_plugin_invoke");
+  m_rust_plugin_on_client_connect = (RustPlugin_OnClientConnect)
+    dlsym(m_rust_plugin_lib, "wpe_rust_plugin_on_client_connect");
+  m_rust_plugin_on_client_disconnect = (RustPlugin_OnClientDisconnect)
+    dlsym(m_rust_plugin_lib, "wpe_rust_plugin_on_client_disconnect");
+
+  Rust::PluginContext *plugin_ctx = new Rust::PluginContext();
+  plugin_ctx->send_to = std::bind(&LocalPlugin::SendTo, this,
+    std::placeholders::_1, std::placeholders::_2);
+  plugin_ctx->id = ctx_next_id++;
+  ctx_array.push_back(plugin_ctx);
+
+  void *metadata = dlsym(m_rust_plugin_lib, "thunder_service_metadata");
+
+  // create and initialize the rust plugin
+  m_rust_plugin = m_rust_plugin_create(shell->ClassName().c_str(), &wpe_send_to, plugin_ctx->id,
+    m_auth_token.c_str(),
+    metadata);
+
+  // XXX: The call to "init" doesn't seem necessary
+  m_rust_plugin_init(m_rust_plugin, nullptr);
+
+  return {};
+}
+
+void
+WPEFramework::Plugin::Rust::LocalPlugin::Deinitialize(PluginHost::IShell *shell)
+{
+  if (m_rust_plugin) {
+    m_rust_plugin_destroy(m_rust_plugin);
+    m_rust_plugin = nullptr;
+  }
+}
+
+void
+WPEFramework::Plugin::Rust::LocalPlugin::SendTo(uint32_t channel_id, const char *json)
+{
+  auto res = Core::ProxyType<Web::JSONBodyType<Core::JSONRPC::Message>>::Create();
+  res->FromString(json);
+  m_service->Submit(channel_id, Core::ProxyType<Core::JSON::IElement>(res));
+}
+
+#if JSON_RPC_CONTEXT
+WPEFramework::Core::ProxyType<WPEFramework::Core::JSONRPC::Message>
+WPEFramework::Plugin::Rust::LocalPlugin::Invoke(
+  const WPEFramework::Core::JSONRPC::Context &ctx,
+  const WPEFramework::Core::JSONRPC::Message &req)
+{
+  Rust::RequestContext req_ctx;
+  req_ctx.channel_id = ctx.ChannelId();
+  req_ctx.auth_token = ctx.Token().c_str();
+
+  m_rust_plugin_invoke(m_rust_plugin, to_string(req).c_str(), req_ctx);
+
+  // indicates to Thunder that this request is being processed asynchronously
+  return {};
+}
+#else
+WPEFramework::Core::ProxyType<WPEFramework::Core::JSONRPC::Message>
+  WPEFramework::Plugin::Rust::LocalPlugin::Invoke(
+    const string& token, const uint32_t channelId, const Core::JSONRPC::Message& req)
+{
+  Rust::RequestContext req_ctx;
+  req_ctx.channel_id = channelId;
+  req_ctx.auth_token = token.c_str();
+
+  m_rust_plugin_invoke(m_rust_plugin, to_string(req).c_str(), req_ctx);
+
+  // indicates to Thunder that this request is being processed asynchronously
+  return {};
+}
+#endif
+void
+WPEFramework::Plugin::Rust::LocalPlugin::Activate(
+  WPEFramework::PluginHost::IShell *shell)
+{
+}
+
+void
+WPEFramework::Plugin::Rust::LocalPlugin::Deactivate()
+{
+}
+
+bool
+WPEFramework::Plugin::Rust::LocalPlugin::Attach(PluginHost::Channel &channel)
+{
+  m_rust_plugin_on_client_connect(m_rust_plugin, channel.Id());
+  return true;
+}
+
+void
+WPEFramework::Plugin::Rust::LocalPlugin::Detach(PluginHost::Channel &channel)
+{
+  m_rust_plugin_on_client_disconnect(m_rust_plugin, channel.Id());
+}
+
+WPEFramework::Core::ProxyType<WPEFramework::Core::JSON::IElement>
+WPEFramework::Plugin::Rust::LocalPlugin::Inbound(const string &identifier)
+{
+  return WPEFramework::Core::ProxyType<WPEFramework::Core::JSON::IElement>(
+    WPEFramework::PluginHost::IFactories::Instance().JSONRPC());
+}
+
+WPEFramework::Core::ProxyType<WPEFramework::Core::JSON::IElement>
+WPEFramework::Plugin::Rust::LocalPlugin::Inbound(const uint32_t id,
+    const Core::ProxyType<Core::JSON::IElement> &element)
+{
+  Core::ProxyType<Core::JSONRPC::Message> req(element);
+
+  Rust::RequestContext req_ctx;
+  req_ctx.channel_id = id;
+  req_ctx.auth_token = "";
+
+  m_rust_plugin_invoke(m_rust_plugin, to_string(*req).c_str(), req_ctx);
+
+  // I don't know what this return value is used for, but Invoke() returns {} to
+  // indicate that the request is being processed asynchronously
+  return {};
+}
+
+void
+WPEFramework::Plugin::Rust::LocalPlugin::AddRef() const
+{
+  // TODO
+}
+
+uint32_t
+WPEFramework::Plugin::Rust::LocalPlugin::Release() const
+{
+  // TODO
+  return 0;
+}
+
+string
+WPEFramework::Plugin::Rust::LocalPlugin::Information() const
+{
+  return { };
+}

--- a/RustAdapter/LocalPlugin.h
+++ b/RustAdapter/LocalPlugin.h
@@ -1,0 +1,145 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace WPEFramework {
+namespace Plugin {
+namespace Rust {
+
+class LocalPlugin : public Rust::IPlugin
+{
+public:
+
+  /**
+   *
+   */
+  LocalPlugin(const RustAdapter::Config &config);
+
+  /**
+   *
+   */
+  ~LocalPlugin() override = default;
+
+  LocalPlugin(const LocalPlugin &) = delete;
+  LocalPlugin& operator = (const LocalPlugin &) = delete;
+
+  /**
+   * IPlugin::Initialize
+   */
+  const string Initialize(PluginHost::IShell *shell) override;
+
+  /**
+   * IPlugin::Deinitialize
+   */
+  void Deinitialize(PluginHost::IShell *shell) override;
+
+  /**
+   * IPlugin Information
+   */
+  string Information() const override;
+
+  /**
+   * IDispatcher -> IUknown -> IReferenceCounted::AddRef
+   */
+  void AddRef() const override;
+
+  /**
+   * IDispatcher -> IUnknown -> IReferenceCounted::AddRef
+   */
+  uint32_t Release() const override;
+
+  BEGIN_INTERFACE_MAP(RustAdapter)
+  INTERFACE_ENTRY(PluginHost::IPlugin)
+  INTERFACE_ENTRY(PluginHost::IPluginExtended)
+  INTERFACE_ENTRY(PluginHost::IDispatcher)
+  INTERFACE_ENTRY(PluginHost::IWebSocket)
+  END_INTERFACE_MAP
+
+  /**
+   * IDispatcher::Activate
+   */
+  void Activate(PluginHost::IShell *shell) override;
+
+  /**
+   *
+   */
+  void Deactivate() override;
+
+  /**
+   *
+   */
+  bool Attach(PluginHost::Channel &channel) override;
+  void Detach(PluginHost::Channel &channel) override;
+
+  /**
+   * WPEFramework::PluginHost::IDispatcher::Invoke
+   */
+#if JSON_RPC_CONTEXT
+  Core::ProxyType<Core::JSONRPC::Message> Invoke(
+    const Core::JSONRPC::Context& context,
+    const Core::JSONRPC::Message& message) override;
+#else
+  Core::ProxyType<Core::JSONRPC::Message> Invoke(
+    const string& token, const uint32_t channelId, const Core::JSONRPC::Message& req) override;
+#endif
+  /**
+   *
+   */
+  Core::ProxyType<Core::JSON::IElement> Inbound(const string &identifier) override;
+  Core::ProxyType<Core::JSON::IElement> Inbound(const uint32_t id,
+    const Core::ProxyType<Core::JSON::IElement> &element) override;
+
+private:
+  using RustPlugin_SendTo = void (*)(uint32_t, const char *, uint32_t ctx_id);
+  using RustPlugin_Create = Rust::Plugin *(*)(const char *name, RustPlugin_SendTo send_to,
+    uint32_t plugin_ctx_id, const char *jwt, void *);
+  using RustPlugin_Destroy = void (*)(Rust::Plugin *p);
+  using RustPlugin_Init = void (*)(Rust::Plugin *p, const char *json);
+  using RustPlugin_Invoke = void (*)(Rust::Plugin *p, const char *json_req,
+    Rust::RequestContext req_ctx);
+  using RustPlugin_OnClientConnect = void (*)(Rust::Plugin *p, uint32_t channel_id);
+  using RustPlugin_OnClientDisconnect = void (*)(Rust::Plugin *p, uint32_t channel_id);
+
+
+  RustPlugin_Create  m_rust_plugin_create;
+  RustPlugin_Destroy m_rust_plugin_destroy;
+  RustPlugin_Init    m_rust_plugin_init;
+  RustPlugin_Invoke  m_rust_plugin_invoke;
+  RustPlugin_OnClientConnect m_rust_plugin_on_client_connect;
+  RustPlugin_OnClientDisconnect m_rust_plugin_on_client_disconnect;
+
+  mutable std::atomic<uint32_t> m_refcount;
+
+  // this is mutable because AddRef() and Release() are const
+  mutable Rust::Plugin *m_rust_plugin;
+
+  // this needs to stay around until plugin is deleted, otherwise
+  // it'll call dlclose() and we'll lose dynamically bound symbols
+  void *m_rust_plugin_lib;
+
+  // we keep a pointer to this to allow rust code to callback into
+  // the Adapter and send messages/events asynchronously
+  // XXX: We could also capture a reference to the channel during
+  // attach/detach, but that may require API changes to Thunder/internal
+  PluginHost::IShell *m_service;
+  RustAdapter::Config m_config;
+  std::string m_auth_token;
+
+private:
+  void SendTo(uint32_t channel_id, const char *json);
+};
+} } }

--- a/RustAdapter/Logger.h
+++ b/RustAdapter/Logger.h
@@ -1,0 +1,28 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <syscall.h>
+
+#ifndef LOGINFO
+#define LOGINFO(fmt, ...) do { fprintf(stderr, "[%d] INFO [%s:%d] %s: " fmt "\n", (int)syscall(SYS_gettid), __FILE__, __LINE__, __FUNCTION__, ##__VA_ARGS__); fflush(stderr); } while (0)
+#define LOGDBG(fmt, ...) do { fprintf(stderr, "[%d] DEBUG [%s:%d] %s: " fmt "\n", (int)syscall(SYS_gettid), __FILE__, __LINE__, __FUNCTION__, ##__VA_ARGS__); fflush(stderr); } while (0)
+#define LOGWARN(fmt, ...) do { fprintf(stderr, "[%d] WARN [%s:%d] %s: " fmt "\n", (int)syscall(SYS_gettid),__FILE__, __LINE__, __FUNCTION__, ##__VA_ARGS__); fflush(stderr); } while (0)
+#define LOGERR(fmt, ...) do { fprintf(stderr, "[%d] ERROR [%s:%d] %s: " fmt "\n", (int)syscall(SYS_gettid), __FILE__, __LINE__, __FUNCTION__, ##__VA_ARGS__); fflush(stderr); } while (0)
+#endif

--- a/RustAdapter/Module.cpp
+++ b/RustAdapter/Module.cpp
@@ -1,0 +1,22 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2020 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Module.h"
+
+MODULE_NAME_DECLARATION(BUILD_REFERENCE)

--- a/RustAdapter/Module.h
+++ b/RustAdapter/Module.h
@@ -1,0 +1,29 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2020 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef MODULE_NAME
+#define MODULE_NAME Plugin_RustAdapter
+#endif
+
+#include <plugins/plugins.h>
+
+#undef EXTERNAL
+#define EXTERNAL

--- a/RustAdapter/RemotePlugin.cpp
+++ b/RustAdapter/RemotePlugin.cpp
@@ -1,0 +1,225 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "RustAdapter.h"
+#include "RemotePlugin.h"
+#include "SocketServer.h"
+#include "Logger.h"
+#include <plugins/Channel.h>
+
+namespace WPEFramework {
+namespace Plugin {
+namespace Rust {
+
+RemotePlugin::RemotePlugin(const RustAdapter::Config &conf)
+  : m_remotePid(0)
+  , m_config(conf)
+{
+}
+
+const string
+RemotePlugin::Initialize(PluginHost::IShell *shell)
+{
+  m_service = shell;
+  m_auth_token = RustAdapter::GetAuthToken(shell, shell->Callsign());
+
+  string address = m_config.Address.Value();
+  printf("ADDR=%s\n", address.c_str());
+  if (address.empty())
+    address = "127.0.0.1";
+
+  if (m_stream.Open(address, 
+                    m_config.Port.Value(),
+                    std::bind(&RemotePlugin::onRead, this, std::placeholders::_1)) < 0)
+  {
+    return string("RustAdapter RemotePlugin couldn't open socket stream");
+  }
+
+  if (m_stream.RunThread() < 0)
+  {
+    return string("RustAdapter RemotePlugin failed to run stream thread");
+  }
+
+  if (m_config.AutoExec)
+  {
+    std::string lib_name = RustAdapter::GetLibraryPathOrName(m_config.LibName.Value(), shell->Callsign());
+    if ((m_remotePid = LaunchRemoteProcess(lib_name, m_stream.GetAddress(), m_stream.GetPort())) < 0)
+    {
+      return string("RustAdapter RemotePlugin failed spawn remote process");
+    }
+  }
+
+  return {};
+}
+
+void
+RemotePlugin::Deinitialize(PluginHost::IShell *shell)
+{
+  
+  LOGDBG("Deinitialize: send exit message to any connected client");
+  m_stream.SendExit();
+
+  if (m_remotePid > 0)
+  {
+    int status;
+    LOGDBG("Deinitialize: waiting on remote %d to close", m_remotePid);
+    waitpid(m_remotePid, &status, 0);
+    LOGDBG("Deinitialize:remote closed status=%d", status);
+  }
+
+  m_stream.Close();
+  LOGDBG("RemotePlugin::Deinitialize exit");
+}
+
+void
+RemotePlugin::SendTo(uint32_t channel_id, const char *json)
+{
+  auto res = Core::ProxyType<Web::JSONBodyType<Core::JSONRPC::Message>>::Create();
+  res->FromString(json);
+  m_service->Submit(channel_id, Core::ProxyType<Core::JSON::IElement>(res));
+}
+#if JSON_RPC_CONTEXT
+WPEFramework::Core::ProxyType<WPEFramework::Core::JSONRPC::Message>
+RemotePlugin::Invoke(
+  const WPEFramework::Core::JSONRPC::Context &ctx,
+  const WPEFramework::Core::JSONRPC::Message &req)
+{
+  string json;
+  req.ToString(json);
+  m_stream.SendInvoke(ctx.ChannelId(), ctx.Token(), json);
+  return {};
+}
+#else
+WPEFramework::Core::ProxyType<WPEFramework::Core::JSONRPC::Message>
+RemotePlugin::Invoke(
+    const string& token, const uint32_t channelId, const Core::JSONRPC::Message& req)
+{
+  string json;
+  req.ToString(json);
+  m_stream.SendInvoke(channelId, token, json);
+  return {};
+}
+#endif
+void
+RemotePlugin::Activate(
+  WPEFramework::PluginHost::IShell *shell)
+{
+}
+
+void
+RemotePlugin::Deactivate()
+{
+}
+
+bool
+RemotePlugin::Attach(PluginHost::Channel &channel)
+{
+  LOGDBG("RemotePlugin::Attach %d\n", channel.Id());
+  m_stream.SendAttach(channel.Id(), true);
+  return true;
+}
+
+void
+RemotePlugin::Detach(PluginHost::Channel &channel)
+{
+  LOGDBG("RemotePlugin::Detach %d\n", channel.Id());
+  m_stream.SendAttach(channel.Id(), false);
+}
+
+WPEFramework::Core::ProxyType<WPEFramework::Core::JSON::IElement>
+RemotePlugin::Inbound(const string &identifier)
+{
+  return WPEFramework::Core::ProxyType<WPEFramework::Core::JSON::IElement>(
+    WPEFramework::PluginHost::IFactories::Instance().JSONRPC());
+}
+
+WPEFramework::Core::ProxyType<WPEFramework::Core::JSON::IElement>
+RemotePlugin::Inbound(const uint32_t id,
+    const Core::ProxyType<Core::JSON::IElement> &element)
+{
+  LOGDBG("NO IMPL %s\n", __PRETTY_FUNCTION__);
+  return {};
+}
+
+void
+RemotePlugin::AddRef() const
+{
+  // TODO
+}
+
+uint32_t
+RemotePlugin::Release() const
+{
+  // TODO
+  return 0;
+}
+
+string
+RemotePlugin::Information() const
+{
+  return { };
+}
+
+void RemotePlugin::onRead(const Response& rsp)
+{
+    LOGDBG("RemotePlugin::onRead response: channel_id=%u, json=\"%s\"", rsp.channel_id, rsp.json.c_str());
+    SendTo(rsp.channel_id, rsp.json.c_str());
+}
+
+int RemotePlugin::LaunchRemoteProcess(const string& rust_shared_lib, const string& host_ip, int port)
+{
+  string appName = "WPEHost";
+
+  int pid = fork();
+
+  if (pid == 0)
+  {
+    std::stringstream ssPort;
+    ssPort << port;
+    
+    char const* argv[] = { 
+      appName.c_str(),
+      rust_shared_lib.c_str(),
+      host_ip.c_str(), 
+      ssPort.str().c_str(), 
+      nullptr
+    };
+
+
+    if (!m_auth_token.empty())
+      setenv("THUNDER_SECURITY_TOKEN", m_auth_token.c_str(), 1);
+
+    if (execvp(appName.c_str(), (char**)argv) < 0)
+    {
+      LOGERR("Failed launch remote app %s: %s", appName.c_str(), strerror(errno));
+      _exit(errno);
+    }
+  }
+  else if (pid < 0)
+  {
+    LOGERR("Failed to fork process");
+  }
+  else
+  {
+    //TODO: verify child is running
+  }
+
+  return pid;
+}
+
+} } }

--- a/RustAdapter/RemotePlugin.h
+++ b/RustAdapter/RemotePlugin.h
@@ -1,0 +1,124 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "SocketServer.h"
+
+namespace WPEFramework {
+namespace Plugin {
+namespace Rust {
+
+class RemotePlugin : public Rust::IPlugin
+{
+public:
+
+  /**
+   *
+   */
+  RemotePlugin(const RustAdapter::Config &conf);
+
+  /**
+   *
+   */
+  ~RemotePlugin() override = default;
+
+  RemotePlugin(const RemotePlugin &) = delete;
+  RemotePlugin& operator = (const RemotePlugin &) = delete;
+
+  /**
+   * IPlugin::Initialize
+   */
+  const string Initialize(PluginHost::IShell *shell) override;
+
+  /**
+   * IPlugin::Deinitialize
+   */
+  void Deinitialize(PluginHost::IShell *shell) override;
+
+  /**
+   * IPlugin Information
+   */
+  string Information() const override;
+
+  /**
+   * IDispatcher -> IUknown -> IReferenceCounted::AddRef
+   */
+  void AddRef() const override;
+
+  /**
+   * IDispatcher -> IUnknown -> IReferenceCounted::AddRef
+   */
+  uint32_t Release() const override;
+
+  BEGIN_INTERFACE_MAP(RustAdapter)
+  INTERFACE_ENTRY(PluginHost::IPlugin)
+  INTERFACE_ENTRY(PluginHost::IPluginExtended)
+  INTERFACE_ENTRY(PluginHost::IDispatcher)
+  INTERFACE_ENTRY(PluginHost::IWebSocket)
+  END_INTERFACE_MAP
+
+  /**
+   * IDispatcher::Activate
+   */
+  void Activate(PluginHost::IShell *shell) override;
+
+  /**
+   *
+   */
+  void Deactivate() override;
+
+  /**
+   *
+   */
+  bool Attach(PluginHost::Channel &channel) override;
+  void Detach(PluginHost::Channel &channel) override;
+
+  /**
+   * WPEFramework::PluginHost::IDispatcher::Invoke
+   */
+#if JSON_RPC_CONTEXT   
+  Core::ProxyType<Core::JSONRPC::Message> Invoke(
+    const Core::JSONRPC::Context& context,
+    const Core::JSONRPC::Message& message) override;
+#else
+  Core::ProxyType<Core::JSONRPC::Message> Invoke(
+    const string& token, const uint32_t channelId, const Core::JSONRPC::Message& req) override;
+#endif
+  /**
+   *
+   */
+  Core::ProxyType<Core::JSON::IElement> Inbound(const string &identifier) override;
+  Core::ProxyType<Core::JSON::IElement> Inbound(const uint32_t id,
+    const Core::ProxyType<Core::JSON::IElement> &element) override;
+
+  void onRead(const Response& rsp);
+private:
+  int LaunchRemoteProcess(const string& rust_shared_lib, const string& host_ip, int port);
+  void SendTo(uint32_t channel_id, const char *json);
+
+  // we keep a pointer to this to allow rust code to callback into
+  // the Adapter and send messages/events asynchronously
+  // XXX: We could also capture a reference to the channel during
+  // attach/detach, but that may require API changes to Thunder/internal
+  PluginHost::IShell *m_service;
+  int m_remotePid;
+  SocketServer m_stream;
+  RustAdapter::Config m_config;
+  std::string m_auth_token;
+};
+
+} } }

--- a/RustAdapter/RustAdapter.cpp
+++ b/RustAdapter/RustAdapter.cpp
@@ -169,7 +169,7 @@ WPEFramework::Plugin::RustAdapter::GetAuthToken(WPEFramework::PluginHost::IShell
   if (auth != nullptr) {
     string encoded;
     if (auth->CreateToken(n, (const uint8_t*) buff, encoded) == WPEFramework::Core::ERROR_NONE) {
-      return encoded;
+      auth_token = encoded;
     }
     auth->Release();
   }

--- a/RustAdapter/RustAdapter.cpp
+++ b/RustAdapter/RustAdapter.cpp
@@ -171,6 +171,7 @@ WPEFramework::Plugin::RustAdapter::GetAuthToken(WPEFramework::PluginHost::IShell
     if (auth->CreateToken(n, (const uint8_t*) buff, encoded) == WPEFramework::Core::ERROR_NONE) {
       return encoded;
     }
+    auth->Release();
   }
 
   return auth_token;

--- a/RustAdapter/RustAdapter.cpp
+++ b/RustAdapter/RustAdapter.cpp
@@ -1,0 +1,177 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "RustAdapter.h"
+#include "LocalPlugin.h"
+#include "RemotePlugin.h"
+#include "Logger.h"
+#include <plugins/Channel.h>
+
+namespace WPEFramework {
+namespace Plugin {
+  SERVICE_REGISTRATION(RustAdapter, 1, 0);
+} }
+
+WPEFramework::Plugin::RustAdapter::RustAdapter()
+  : m_refcount(1)
+{
+}
+
+const string
+WPEFramework::Plugin::RustAdapter::Initialize(PluginHost::IShell *shell)
+{
+  /* The RustAdapter plugin should always run in-process
+     We run the rust plugin itself either in-process or out-of-process
+     base the config setting */
+
+  RustAdapter::Config conf;
+  conf.FromString(shell->ConfigLine());
+
+  LOGINFO("RustAdapter::Initialize Config=%s", shell->ConfigLine().c_str());
+
+  if (conf.OutOfProcess)
+    m_impl.reset(new WPEFramework::Plugin::Rust::RemotePlugin(conf));
+  else
+    m_impl.reset(new WPEFramework::Plugin::Rust::LocalPlugin(conf));
+
+  return m_impl->Initialize(shell);
+}
+
+void
+WPEFramework::Plugin::RustAdapter::Deinitialize(PluginHost::IShell *shell)
+{
+  return m_impl->Deinitialize(shell);
+}
+
+string
+WPEFramework::Plugin::RustAdapter::Information() const
+{
+  return m_impl->Information();
+}
+
+void
+WPEFramework::Plugin::RustAdapter::AddRef() const
+{
+  m_refcount++;
+}
+
+uint32_t
+WPEFramework::Plugin::RustAdapter::Release() const
+{
+  uint32_t n = m_refcount.fetch_sub(1);
+  if (n == 1) {
+    delete this;
+    return Core::ERROR_DESTRUCTION_SUCCEEDED;
+  }
+
+  return Core::ERROR_NONE;
+}
+
+#if JSON_RPC_CONTEXT
+WPEFramework::Core::ProxyType<WPEFramework::Core::JSONRPC::Message>
+WPEFramework::Plugin::RustAdapter::Invoke(
+  const WPEFramework::Core::JSONRPC::Context &ctx,
+  const WPEFramework::Core::JSONRPC::Message &req)
+{
+  return m_impl->Invoke(ctx, req);
+}
+#else
+WPEFramework::Core::ProxyType<WPEFramework::Core::JSONRPC::Message> 
+  WPEFramework::Plugin::RustAdapter::Invoke(
+    const string& token, const uint32_t channelId, const WPEFramework::Core::JSONRPC::Message& req)
+{
+  return m_impl->Invoke(token, channelId, req);
+}
+#endif
+
+void
+WPEFramework::Plugin::RustAdapter::Activate(
+  WPEFramework::PluginHost::IShell *shell)
+{
+  m_impl->Activate(shell);
+}
+
+void
+WPEFramework::Plugin::RustAdapter::Deactivate()
+{
+  m_impl->Deactivate();
+}
+
+bool
+WPEFramework::Plugin::RustAdapter::Attach(PluginHost::Channel &channel)
+{
+  return m_impl->Attach(channel);
+}
+
+void
+WPEFramework::Plugin::RustAdapter::Detach(PluginHost::Channel &channel)
+{
+  m_impl->Detach(channel);
+}
+
+WPEFramework::Core::ProxyType<WPEFramework::Core::JSON::IElement>
+WPEFramework::Plugin::RustAdapter::Inbound(const string &identifier)
+{
+  return m_impl->Inbound(identifier);
+}
+
+WPEFramework::Core::ProxyType<WPEFramework::Core::JSON::IElement>
+WPEFramework::Plugin::RustAdapter::Inbound(const uint32_t id,
+    const Core::ProxyType<Core::JSON::IElement> &element)
+{
+  return m_impl->Inbound(id, element);
+}
+
+std::string
+WPEFramework::Plugin::RustAdapter::GetLibraryPathOrName(
+  const std::string &lib_name,
+  const std::string &callsign)
+{
+  std::stringstream shared_library_name;
+  if (!lib_name.empty())
+    shared_library_name << lib_name;
+  else {
+    shared_library_name << "lib";
+    for (char c : callsign)
+      shared_library_name << static_cast<char>(std::tolower(c));
+    shared_library_name << ".so";
+  }
+  return shared_library_name.str();
+}
+
+std::string
+WPEFramework::Plugin::RustAdapter::GetAuthToken(WPEFramework::PluginHost::IShell* service, const std::string &callsign)
+{
+  std::string auth_token;
+
+  char buff[256];
+  memset(buff, 0, sizeof(buff));
+
+  int n = snprintf(buff, sizeof(buff), "plugin://%s", callsign.c_str());
+  buff[255] = '\0';
+
+  auto auth = service->QueryInterfaceByCallsign<WPEFramework::PluginHost::IAuthenticate>("SecurityAgent");
+  if (auth != nullptr) {
+    string encoded;
+    if (auth->CreateToken(n, (const uint8_t*) buff, encoded) == WPEFramework::Core::ERROR_NONE) {
+      return encoded;
+    }
+  }
+
+  return auth_token;
+}

--- a/RustAdapter/RustAdapter.h
+++ b/RustAdapter/RustAdapter.h
@@ -1,0 +1,167 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "Module.h"
+#include "RustPlugin.h"
+
+namespace WPEFramework {
+namespace Plugin {
+
+namespace Rust {
+  struct RequestContext;
+  struct PluginContext;
+  struct Plugin;
+}
+
+class RustAdapter : public Rust::IPlugin
+{
+public:
+  class Config : public Core::JSON::Container
+  {
+  private:
+    Config& operator=(const Config&);
+  public:
+    Config(const Config &rhs)
+    {
+      Add(_T("outofprocess"), &OutOfProcess);
+      Add(_T("address"), &Address);
+      Add(_T("port"), &Port);
+      Add(_T("autoexec"), &AutoExec);
+      Add(_T("libname"), &LibName);
+      OutOfProcess = rhs.OutOfProcess;;
+      Address = rhs.Address;
+      Port = rhs.Port;
+      AutoExec = rhs.AutoExec;
+      LibName = rhs.LibName;
+    }
+
+    Config() : Core::JSON::Container(), OutOfProcess(true)
+    {
+      Add(_T("outofprocess"), &OutOfProcess);
+      Add(_T("address"), &Address);
+      Add(_T("port"), &Port);
+      Add(_T("autoexec"), &AutoExec);
+      Add(_T("libname"), &LibName);
+    }
+    ~Config()
+    {
+    }
+  public:
+    Core::JSON::Boolean OutOfProcess;
+    Core::JSON::String Address;
+    Core::JSON::DecUInt16 Port;
+    Core::JSON::Boolean AutoExec;
+    Core::JSON::String LibName;
+  };
+
+  /**
+   *
+   */
+  RustAdapter();
+
+  /**
+   *
+   */
+  ~RustAdapter() override = default;
+
+  RustAdapter(const RustAdapter &) = delete;
+  RustAdapter& operator = (const RustAdapter &) = delete;
+
+  /**
+   * IPlugin::Initialize
+   */
+  const string Initialize(PluginHost::IShell *shell) override;
+
+  /**
+   * IPlugin::Deinitialize
+   */
+  void Deinitialize(PluginHost::IShell *shell) override;
+
+  /**
+   * IPlugin Information
+   */
+  string Information() const override;
+
+  /**
+   * IDispatcher -> IUknown -> IReferenceCounted::AddRef
+   */
+  void AddRef() const override;
+
+  /**
+   * IDispatcher -> IUnknown -> IReferenceCounted::AddRef
+   */
+  uint32_t Release() const override;
+
+  /**
+   * IDispatcher::Activate
+   */
+  void Activate(PluginHost::IShell *shell) override;
+
+  /**
+   *
+   */
+  void Deactivate() override;
+
+  /**
+   *
+   */
+  bool Attach(PluginHost::Channel &channel) override;
+  void Detach(PluginHost::Channel &channel) override;
+
+  /**
+   * WPEFramework::PluginHost::IDispatcher::Invoke
+   */
+#if JSON_RPC_CONTEXT
+  Core::ProxyType<Core::JSONRPC::Message> Invoke(
+    const Core::JSONRPC::Context& context,
+    const Core::JSONRPC::Message& message) override;
+#else 
+  Core::ProxyType<Core::JSONRPC::Message> Invoke(
+    const string& token, const uint32_t channelId, const Core::JSONRPC::Message& message) override;
+#endif
+
+  /**
+   *
+   */
+  Core::ProxyType<Core::JSON::IElement> Inbound(const string &identifier) override;
+  Core::ProxyType<Core::JSON::IElement> Inbound(const uint32_t id,
+    const Core::ProxyType<Core::JSON::IElement> &element) override;
+
+  BEGIN_INTERFACE_MAP(RustAdapter)
+  INTERFACE_ENTRY(PluginHost::IPlugin)
+  INTERFACE_ENTRY(PluginHost::IPluginExtended)
+  INTERFACE_ENTRY(PluginHost::IDispatcher)
+  INTERFACE_ENTRY(PluginHost::IWebSocket)
+  END_INTERFACE_MAP
+
+  static std::string GetLibraryPathOrName(
+    const std::string& libname,
+    const std::string& callsign);
+
+  static std::string GetAuthToken(WPEFramework::PluginHost::IShell* service, const std::string &callsign);
+
+private:
+  std::unique_ptr<Rust::IPlugin> m_impl;
+
+  // needs to be mutable because Release() is const
+  mutable std::atomic<uint32_t> m_refcount;
+};
+
+} }

--- a/RustAdapter/RustPlugin.h
+++ b/RustAdapter/RustPlugin.h
@@ -1,0 +1,31 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2020 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+namespace WPEFramework {
+namespace Plugin {
+namespace Rust {
+  struct IPlugin 
+    : public WPEFramework::PluginHost::IPluginExtended
+    , public WPEFramework::PluginHost::IDispatcher
+    , public WPEFramework::PluginHost::IWebSocket
+  {
+  };
+} } }
+

--- a/RustAdapter/SocketServer.cpp
+++ b/RustAdapter/SocketServer.cpp
@@ -1,0 +1,452 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "SocketServer.h"
+#include "Logger.h"
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <netinet/ip.h>
+#include <arpa/inet.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+enum CommandID
+{
+  ID_INVOKE = 1,
+  ID_ATTACH,
+  ID_EXIT
+};
+
+#pragma pack(push,1)
+struct InvoketHeader
+{
+  uint32_t command_id;
+  uint32_t channel_id;
+  uint32_t token_len;
+  uint32_t json_len;
+};
+#pragma pack(pop) 
+
+#pragma pack(push,1)
+struct AttachHeader
+{
+  uint32_t command_id;
+  uint32_t channel_id;
+  uint8_t attach;
+};
+#pragma pack(pop)
+
+#pragma pack(push,1)
+struct ResponseHeader
+{
+  uint32_t channel_id;
+  uint32_t json_len;
+};
+#pragma pack(pop) 
+
+Response::Response()
+: channel_id(0), json()
+{
+}
+
+Response::Response(uint32_t channel, const string& json_str)
+: channel_id(channel), json(json_str)
+{
+}
+
+#define CLIENT_DISCONNECT -2
+
+SocketServer::SocketServer()
+: m_serverSocket(0)
+, m_clientSocket(0)
+, m_running(false)
+, m_address()
+, m_port(0)
+{
+
+}
+
+SocketServer::~SocketServer()
+{
+  Close();
+}
+
+int SocketServer::Open(const string& address, int port, const function<void (const Response&)>& reader)
+{
+  int sock;
+  struct sockaddr_in addr;
+  int rc;
+
+  sock = socket(AF_INET, SOCK_STREAM, 0);
+
+  if (sock < 0)
+  {
+    LOGERR("SocketServer::Open socket create failed: %s", strerror(errno));
+    return -1;
+  }
+
+  memset(&addr, 0, sizeof(address));
+  addr.sin_family = AF_INET;
+  addr.sin_port = htons(port);
+  
+  rc = inet_pton(AF_INET, address.c_str(), &addr.sin_addr);
+
+  if (rc == 0)
+  {
+    LOGERR("SocketServer::Open inet_pton %s invalid ip format", address.c_str());
+    return -1;
+  }
+  else if (rc < 0)
+  {
+    LOGERR("SocketServer::Open inet_pton %s failed: %s", address.c_str(), strerror(errno));
+    return -1;
+  }
+  
+  LOGDBG("SocketServer::Open host_ip=%s sin_addr=%d (note that INADDR_ANY=%d)", address.c_str(), addr.sin_addr.s_addr, INADDR_ANY);
+
+  int sock_flags = fcntl (sock, F_GETFD, 0);
+  if (sock_flags < 0)
+  {
+    LOGERR("SocketServer::Open fcntl get failed: %s", strerror(errno));
+    return -1;
+  }
+
+  sock_flags |= FD_CLOEXEC;
+
+  if (fcntl(sock, F_SETFD, sock_flags) < 0)
+  {
+    LOGERR("SocketServer::Open fcntl set failed: %s", strerror(errno));
+    return -1;
+  }
+
+  if (bind(sock, (struct sockaddr*)&addr, sizeof(addr)) < 0)
+  {
+    LOGERR("SocketServer::Open bind failed: %s", strerror(errno));
+    return -1;
+  }
+
+  if (listen(sock, 4) < 0)
+  {
+    LOGERR("SocketServer::Open listen failed: %s", strerror(errno));
+    return -1;
+  }
+
+  m_reader = reader;
+  m_serverSocket = sock;
+  m_address = address;
+
+  if (port)
+  {
+    m_port = port;
+  }
+  else
+  {
+    struct sockaddr_in cur;
+    socklen_t len = sizeof(cur);
+    if (getsockname(sock, (struct sockaddr *)&cur, &len) ==-0)
+    {
+      m_port = ntohs(cur.sin_port);
+    }
+    else
+    {
+      LOGERR("SocketServer::Open getsockname failed: %s", strerror(errno));
+    }
+  }
+
+  LOGDBG("SocketServer::Open successfully running on port %d", m_port);
+  return 0;
+}
+
+int SocketServer::RunThread()
+{
+  if (pthread_create(&m_thread, nullptr, SocketServer::RunThreadFunc, this) != 0)
+  {
+    LOGERR("SocketServer::Open failed to create thread: %s",strerror(errno));
+    return -1;
+  }
+  return 0;
+}
+
+void* SocketServer::RunThreadFunc(void* arg)
+{
+  SocketServer* ss = (SocketServer*)arg;
+  ss->Run();
+  return nullptr;
+}
+
+int SocketServer::Run()
+{
+  if (m_serverSocket <= 0 || m_running)
+    return -1;
+
+  m_running = true;
+
+  while (m_running)
+  {
+    fd_set m_readSet;
+    fd_set m_exceptSet;
+    struct timeval tv;
+    int res;
+
+    FD_ZERO(&m_readSet);
+    FD_ZERO(&m_exceptSet);
+    FD_SET(m_serverSocket, &m_readSet);
+    FD_SET(m_serverSocket, &m_exceptSet);    
+    if (m_clientSocket)
+    {
+      FD_SET(m_clientSocket, &m_readSet);
+      FD_SET(m_clientSocket, &m_exceptSet);    
+    }
+
+    tv.tv_sec = 10;
+    tv.tv_usec = 0;
+    res = select((m_clientSocket > m_serverSocket ? m_clientSocket : m_serverSocket) + 1, 
+                 &m_readSet, NULL, &m_exceptSet, &tv);
+
+    if (!m_running)
+      break;
+
+    if (res < 0)
+    {
+      LOGERR("SocketServer::Open select failed: %s", strerror(errno));
+      return -1;
+    }
+
+    if (res == 0)
+      continue;
+
+    if (FD_ISSET(m_serverSocket, &m_readSet))
+    {
+      int clsock;
+      struct sockaddr_in claddr;
+      socklen_t cllen;
+      
+      cllen = sizeof(claddr);
+      memset(&claddr, 0, cllen);
+      
+      clsock = accept(m_serverSocket, (struct sockaddr*)&claddr, &cllen);
+      if (clsock < 0)
+      {
+        LOGERR("SocketServer::Open accept failed: %s", strerror(errno));
+      }
+      else
+      {
+        LOGDBG("SocketServer::Open client connected");
+        m_clientSocket = clsock;
+      }
+    }
+
+    if (m_clientSocket)
+    {
+      if (FD_ISSET(m_clientSocket, &m_readSet))
+      {
+        Response rsp;
+        int rc = ReadResponse(rsp);
+        if (rc >= 0)
+        {
+          m_reader(rsp);
+        }
+        else if (rc == CLIENT_DISCONNECT)
+        {
+          LOGDBG("SocketServer::Open client disconnected");
+          close(m_clientSocket);
+          m_clientSocket = 0;
+        }
+      }
+    }
+  }
+  return 0;
+}
+
+string SocketServer::GetAddress() const
+{
+  return m_address;
+}
+
+int SocketServer::GetPort() const
+{
+  return m_port; 
+}
+
+void SocketServer::Close()
+{
+  if (m_serverSocket > 0)
+  {
+    if (m_running)
+    {
+      m_running = false;
+    }
+    close(m_clientSocket);
+    close(m_serverSocket);
+    m_serverSocket = 0;
+  }
+}
+
+int SocketServer::ReadExact(uint8_t* p, int len)
+{
+  if (m_serverSocket <= 0 || m_clientSocket <= 0)
+    return -1;
+
+  int remaining = len;
+
+  while (remaining > 0)
+  {
+    int num = (int)read(m_clientSocket, p, remaining);
+
+    if (num <= 0)
+    {
+        LOGERR("SocketServer::ReadExact failed: num=%d", num);
+
+        if (num == 0)
+          return CLIENT_DISCONNECT;
+
+        return -1;
+    }
+    else
+    {
+      p += num;
+      remaining -= num;
+    }
+  }
+
+  if (remaining != 0)
+  {
+    LOGERR("SocketServer::ReadExact: failed: remaining=%d", remaining);
+    return -1;
+  }
+
+  return len;
+}
+
+int SocketServer::SendInvoke(uint32_t channel_id, const string& token, const string& json)
+{
+  if (m_serverSocket <= 0 || m_clientSocket <= 0)
+    return -1;
+  
+  InvoketHeader header = {
+    htonl(ID_INVOKE),
+    htonl(channel_id),
+    htonl((uint32_t)token.length()),
+    htonl((uint32_t)json.length())
+  };
+
+  int num = send(m_clientSocket, &header, sizeof(header), MSG_NOSIGNAL);
+  if (num != sizeof(header))
+  {
+    LOGERR("SocketServer::SendInvoke failed to send header: num=%d", num);
+    return -1;
+  }
+
+  if (token.length() > 0)
+  {
+    num = send(m_clientSocket, token.c_str(), token.length(), MSG_NOSIGNAL);
+    if (num != (ssize_t)token.length())
+    {
+      LOGERR("SocketServer::SendInvoke failed to send token: num=%d", num);
+      return -1;
+    }
+  }
+
+  if (json.length() > 0)
+  {
+    num = send(m_clientSocket, json.c_str(), json.length(), MSG_NOSIGNAL);
+    if (num != (ssize_t)json.length())
+    {
+      LOGERR("SocketServer::SendInvoke failed to send json: num=%d", num);
+      return -1;
+    }
+  }
+  return 0;
+}
+
+int SocketServer::SendAttach(uint32_t channel_id, bool attach)
+{
+  if (m_serverSocket <= 0 || m_clientSocket <= 0)
+    return -1;
+
+  AttachHeader header = {
+    htonl(ID_ATTACH),
+    htonl(channel_id),
+    attach ? (uint8_t)1 : (uint8_t)0
+  };
+
+  int num = send(m_clientSocket, &header, sizeof(header), MSG_NOSIGNAL);
+  if (num != sizeof(header))
+  {
+    LOGERR("SocketServer::SendAttach failed to send header: num=%d", num);
+    return -1;
+  }
+  return 0;
+}
+
+int SocketServer::SendExit()
+{
+  if (m_serverSocket <= 0 || m_clientSocket <= 0)
+    return -1;
+
+  uint32_t command_id = htonl(ID_EXIT);
+  int num = send(m_clientSocket, &command_id, sizeof(command_id), MSG_NOSIGNAL);
+  if (num != sizeof(command_id))
+  {
+    LOGERR("SocketServer::SendExit failed: num=%d", num);
+    return -1;
+  }
+
+  /*break out of reader thread*/
+  m_running = false;
+
+  return 0;
+}
+
+int SocketServer::ReadResponse(Response& rsp)
+{
+  if (m_serverSocket <= 0 || m_clientSocket <= 0)
+    return -1;
+
+  ResponseHeader header;
+  int rc;
+
+  if ((rc = ReadExact((uint8_t*)&header, (int)sizeof(ResponseHeader))) <= 0)
+  {
+    return rc;
+  }
+
+  rsp.channel_id = ntohl(header.channel_id);
+  header.json_len = ntohl(header.json_len);
+
+  LOGDBG("SocketServer::ReadResponse read header: channel_id=%u, json_len=%u", 
+    rsp.channel_id, header.json_len);
+
+  if (header.json_len > 0)
+  {
+    uint8_t* buffer;
+    buffer = (uint8_t*)malloc(header.json_len+1);
+
+    if ((rc = ReadExact(buffer, (int)header.json_len)) <= 0)
+    {
+      free(buffer);
+      return rc;
+    }
+    
+    buffer[header.json_len] = 0;
+    rsp.json = (char*)buffer;
+    free(buffer);
+  }
+  return 0;
+}

--- a/RustAdapter/SocketServer.h
+++ b/RustAdapter/SocketServer.h
@@ -1,0 +1,63 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string>
+#include <functional>
+#include <pthread.h>
+
+using std::string;
+using std::function;
+
+struct Response
+{
+  uint32_t channel_id;
+  string json;
+
+  Response();
+  Response(uint32_t channel, const string& json_str);
+};
+
+class SocketServer
+{
+public:
+  SocketServer();
+  ~SocketServer();
+  int Open(const string& address, int port, const function<void (const Response&)>& reader);
+  int RunThread();
+  int Run();
+  void Close();
+  string GetAddress() const;
+  int GetPort() const;
+  int SendInvoke(uint32_t channel_id, const string& token, const string& json);
+  int SendAttach(uint32_t channel_id, bool attach);
+  int SendExit();
+  int ReadResponse(Response& cmd);
+private:
+  int ReadExact(uint8_t* p, int len);
+  static void* RunThreadFunc(void* arg);
+
+  int m_serverSocket;
+  int m_clientSocket;  
+  function<void (const Response&)> m_reader;
+  bool m_running;
+  pthread_t m_thread;
+  string m_address;
+  int m_port;
+};


### PR DESCRIPTION
(cherry picked from commit b3018d54feeec44daf2c615ce22cd2cee2052cc8)

Add rust adapter process for outofprocess mode

(cherry picked from commit 976bad478ef78e789c734a50fd61d1b9c8805cc3)

improve rust remote startup error handling

(cherry picked from commit c96cd6df52dfc3f0f503c9b6b73430c412413610)

changes to support remote debug

(cherry picked from commit 0b98bb734c3645f0b24051a0a61fe732d3b526fd)

remote send_to mut hack

(cherry picked from commit cd35c300a1a3146500f5b445990e767b2dd2c450)

rename rust_adapter_process to WPEHost

(cherry picked from commit 81ce0f9f06cd981366450bf5634b655ef4691f49)

move rust WPEHost from rdkservices to thunder_rs

(cherry picked from commit 0044095c19494b7bbb69044f96887092f0d334bf)

Changed C++/Rust interface to exclude the use of void pointers.

(cherry picked from commit ab7888fa66dac52e2756ff31c7a466f501e62f72)

allows RustAdapter to build with older Thunder version

(cherry picked from commit fdec24139023e980e4fe08ad18f2b887245f9d02)

Added capability to override the rust shared library name. Currently code uses the callsign
name.

(cherry picked from commit f2bc1e7cdc883f5e96eb2afa4305f1ec7c4ef7b9)

Added Athorization token to plugin's configuration.

(cherry picked from commit 0824cd19e7f0dfc5fda966570cddf55ef5e70bd3)

Co-authored-by: mrollins <mark_rollins@cable.comcast.com>
Co-authored-by: Karunakaran A <48997923+karuna2git@users.noreply.github.com>
(cherry picked from commit 06a74bf0ae0b6954807d84354094ba9288ad43b6)