### PR TITLE
RDKTV-17958: After waking TV from standby Audio not routed to eArc.

### DIFF
--- a/DisplaySettings/CHANGELOG.md
+++ b/DisplaySettings/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+##[1.0.7] - 2022-09-08
+### Fixed
+- Fixed No audio from AVR issue in case of delayed HPD scenarios
 
 ##[1.0.6] - 2022-09-01
 ### Changed

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -77,7 +77,7 @@ using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 6
+#define API_VERSION_NUMBER_PATCH 7
 
 static bool isCecArcRoutingThreadEnabled = false;
 static bool isCecEnabled = false;
@@ -787,6 +787,16 @@ namespace WPEFramework {
                             if(hdmiin_hotplug_conn) {
                                 aPort.getSupportedARCTypes(&types);
                                 LOGINFO("Received IARM_BUS_DSMGR_EVENT_HDMI_IN_HOTPLUG  HDMI_ARC Port, types: %d \n",  types);
+				if((types & dsAUDIOARCSUPPORT_eARC)) {
+                                    if ((DisplaySettings::_instance->m_hdmiCecAudioDeviceDetected== true) && \
+						   (DisplaySettings::_instance->m_hdmiInAudioDeviceConnected == false)) {
+                                        LOGINFO("m_hdmiInAudioDeviceConnected... %d, Triggering Power status request", DisplaySettings::_instance->m_hdmiInAudioDeviceConnected);
+                                        std::lock_guard<std::mutex> lock(DisplaySettings::_instance->m_arcRoutingStateMutex);
+                                        DisplaySettings::_instance->m_hdmiInAudioDevicePowerState = AUDIO_DEVICE_POWER_STATE_REQUEST;
+                                        DisplaySettings::_instance->m_cecArcRoutingThreadRun = true;
+                                        DisplaySettings::_instance->arcRoutingCV.notify_one();
+                                    }
+                                }
 			    }
                             else {
                                 if (DisplaySettings::_instance->m_hdmiInAudioDeviceConnected == true) {


### PR DESCRIPTION
Reason for Change: eArc not enabled due to delayed HPD event Test Procedure: As per Jira
Risks: Low

Signed-off-by: shashank.kumar@sky.uk <shashank.kumar@sky.uk>