### PR TITLE
RDK-37906,37083 and json_validator file updation

### DIFF
--- a/.github/workflows/json_validator.yml
+++ b/.github/workflows/json_validator.yml
@@ -12,12 +12,10 @@ jobs:
     name: Validate json files
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0 
 
       - name: Get modified/added json files
         id: json-files
-        uses: tj-actions/changed-files@v23.2
+        uses: tj-actions/changed-files@v19
         with:
           files: |
             **/*.json

--- a/Tools/json_generator/generator_json.py
+++ b/Tools/json_generator/generator_json.py
@@ -2269,10 +2269,12 @@ def CreateDocument(schema, path):
                         matches+=m
             try:
                 version = matches[0]
+                link_to_version="https://github.com/rdkcentral/rdkservices/blob/main/"+os.path.basename(os.path.dirname(args.path[0]))+"/CHANGELOG.md"
             except:
                 log.Error("Version not found in the CHANGELOG.md file")
         else:
             version = "1.0.0"
+            link_to_version=""
 
         plugin_class = None
         if "callsign" in info:
@@ -2322,7 +2324,10 @@ def CreateDocument(schema, path):
         # Emit title bar
         if "title" in info:
             MdHeader(info["title"])
-        MdParagraph(bold("Version: " + version))
+        MdParagraph(bold("Version: [{}]({})").format(version,link_to_version))
+
+ 
+
         MdParagraph("A %s %s for Thunder framework." % (plugin_class, document_type))
 
         if document_type == "interface":
@@ -2363,7 +2368,6 @@ def CreateDocument(schema, path):
             if prop in d2:
                 tmp.update(d2[prop])
             return tmp
-
 
         MdHeader("Abbreviation, Acronyms and Terms")
         MdParagraph((

--- a/Tools/json_generator/schemas/interface.schema.json
+++ b/Tools/json_generator/schemas/interface.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema#",
   "type": "object",
   "properties": {
     "jsonrpc": {
@@ -61,12 +61,12 @@
             "params": {
               "description": "JSON-Schema of the procedure parameters.",
               "type": "object",
-              "$ref": "http://json-schema.org/draft-07/schema#"
+              "$ref": "https://json-schema.org/draft/2020-12/schema#"
             },
             "result": {
               "description": "JSON-Schema of the procedure result.",
               "type": "object",
-              "$ref": "http://json-schema.org/draft-07/schema#"
+              "$ref": "https://json-schema.org/draft/2020-12/schema#"
             },
             "events": {
               "description": "Events related.",
@@ -150,7 +150,7 @@
             "params": {
               "description": "JSON-Schema of the property value.",
               "type": "object",
-              "$ref": "http://json-schema.org/draft-07/schema#"
+              "$ref": "https://json-schema.org/draft/2020-12/schema#"
             },
             "events": {
               "description": "Events related.",
@@ -227,7 +227,7 @@
             "params": {
               "description": "JSON-Schema of the event params.",
               "type": "object",
-              "$ref": "http://json-schema.org/draft-07/schema#"
+              "$ref": "https://json-schema.org/draft/2020-12/schema#"
             }
           },
           "required": [

--- a/Tools/json_generator/schemas/plugin.schema.json
+++ b/Tools/json_generator/schemas/plugin.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema#",
   "type": "object",
   "properties": {
     "history": {
@@ -174,7 +174,7 @@
             "params": {
               "description": "JSON-Schema of the configuration properties.",
               "type": "object",
-              "$ref": "http://json-schema.org/draft-07/schema#"
+              "$ref": "https://json-schema.org/draft/2020-12/schema#"
             }
           },
           "required": [

--- a/docs/api/AVInputPlugin.md
+++ b/docs/api/AVInputPlugin.md
@@ -2,7 +2,7 @@
 <a name="AVInput_Plugin"></a>
 # AVInput Plugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/AVInput/CHANGELOG.md)**
 
 A org.rdk.AVInput plugin for Thunder framework.
 

--- a/docs/api/ActivityMonitorPlugin.md
+++ b/docs/api/ActivityMonitorPlugin.md
@@ -2,7 +2,7 @@
 <a name="ActivityMonitor_Plugin"></a>
 # ActivityMonitor Plugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/ActivityMonitor/CHANGELOG.md)**
 
 A org.rdk.ActivityMonitor plugin for Thunder framework.
 

--- a/docs/api/BluetoothPlugin.md
+++ b/docs/api/BluetoothPlugin.md
@@ -2,7 +2,7 @@
 <a name="Bluetooth_Plugin"></a>
 # Bluetooth Plugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/Bluetooth/CHANGELOG.md)**
 
 A org.rdk.Bluetooth plugin for Thunder framework.
 

--- a/docs/api/CompositeInputPlugin.md
+++ b/docs/api/CompositeInputPlugin.md
@@ -2,7 +2,7 @@
 <a name="CompositeInput_Plugin"></a>
 # CompositeInput Plugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/CompositeInput/CHANGELOG.md)**
 
 A org.rdk.CompositeInput plugin for Thunder framework.
 

--- a/docs/api/ContinueWatchingPlugin.md
+++ b/docs/api/ContinueWatchingPlugin.md
@@ -2,7 +2,7 @@
 <a name="ContinueWatching_Plugin"></a>
 # ContinueWatching Plugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/ContinueWatching/CHANGELOG.md)**
 
 A org.rdk.ContinueWatching plugin for Thunder framework.
 

--- a/docs/api/ControlServicePlugin.md
+++ b/docs/api/ControlServicePlugin.md
@@ -2,7 +2,7 @@
 <a name="ControlService_Plugin"></a>
 # ControlService Plugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/ControlService/CHANGELOG.md)**
 
 A org.rdk.ControlService plugin for Thunder framework.
 

--- a/docs/api/DTVPlugin.md
+++ b/docs/api/DTVPlugin.md
@@ -2,7 +2,7 @@
 <a name="DTV_Plugin"></a>
 # DTV Plugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/DTV/CHANGELOG.md)**
 
 A DTV plugin for Thunder framework.
 

--- a/docs/api/DataCapturePlugin.md
+++ b/docs/api/DataCapturePlugin.md
@@ -2,7 +2,7 @@
 <a name="DataCapture_Plugin"></a>
 # DataCapture Plugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/DataCapture/CHANGELOG.md)**
 
 A org.rdk.dataCapture plugin for Thunder framework.
 

--- a/docs/api/DeviceDiagnosticsPlugin.md
+++ b/docs/api/DeviceDiagnosticsPlugin.md
@@ -2,7 +2,7 @@
 <a name="DeviceDiagnostics_Plugin"></a>
 # DeviceDiagnostics Plugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/DeviceDiagnostics/CHANGELOG.md)**
 
 A org.rdk.DeviceDiagnostics plugin for Thunder framework.
 

--- a/docs/api/DeviceIdentificationPlugin.md
+++ b/docs/api/DeviceIdentificationPlugin.md
@@ -2,7 +2,7 @@
 <a name="DeviceIdentification_Plugin"></a>
 # DeviceIdentification Plugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/DeviceIdentification/CHANGELOG.md)**
 
 A DeviceIdentification plugin for Thunder framework.
 

--- a/docs/api/DeviceInfoPlugin.md
+++ b/docs/api/DeviceInfoPlugin.md
@@ -2,7 +2,7 @@
 <a name="DeviceInfo_Plugin"></a>
 # DeviceInfo Plugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/DeviceInfo/CHANGELOG.md)**
 
 A DeviceInfo plugin for Thunder framework.
 

--- a/docs/api/DisplayInfoPlugin.md
+++ b/docs/api/DisplayInfoPlugin.md
@@ -2,7 +2,7 @@
 <a name="DisplayInfo_Plugin"></a>
 # DisplayInfo Plugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/DisplayInfo/CHANGELOG.md)**
 
 A DisplayInfo plugin for Thunder framework.
 

--- a/docs/api/DisplaySettingsPlugin.md
+++ b/docs/api/DisplaySettingsPlugin.md
@@ -2,7 +2,7 @@
 <a name="DisplaySettings_Plugin"></a>
 # DisplaySettings Plugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/DisplaySettings/CHANGELOG.md)**
 
 A org.rdk.DisplaySettings plugin for Thunder framework.
 

--- a/docs/api/FireboltMediaPlayerPlugin.md
+++ b/docs/api/FireboltMediaPlayerPlugin.md
@@ -2,7 +2,7 @@
 <a name="FireboltMediaPlayerPlugin"></a>
 # FireboltMediaPlayerPlugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/FireboltMediaPlayer/CHANGELOG.md)**
 
 A org.rdk.FireboltMediaPlayer plugin for Thunder framework.
 

--- a/docs/api/FrameRatePlugin.md
+++ b/docs/api/FrameRatePlugin.md
@@ -2,7 +2,7 @@
 <a name="FrameRate_Plugin"></a>
 # FrameRate Plugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/FrameRate/CHANGELOG.md)**
 
 A org.rdk.FrameRate plugin for Thunder framework.
 

--- a/docs/api/FrontPanelPlugin.md
+++ b/docs/api/FrontPanelPlugin.md
@@ -2,7 +2,7 @@
 <a name="FrontPanel_Plugin"></a>
 # FrontPanel Plugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/FrontPanel/CHANGELOG.md)**
 
 A org.rdk.FrontPanel plugin for Thunder framework.
 

--- a/docs/api/HdcpProfilePlugin.md
+++ b/docs/api/HdcpProfilePlugin.md
@@ -2,7 +2,7 @@
 <a name="HdcpProfile_Plugin"></a>
 # HdcpProfile Plugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/HdcpProfile/CHANGELOG.md)**
 
 A org.rdk.HdcpProfile plugin for Thunder framework.
 

--- a/docs/api/HdmiCecPlugin.md
+++ b/docs/api/HdmiCecPlugin.md
@@ -2,7 +2,7 @@
 <a name="HdmiCecPlugin"></a>
 # HdmiCecPlugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/HdmiCec/CHANGELOG.md)**
 
 A org.rdk.HdmiCec plugin for Thunder framework.
 

--- a/docs/api/HdmiCecSinkPlugin.md
+++ b/docs/api/HdmiCecSinkPlugin.md
@@ -2,7 +2,7 @@
 <a name="HdmiCecSinkPlugin"></a>
 # HdmiCecSinkPlugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/HdmiCecSink/CHANGELOG.md)**
 
 A org.rdk.HdmiCecSink plugin for Thunder framework.
 

--- a/docs/api/HdmiCec_2Plugin.md
+++ b/docs/api/HdmiCec_2Plugin.md
@@ -2,7 +2,7 @@
 <a name="HdmiCec_2Plugin"></a>
 # HdmiCec_2Plugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/HdmiCec_2/CHANGELOG.md)**
 
 A org.rdk.HdmiCec_2 plugin for Thunder framework.
 
@@ -54,6 +54,7 @@ HdmiCec_2 interface methods:
 | [getOTPEnabled](#getOTPEnabled) | Returns HDMI-CEC OTP option enabled status |
 | [getVendorId](#getVendorId) | Returns the vendor ID set by the application |
 | [performOTPAction](#performOTPAction) | Turns on the TV and takes back the input to the device |
+| [sendKeyPressEvent](#sendKeyPressEvent) | Sends the CEC \<User Control Pressed\> message when TV remote key is pressed |
 | [sendStandbyMessage](#sendStandbyMessage) | Sends a CEC \<Standby\> message to the logical address of the device |
 | [setEnabled](#setEnabled) | Enables or disables HDMI-CEC driver |
 | [setOSDName](#setOSDName) | Sets the OSD name of the application |
@@ -382,6 +383,58 @@ This method takes no parameters.
     "jsonrpc": "2.0",
     "id": 42,
     "method": "org.rdk.HdmiCec_2.1.performOTPAction"
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "success": true
+    }
+}
+```
+
+<a name="sendKeyPressEvent"></a>
+## *sendKeyPressEvent*
+
+Sends the CEC \<User Control Pressed\> message when TV remote key is pressed.
+  
+### Event 
+
+ No Events.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.logicalAddress | integer | Logical address of the device |
+| params.keyCode | integer | The key code for the pressed key |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.success | boolean | Whether the request succeeded |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.HdmiCec_2.1.sendKeyPressEvent",
+    "params": {
+        "logicalAddress": 0,
+        "keyCode": 65
+    }
 }
 ```
 

--- a/docs/api/HdmiInputPlugin.md
+++ b/docs/api/HdmiInputPlugin.md
@@ -2,7 +2,7 @@
 <a name="HdmiInputPlugin"></a>
 # HdmiInputPlugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/HdmiInput/CHANGELOG.md)**
 
 A org.rdk.HdmiInput plugin for Thunder framework.
 

--- a/docs/api/LinearPlaybackControlPlugin.md
+++ b/docs/api/LinearPlaybackControlPlugin.md
@@ -2,7 +2,7 @@
 <a name="Linear_Playback_Control_Plugin"></a>
 # Linear Playback Control Plugin
 
-**Version: 1.0.0**
+**Version: [1.0.0]()**
 
 A LinearPlaybackControl plugin for Thunder framework.
 

--- a/docs/api/LocationSyncPlugin.md
+++ b/docs/api/LocationSyncPlugin.md
@@ -2,7 +2,7 @@
 <a name="Location_Sync_Plugin"></a>
 # Location Sync Plugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/LocationSync/CHANGELOG.md)**
 
 A LocationSync plugin for Thunder framework.
 

--- a/docs/api/LoggingPreferencesPlugin.md
+++ b/docs/api/LoggingPreferencesPlugin.md
@@ -2,7 +2,7 @@
 <a name="LoggingPreferencesPlugin"></a>
 # LoggingPreferencesPlugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/LoggingPreferences/CHANGELOG.md)**
 
 A org.rdk.LoggingPreferences plugin for Thunder framework.
 

--- a/docs/api/MaintenanceManagerPlugin.md
+++ b/docs/api/MaintenanceManagerPlugin.md
@@ -2,7 +2,7 @@
 <a name="MaintenanceManagerPlugin"></a>
 # MaintenanceManagerPlugin
 
-**Version: 1.0.2**
+**Version: [1.0.2](https://github.com/rdkcentral/rdkservices/blob/main/MaintenanceManager/CHANGELOG.md)**
 
 A org.rdk.MaintenanceManager plugin for Thunder framework.
 

--- a/docs/api/MessengerPlugin.md
+++ b/docs/api/MessengerPlugin.md
@@ -2,7 +2,7 @@
 <a name="Messenger_Plugin"></a>
 # Messenger Plugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/Messenger/CHANGELOG.md)**
 
 A Messenger plugin for Thunder framework.
 

--- a/docs/api/MonitorPlugin.md
+++ b/docs/api/MonitorPlugin.md
@@ -2,7 +2,7 @@
 <a name="Monitor_Plugin"></a>
 # Monitor Plugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/Monitor/CHANGELOG.md)**
 
 A Monitor plugin for Thunder framework.
 

--- a/docs/api/MotionDetectionPlugin.md
+++ b/docs/api/MotionDetectionPlugin.md
@@ -2,7 +2,7 @@
 <a name="MotionDetectionPlugin"></a>
 # MotionDetectionPlugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/MotionDetection/CHANGELOG.md)**
 
 A org.rdk.MotionDetection plugin for Thunder framework.
 

--- a/docs/api/NetworkPlugin.md
+++ b/docs/api/NetworkPlugin.md
@@ -2,7 +2,7 @@
 <a name="NetworkPlugin"></a>
 # NetworkPlugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/Network/CHANGELOG.md)**
 
 A org.rdk.Network plugin for Thunder framework.
 

--- a/docs/api/OCIContainerPlugin.md
+++ b/docs/api/OCIContainerPlugin.md
@@ -2,7 +2,7 @@
 <a name="OCIContainer_Plugin"></a>
 # OCIContainer Plugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/OCIContainer/CHANGELOG.md)**
 
 A org.rdk.OCIContainer plugin for Thunder framework.
 

--- a/docs/api/OpenCDMiPlugin.md
+++ b/docs/api/OpenCDMiPlugin.md
@@ -2,7 +2,7 @@
 <a name="OpenCDMi_Plugin"></a>
 # OpenCDMi Plugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/OpenCDMi/CHANGELOG.md)**
 
 A OCDM plugin for Thunder framework.
 

--- a/docs/api/PackagerPlugin.md
+++ b/docs/api/PackagerPlugin.md
@@ -2,7 +2,7 @@
 <a name="Packager_Plugin"></a>
 # Packager Plugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/Packager/CHANGELOG.md)**
 
 A Packager plugin for Thunder framework.
 

--- a/docs/api/PersistentStorePlugin.md
+++ b/docs/api/PersistentStorePlugin.md
@@ -2,7 +2,7 @@
 <a name="PersistentStore_Plugin"></a>
 # PersistentStore Plugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/PersistentStore/CHANGELOG.md)**
 
 A org.rdk.PersistentStore plugin for Thunder framework.
 

--- a/docs/api/PlayerInfoPlugin.md
+++ b/docs/api/PlayerInfoPlugin.md
@@ -2,7 +2,7 @@
 <a name="Player_Info_Plugin"></a>
 # Player Info Plugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/PlayerInfo/CHANGELOG.md)**
 
 A PlayerInfo plugin for Thunder framework.
 

--- a/docs/api/RDKShellPlugin.md
+++ b/docs/api/RDKShellPlugin.md
@@ -2,7 +2,7 @@
 <a name="RDKShell_Plugin"></a>
 # RDKShell Plugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/RDKShell/CHANGELOG.md)**
 
 A org.rdk.RDKShell plugin for Thunder framework.
 

--- a/docs/api/RemoteActionMappingPlugin.md
+++ b/docs/api/RemoteActionMappingPlugin.md
@@ -2,7 +2,7 @@
 <a name="RemoteActionMapping_Plugin"></a>
 # RemoteActionMapping Plugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/RemoteActionMapping/CHANGELOG.md)**
 
 A org.rdk.RemoteActionMapping plugin for Thunder framework.
 

--- a/docs/api/ScreenCapturePlugin.md
+++ b/docs/api/ScreenCapturePlugin.md
@@ -2,7 +2,7 @@
 <a name="ScreenCapture_Plugin"></a>
 # ScreenCapture Plugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/ScreenCapture/CHANGELOG.md)**
 
 A org.rdk.ScreenCapture plugin for Thunder framework.
 

--- a/docs/api/SecurityAgentPlugin.md
+++ b/docs/api/SecurityAgentPlugin.md
@@ -2,7 +2,7 @@
 <a name="SecurityAgent_Plugin"></a>
 # SecurityAgent Plugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/SecurityAgent/CHANGELOG.md)**
 
 A SecurityAgent plugin for Thunder framework.
 

--- a/docs/api/StateObserverPlugin.md
+++ b/docs/api/StateObserverPlugin.md
@@ -2,7 +2,7 @@
 <a name="StateObserver_Plugin"></a>
 # StateObserver Plugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/StateObserver/CHANGELOG.md)**
 
 A com.comcast.StateObserver plugin for Thunder framework.
 

--- a/docs/api/SystemAudioPlayerPlugin.md
+++ b/docs/api/SystemAudioPlayerPlugin.md
@@ -2,7 +2,7 @@
 <a name="SystemAudioPlayer_Plugin"></a>
 # SystemAudioPlayer Plugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/SystemAudioPlayer/CHANGELOG.md)**
 
 A org.rdk.SystemAudioPlayer plugin for Thunder framework.
 

--- a/docs/api/SystemPlugin.md
+++ b/docs/api/SystemPlugin.md
@@ -2,7 +2,7 @@
 <a name="System_Plugin"></a>
 # System Plugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/SystemServices/CHANGELOG.md)**
 
 A org.rdk.System plugin for Thunder framework.
 

--- a/docs/api/TelemetryPlugin.md
+++ b/docs/api/TelemetryPlugin.md
@@ -2,7 +2,7 @@
 <a name="Telemetry_Plugin"></a>
 # Telemetry Plugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/Telemetry/CHANGELOG.md)**
 
 A org.rdk.Telemetry plugin for Thunder framework.
 

--- a/docs/api/TextToSpeechPlugin.md
+++ b/docs/api/TextToSpeechPlugin.md
@@ -2,7 +2,7 @@
 <a name="TextToSpeech_Plugin"></a>
 # TextToSpeech Plugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/TextToSpeech/CHANGELOG.md)**
 
 A org.rdk.TextToSpeech plugin for Thunder framework.
 

--- a/docs/api/TimerPlugin.md
+++ b/docs/api/TimerPlugin.md
@@ -2,7 +2,7 @@
 <a name="Timer_Plugin"></a>
 # Timer Plugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/Timer/CHANGELOG.md)**
 
 A org.rdk.Timer plugin for Thunder framework.
 

--- a/docs/api/TraceControlPlugin.md
+++ b/docs/api/TraceControlPlugin.md
@@ -2,7 +2,7 @@
 <a name="TraceControl_Plugin"></a>
 # TraceControl Plugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/TraceControl/CHANGELOG.md)**
 
 A TraceControl plugin for Thunder framework.
 

--- a/docs/api/UsbAccessPlugin.md
+++ b/docs/api/UsbAccessPlugin.md
@@ -2,7 +2,7 @@
 <a name="UsbAccess_Plugin"></a>
 # UsbAccess Plugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/UsbAccess/CHANGELOG.md)**
 
 A org.rdk.UsbAccess plugin for Thunder framework.
 

--- a/docs/api/UserPreferencesPlugin.md
+++ b/docs/api/UserPreferencesPlugin.md
@@ -2,7 +2,7 @@
 <a name="UserPreferences_Plugin"></a>
 # UserPreferences Plugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/UserPreferences/CHANGELOG.md)**
 
 A org.rdk.UserPreferences plugin for Thunder framework.
 

--- a/docs/api/VoiceControlPlugin.md
+++ b/docs/api/VoiceControlPlugin.md
@@ -1,8 +1,8 @@
 <!-- Generated automatically, DO NOT EDIT! -->
-<a name="head.VoiceControl_API"></a>
-# VoiceControl API
+<a name="VoiceControl_Plugin"></a>
+# VoiceControl Plugin
 
-**Version: 1.0.0**
+**Version: [1.2.0](https://github.com/rdkcentral/rdkservices/blob/main/VoiceControl/CHANGELOG.md)**
 
 A org.rdk.VoiceControl plugin for Thunder framework.
 
@@ -19,44 +19,46 @@ A org.rdk.VoiceControl plugin for Thunder framework.
 
 [[Refer to this link](userguide/aat.md)]
 
-<a name="head.Description"></a>
+<a name="Description"></a>
 # Description
 
 The `VoiceControl` plugin manages voice control sessions.
 
-The plugin is designed to be loaded and executed within the Thunder framework. For more information about the framework refer to [[Thunder](#ref.Thunder)].
+The plugin is designed to be loaded and executed within the Thunder framework. For more information about the framework refer to [[Thunder](#Thunder)].
 
-<a name="head.Configuration"></a>
+<a name="Configuration"></a>
 # Configuration
 
 The table below lists configuration options of the plugin.
 
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
-| classname | string | Class name: *VoiceControl* |
+| callsign | string | Plugin instance name (default: *org.rdk.VoiceControl*) |
+| classname | string | Class name: *org.rdk.VoiceControl* |
+| locator | string | Library name: *libWPEFrameworkVoiceControl.so* |
 | autostart | boolean | Determines if the plugin shall be started automatically along with the framework |
 
-<a name="head.Methods"></a>
+<a name="Methods"></a>
 # Methods
 
-The following methods are provided by the VoiceControl plugin:
+The following methods are provided by the org.rdk.VoiceControl plugin:
 
 VoiceControl interface methods:
 
 | Method | Description |
 | :-------- | :-------- |
-| [configureVoice](#method.configureVoice) | Configures the RDK's voice stack |
-| [sendVoiceMessage](#method.sendVoiceMessage) | Sends a message to the Voice Server |
-| [setVoiceInit](#method.setVoiceInit) | Sets the application metadata in the INIT message that gets sent to the Voice Server |
-| [voiceSessionByText](#method.voiceSessionByText) | Sends a voice session with a transcription string to simulate a real voice session for QA |
-| [voiceSessionTypes](#method.voiceSessionTypes) | Retrieves the types of voice sessions which are supported by the platform |
-| [voiceSessionRequest](#method.voiceSessionRequest) | Requests a voice session using the specified request type and optional parameters |
-| [voiceSessionTerminate](#method.voiceSessionTerminate) | Terminates a voice session using the specified session identifier |
-| [voiceStatus](#method.voiceStatus) | Returns the current status of the RDK voice stack |
+| [configureVoice](#configureVoice) | Configures the RDK's voice stack |
+| [sendVoiceMessage](#sendVoiceMessage) | Sends a message to the Voice Server |
+| [setVoiceInit](#setVoiceInit) | Sets the application metadata in the INIT message that gets sent to the Voice Server |
+| [voiceSessionByText](#voiceSessionByText) | Sends a voice session with a transcription string to simulate a real voice session for QA |
+| [voiceSessionTypes](#voiceSessionTypes) | Retrieves the types of voice sessions which are supported by the platform |
+| [voiceSessionRequest](#voiceSessionRequest) | Requests a voice session using the specified request type and optional parameters |
+| [voiceSessionTerminate](#voiceSessionTerminate) | Terminates a voice session using the specified session identifier |
+| [voiceStatus](#voiceStatus) | Returns the current status of the RDK voice stack |
 
 
-<a name="method.configureVoice"></a>
-## *configureVoice [<sup>method</sup>](#head.Methods)*
+<a name="configureVoice"></a>
+## *configureVoice*
 
 Configures the RDK's voice stack. NOTE: The URL Scheme determines which API protocol is used. Supported URL schemes include:
 
@@ -106,7 +108,7 @@ Configures the RDK's voice stack. NOTE: The URL Scheme determines which API prot
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "VoiceControl.1.configureVoice",
+    "method": "org.rdk.VoiceControl.1.configureVoice",
     "params": {
         "urlAll": "ws://voiceserver.com/voice/ptt",
         "urlPtt": "vrng://vrex-next-gen-api.vrexcore.net/vrex/speech/websocket",
@@ -140,8 +142,8 @@ Configures the RDK's voice stack. NOTE: The URL Scheme determines which API prot
 }
 ```
 
-<a name="method.sendVoiceMessage"></a>
-## *sendVoiceMessage [<sup>method</sup>](#head.Methods)*
+<a name="sendVoiceMessage"></a>
+## *sendVoiceMessage*
 
 Sends a message to the Voice Server. The specification of this message is not in the scope of this document. Example use cases for this API call include sending context or sending ASR blobs to the server.
 
@@ -174,7 +176,7 @@ Sends a message to the Voice Server. The specification of this message is not in
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "VoiceControl.1.sendVoiceMessage",
+    "method": "org.rdk.VoiceControl.1.sendVoiceMessage",
     "params": {
         "msgType": "ars",
         "trx": "1b11359e-23fe-4f2f-9ba8-cc19b87203cf",
@@ -196,8 +198,8 @@ Sends a message to the Voice Server. The specification of this message is not in
 }
 ```
 
-<a name="method.setVoiceInit"></a>
-## *setVoiceInit [<sup>method</sup>](#head.Methods)*
+<a name="setVoiceInit"></a>
+## *setVoiceInit*
 
 Sets the application metadata in the INIT message that gets sent to the Voice Server. The specification of this blob is not in the scope of this document, but it MUST be a JSON blob.
 
@@ -229,7 +231,7 @@ Sets the application metadata in the INIT message that gets sent to the Voice Se
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "VoiceControl.1.setVoiceInit",
+    "method": "org.rdk.VoiceControl.1.setVoiceInit",
     "params": {
         "capabilities": [
             "PRV"
@@ -251,8 +253,8 @@ Sets the application metadata in the INIT message that gets sent to the Voice Se
 }
 ```
 
-<a name="method.voiceSessionByText"></a>
-## *voiceSessionByText [<sup>method</sup>](#head.Methods)*
+<a name="voiceSessionByText"></a>
+## *voiceSessionByText*
 
 Sends a voice session with a transcription string to simulate a real voice session for QA. Example use cases for this API call include rack and automation testing.
 
@@ -268,7 +270,7 @@ Sends a voice session with a transcription string to simulate a real voice sessi
 
 > This API is **deprecated** and may be removed in the future. It is no longer recommended for use in new implementations.
 
-Also see: [onSessionBegin](#event.onSessionBegin), [onStreamBegin](#event.onStreamBegin), [onServerMessage](#event.onServerMessage), [onStreamEnd](#event.onStreamEnd), [onSessionEnd](#event.onSessionEnd)
+Also see: [onSessionBegin](#onSessionBegin), [onStreamBegin](#onStreamBegin), [onServerMessage](#onServerMessage), [onStreamEnd](#onStreamEnd), [onSessionEnd](#onSessionEnd)
 
 ### Parameters
 
@@ -293,7 +295,7 @@ Also see: [onSessionBegin](#event.onSessionBegin), [onStreamBegin](#event.onStre
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "VoiceControl.1.voiceSessionByText",
+    "method": "org.rdk.VoiceControl.1.voiceSessionByText",
     "params": {
         "transcription": "Watch Comedy Central",
         "type": "PTT"
@@ -313,8 +315,8 @@ Also see: [onSessionBegin](#event.onSessionBegin), [onStreamBegin](#event.onStre
 }
 ```
 
-<a name="method.voiceSessionTypes"></a>
-## *voiceSessionTypes [<sup>method</sup>](#head.Methods)*
+<a name="voiceSessionTypes"></a>
+## *voiceSessionTypes*
 
 Retrieves the types of voice sessions which are supported by the platform.
 
@@ -354,7 +356,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "VoiceControl.1.voiceSessionTypes"
+    "method": "org.rdk.VoiceControl.1.voiceSessionTypes"
 }
 ```
 
@@ -373,8 +375,8 @@ This method takes no parameters.
 }
 ```
 
-<a name="method.voiceSessionRequest"></a>
-## *voiceSessionRequest [<sup>method</sup>](#head.Methods)*
+<a name="voiceSessionRequest"></a>
+## *voiceSessionRequest*
 
 Requests a voice session using the specified request type and optional parameters.
 
@@ -388,7 +390,7 @@ Requests a voice session using the specified request type and optional parameter
 | `onStreamEnd` |Triggers if streaming audio is stopped from the device |
 | `onSessionEnd` |Triggers if interaction with the server is end|.
 
-Also see: [onSessionBegin](#event.onSessionBegin), [onStreamBegin](#event.onStreamBegin), [onServerMessage](#event.onServerMessage), [onStreamEnd](#event.onStreamEnd), [onSessionEnd](#event.onSessionEnd)
+Also see: [onSessionBegin](#onSessionBegin), [onStreamBegin](#onStreamBegin), [onServerMessage](#onServerMessage), [onStreamEnd](#onStreamEnd), [onSessionEnd](#onSessionEnd)
 
 ### Parameters
 
@@ -396,7 +398,7 @@ Also see: [onSessionBegin](#event.onSessionBegin), [onStreamBegin](#event.onStre
 | :-------- | :-------- | :-------- |
 | params | object |  |
 | params?.transcription | string | <sup>*(optional)*</sup> The transcription text to be sent to the voice server for request types "ptt_transcription" and "mic_transcription" |
-| params.type | string | The request type to initiate the voice session (see [voiceSessionTypes](#method.voiceSessionTypes) API for list of request types) |
+| params.type | string | The request type to initiate the voice session (see [voiceSessionTypes](#voiceSessionTypes) API for list of request types) |
 
 ### Result
 
@@ -413,7 +415,7 @@ Also see: [onSessionBegin](#event.onSessionBegin), [onStreamBegin](#event.onStre
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "VoiceControl.1.voiceSessionRequest",
+    "method": "org.rdk.VoiceControl.1.voiceSessionRequest",
     "params": {
         "transcription": "Watch Comedy Central",
         "type": "ptt_transcription"
@@ -433,8 +435,8 @@ Also see: [onSessionBegin](#event.onSessionBegin), [onStreamBegin](#event.onStre
 }
 ```
 
-<a name="method.voiceSessionTerminate"></a>
-## *voiceSessionTerminate [<sup>method</sup>](#head.Methods)*
+<a name="voiceSessionTerminate"></a>
+## *voiceSessionTerminate*
 
 Terminates a voice session using the specified session identifier.
 
@@ -447,7 +449,7 @@ Terminates a voice session using the specified session identifier.
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
 | params | object |  |
-| params.sessionId | string | The session identifier of the session from the [onSessionBegin](#event.onSessionBegin) event |
+| params.sessionId | string | The session identifier of the session from the [onSessionBegin](#onSessionBegin) event |
 
 ### Result
 
@@ -464,7 +466,7 @@ Terminates a voice session using the specified session identifier.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "VoiceControl.1.voiceSessionTerminate",
+    "method": "org.rdk.VoiceControl.1.voiceSessionTerminate",
     "params": {
         "sessionId": "1b11359e-23fe-4f2f-9ba8-cc19b87203cf"
     }
@@ -483,8 +485,8 @@ Terminates a voice session using the specified session identifier.
 }
 ```
 
-<a name="method.voiceStatus"></a>
-## *voiceStatus [<sup>method</sup>](#head.Methods)*
+<a name="voiceStatus"></a>
+## *voiceStatus*
 
 Returns the current status of the RDK voice stack. This includes which URLs the stack is currently configured for along with the status for each device type.
 
@@ -523,7 +525,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "VoiceControl.1.voiceStatus"
+    "method": "org.rdk.VoiceControl.1.voiceStatus"
 }
 ```
 
@@ -555,27 +557,27 @@ This method takes no parameters.
 }
 ```
 
-<a name="head.Notifications"></a>
+<a name="Notifications"></a>
 # Notifications
 
-Notifications are autonomous events, triggered by the internals of the implementation, and broadcasted via JSON-RPC to all registered observers. Refer to [[Thunder](#ref.Thunder)] for information on how to register for a notification.
+Notifications are autonomous events, triggered by the internals of the implementation, and broadcasted via JSON-RPC to all registered observers. Refer to [[Thunder](#Thunder)] for information on how to register for a notification.
 
-The following events are provided by the VoiceControl plugin:
+The following events are provided by the org.rdk.VoiceControl plugin:
 
 VoiceControl interface events:
 
 | Event | Description |
 | :-------- | :-------- |
-| [onKeywordVerification](#event.onKeywordVerification) | Triggered when a keyword verification result is received |
-| [onServerMessage](#event.onServerMessage) | Triggered when a message is received from the Voice Server |
-| [onSessionBegin](#event.onSessionBegin) | Triggered when a voice session begins |
-| [onSessionEnd](#event.onSessionEnd) | Triggered when the interaction with the server has concluded |
-| [onStreamBegin](#event.onStreamBegin) | Triggered when a device starts streaming voice data to the RDK |
-| [onStreamEnd](#event.onStreamEnd) | Triggered when the device has stopped streaming audio |
+| [onKeywordVerification](#onKeywordVerification) | Triggered when a keyword verification result is received |
+| [onServerMessage](#onServerMessage) | Triggered when a message is received from the Voice Server |
+| [onSessionBegin](#onSessionBegin) | Triggered when a voice session begins |
+| [onSessionEnd](#onSessionEnd) | Triggered when the interaction with the server has concluded |
+| [onStreamBegin](#onStreamBegin) | Triggered when a device starts streaming voice data to the RDK |
+| [onStreamEnd](#onStreamEnd) | Triggered when the device has stopped streaming audio |
 
 
-<a name="event.onKeywordVerification"></a>
-## *onKeywordVerification [<sup>event</sup>](#head.Notifications)*
+<a name="onKeywordVerification"></a>
+## *onKeywordVerification*
 
 Triggered when a keyword verification result is received.
 
@@ -602,8 +604,8 @@ Triggered when a keyword verification result is received.
 }
 ```
 
-<a name="event.onServerMessage"></a>
-## *onServerMessage [<sup>event</sup>](#head.Notifications)*
+<a name="onServerMessage"></a>
+## *onServerMessage*
 
 Triggered when a message is received from the Voice Server. The `params` value is a contract between the Voice Server and the Application. The definition of this object is outside of the scope of this document.
 
@@ -612,10 +614,10 @@ Triggered when a message is received from the Voice Server. The `params` value i
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
 | params | object |  |
+| params?.maskPii | boolean | <sup>*(optional)*</sup> Indicated is PII should be masked (1 - mask PII, 0 display PII |
 | params.msgType | string | Message type from the server |
 | params.trx | string | The unique id of the voice session |
 | params.created | number | The timestamp for server information |
-| params.maskPii | boolean | Whether the PII info should be masked |
 | params.msgPayload | object | Vrex server information |
 
 ### Example
@@ -625,17 +627,17 @@ Triggered when a message is received from the Voice Server. The `params` value i
     "jsonrpc": "2.0",
     "method": "client.events.1.onServerMessage",
     "params": {
+        "maskPii": true,
         "msgType": "ars",
         "trx": "1b11359e-23fe-4f2f-9ba8-cc19b87203cf",
         "created": 91890278389232,
-        "maskPii": true,
         "msgPayload": {}
     }
 }
 ```
 
-<a name="event.onSessionBegin"></a>
-## *onSessionBegin [<sup>event</sup>](#head.Notifications)*
+<a name="onSessionBegin"></a>
+## *onSessionBegin*
 
 Triggered when a voice session begins.
 
@@ -664,8 +666,8 @@ Triggered when a voice session begins.
 }
 ```
 
-<a name="event.onSessionEnd"></a>
-## *onSessionEnd [<sup>event</sup>](#head.Notifications)*
+<a name="onSessionEnd"></a>
+## *onSessionEnd*
 
 Triggered when the interaction with the server has concluded.
 
@@ -679,7 +681,7 @@ Triggered when the interaction with the server has concluded.
 | params?.serverStats.serverIp | string | The ip of the voice server |
 | params?.serverStats.connectTime | number | The connection time of the voice server |
 | params.remoteId | integer | The voice device identifier |
-| params.maskPii | boolean | Whether the PII info should be masked |
+| params?.maskPii | boolean | <sup>*(optional)*</sup> Indicated is PII should be masked (1 - mask PII, 0 display PII |
 | params.sessionId | string | The unique identifier for the voice session, generated by the underlying RDK stack |
 | params?.result | string | <sup>*(optional)*</sup> The result of the voice session. This also determines which object will be in the parameters (`success`, `error`, `abort`, `shortUtterance`) |
 | params?.success | object | <sup>*(optional)*</sup> This optional object is included only if the `result` value is `success` |
@@ -731,8 +733,8 @@ Triggered when the interaction with the server has concluded.
 }
 ```
 
-<a name="event.onStreamBegin"></a>
-## *onStreamBegin [<sup>event</sup>](#head.Notifications)*
+<a name="onStreamBegin"></a>
+## *onStreamBegin*
 
 Triggered when a device starts streaming voice data to the RDK. This event is optional, and will most likely be used for follow up sessions.
 
@@ -757,8 +759,8 @@ Triggered when a device starts streaming voice data to the RDK. This event is op
 }
 ```
 
-<a name="event.onStreamEnd"></a>
-## *onStreamEnd [<sup>event</sup>](#head.Notifications)*
+<a name="onStreamEnd"></a>
+## *onStreamEnd*
 
 Triggered when the device has stopped streaming audio.
 

--- a/docs/api/WarehousePlugin.md
+++ b/docs/api/WarehousePlugin.md
@@ -2,7 +2,7 @@
 <a name="Warehouse_Plugin"></a>
 # Warehouse Plugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/Warehouse/CHANGELOG.md)**
 
 A org.rdk.Warehouse plugin for Thunder framework.
 

--- a/docs/api/WebKitBrowserPlugin.md
+++ b/docs/api/WebKitBrowserPlugin.md
@@ -2,7 +2,7 @@
 <a name="WebKitBrowser_Plugin"></a>
 # WebKitBrowser Plugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/WebKitBrowser/CHANGELOG.md)**
 
 A WebKitBrowser plugin for Thunder framework.
 

--- a/docs/api/WifiPlugin.md
+++ b/docs/api/WifiPlugin.md
@@ -2,7 +2,7 @@
 <a name="Wifi_Plugin"></a>
 # Wifi Plugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/WifiManager/CHANGELOG.md)**
 
 A org.rdk.Wifi plugin for Thunder framework.
 

--- a/docs/api/XCastPlugin.md
+++ b/docs/api/XCastPlugin.md
@@ -2,7 +2,7 @@
 <a name="XCast_Plugin"></a>
 # XCast Plugin
 
-**Version: 1.0.0**
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/XCast/CHANGELOG.md)**
 
 A org.rdk.Xcast plugin for Thunder framework.
 


### PR DESCRIPTION
"RDK-37906 : Add Hyperlinks to the version
RDK-37083 : Update JSON schema spec version
Updated Json-Validator yaml file"

Reason for change:
RDK-37906 : In current documentation, the version is simply in string format. Add a hyperlink to the version so that it points to corresponding plugin's CHANGELOG.md file, so that we can get more info on version
RDK-37083 : The RDK Services are currently defined using JSON schema Draft-07. The current spec version is 2020-12. Hence updated the schema with latest version
Updated Json-Validator yaml file : Its been identified that the current json validator takes json files which are not present in the commit. Hence modified the changes accordngly

Test Procedure: Executed and verified by generating api documentation in docsify
Risks: Create None
Signed-off-by: Rekha Jayaram "[Rekha_Jayaram3@comcast.com](mailto:Rekha_Jayaram3@comcast.com)"

Jira link :
https://ccp.sys.comcast.net/browse/RDK-37906
https://ccp.sys.comcast.net/browse/RDK-37083