### PR TITLE
RDKTV-17901: [eARC]eARC AVR doesn’t work after set parameter “HDMI-CEC”

### DIFF
--- a/DisplaySettings/CHANGELOG.md
+++ b/DisplaySettings/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+##[1.0.4] - 2022-08-31
+### Changed
+- Changed functionality to route audio to AVR on HDMI CEC off incase of eArc devices as well.
+
 ## [1.0.3] - 2022-08-25
 ### Fixed
 - Fixed std:: Displaysettings side JSONRPC::LinkType crash fix

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -77,7 +77,7 @@ using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 3
+#define API_VERSION_NUMBER_PATCH 4
 
 static bool isCecArcRoutingThreadEnabled = false;
 static bool isCecEnabled = false;
@@ -4782,6 +4782,25 @@ namespace WPEFramework {
 		isCecEnabled = true;
 	      } else{
 		isCecEnabled = false;
+		try
+                    {
+                        if(m_hdmiInAudioDeviceConnected ==  true) {
+                            m_hdmiInAudioDeviceConnected = false;
+                            connectedAudioPortUpdated(dsAUDIOPORT_TYPE_HDMI_ARC, false);
+
+                            device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort("HDMI_ARC0");
+                            LOGINFO("cec Disabled: Disable ARC\n");
+                            aPort.enableARC(dsAUDIOARCSUPPORT_ARC, false);
+                            m_arcAudioEnabled = false;
+                        }
+                        else {
+                            LOGINFO("Skip Disable ARC and not notifying the UI as  m_hdmiInAudioDeviceConnected = false\n");
+                        }
+                    }
+                    catch (const device::Exception& err)
+                    {
+                        LOG_DEVICE_EXCEPTION1(string("HDMI_ARC0"));
+                    }
 	      }
 
               LOGINFO("updated isCecEnabled [%d] ... \n", isCecEnabled);


### PR DESCRIPTION
Reason for change: Audio routes to eArc on cec off where as it should be on TV speakers
Test Procedure: check ticket
Risks: Low

Signed-off-by: shashank.kumar@sky.uk <shashank.kumar@sky.uk>