### PR TITLE
RDKTV-19091 : WpeFramework crash with shared_count display settings

### DIFF
--- a/DisplaySettings/CHANGELOG.md
+++ b/DisplaySettings/CHANGELOG.md
@@ -5,10 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.1] - 2022-08-18
+## [1.0.3] - 2022-08-25
 ### Fixed
-- RDKTV-18555 Device locked up for 2 minutes after turning BUILT-IN SPEAKER
-  setting OFF while using input
+- Fixed std:: Displaysettings side JSONRPC::LinkType crash fix
+
+### Fixed
+## [1.0.1] - 2022-08-18
+- Optimize include
 
 ## [1.0.0] - 2022-05-11
 ### Added

--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -209,9 +209,9 @@ namespace WPEFramework {
             bool checkPortName(std::string& name) const;
             IARM_Bus_PWRMgr_PowerState_t getSystemPowerState();
 
-	    std::shared_ptr<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>> getHdmiCecSinkPlugin();
-	    std::shared_ptr<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement> > m_client;
-	    std::shared_ptr<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>> getSystemPlugin();
+	    void getHdmiCecSinkPlugin();
+	    WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>* m_client;
+	    std::vector<std::string> m_clientRegisteredEventNames;
 	    uint32_t subscribeForHdmiCecSinkEvent(const char* eventName);
 	    bool setUpHdmiCecSinkArcRouting (bool arcEnable);
 	    bool requestShortAudioDescriptor();
@@ -221,6 +221,7 @@ namespace WPEFramework {
 	    bool getHdmiCecSinkAudioDeviceConnectedStatus();
 	    static void  cecArcRoutingThread();
 	    void onTimer();
+	    void stopCecTimeAndUnsubscriveEvent();
             void checkAudioDeviceDetectionTimer();
 
 	    TpTimer m_timer;


### PR DESCRIPTION
Reason for change:
Fixed Display Settings distractor.
HdmiCecSink shared_ptr cross reference in DisplaySettings
plugin is removed.
Test Procedure: refer jira.
Risks: Low

Change-Id: I86fd490a69edac3304ac6b2a56e9e82bcecdddf2
Signed-off-by: apatel859 amit_patel5@comcast.com
Signed-off-by:Anooj Cheriyan Anooj_Cheriyan@comcast.com
(cherry picked from commit b07d2b7)
(cherry picked from commit aafdc66)
(cherry picked from commit 895844b)
(cherry picked from commit 1e604e3411cbd8a16b10080af0063e4904024191)