### PR TITLE
AMLOGIC-3543: osdName is NA for connected HDMIs

### DIFF
--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -2342,7 +2342,7 @@ namespace WPEFramework
 
 				case CECDeviceParams::REQUEST_OSD_NAME :	
 				{
-					_instance->smConnection->sendTo(LogicalAddress(logicalAddress), MessageEncoder().encode(GiveOSDName()), 200);
+					_instance->smConnection->sendTo(LogicalAddress(logicalAddress), MessageEncoder().encode(GiveOSDName()), 500);
 				}
 					break;
 


### PR DESCRIPTION
Reason for change: Give OSD Name write failure, reattempt is not happening. Increased timeout of GiveOsdName request to reattempt.
Test Procedure: Refer ticket for test procedure.
Risks: Low
Signed-off-by: bp-ynagas047 <yeshwanth.nagaswamy@sky.uk>