### PR TITLE
RDKTV-18035: Audio did not switch to e-ARC during playback.

### DIFF
--- a/HdmiCecSink/CHANGELOG.md
+++ b/HdmiCecSink/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2022-09-08
+### Fixed
+- Fix for resetting retry count for Physical address query.
+- Fix for handling AVR transition state.
+
 ## [1.0.0] - 2022-05-11
 ### Added
 - Add CHANGELOG


### PR DESCRIPTION
Reason for change: Physical address request counter resetting once acquired. Update audioDevicePowerStatus request flag only when Audio device is in Standby or in ON state.
Test Procedure: Refer ticket.
Risks: Low
Signed-off-by: bp-ynagas047 <yeshwanth.nagaswamy@sky.uk>