### PR TITLE
RDKTV-19417: WebProcess crash in WebCore::Page::setActivityState

### DIFF
--- a/WebKitBrowser/WebKitImplementation.cpp
+++ b/WebKitBrowser/WebKitImplementation.cpp
@@ -2201,6 +2201,7 @@ static GSourceFuncs _handlerIntervention =
 
             webkit_settings_set_enable_encrypted_media(preferences, TRUE);
             webkit_settings_set_enable_mediasource(preferences, TRUE);
+            webkit_settings_set_enable_page_cache(preferences, FALSE);
 
             // Turn on/off WebGL
             webkit_settings_set_enable_webgl(preferences, _config.WebGLEnabled.Value());
@@ -2402,6 +2403,9 @@ static GSourceFuncs _handlerIntervention =
 
             // Turn on/off local storage
             WKPreferencesSetLocalStorageEnabled(preferences, _localStorageEnabled);
+
+            // Turn off BackForwardList
+            WKPreferencesSetPageCacheEnabled(preferences, FALSE);
 
             // Media Content Types Requiring Hardware Support
             if (_config.MediaContentTypesRequiringHardwareSupport.IsSet() == true


### PR DESCRIPTION
Reason for change: On app exit, WebGLRenderingContextBase is not
removed from the ActivityStateChangeObservers list as
WebGLRenderingContextBase couldn't reach Page through
canvas->document() (Frame was detached from Document when CachedPage
is created for about:blank). This change avoids creating CachedPage
by disabling PageCahe i.e BackForwardList

Test Procedure: Do multiple Lightning app launches and ensure the
reported crash is not observed
Risks: None

Signed-off-by: Vivek.A <vivek_arumugam@comcast.com>