### PR TITLE
RDKTV-18719 : WpeFramework crash fix

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -274,22 +274,18 @@ namespace WPEFramework {
 
 	    m_subscribed = false; //HdmiCecSink event subscription
 	    m_hdmiInAudioDeviceConnected = false;
-        m_arcAudioEnabled = false;
+	    m_arcAudioEnabled = false;
 	    m_hdmiCecAudioDeviceDetected = false;
             m_hdmiInAudioDevicePowerState = AUDIO_DEVICE_POWER_STATE_UNKNOWN;
 	    m_currentArcRoutingState = ARC_STATE_ARC_TERMINATED;
 	    m_cecArcRoutingThreadRun = false;
 	    isCecArcRoutingThreadEnabled = true;
             m_isPwrMgr2RFCEnabled = false;
-	    m_arcRoutingThread = std::thread(cecArcRoutingThread);
-	    m_timer.connect(std::bind(&DisplaySettings::onTimer, this));
-            m_AudioDeviceDetectTimer.connect(std::bind(&DisplaySettings::checkAudioDeviceDetectionTimer, this));
         }
 
         DisplaySettings::~DisplaySettings()
         {
-            LOGINFO("dtor  ");
-            stopCecTimeAndUnsubscriveEvent();
+            LOGINFO ("\nDisplaySettings.cpp: dtor  \n");
         }
 
         void DisplaySettings::AudioPortsReInitialize()
@@ -493,6 +489,10 @@ namespace WPEFramework {
 
         const string DisplaySettings::Initialize(PluginHost::IShell* /* service */)
         {
+	    m_arcRoutingThread = std::thread(cecArcRoutingThread);
+	    m_timer.connect(std::bind(&DisplaySettings::onTimer, this));
+            m_AudioDeviceDetectTimer.connect(std::bind(&DisplaySettings::checkAudioDeviceDetectionTimer, this));
+
             InitializeIARM();
 
             if (IARM_BUS_PWRMGR_POWERSTATE_ON == getSystemPowerState())
@@ -3953,6 +3953,7 @@ namespace WPEFramework {
                     LOGERR("HdmiCecSink Initialisation failed\n");
                 }
                 else {
+                    WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>* client = (WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>*) m_client;
                     JsonObject hdmiCecSinkResult;
                     JsonObject param;
 
@@ -3963,7 +3964,7 @@ namespace WPEFramework {
                     }
 
                     LOGINFO("ARC Routing - %d \n", arcEnable);
-                    m_client->Invoke<JsonObject, JsonObject>(2000, "setupARCRouting", param, hdmiCecSinkResult);
+                    client->Invoke<JsonObject, JsonObject>(2000, "setupARCRouting", param, hdmiCecSinkResult);
                     if (!hdmiCecSinkResult["success"].Boolean()) {
 			success = false;
                         LOGERR("HdmiCecSink Plugin returned error\n");
@@ -3989,10 +3990,11 @@ namespace WPEFramework {
                     LOGERR("HdmiCecSink Initialisation failed\n");
                 }
                 else {
+                    WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>* client = (WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>*) m_client;
                     JsonObject hdmiCecSinkResult;
                     JsonObject param;
 
-                    m_client->Invoke<JsonObject, JsonObject>(2000, "getEnabled", param, hdmiCecSinkResult);
+                    client->Invoke<JsonObject, JsonObject>(2000, "getEnabled", param, hdmiCecSinkResult);
 
 		    cecEnable = hdmiCecSinkResult["enabled"].Boolean();
 		    LOGINFO("get-cecEnabled [%d]\n",cecEnable);
@@ -4021,10 +4023,11 @@ namespace WPEFramework {
                     LOGERR("HdmiCecSink Initialisation failed\n");
                 }
                 else {
+                    WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>* client = (WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>*) m_client;
                     JsonObject hdmiCecSinkResult;
                     JsonObject param;
 
-                    m_client->Invoke<JsonObject, JsonObject>(2000, "getAudioDeviceConnectedStatus", param, hdmiCecSinkResult);
+                    client->Invoke<JsonObject, JsonObject>(2000, "getAudioDeviceConnectedStatus", param, hdmiCecSinkResult);
 
                     hdmiAudioDeviceDetected = hdmiCecSinkResult["connected"].Boolean();
                     LOGINFO("getAudioDeviceConnectedStatus [%d]\n",hdmiAudioDeviceDetected);
@@ -4052,11 +4055,12 @@ namespace WPEFramework {
                     LOGERR("HdmiCecSink Initialisation failed\n");
                 }
                 else {
+                    WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>* client = (WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>*) m_client;
                     JsonObject hdmiCecSinkResult;
                     JsonObject param;
 
                     LOGINFO("Send Audio Device Power On !!!\n");
-                    m_client->Invoke<JsonObject, JsonObject>(2000, "sendAudioDevicePowerOnMessage", param, hdmiCecSinkResult);
+                    client->Invoke<JsonObject, JsonObject>(2000, "sendAudioDevicePowerOnMessage", param, hdmiCecSinkResult);
                     if (!hdmiCecSinkResult["success"].Boolean()) {
                         success = false;
                         LOGERR("HdmiCecSink Plugin returned error\n");
@@ -4081,11 +4085,12 @@ namespace WPEFramework {
                     LOGERR("HdmiCecSink plugin not accessible\n");
                 }
                 else {
+                    WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>* client = (WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>*) m_client;
                     JsonObject hdmiCecSinkResult;
                     JsonObject param;
 
                     LOGINFO("Requesting Short Audio Descriptor \n");
-                    m_client->Invoke<JsonObject, JsonObject>(2000, "requestShortAudioDescriptor", param, hdmiCecSinkResult);
+                    client->Invoke<JsonObject, JsonObject>(2000, "requestShortAudioDescriptor", param, hdmiCecSinkResult);
                     if (!hdmiCecSinkResult["success"].Boolean()) {
                         success = false;
                         LOGERR("HdmiCecSink Plugin returned error\n");
@@ -4110,11 +4115,12 @@ namespace WPEFramework {
                     LOGERR("HdmiCecSink plugin not accessible\n");
                 }
                 else {
+                    WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>* client = (WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>*) m_client;
                     JsonObject hdmiCecSinkResult;
                     JsonObject param;
 
                     LOGINFO("Requesting Audio Device power Status \n");
-                    m_client->Invoke<JsonObject, JsonObject>(2000, "requestAudioDevicePowerStatus", param, hdmiCecSinkResult);
+                    client->Invoke<JsonObject, JsonObject>(2000, "requestAudioDevicePowerStatus", param, hdmiCecSinkResult);
                     if (!hdmiCecSinkResult["success"].Boolean()) {
                         success = false;
                         LOGERR("HdmiCecSink Plugin returned error\n");
@@ -4321,7 +4327,7 @@ namespace WPEFramework {
             if(m_client == nullptr)
             { 
                 Core::SystemInfo::SetEnvironment(_T("THUNDER_ACCESS"), (_T("127.0.0.1:9998")));
-                m_client = (WPEFramework::JSONRPC::LinkType<Core::JSON::IElement>*)new WPEFramework::JSONRPC::LinkType<Core::JSON::IElement>(_T(HDMICECSINK_CALLSIGN_VER), (_T(HDMICECSINK_CALLSIGN_VER)));
+                m_client = new WPEFramework::JSONRPC::LinkType<Core::JSON::IElement>(_T(HDMICECSINK_CALLSIGN_VER), (_T(HDMICECSINK_CALLSIGN_VER)));
                 LOGINFO("DisplaySettings getHdmiCecSinkPlugin init m_client\n");
             }
         }
@@ -4519,33 +4525,34 @@ namespace WPEFramework {
             }
 
 	    if(err == Core::ERROR_NONE) {
+                WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>* client = (WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>*) m_client;
                 /* Register handlers for Event reception. */
                 if(strcmp(eventName, HDMICECSINK_ARC_INITIATION_EVENT) == 0) {
-                    err =m_client->Subscribe<JsonObject>(1000, eventName
+                    err =client->Subscribe<JsonObject>(1000, eventName
                             , &DisplaySettings::onARCInitiationEventHandler, this);
                     m_clientRegisteredEventNames.push_back(eventName);
                 } else if(strcmp(eventName, HDMICECSINK_ARC_TERMINATION_EVENT) == 0) {
-                    err =m_client->Subscribe<JsonObject>(1000, eventName
+                    err =client->Subscribe<JsonObject>(1000, eventName
                             , &DisplaySettings::onARCTerminationEventHandler, this);
                     m_clientRegisteredEventNames.push_back(eventName);
                 } else if(strcmp(eventName, HDMICECSINK_SHORT_AUDIO_DESCRIPTOR_EVENT) == 0) {
-                    err =m_client->Subscribe<JsonObject>(1000, eventName
+                    err =client->Subscribe<JsonObject>(1000, eventName
                             , &DisplaySettings::onShortAudioDescriptorEventHandler, this);
                     m_clientRegisteredEventNames.push_back(eventName);
                 } else if(strcmp(eventName, HDMICECSINK_SYSTEM_AUDIO_MODE_EVENT) == 0) {
-                    err =m_client->Subscribe<JsonObject>(1000, eventName
+                    err =client->Subscribe<JsonObject>(1000, eventName
                             , &DisplaySettings::onSystemAudioModeEventHandler, this);
                     m_clientRegisteredEventNames.push_back(eventName);
                 } else if(strcmp(eventName, HDMICECSINK_AUDIO_DEVICE_CONNECTED_STATUS_EVENT) == 0) {
-                    err =m_client->Subscribe<JsonObject>(1000, eventName
+                    err =client->Subscribe<JsonObject>(1000, eventName
                             , &DisplaySettings::onAudioDeviceConnectedStatusEventHandler, this);
                     m_clientRegisteredEventNames.push_back(eventName);
                 } else if(strcmp(eventName, HDMICECSINK_CEC_ENABLED_EVENT) == 0) {
-                    err =m_client->Subscribe<JsonObject>(1000, eventName
+                    err =client->Subscribe<JsonObject>(1000, eventName
                             , &DisplaySettings::onCecEnabledEventHandler, this);
                     m_clientRegisteredEventNames.push_back(eventName);
                 } else if(strcmp(eventName, HDMICECSINK_AUDIO_DEVICE_POWER_STATUS_EVENT) == 0) {
-                    err =m_client->Subscribe<JsonObject>(1000, eventName
+                    err =client->Subscribe<JsonObject>(1000, eventName
                             , &DisplaySettings::onAudioDevicePowerStatusEventHandler, this);
                     m_clientRegisteredEventNames.push_back(eventName);
 		} else {
@@ -4906,7 +4913,7 @@ namespace WPEFramework {
 	}
 
         void DisplaySettings::stopCecTimeAndUnsubscriveEvent() {
-            LOGINFO("de-init cec timer and subscribbed event ");
+            LOGINFO ("\nDisplaySettings.cpp: de-init cec timer and subscribbed event \n");
             {
                 lock_guard<mutex> lck(m_callMutex);
                 if ( m_timer.isActive()) {
@@ -4916,14 +4923,16 @@ namespace WPEFramework {
                 if ( m_AudioDeviceDetectTimer.isActive()) {
                     m_AudioDeviceDetectTimer.stop();
                 }
-                for (std::string eventName : m_clientRegisteredEventNames) {
-                    m_client->Unsubscribe(1000, _T(eventName));
-                    LOGINFO("Unsubscribing event %s", eventName.c_str());
-	        }
-                m_clientRegisteredEventNames.clear();
                 if (nullptr != m_client) {
-                    LOGINFO("deleting m_client ");
-                    delete m_client; m_client = nullptr;
+                    WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>* client = (WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>*) m_client;
+                    for (std::string eventName : m_clientRegisteredEventNames) {
+                        client->Unsubscribe(1000, _T(eventName));
+                        LOGINFO ("\nDisplaySettings.cpp: Unsubscribing event %s\n", eventName.c_str());
+                    }
+                    m_clientRegisteredEventNames.clear();
+
+                    LOGINFO ("\nDisplaySettings.cpp: deleting m_client \n");
+                    delete client; m_client = nullptr;
                 }
             }
         }

--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -210,7 +210,7 @@ namespace WPEFramework {
             IARM_Bus_PWRMgr_PowerState_t getSystemPowerState();
 
 	    void getHdmiCecSinkPlugin();
-	    WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>* m_client;
+	    void* m_client;
 	    std::vector<std::string> m_clientRegisteredEventNames;
 	    uint32_t subscribeForHdmiCecSinkEvent(const char* eventName);
 	    bool setUpHdmiCecSinkArcRouting (bool arcEnable);


### PR DESCRIPTION
Reason for change:
HdmiCecSink shared_ptr cross reference in DisplaySettings
plugin is removed.
Test Procedure: None
Risks: Low

Change-Id: Ic90a1f7df790a3636c540006b2137d1bf3d549b3
Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>