### PR TITLE
RDKTV-19389 LLAMA-7398 : WPEFramework Process crashed

### DIFF
--- a/DisplaySettings/CHANGELOG.md
+++ b/DisplaySettings/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+##[1.0.5] - 2022-09-01
+### Changed
+- Fixed DisplaySettings::sendHdmiCecSinkAudioDevicePowerOn fprintf.c crash
+
 ##[1.0.4] - 2022-08-31
 ### Changed
 - Changed functionality to route audio to AVR on HDMI CEC off incase of eArc devices as well.

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -77,7 +77,7 @@ using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 4
+#define API_VERSION_NUMBER_PATCH 5
 
 static bool isCecArcRoutingThreadEnabled = false;
 static bool isCecEnabled = false;
@@ -3956,7 +3956,7 @@ namespace WPEFramework {
                     JsonObject hdmiCecSinkResult;
                     JsonObject param;
 
-                    LOGINFO("%s: Send Audio Device Power On !!!\n");
+                    LOGINFO("Send Audio Device Power On !!!\n");
                     m_client->Invoke<JsonObject, JsonObject>(2000, "sendAudioDevicePowerOnMessage", param, hdmiCecSinkResult);
                     if (!hdmiCecSinkResult["success"].Boolean()) {
                         success = false;
@@ -4163,7 +4163,7 @@ namespace WPEFramework {
                                 }
                             }
                             else {
-                                LOGINFO("%s: No handling required\n");
+                                LOGINFO("%s: No handling required\n",__FUNCTION__);
                             }
                        }
                     }
@@ -4633,7 +4633,7 @@ namespace WPEFramework {
                         aPort.getSupportedARCTypes(&types);
                         if((types & dsAUDIOARCSUPPORT_eARC) && (m_hdmiInAudioDeviceConnected == false)) {
                             m_hdmiInAudioDeviceConnected = true;
-                            LOGINFO("%s: eARC device sent system audio mode ON: Notify UI !!! \n");
+                            LOGINFO("%s: eARC device sent system audio mode ON: Notify UI !!! \n",__FUNCTION__);
                             connectedAudioPortUpdated(dsAUDIOPORT_TYPE_HDMI_ARC, true);
                         }
 			else if(types & dsAUDIOARCSUPPORT_ARC) {
@@ -4742,7 +4742,7 @@ namespace WPEFramework {
                     aPort.getSupportedARCTypes(&types);
                     if((types & dsAUDIOARCSUPPORT_eARC) && (m_hdmiInAudioDeviceConnected == false)) {
                         m_hdmiInAudioDeviceConnected = true;
-                        LOGINFO("%s: Triggered from HPD: eARC audio device power on: Notify UI !!! \n");
+                        LOGINFO("Triggered from HPD: eARC audio device power on: Notify UI !!! \n");
                         connectedAudioPortUpdated(dsAUDIOPORT_TYPE_HDMI_ARC, true);
                     }
                     else if(types & dsAUDIOARCSUPPORT_ARC) {


### PR DESCRIPTION
Reason for change:
Fixed DisplaySettings::sendHdmiCecSinkAudioDevicePowerOn fprintf.c crash
Fix missing parameter from print macros causing crashes

(cherry picked from commit 54595d8b8ea0a1ab7f72e1b9157b0d127f70a280)

Change-Id: Ic7d017a55dab5a705ee2f622364a9a3ac0b4ab93
(cherry picked from commit 3e085b35dd01fae8048208cc9c1fdfca6fddd753)