### PR TITLE
RDKTV-19091 : WpeFramework crash with shared_count display settings

### DIFF
--- a/DisplaySettings/CHANGELOG.md
+++ b/DisplaySettings/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] - 2022-08-25
+### Fixed
+- Fixed std:: RDKTV-19091 : WpeFramework crash fix
+
 ## [1.0.2] - 2022-08-18
 ### Fixed
 - RDKTV-18555 Device locked up for 2 minutes after turning BUILT-IN SPEAKER

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -77,7 +77,7 @@ using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 2
+#define API_VERSION_NUMBER_PATCH 3
 
 static bool isCecArcRoutingThreadEnabled = false;
 static bool isCecEnabled = false;
@@ -168,6 +168,7 @@ namespace WPEFramework {
         {
             LOGINFO("ctor");
             DisplaySettings::_instance = this;
+            m_client = nullptr;
 
             CreateHandler({ 2 });
 
@@ -283,15 +284,8 @@ namespace WPEFramework {
 
         DisplaySettings::~DisplaySettings()
         {
-            LOGINFO("dtor");
-            lock_guard<mutex> lck(m_callMutex);
-            if ( m_timer.isActive()) {
-                m_timer.stop();
-            }
-
-            if ( m_AudioDeviceDetectTimer.isActive()) {
-                m_AudioDeviceDetectTimer.stop();
-            }
+            LOGINFO("dtor  ");
+            stopCecTimeAndUnsubscriveEvent();
         }
 
         void DisplaySettings::AudioPortsReInitialize()
@@ -535,6 +529,7 @@ namespace WPEFramework {
             {
                 LOGERR("exception in thread join %s", e.what());
             }
+            stopCecTimeAndUnsubscriveEvent();
 
             DeinitializeIARM();
             DisplaySettings::_instance = nullptr;
@@ -3854,8 +3849,8 @@ namespace WPEFramework {
             bool success = true;
 
             if (Utils::isPluginActivated(HDMICECSINK_CALLSIGN)) {
-                auto hdmiCecSinkPlugin = getHdmiCecSinkPlugin();
-                if (!hdmiCecSinkPlugin) {
+                getHdmiCecSinkPlugin();
+                if (!m_client) {
                     LOGERR("HdmiCecSink Initialisation failed\n");
                 }
                 else {
@@ -3869,7 +3864,7 @@ namespace WPEFramework {
                     }
 
                     LOGINFO("ARC Routing - %d \n", arcEnable);
-                    hdmiCecSinkPlugin->Invoke<JsonObject, JsonObject>(2000, "setupARCRouting", param, hdmiCecSinkResult);
+                    m_client->Invoke<JsonObject, JsonObject>(2000, "setupARCRouting", param, hdmiCecSinkResult);
                     if (!hdmiCecSinkResult["success"].Boolean()) {
 			success = false;
                         LOGERR("HdmiCecSink Plugin returned error\n");
@@ -3890,15 +3885,15 @@ namespace WPEFramework {
 	    bool cecEnable = false;
 
             if (Utils::isPluginActivated(HDMICECSINK_CALLSIGN)) {
-                auto hdmiCecSinkPlugin = getHdmiCecSinkPlugin();
-                if (!hdmiCecSinkPlugin) {
+                getHdmiCecSinkPlugin();
+                if (!m_client) {
                     LOGERR("HdmiCecSink Initialisation failed\n");
                 }
                 else {
                     JsonObject hdmiCecSinkResult;
                     JsonObject param;
 
-                    hdmiCecSinkPlugin->Invoke<JsonObject, JsonObject>(2000, "getEnabled", param, hdmiCecSinkResult);
+                    m_client->Invoke<JsonObject, JsonObject>(2000, "getEnabled", param, hdmiCecSinkResult);
 
 		    cecEnable = hdmiCecSinkResult["enabled"].Boolean();
 		    LOGINFO("get-cecEnabled [%d]\n",cecEnable);
@@ -3922,15 +3917,15 @@ namespace WPEFramework {
             bool hdmiAudioDeviceDetected = false;
 
             if (Utils::isPluginActivated(HDMICECSINK_CALLSIGN)) {
-                auto hdmiCecSinkPlugin = getHdmiCecSinkPlugin();
-                if (!hdmiCecSinkPlugin) {
+                getHdmiCecSinkPlugin();
+                if (!m_client) {
                     LOGERR("HdmiCecSink Initialisation failed\n");
                 }
                 else {
                     JsonObject hdmiCecSinkResult;
                     JsonObject param;
 
-                    hdmiCecSinkPlugin->Invoke<JsonObject, JsonObject>(2000, "getAudioDeviceConnectedStatus", param, hdmiCecSinkResult);
+                    m_client->Invoke<JsonObject, JsonObject>(2000, "getAudioDeviceConnectedStatus", param, hdmiCecSinkResult);
 
                     hdmiAudioDeviceDetected = hdmiCecSinkResult["connected"].Boolean();
                     LOGINFO("getAudioDeviceConnectedStatus [%d]\n",hdmiAudioDeviceDetected);
@@ -3953,8 +3948,8 @@ namespace WPEFramework {
             bool success = true;
 
             if (Utils::isPluginActivated(HDMICECSINK_CALLSIGN)) {
-                auto hdmiCecSinkPlugin = getHdmiCecSinkPlugin();
-                if (!hdmiCecSinkPlugin) {
+                getHdmiCecSinkPlugin();
+                if (!m_client) {
                     LOGERR("HdmiCecSink Initialisation failed\n");
                 }
                 else {
@@ -3962,7 +3957,7 @@ namespace WPEFramework {
                     JsonObject param;
 
                     LOGINFO("%s: Send Audio Device Power On !!!\n");
-                    hdmiCecSinkPlugin->Invoke<JsonObject, JsonObject>(2000, "sendAudioDevicePowerOnMessage", param, hdmiCecSinkResult);
+                    m_client->Invoke<JsonObject, JsonObject>(2000, "sendAudioDevicePowerOnMessage", param, hdmiCecSinkResult);
                     if (!hdmiCecSinkResult["success"].Boolean()) {
                         success = false;
                         LOGERR("HdmiCecSink Plugin returned error\n");
@@ -3982,8 +3977,8 @@ namespace WPEFramework {
             bool success = true;
 
             if (Utils::isPluginActivated(HDMICECSINK_CALLSIGN)) {
-                auto hdmiCecSinkPlugin = getHdmiCecSinkPlugin();
-                if (!hdmiCecSinkPlugin) {
+                getHdmiCecSinkPlugin();
+                if (!m_client) {
                     LOGERR("HdmiCecSink plugin not accessible\n");
                 }
                 else {
@@ -3991,7 +3986,7 @@ namespace WPEFramework {
                     JsonObject param;
 
                     LOGINFO("Requesting Short Audio Descriptor \n");
-                    hdmiCecSinkPlugin->Invoke<JsonObject, JsonObject>(2000, "requestShortAudioDescriptor", param, hdmiCecSinkResult);
+                    m_client->Invoke<JsonObject, JsonObject>(2000, "requestShortAudioDescriptor", param, hdmiCecSinkResult);
                     if (!hdmiCecSinkResult["success"].Boolean()) {
                         success = false;
                         LOGERR("HdmiCecSink Plugin returned error\n");
@@ -4011,8 +4006,8 @@ namespace WPEFramework {
             bool success = true;
 
             if (Utils::isPluginActivated(HDMICECSINK_CALLSIGN)) {
-                auto hdmiCecSinkPlugin = getHdmiCecSinkPlugin();
-                if (!hdmiCecSinkPlugin) {
+                getHdmiCecSinkPlugin();
+                if (!m_client) {
                     LOGERR("HdmiCecSink plugin not accessible\n");
                 }
                 else {
@@ -4020,7 +4015,7 @@ namespace WPEFramework {
                     JsonObject param;
 
                     LOGINFO("Requesting Audio Device power Status \n");
-                    hdmiCecSinkPlugin->Invoke<JsonObject, JsonObject>(2000, "requestAudioDevicePowerStatus", param, hdmiCecSinkResult);
+                    m_client->Invoke<JsonObject, JsonObject>(2000, "requestAudioDevicePowerStatus", param, hdmiCecSinkResult);
                     if (!hdmiCecSinkResult["success"].Boolean()) {
                         success = false;
                         LOGERR("HdmiCecSink Plugin returned error\n");
@@ -4222,17 +4217,16 @@ namespace WPEFramework {
 
 
         // Thunder plugins communication
-        std::shared_ptr<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>> DisplaySettings::getHdmiCecSinkPlugin()
+        void DisplaySettings::getHdmiCecSinkPlugin()
         {
-            Core::SystemInfo::SetEnvironment(_T("THUNDER_ACCESS"), (_T("127.0.0.1:9998")));
-            return make_shared<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>>("org.rdk.HdmiCecSink.1", "");
+            if(m_client == nullptr)
+            { 
+                Core::SystemInfo::SetEnvironment(_T("THUNDER_ACCESS"), (_T("127.0.0.1:9998")));
+                m_client = (WPEFramework::JSONRPC::LinkType<Core::JSON::IElement>*)new WPEFramework::JSONRPC::LinkType<Core::JSON::IElement>(_T(HDMICECSINK_CALLSIGN_VER), (_T(HDMICECSINK_CALLSIGN_VER)));
+                LOGINFO("DisplaySettings getHdmiCecSinkPlugin init m_client\n");
+            }
         }
 
-        std::shared_ptr<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>> DisplaySettings::getSystemPlugin()
-        {
-            Core::SystemInfo::SetEnvironment(_T("THUNDER_ACCESS"), (_T("127.0.0.1:9998")));
-            return make_shared<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>>("org.rdk.System.1", "");
-        }
 
         IARM_Bus_PWRMgr_PowerState_t DisplaySettings::getSystemPowerState()
         {
@@ -4418,7 +4412,7 @@ namespace WPEFramework {
             LOGINFO("Attempting to subscribe for event: %s\n", eventName);
             Core::SystemInfo::SetEnvironment(_T("THUNDER_ACCESS"), (_T(SERVER_DETAILS)));
             if (nullptr == m_client) {
-                m_client = make_shared<WPEFramework::JSONRPC::LinkType<Core::JSON::IElement>>(_T(HDMICECSINK_CALLSIGN_VER), (_T(HDMICECSINK_CALLSIGN_VER)));
+                getHdmiCecSinkPlugin();
                 if (nullptr == m_client) {
                     LOGERR("JSONRPC: %s: client initialization failed", HDMICECSINK_CALLSIGN_VER);
                     err = Core::ERROR_UNAVAILABLE;
@@ -4430,24 +4424,31 @@ namespace WPEFramework {
                 if(strcmp(eventName, HDMICECSINK_ARC_INITIATION_EVENT) == 0) {
                     err =m_client->Subscribe<JsonObject>(1000, eventName
                             , &DisplaySettings::onARCInitiationEventHandler, this);
+                    m_clientRegisteredEventNames.push_back(eventName);
                 } else if(strcmp(eventName, HDMICECSINK_ARC_TERMINATION_EVENT) == 0) {
                     err =m_client->Subscribe<JsonObject>(1000, eventName
                             , &DisplaySettings::onARCTerminationEventHandler, this);
+                    m_clientRegisteredEventNames.push_back(eventName);
                 } else if(strcmp(eventName, HDMICECSINK_SHORT_AUDIO_DESCRIPTOR_EVENT) == 0) {
                     err =m_client->Subscribe<JsonObject>(1000, eventName
                             , &DisplaySettings::onShortAudioDescriptorEventHandler, this);
+                    m_clientRegisteredEventNames.push_back(eventName);
                 } else if(strcmp(eventName, HDMICECSINK_SYSTEM_AUDIO_MODE_EVENT) == 0) {
                     err =m_client->Subscribe<JsonObject>(1000, eventName
                             , &DisplaySettings::onSystemAudioModeEventHandler, this);
+                    m_clientRegisteredEventNames.push_back(eventName);
                 } else if(strcmp(eventName, HDMICECSINK_AUDIO_DEVICE_CONNECTED_STATUS_EVENT) == 0) {
                     err =m_client->Subscribe<JsonObject>(1000, eventName
                             , &DisplaySettings::onAudioDeviceConnectedStatusEventHandler, this);
+                    m_clientRegisteredEventNames.push_back(eventName);
                 } else if(strcmp(eventName, HDMICECSINK_CEC_ENABLED_EVENT) == 0) {
                     err =m_client->Subscribe<JsonObject>(1000, eventName
                             , &DisplaySettings::onCecEnabledEventHandler, this);
+                    m_clientRegisteredEventNames.push_back(eventName);
                 } else if(strcmp(eventName, HDMICECSINK_AUDIO_DEVICE_POWER_STATUS_EVENT) == 0) {
                     err =m_client->Subscribe<JsonObject>(1000, eventName
                             , &DisplaySettings::onAudioDevicePowerStatusEventHandler, this);
+                    m_clientRegisteredEventNames.push_back(eventName);
 		} else {
                      err = Core::ERROR_UNAVAILABLE;
                      LOGERR("Unsupported Event: %s ", eventName);
@@ -4785,6 +4786,29 @@ namespace WPEFramework {
 
               LOGINFO("updated isCecEnabled [%d] ... \n", isCecEnabled);
 	}
+
+        void DisplaySettings::stopCecTimeAndUnsubscriveEvent() {
+            LOGINFO("de-init cec timer and subscribbed event ");
+            {
+                lock_guard<mutex> lck(m_callMutex);
+                if ( m_timer.isActive()) {
+                    m_timer.stop();
+                }
+
+                if ( m_AudioDeviceDetectTimer.isActive()) {
+                    m_AudioDeviceDetectTimer.stop();
+                }
+                for (std::string eventName : m_clientRegisteredEventNames) {
+                    m_client->Unsubscribe(1000, _T(eventName));
+                    LOGINFO("Unsubscribing event %s", eventName.c_str());
+	        }
+                m_clientRegisteredEventNames.clear();
+                if (nullptr != m_client) {
+                    LOGINFO("deleting m_client ");
+                    delete m_client; m_client = nullptr;
+                }
+            }
+        }
 
         // 6.
         void DisplaySettings::onTimer()

--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -208,9 +208,9 @@ namespace WPEFramework {
             bool checkPortName(std::string& name) const;
             IARM_Bus_PWRMgr_PowerState_t getSystemPowerState();
 
-	    std::shared_ptr<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>> getHdmiCecSinkPlugin();
-	    std::shared_ptr<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement> > m_client;
-	    std::shared_ptr<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>> getSystemPlugin();
+	    void getHdmiCecSinkPlugin();
+	    WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>* m_client;
+	    std::vector<std::string> m_clientRegisteredEventNames;
 	    uint32_t subscribeForHdmiCecSinkEvent(const char* eventName);
 	    bool setUpHdmiCecSinkArcRouting (bool arcEnable);
 	    bool requestShortAudioDescriptor();
@@ -220,6 +220,7 @@ namespace WPEFramework {
 	    bool getHdmiCecSinkAudioDeviceConnectedStatus();
 	    static void  cecArcRoutingThread();
 	    void onTimer();
+	    void stopCecTimeAndUnsubscriveEvent();
             void checkAudioDeviceDetectionTimer();
 
 	    TpTimer m_timer;


### PR DESCRIPTION
Reason for change:
Fixed Display Settings distractor.
HdmiCecSink shared_ptr cross reference in DisplaySettings
plugin is removed.
Test Procedure: refer jira.
Risks: Low

Change-Id: I86fd490a69edac3304ac6b2a56e9e82bcecdddf2
Signed-off-by: apatel859 amit_patel5@comcast.com
Signed-off-by:Anooj Cheriyan Anooj_Cheriyan@comcast.com
(cherry picked from commit b07d2b7)
(cherry picked from commit aafdc66)
(cherry picked from commit 895844b)