### PR TITLE
Clean up expectations

### DIFF
--- a/Tests/mocks/IarmBusMock.h
+++ b/Tests/mocks/IarmBusMock.h
@@ -6,6 +6,29 @@
 
 class IarmBusImplMock : public IarmBusImpl {
 public:
+    IarmBusImplMock()
+        : IarmBusImpl()
+    {
+        // Defaults:
+        ON_CALL(*this, IARM_Bus_IsConnected(::testing::_, ::testing::_))
+            .WillByDefault(::testing::Invoke(
+                [](const char*, int* isRegistered) {
+                    *isRegistered = 1;
+                    return IARM_RESULT_SUCCESS;
+                }));
+        ON_CALL(*this, IARM_Bus_Init(::testing::_))
+            .WillByDefault(::testing::Return(IARM_RESULT_SUCCESS));
+        ON_CALL(*this, IARM_Bus_Connect())
+            .WillByDefault(::testing::Return(IARM_RESULT_SUCCESS));
+        ON_CALL(*this, IARM_Bus_RegisterEventHandler(::testing::_, ::testing::_, ::testing::_))
+            .WillByDefault(::testing::Return(IARM_RESULT_SUCCESS));
+        ON_CALL(*this, IARM_Bus_UnRegisterEventHandler(::testing::_, ::testing::_))
+            .WillByDefault(::testing::Return(IARM_RESULT_SUCCESS));
+        ON_CALL(*this, IARM_Bus_Call(::testing::_, ::testing::_, ::testing::_, ::testing::_))
+            .WillByDefault(::testing::Return(IARM_RESULT_SUCCESS));
+        ON_CALL(*this, IARM_Bus_RegisterCall(::testing::_, ::testing::_))
+            .WillByDefault(::testing::Return(IARM_RESULT_SUCCESS));
+    }
     virtual ~IarmBusImplMock() = default;
 
     MOCK_METHOD(IARM_Result_t, IARM_Bus_Init, (const char* name), (override));
@@ -13,6 +36,6 @@ public:
     MOCK_METHOD(IARM_Result_t, IARM_Bus_IsConnected, (const char* memberName, int* isRegistered), (override));
     MOCK_METHOD(IARM_Result_t, IARM_Bus_RegisterEventHandler, (const char* ownerName, IARM_EventId_t eventId, IARM_EventHandler_t handler), (override));
     MOCK_METHOD(IARM_Result_t, IARM_Bus_UnRegisterEventHandler, (const char* ownerName, IARM_EventId_t eventId), (override));
-    MOCK_METHOD(IARM_Result_t, IARM_Bus_Call, (const char *ownerName, const char *methodName, void *arg, size_t argLen), (override));
-    MOCK_METHOD(IARM_Result_t, IARM_Bus_RegisterCall, (const char *methodName, IARM_BusCall_t handler), (override));
+    MOCK_METHOD(IARM_Result_t, IARM_Bus_Call, (const char* ownerName, const char* methodName, void* arg, size_t argLen), (override));
+    MOCK_METHOD(IARM_Result_t, IARM_Bus_RegisterCall, (const char* methodName, IARM_BusCall_t handler), (override));
 };

--- a/Tests/tests/test_AVInput.cpp
+++ b/Tests/tests/test_AVInput.cpp
@@ -53,15 +53,8 @@ protected:
     {
         IarmBus::getInstance().impl = &iarmBusImplMock;
 
-        ON_CALL(iarmBusImplMock, IARM_Bus_IsConnected(::testing::_, ::testing::_))
+        ON_CALL(iarmBusImplMock, IARM_Bus_RegisterEventHandler(::testing::_, ::testing::_, ::testing::_))
             .WillByDefault(::testing::Invoke(
-                [](const char*, int* isRegistered) {
-                    *isRegistered = 1;
-                    return IARM_RESULT_SUCCESS;
-                }));
-        EXPECT_CALL(iarmBusImplMock, IARM_Bus_RegisterEventHandler(::testing::_, ::testing::_, ::testing::_))
-            .Times(::testing::AnyNumber())
-            .WillRepeatedly(::testing::Invoke(
                 [&](const char* ownerName, IARM_EventId_t eventId, IARM_EventHandler_t handler) {
                     if ((string(IARM_BUS_DSMGR_NAME) == string(ownerName)) && (eventId == IARM_BUS_DSMGR_EVENT_HDMI_IN_HOTPLUG)) {
                         EXPECT_TRUE(handler != nullptr);
@@ -74,9 +67,6 @@ protected:
     }
     virtual ~AVInputInitializedTest() override
     {
-        ON_CALL(iarmBusImplMock, IARM_Bus_UnRegisterEventHandler(::testing::_, ::testing::_))
-            .WillByDefault(::testing::Return(IARM_RESULT_SUCCESS));
-
         plugin->Deinitialize(nullptr);
 
         IarmBus::getInstance().impl = nullptr;
@@ -140,9 +130,8 @@ TEST_F(AVInputTest, contentProtected)
 
 TEST_F(AVInputDsTest, numberOfInputs)
 {
-    EXPECT_CALL(hdmiInputImplMock, getNumberOfInputs())
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::Return(1));
+    ON_CALL(hdmiInputImplMock, getNumberOfInputs())
+        .WillByDefault(::testing::Return(1));
 
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("numberOfInputs"), _T("{}"), response));
     EXPECT_EQ(response, string("{\"numberOfInputs\":1,\"success\":true}"));
@@ -150,9 +139,8 @@ TEST_F(AVInputDsTest, numberOfInputs)
 
 TEST_F(AVInputDsTest, currentVideoMode)
 {
-    EXPECT_CALL(hdmiInputImplMock, getCurrentVideoMode())
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::Return(string("unknown")));
+    ON_CALL(hdmiInputImplMock, getCurrentVideoMode())
+        .WillByDefault(::testing::Return(string("unknown")));
 
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("currentVideoMode"), _T("{}"), response));
     EXPECT_EQ(response, string("{\"currentVideoMode\":\"unknown\",\"success\":true}"));
@@ -160,6 +148,7 @@ TEST_F(AVInputDsTest, currentVideoMode)
 
 TEST_F(AVInputInitializedEventDsTest, onAVInputActive)
 {
+    ASSERT_TRUE(dsHdmiEventHandler != nullptr);
     ON_CALL(hdmiInputImplMock, getNumberOfInputs())
         .WillByDefault(::testing::Return(1));
     ON_CALL(hdmiInputImplMock, isPortConnected(::testing::_))

--- a/Tests/tests/test_DeviceAudioCapabilities.cpp
+++ b/Tests/tests/test_DeviceAudioCapabilities.cpp
@@ -23,13 +23,6 @@ protected:
         IarmBus::getInstance().impl = &iarmBusImplMock;
         device::Manager::getInstance().impl = &managerImplMock;
 
-        EXPECT_CALL(iarmBusImplMock, IARM_Bus_IsConnected(::testing::_, ::testing::_))
-            .Times(::testing::AnyNumber())
-            .WillRepeatedly(::testing::Invoke(
-                [](const char*, int* isRegistered) {
-                    *isRegistered = 1;
-                    return IARM_RESULT_SUCCESS;
-                }));
         EXPECT_CALL(managerImplMock, Initialize())
             .Times(::testing::AnyNumber())
             .WillRepeatedly(::testing::Return());
@@ -83,12 +76,10 @@ TEST_F(DeviceAudioCapabilitiesDsTest, SupportedAudioPorts)
     string audioPort(_T("HDMI0"));
     string element;
 
-    EXPECT_CALL(audioOutputPortMock, getName())
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::ReturnRef(audioPort));
-    EXPECT_CALL(hostImplMock, getAudioOutputPorts())
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::Return(device::List<device::AudioOutputPort>({ audioOutputPort })));
+    ON_CALL(audioOutputPortMock, getName())
+        .WillByDefault(::testing::ReturnRef(audioPort));
+    ON_CALL(hostImplMock, getAudioOutputPorts())
+        .WillByDefault(::testing::Return(device::List<device::AudioOutputPort>({ audioOutputPort })));
 
     EXPECT_EQ(Core::ERROR_NONE, interface->SupportedAudioPorts(supportedAudioPorts));
     ASSERT_TRUE(supportedAudioPorts != nullptr);
@@ -107,20 +98,17 @@ TEST_F(DeviceAudioCapabilitiesDsTest, AudioCapabilities_noParam)
     string audioPort(_T("HDMI0"));
     Exchange::IDeviceAudioCapabilities::AudioCapability element;
 
-    EXPECT_CALL(audioOutputPortMock, getAudioCapabilities(::testing::_))
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::Invoke(
+    ON_CALL(audioOutputPortMock, getAudioCapabilities(::testing::_))
+        .WillByDefault(::testing::Invoke(
             [&](int* capabilities) {
                 ASSERT_TRUE(capabilities != nullptr);
                 EXPECT_EQ(*capabilities, dsAUDIOSUPPORT_NONE);
                 *capabilities = dsAUDIOSUPPORT_ATMOS | dsAUDIOSUPPORT_DDPLUS;
             }));
-    EXPECT_CALL(hostImplMock, getDefaultAudioPortName())
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::Return(audioPort));
-    EXPECT_CALL(hostImplMock, getAudioOutputPort(::testing::_))
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::ReturnRef(audioOutputPort));
+    ON_CALL(hostImplMock, getDefaultAudioPortName())
+        .WillByDefault(::testing::Return(audioPort));
+    ON_CALL(hostImplMock, getAudioOutputPort(::testing::_))
+        .WillByDefault(::testing::ReturnRef(audioOutputPort));
 
     EXPECT_EQ(Core::ERROR_NONE, interface->AudioCapabilities(string(), audioCapabilities));
     ASSERT_TRUE(audioCapabilities != nullptr);
@@ -141,20 +129,17 @@ TEST_F(DeviceAudioCapabilitiesDsTest, MS12Capabilities_noParam)
     string audioPort(_T("HDMI0"));
     Exchange::IDeviceAudioCapabilities::MS12Capability element;
 
-    EXPECT_CALL(audioOutputPortMock, getMS12Capabilities(::testing::_))
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::Invoke(
+    ON_CALL(audioOutputPortMock, getMS12Capabilities(::testing::_))
+        .WillByDefault(::testing::Invoke(
             [&](int* capabilities) {
                 ASSERT_TRUE(capabilities != nullptr);
                 EXPECT_EQ(*capabilities, dsMS12SUPPORT_NONE);
                 *capabilities = dsMS12SUPPORT_DolbyVolume | dsMS12SUPPORT_InteligentEqualizer;
             }));
-    EXPECT_CALL(hostImplMock, getDefaultAudioPortName())
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::Return(audioPort));
-    EXPECT_CALL(hostImplMock, getAudioOutputPort(::testing::_))
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::ReturnRef(audioOutputPort));
+    ON_CALL(hostImplMock, getDefaultAudioPortName())
+        .WillByDefault(::testing::Return(audioPort));
+    ON_CALL(hostImplMock, getAudioOutputPort(::testing::_))
+        .WillByDefault(::testing::ReturnRef(audioOutputPort));
 
     EXPECT_EQ(Core::ERROR_NONE, interface->MS12Capabilities(string(), ms12Capabilities));
     ASSERT_TRUE(ms12Capabilities != nullptr);
@@ -176,15 +161,12 @@ TEST_F(DeviceAudioCapabilitiesDsTest, SupportedMS12AudioProfiles_noParam)
     string audioPortMS12AudioProfile(_T("Movie"));
     string element;
 
-    EXPECT_CALL(audioOutputPortMock, getMS12AudioProfileList())
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::Return(std::vector<std::string>({ audioPortMS12AudioProfile })));
-    EXPECT_CALL(hostImplMock, getDefaultAudioPortName())
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::Return(audioPort));
-    EXPECT_CALL(hostImplMock, getAudioOutputPort(::testing::_))
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::ReturnRef(audioOutputPort));
+    ON_CALL(audioOutputPortMock, getMS12AudioProfileList())
+        .WillByDefault(::testing::Return(std::vector<std::string>({ audioPortMS12AudioProfile })));
+    ON_CALL(hostImplMock, getDefaultAudioPortName())
+        .WillByDefault(::testing::Return(audioPort));
+    ON_CALL(hostImplMock, getAudioOutputPort(::testing::_))
+        .WillByDefault(::testing::ReturnRef(audioOutputPort));
 
     EXPECT_EQ(Core::ERROR_NONE, interface->SupportedMS12AudioProfiles(string(), supportedMS12AudioProfiles));
     ASSERT_TRUE(supportedMS12AudioProfiles != nullptr);
@@ -198,9 +180,8 @@ TEST_F(DeviceAudioCapabilitiesDsTest, SupportedAudioPorts_exception)
 {
     RPC::IStringIterator* supportedAudioPorts = nullptr;
 
-    EXPECT_CALL(hostImplMock, getAudioOutputPorts())
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::Invoke(
+    ON_CALL(hostImplMock, getAudioOutputPorts())
+        .WillByDefault(::testing::Invoke(
             [&]() -> device::List<device::AudioOutputPort> {
                 throw device::Exception("test");
             }));
@@ -213,9 +194,8 @@ TEST_F(DeviceAudioCapabilitiesDsTest, AudioCapabilities_HDMI0_exception)
 {
     Exchange::IDeviceAudioCapabilities::IAudioCapabilityIterator* audioCapabilities = nullptr;
 
-    EXPECT_CALL(hostImplMock, getAudioOutputPort(::testing::_))
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::Invoke(
+    ON_CALL(hostImplMock, getAudioOutputPort(::testing::_))
+        .WillByDefault(::testing::Invoke(
             [&](const std::string& name) -> device::AudioOutputPort& {
                 EXPECT_EQ(name, _T("HDMI0"));
                 throw device::Exception("test");
@@ -229,9 +209,8 @@ TEST_F(DeviceAudioCapabilitiesDsTest, MS12Capabilities_HDMI0_exception)
 {
     Exchange::IDeviceAudioCapabilities::IMS12CapabilityIterator* ms12Capabilities = nullptr;
 
-    EXPECT_CALL(hostImplMock, getAudioOutputPort(::testing::_))
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::Invoke(
+    ON_CALL(hostImplMock, getAudioOutputPort(::testing::_))
+        .WillByDefault(::testing::Invoke(
             [&](const std::string& name) -> device::AudioOutputPort& {
                 EXPECT_EQ(name, _T("HDMI0"));
                 throw device::Exception("test");
@@ -245,9 +224,8 @@ TEST_F(DeviceAudioCapabilitiesDsTest, SupportedMS12AudioProfiles_HDMI0_exception
 {
     RPC::IStringIterator* supportedMS12AudioProfiles = nullptr;
 
-    EXPECT_CALL(hostImplMock, getAudioOutputPort(::testing::_))
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::Invoke(
+    ON_CALL(hostImplMock, getAudioOutputPort(::testing::_))
+        .WillByDefault(::testing::Invoke(
             [&](const std::string& name) -> device::AudioOutputPort& {
                 EXPECT_EQ(name, _T("HDMI0"));
                 throw device::Exception("test");

--- a/Tests/tests/test_DeviceIdentification.cpp
+++ b/Tests/tests/test_DeviceIdentification.cpp
@@ -72,8 +72,6 @@ protected:
                                              "      \"outofprocess\":false\n"
                                              "   }\n"
                                              "}"));
-        ON_CALL(service, Locator())
-            .WillByDefault(::testing::Return(string()));
         ON_CALL(service, SubSystems())
             .WillByDefault(::testing::Invoke(
                 [&]() {

--- a/Tests/tests/test_DeviceInfo.cpp
+++ b/Tests/tests/test_DeviceInfo.cpp
@@ -18,13 +18,6 @@ protected:
     {
         IarmBus::getInstance().impl = &iarmBusImplMock;
 
-        ON_CALL(iarmBusImplMock, IARM_Bus_IsConnected(::testing::_, ::testing::_))
-            .WillByDefault(::testing::Invoke(
-                [](const char*, int* isRegistered) {
-                    *isRegistered = 1;
-                    return IARM_RESULT_SUCCESS;
-                }));
-
         deviceInfoImplementation = Core::ProxyType<Plugin::DeviceInfoImplementation>::Create();
 
         interface = static_cast<Exchange::IDeviceInfo*>(

--- a/Tests/tests/test_DeviceInfoJsonRpc.cpp
+++ b/Tests/tests/test_DeviceInfoJsonRpc.cpp
@@ -51,20 +51,10 @@ protected:
         IarmBus::getInstance().impl = &iarmBusImplMock;
         device::Manager::getInstance().impl = &managerImplMock;
 
-        ON_CALL(iarmBusImplMock, IARM_Bus_IsConnected(::testing::_, ::testing::_))
-            .WillByDefault(::testing::Invoke(
-                [](const char*, int* isRegistered) {
-                    *isRegistered = 1;
-                    return IARM_RESULT_SUCCESS;
-                }));
-        ON_CALL(managerImplMock, Initialize())
-            .WillByDefault(::testing::Return());
         ON_CALL(service, ConfigLine())
             .WillByDefault(::testing::Return("{\"root\":{\"mode\":\"Off\"}}"));
         ON_CALL(service, WebPrefix())
             .WillByDefault(::testing::Return(webPrefix));
-        ON_CALL(service, Version())
-            .WillByDefault(::testing::Return(string()));
         ON_CALL(service, SubSystems())
             .WillByDefault(::testing::Invoke(
                 [&]() {
@@ -219,12 +209,10 @@ TEST_F(DeviceInfoJsonRpcInitializedDsTest, supportedaudioports)
     audioOutputPort.impl = &audioOutputPortMock;
     string audioPort(_T("HDMI0"));
 
-    EXPECT_CALL(audioOutputPortMock, getName())
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::ReturnRef(audioPort));
-    EXPECT_CALL(hostImplMock, getAudioOutputPorts())
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::Return(device::List<device::AudioOutputPort>({ audioOutputPort })));
+    ON_CALL(audioOutputPortMock, getName())
+        .WillByDefault(::testing::ReturnRef(audioPort));
+    ON_CALL(hostImplMock, getAudioOutputPorts())
+        .WillByDefault(::testing::Return(device::List<device::AudioOutputPort>({ audioOutputPort })));
 
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("supportedaudioports"), _T(""), response));
     EXPECT_EQ(response, _T("{\"supportedAudioPorts\":[\"HDMI0\"]}"));
@@ -237,12 +225,10 @@ TEST_F(DeviceInfoJsonRpcInitializedDsTest, supportedvideodisplays)
     videoOutputPort.impl = &videoOutputPortMock;
     string videoPort(_T("HDMI0"));
 
-    EXPECT_CALL(videoOutputPortMock, getName())
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::ReturnRef(videoPort));
-    EXPECT_CALL(hostImplMock, getVideoOutputPorts())
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::Return(device::List<device::VideoOutputPort>({ videoOutputPort })));
+    ON_CALL(videoOutputPortMock, getName())
+        .WillByDefault(::testing::ReturnRef(videoPort));
+    ON_CALL(hostImplMock, getVideoOutputPorts())
+        .WillByDefault(::testing::Return(device::List<device::VideoOutputPort>({ videoOutputPort })));
 
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("supportedvideodisplays"), _T(""), response));
     EXPECT_EQ(response, _T("{\"supportedVideoDisplays\":[\"HDMI0\"]}"));
@@ -250,13 +236,10 @@ TEST_F(DeviceInfoJsonRpcInitializedDsTest, supportedvideodisplays)
 
 TEST_F(DeviceInfoJsonRpcInitializedDsTest, hostedid)
 {
-    std::vector<uint8_t> edidVec({ 't', 'e', 's', 't' });
-
-    EXPECT_CALL(hostImplMock, getHostEDID(::testing::_))
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::Invoke(
+    ON_CALL(hostImplMock, getHostEDID(::testing::_))
+        .WillByDefault(::testing::Invoke(
             [&](std::vector<uint8_t>& edid) {
-                edid = edidVec;
+                edid = { 't', 'e', 's', 't' };
             }));
 
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("hostedid"), _T(""), response));
@@ -274,18 +257,14 @@ TEST_F(DeviceInfoJsonRpcInitializedDsTest, defaultresolution)
     string videoPort(_T("HDMI0"));
     string videoPortDefaultResolution(_T("1080p"));
 
-    EXPECT_CALL(videoResolutionMock, getName())
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::ReturnRef(videoPortDefaultResolution));
-    EXPECT_CALL(videoOutputPortMock, getDefaultResolution())
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::ReturnRef(videoResolution));
-    EXPECT_CALL(hostImplMock, getDefaultVideoPortName())
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::Return(videoPort));
-    EXPECT_CALL(hostImplMock, getVideoOutputPort(::testing::_))
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::ReturnRef(videoOutputPort));
+    ON_CALL(videoResolutionMock, getName())
+        .WillByDefault(::testing::ReturnRef(videoPortDefaultResolution));
+    ON_CALL(videoOutputPortMock, getDefaultResolution())
+        .WillByDefault(::testing::ReturnRef(videoResolution));
+    ON_CALL(hostImplMock, getDefaultVideoPortName())
+        .WillByDefault(::testing::Return(videoPort));
+    ON_CALL(hostImplMock, getVideoOutputPort(::testing::_))
+        .WillByDefault(::testing::ReturnRef(videoOutputPort));
 
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("defaultresolution"), _T(""), response));
     EXPECT_EQ(response, _T("{\"defaultResolution\":\"1080p\"}"));
@@ -305,27 +284,20 @@ TEST_F(DeviceInfoJsonRpcInitializedDsVideoOutputTest, supportedresolutions)
     string videoPort(_T("HDMI0"));
     string videoPortSupportedResolution(_T("1080p"));
 
-    EXPECT_CALL(videoResolutionMock, getName())
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::ReturnRef(videoPortSupportedResolution));
-    EXPECT_CALL(videoOutputPortTypeMock, getSupportedResolutions())
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::Return(device::List<device::VideoResolution>({ videoResolution })));
-    EXPECT_CALL(videoOutputPortTypeMock, getId())
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::Return(0));
-    EXPECT_CALL(videoOutputPortMock, getType())
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::ReturnRef(videoOutputPortType));
-    EXPECT_CALL(hostImplMock, getDefaultVideoPortName())
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::Return(videoPort));
-    EXPECT_CALL(hostImplMock, getVideoOutputPort(::testing::_))
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::ReturnRef(videoOutputPort));
-    EXPECT_CALL(videoOutputPortConfigImplMock, getPortType(::testing::_))
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::ReturnRef(videoOutputPortType));
+    ON_CALL(videoResolutionMock, getName())
+        .WillByDefault(::testing::ReturnRef(videoPortSupportedResolution));
+    ON_CALL(videoOutputPortTypeMock, getSupportedResolutions())
+        .WillByDefault(::testing::Return(device::List<device::VideoResolution>({ videoResolution })));
+    ON_CALL(videoOutputPortTypeMock, getId())
+        .WillByDefault(::testing::Return(0));
+    ON_CALL(videoOutputPortMock, getType())
+        .WillByDefault(::testing::ReturnRef(videoOutputPortType));
+    ON_CALL(hostImplMock, getDefaultVideoPortName())
+        .WillByDefault(::testing::Return(videoPort));
+    ON_CALL(hostImplMock, getVideoOutputPort(::testing::_))
+        .WillByDefault(::testing::ReturnRef(videoOutputPort));
+    ON_CALL(videoOutputPortConfigImplMock, getPortType(::testing::_))
+        .WillByDefault(::testing::ReturnRef(videoOutputPortType));
 
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("supportedresolutions"), _T(""), response));
     EXPECT_EQ(response, _T("{\"supportedResolutions\":[\"1080p\"]}"));
@@ -338,15 +310,12 @@ TEST_F(DeviceInfoJsonRpcInitializedDsVideoOutputTest, supportedhdcp)
     videoOutputPort.impl = &videoOutputPortMock;
     string videoPort(_T("HDMI0"));
 
-    EXPECT_CALL(videoOutputPortMock, getHDCPProtocol())
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::Return(dsHDCP_VERSION_2X));
-    EXPECT_CALL(hostImplMock, getDefaultVideoPortName())
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::Return(videoPort));
-    EXPECT_CALL(videoOutputPortConfigImplMock, getPort(::testing::_))
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::ReturnRef(videoOutputPort));
+    ON_CALL(videoOutputPortMock, getHDCPProtocol())
+        .WillByDefault(::testing::Return(dsHDCP_VERSION_2X));
+    ON_CALL(hostImplMock, getDefaultVideoPortName())
+        .WillByDefault(::testing::Return(videoPort));
+    ON_CALL(videoOutputPortConfigImplMock, getPort(::testing::_))
+        .WillByDefault(::testing::ReturnRef(videoOutputPort));
 
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("supportedhdcp"), _T(""), response));
     EXPECT_EQ(response, _T("{\"supportedHDCPVersion\":\"2.2\"}"));
@@ -359,20 +328,17 @@ TEST_F(DeviceInfoJsonRpcInitializedDsTest, audiocapabilities)
     audioOutputPort.impl = &audioOutputPortMock;
     string audioPort(_T("HDMI0"));
 
-    EXPECT_CALL(audioOutputPortMock, getAudioCapabilities(::testing::_))
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::Invoke(
+    ON_CALL(audioOutputPortMock, getAudioCapabilities(::testing::_))
+        .WillByDefault(::testing::Invoke(
             [&](int* capabilities) {
                 ASSERT_TRUE(capabilities != nullptr);
                 EXPECT_EQ(*capabilities, dsAUDIOSUPPORT_NONE);
                 *capabilities = dsAUDIOSUPPORT_ATMOS | dsAUDIOSUPPORT_DD | dsAUDIOSUPPORT_DDPLUS | dsAUDIOSUPPORT_DAD | dsAUDIOSUPPORT_DAPv2 | dsAUDIOSUPPORT_MS12;
             }));
-    EXPECT_CALL(hostImplMock, getDefaultAudioPortName())
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::Return(audioPort));
-    EXPECT_CALL(hostImplMock, getAudioOutputPort(::testing::_))
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::ReturnRef(audioOutputPort));
+    ON_CALL(hostImplMock, getDefaultAudioPortName())
+        .WillByDefault(::testing::Return(audioPort));
+    ON_CALL(hostImplMock, getAudioOutputPort(::testing::_))
+        .WillByDefault(::testing::ReturnRef(audioOutputPort));
 
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("audiocapabilities"), _T(""), response));
     EXPECT_EQ(response, _T("{\"AudioCapabilities\":[\"ATMOS\",\"DOLBY DIGITAL\",\"DOLBY DIGITAL PLUS\",\"Dual Audio Decode\",\"DAPv2\",\"MS12\"]}"));
@@ -385,20 +351,17 @@ TEST_F(DeviceInfoJsonRpcInitializedDsTest, ms12capabilities)
     audioOutputPort.impl = &audioOutputPortMock;
     string audioPort(_T("HDMI0"));
 
-    EXPECT_CALL(audioOutputPortMock, getMS12Capabilities(::testing::_))
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::Invoke(
+    ON_CALL(audioOutputPortMock, getMS12Capabilities(::testing::_))
+        .WillByDefault(::testing::Invoke(
             [&](int* capabilities) {
                 ASSERT_TRUE(capabilities != nullptr);
                 EXPECT_EQ(*capabilities, dsMS12SUPPORT_NONE);
                 *capabilities = dsMS12SUPPORT_DolbyVolume | dsMS12SUPPORT_InteligentEqualizer | dsMS12SUPPORT_DialogueEnhancer;
             }));
-    EXPECT_CALL(hostImplMock, getDefaultAudioPortName())
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::Return(audioPort));
-    EXPECT_CALL(hostImplMock, getAudioOutputPort(::testing::_))
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::ReturnRef(audioOutputPort));
+    ON_CALL(hostImplMock, getDefaultAudioPortName())
+        .WillByDefault(::testing::Return(audioPort));
+    ON_CALL(hostImplMock, getAudioOutputPort(::testing::_))
+        .WillByDefault(::testing::ReturnRef(audioOutputPort));
 
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("ms12capabilities"), _T(""), response));
     EXPECT_EQ(response, _T("{\"MS12Capabilities\":[\"Dolby Volume\",\"Inteligent Equalizer\",\"Dialogue Enhancer\"]}"));
@@ -412,15 +375,12 @@ TEST_F(DeviceInfoJsonRpcInitializedDsTest, supportedms12audioprofiles)
     string audioPort(_T("HDMI0"));
     string audioPortMS12AudioProfile(_T("Movie"));
 
-    EXPECT_CALL(audioOutputPortMock, getMS12AudioProfileList())
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::Return(std::vector<std::string>({ audioPortMS12AudioProfile })));
-    EXPECT_CALL(hostImplMock, getDefaultAudioPortName())
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::Return(audioPort));
-    EXPECT_CALL(hostImplMock, getAudioOutputPort(::testing::_))
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::ReturnRef(audioOutputPort));
+    ON_CALL(audioOutputPortMock, getMS12AudioProfileList())
+        .WillByDefault(::testing::Return(std::vector<std::string>({ audioPortMS12AudioProfile })));
+    ON_CALL(hostImplMock, getDefaultAudioPortName())
+        .WillByDefault(::testing::Return(audioPort));
+    ON_CALL(hostImplMock, getAudioOutputPort(::testing::_))
+        .WillByDefault(::testing::ReturnRef(audioOutputPort));
 
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("supportedms12audioprofiles"), _T(""), response));
     EXPECT_EQ(response, _T("{\"supportedMS12AudioProfiles\":[\"Movie\"]}"));

--- a/Tests/tests/test_DeviceInfoWeb.cpp
+++ b/Tests/tests/test_DeviceInfoWeb.cpp
@@ -56,20 +56,10 @@ protected:
         IarmBus::getInstance().impl = &iarmBusImplMock;
         device::Manager::getInstance().impl = &managerImplMock;
 
-        ON_CALL(iarmBusImplMock, IARM_Bus_IsConnected(::testing::_, ::testing::_))
-            .WillByDefault(::testing::Invoke(
-                [](const char*, int* isRegistered) {
-                    *isRegistered = 1;
-                    return IARM_RESULT_SUCCESS;
-                }));
-        ON_CALL(managerImplMock, Initialize())
-            .WillByDefault(::testing::Return());
         ON_CALL(service, ConfigLine())
             .WillByDefault(::testing::Return("{\"root\":{\"mode\":\"Off\"}}"));
         ON_CALL(service, WebPrefix())
             .WillByDefault(::testing::Return(webPrefix));
-        ON_CALL(service, Version())
-            .WillByDefault(::testing::Return(string()));
         ON_CALL(service, SubSystems())
             .WillByDefault(::testing::Invoke(
                 [&]() {

--- a/Tests/tests/test_DeviceVideoCapabilities.cpp
+++ b/Tests/tests/test_DeviceVideoCapabilities.cpp
@@ -26,13 +26,6 @@ protected:
         IarmBus::getInstance().impl = &iarmBusImplMock;
         device::Manager::getInstance().impl = &managerImplMock;
 
-        EXPECT_CALL(iarmBusImplMock, IARM_Bus_IsConnected(::testing::_, ::testing::_))
-            .Times(::testing::AnyNumber())
-            .WillRepeatedly(::testing::Invoke(
-                [](const char*, int* isRegistered) {
-                    *isRegistered = 1;
-                    return IARM_RESULT_SUCCESS;
-                }));
         EXPECT_CALL(managerImplMock, Initialize())
             .Times(::testing::AnyNumber())
             .WillRepeatedly(::testing::Return());
@@ -88,12 +81,10 @@ TEST_F(DeviceVideoCapabilitiesDsTest, SupportedVideoDisplays)
     string videoPort(_T("HDMI0"));
     string element;
 
-    EXPECT_CALL(videoOutputPortMock, getName())
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::ReturnRef(videoPort));
-    EXPECT_CALL(hostImplMock, getVideoOutputPorts())
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::Return(device::List<device::VideoOutputPort>({ videoOutputPort })));
+    ON_CALL(videoOutputPortMock, getName())
+        .WillByDefault(::testing::ReturnRef(videoPort));
+    ON_CALL(hostImplMock, getVideoOutputPorts())
+        .WillByDefault(::testing::Return(device::List<device::VideoOutputPort>({ videoOutputPort })));
 
     EXPECT_EQ(Core::ERROR_NONE, interface->SupportedVideoDisplays(supportedVideoDisplays));
     ASSERT_TRUE(supportedVideoDisplays != nullptr);
@@ -105,14 +96,12 @@ TEST_F(DeviceVideoCapabilitiesDsTest, SupportedVideoDisplays)
 
 TEST_F(DeviceVideoCapabilitiesDsTest, HostEDID)
 {
-    std::vector<uint8_t> edidVec({ 't', 'e', 's', 't' });
     string edid;
 
-    EXPECT_CALL(hostImplMock, getHostEDID(::testing::_))
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::Invoke(
+    ON_CALL(hostImplMock, getHostEDID(::testing::_))
+        .WillByDefault(::testing::Invoke(
             [&](std::vector<uint8_t>& edid) {
-                edid = edidVec;
+                edid = { 't', 'e', 's', 't' };
             }));
 
     EXPECT_EQ(Core::ERROR_NONE, interface->HostEDID(edid));
@@ -131,18 +120,14 @@ TEST_F(DeviceVideoCapabilitiesDsTest, DefaultResolution_noParam)
     string videoPortDefaultResolution(_T("1080p"));
     string defaultResolution;
 
-    EXPECT_CALL(videoResolutionMock, getName())
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::ReturnRef(videoPortDefaultResolution));
-    EXPECT_CALL(videoOutputPortMock, getDefaultResolution())
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::ReturnRef(videoResolution));
-    EXPECT_CALL(hostImplMock, getDefaultVideoPortName())
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::Return(videoPort));
-    EXPECT_CALL(hostImplMock, getVideoOutputPort(::testing::_))
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::ReturnRef(videoOutputPort));
+    ON_CALL(videoResolutionMock, getName())
+        .WillByDefault(::testing::ReturnRef(videoPortDefaultResolution));
+    ON_CALL(videoOutputPortMock, getDefaultResolution())
+        .WillByDefault(::testing::ReturnRef(videoResolution));
+    ON_CALL(hostImplMock, getDefaultVideoPortName())
+        .WillByDefault(::testing::Return(videoPort));
+    ON_CALL(hostImplMock, getVideoOutputPort(::testing::_))
+        .WillByDefault(::testing::ReturnRef(videoOutputPort));
 
     EXPECT_EQ(Core::ERROR_NONE, interface->DefaultResolution(string(), defaultResolution));
     EXPECT_EQ(defaultResolution, videoPortDefaultResolution);
@@ -164,27 +149,20 @@ TEST_F(DeviceVideoCapabilitiesDsTest, SupportedResolutions_noParam)
     string videoPortSupportedResolution(_T("1080p"));
     string element;
 
-    EXPECT_CALL(videoResolutionMock, getName())
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::ReturnRef(videoPortSupportedResolution));
-    EXPECT_CALL(videoOutputPortTypeMock, getSupportedResolutions())
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::Return(device::List<device::VideoResolution>({ videoResolution })));
-    EXPECT_CALL(videoOutputPortTypeMock, getId())
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::Return(0));
-    EXPECT_CALL(videoOutputPortMock, getType())
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::ReturnRef(videoOutputPortType));
-    EXPECT_CALL(hostImplMock, getDefaultVideoPortName())
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::Return(videoPort));
-    EXPECT_CALL(hostImplMock, getVideoOutputPort(::testing::_))
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::ReturnRef(videoOutputPort));
-    EXPECT_CALL(videoOutputPortConfigImplMock, getPortType(::testing::_))
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::ReturnRef(videoOutputPortType));
+    ON_CALL(videoResolutionMock, getName())
+        .WillByDefault(::testing::ReturnRef(videoPortSupportedResolution));
+    ON_CALL(videoOutputPortTypeMock, getSupportedResolutions())
+        .WillByDefault(::testing::Return(device::List<device::VideoResolution>({ videoResolution })));
+    ON_CALL(videoOutputPortTypeMock, getId())
+        .WillByDefault(::testing::Return(0));
+    ON_CALL(videoOutputPortMock, getType())
+        .WillByDefault(::testing::ReturnRef(videoOutputPortType));
+    ON_CALL(hostImplMock, getDefaultVideoPortName())
+        .WillByDefault(::testing::Return(videoPort));
+    ON_CALL(hostImplMock, getVideoOutputPort(::testing::_))
+        .WillByDefault(::testing::ReturnRef(videoOutputPort));
+    ON_CALL(videoOutputPortConfigImplMock, getPortType(::testing::_))
+        .WillByDefault(::testing::ReturnRef(videoOutputPortType));
 
     EXPECT_EQ(Core::ERROR_NONE, interface->SupportedResolutions(string(), supportedResolutions));
     ASSERT_TRUE(supportedResolutions != nullptr);
@@ -202,15 +180,12 @@ TEST_F(DeviceVideoCapabilitiesDsTest, SupportedHdcp_noParam)
     string videoPort(_T("HDMI0"));
     auto supportedHDCPVersion = Exchange::IDeviceVideoCapabilities::CopyProtection::HDCP_UNAVAILABLE;
 
-    EXPECT_CALL(videoOutputPortMock, getHDCPProtocol())
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::Return(dsHDCP_VERSION_2X));
-    EXPECT_CALL(hostImplMock, getDefaultVideoPortName())
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::Return(videoPort));
-    EXPECT_CALL(videoOutputPortConfigImplMock, getPort(::testing::_))
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::ReturnRef(videoOutputPort));
+    ON_CALL(videoOutputPortMock, getHDCPProtocol())
+        .WillByDefault(::testing::Return(dsHDCP_VERSION_2X));
+    ON_CALL(hostImplMock, getDefaultVideoPortName())
+        .WillByDefault(::testing::Return(videoPort));
+    ON_CALL(videoOutputPortConfigImplMock, getPort(::testing::_))
+        .WillByDefault(::testing::ReturnRef(videoOutputPort));
 
     EXPECT_EQ(Core::ERROR_NONE, interface->SupportedHdcp(string(), supportedHDCPVersion));
     EXPECT_EQ(supportedHDCPVersion, Exchange::IDeviceVideoCapabilities::CopyProtection::HDCP_22);
@@ -220,9 +195,8 @@ TEST_F(DeviceVideoCapabilitiesDsTest, SupportedVideoDisplays_exception)
 {
     RPC::IStringIterator* supportedVideoDisplays = nullptr;
 
-    EXPECT_CALL(hostImplMock, getVideoOutputPorts())
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::Invoke(
+    ON_CALL(hostImplMock, getVideoOutputPorts())
+        .WillByDefault(::testing::Invoke(
             [&]() -> device::List<device::VideoOutputPort> {
                 throw device::Exception("test");
             }));
@@ -235,9 +209,8 @@ TEST_F(DeviceVideoCapabilitiesDsTest, HostEDID_exception)
 {
     string edid;
 
-    EXPECT_CALL(hostImplMock, getHostEDID(::testing::_))
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::Invoke(
+    ON_CALL(hostImplMock, getHostEDID(::testing::_))
+        .WillByDefault(::testing::Invoke(
             [&](std::vector<uint8_t>& edid) {
                 throw device::Exception("test");
             }));
@@ -250,9 +223,8 @@ TEST_F(DeviceVideoCapabilitiesDsTest, DefaultResolution_HDMI0_exception)
 {
     string defaultResolution;
 
-    EXPECT_CALL(hostImplMock, getVideoOutputPort(::testing::_))
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::Invoke(
+    ON_CALL(hostImplMock, getVideoOutputPort(::testing::_))
+        .WillByDefault(::testing::Invoke(
             [&](const std::string& name) -> device::VideoOutputPort& {
                 EXPECT_EQ(name, _T("HDMI0"));
                 throw device::Exception("test");
@@ -266,9 +238,8 @@ TEST_F(DeviceVideoCapabilitiesDsTest, SupportedResolutions_HDMI0_exception)
 {
     RPC::IStringIterator* supportedResolutions = nullptr;
 
-    EXPECT_CALL(hostImplMock, getVideoOutputPort(::testing::_))
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::Invoke(
+    ON_CALL(hostImplMock, getVideoOutputPort(::testing::_))
+        .WillByDefault(::testing::Invoke(
             [&](const std::string& name) -> device::VideoOutputPort& {
                 EXPECT_EQ(name, _T("HDMI0"));
                 throw device::Exception("test");
@@ -282,9 +253,8 @@ TEST_F(DeviceVideoCapabilitiesDsTest, SupportedHdcp_HDMI0_exception)
 {
     auto supportedHDCPVersion = Exchange::IDeviceVideoCapabilities::CopyProtection::HDCP_UNAVAILABLE;
 
-    EXPECT_CALL(videoOutputPortConfigImplMock, getPort(::testing::_))
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::Invoke(
+    ON_CALL(videoOutputPortConfigImplMock, getPort(::testing::_))
+        .WillByDefault(::testing::Invoke(
             [&](const std::string& name) -> device::VideoOutputPort& {
                 EXPECT_EQ(name, _T("HDMI0"));
                 throw device::Exception("test");

--- a/Tests/tests/test_FrameRate.cpp
+++ b/Tests/tests/test_FrameRate.cpp
@@ -40,12 +40,6 @@ protected:
     {
         IarmBus::getInstance().impl = &iarmBusImplMock;
 
-        ON_CALL(iarmBusImplMock, IARM_Bus_IsConnected(::testing::_, ::testing::_))
-            .WillByDefault(::testing::Invoke(
-                [](const char*, int* isRegistered) {
-                    *isRegistered = 1;
-                    return IARM_RESULT_SUCCESS;
-                }));
         ON_CALL(iarmBusImplMock, IARM_Bus_RegisterEventHandler(::testing::_, ::testing::_, ::testing::_))
             .WillByDefault(::testing::Invoke(
                 [&](const char* ownerName, IARM_EventId_t eventId, IARM_EventHandler_t handler) {
@@ -62,9 +56,6 @@ protected:
     }
     virtual ~FrameRateInitializedTest() override
     {
-        ON_CALL(iarmBusImplMock, IARM_Bus_UnRegisterEventHandler(::testing::_, ::testing::_))
-            .WillByDefault(::testing::Return(IARM_RESULT_SUCCESS));
-
         plugin->Deinitialize(nullptr);
 
         IarmBus::getInstance().impl = nullptr;
@@ -147,9 +138,8 @@ TEST_F(FrameRateTest, setCollectionFrequency_startFpsCollection_stopFpsCollectio
 
 TEST_F(FrameRateDsTest, setFrmMode)
 {
-    EXPECT_CALL(videoDeviceMock, setFRFMode(::testing::_))
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::Invoke(
+    ON_CALL(videoDeviceMock, setFRFMode(::testing::_))
+        .WillByDefault(::testing::Invoke(
             [&](int param) {
                 EXPECT_EQ(param, 0);
                 return 0;
@@ -161,9 +151,8 @@ TEST_F(FrameRateDsTest, setFrmMode)
 
 TEST_F(FrameRateDsTest, getFrmMode)
 {
-    EXPECT_CALL(videoDeviceMock, getFRFMode(::testing::_))
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::Invoke(
+    ON_CALL(videoDeviceMock, getFRFMode(::testing::_))
+        .WillByDefault(::testing::Invoke(
             [&](int* param) {
                 *param = 0;
                 return 0;
@@ -175,9 +164,8 @@ TEST_F(FrameRateDsTest, getFrmMode)
 
 TEST_F(FrameRateDsTest, setDisplayFrameRate)
 {
-    EXPECT_CALL(videoDeviceMock, setDisplayframerate(::testing::_))
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::Invoke(
+    ON_CALL(videoDeviceMock, setDisplayframerate(::testing::_))
+        .WillByDefault(::testing::Invoke(
             [&](const char* param) {
                 EXPECT_EQ(param, string("3840x2160px48"));
                 return 0;
@@ -189,9 +177,8 @@ TEST_F(FrameRateDsTest, setDisplayFrameRate)
 
 TEST_F(FrameRateDsTest, getDisplayFrameRate)
 {
-    EXPECT_CALL(videoDeviceMock, getCurrentDisframerate(::testing::_))
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(::testing::Invoke(
+    ON_CALL(videoDeviceMock, getCurrentDisframerate(::testing::_))
+        .WillByDefault(::testing::Invoke(
             [&](char* param) {
                 string framerate("3840x2160px48");
                 ::memcpy(param, framerate.c_str(), framerate.length());
@@ -204,6 +191,7 @@ TEST_F(FrameRateDsTest, getDisplayFrameRate)
 
 TEST_F(FrameRateInitializedEventTest, onDisplayFrameRateChanging)
 {
+    ASSERT_TRUE(handlerOnDisplayFrameRateChanging != nullptr);
     EXPECT_CALL(service, Submit(::testing::_, ::testing::_))
         .Times(1)
         .WillOnce(::testing::Invoke(
@@ -227,6 +215,7 @@ TEST_F(FrameRateInitializedEventTest, onDisplayFrameRateChanging)
 
 TEST_F(FrameRateInitializedEventTest, onDisplayFrameRateChanged)
 {
+    ASSERT_TRUE(handlerOnDisplayFrameRateChanged != nullptr);
     EXPECT_CALL(service, Submit(::testing::_, ::testing::_))
         .Times(1)
         .WillOnce(::testing::Invoke(

--- a/Tests/tests/test_LocationSync.cpp
+++ b/Tests/tests/test_LocationSync.cpp
@@ -87,8 +87,6 @@ protected:
                 [&](const PluginHost::ISubSystem::subsystem type, WPEFramework::Core::IUnknown* information) {
                     subSystem.SystemInfo::Set(type, information);
                 }));
-        ON_CALL(service, Version())
-            .WillByDefault(::testing::Return(string()));
 
         dispatcher = static_cast<PluginHost::IDispatcher*>(
             plugin->QueryInterface(PluginHost::IDispatcher::ID));
@@ -183,8 +181,9 @@ TEST_F(LocationSyncTest, activateWithUnreachableHost_location_deactivate)
                                          "\"retries\":1,\n"
                                          "\"source\":\"http://jsonip.metrological.com:1234/?maf=true\"\n"
                                          "}"));
-    ON_CALL(subSystem, Set(::testing::_, ::testing::_))
-        .WillByDefault(::testing::Invoke(
+    EXPECT_CALL(subSystem, Set(::testing::_, ::testing::_))
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(::testing::Invoke(
             [&](const PluginHost::ISubSystem::subsystem type, WPEFramework::Core::IUnknown* information) {
                 subSystem.SystemInfo::Set(type, information);
                 if (type == PluginHost::ISubSystem::LOCATION) {

--- a/Tests/tests/test_LoggingPreferences.cpp
+++ b/Tests/tests/test_LoggingPreferences.cpp
@@ -53,13 +53,6 @@ protected:
     {
         IarmBus::getInstance().impl = &iarmBusImplMock;
 
-        ON_CALL(iarmBusImplMock, IARM_Bus_IsConnected(::testing::_, ::testing::_))
-            .WillByDefault(::testing::Invoke(
-                [](const char*, int* isRegistered) {
-                    *isRegistered = 1;
-                    return IARM_RESULT_SUCCESS;
-                }));
-
         EXPECT_EQ(string(""), plugin->Initialize(nullptr));
     }
     virtual ~LoggingPreferencesInitializedTest() override
@@ -108,12 +101,13 @@ TEST_F(LoggingPreferencesTest, paramsMissing)
 
 TEST_F(LoggingPreferencesInitializedTest, getKeystrokeMask)
 {
-    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
-        .WillOnce(
+    ON_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .WillByDefault(
             [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
-                EXPECT_TRUE(strcmp(methodName, IARM_BUS_SYSMGR_API_GetKeyCodeLoggingPref) == 0);
-                auto* param = static_cast<IARM_BUS_SYSMGR_KEYCodeLoggingInfo_Param_t*>(arg);
-                param->logStatus = 1; //Setting 1 returns response as false
+                if (strcmp(methodName, IARM_BUS_SYSMGR_API_GetKeyCodeLoggingPref) == 0) {
+                    auto* param = static_cast<IARM_BUS_SYSMGR_KEYCodeLoggingInfo_Param_t*>(arg);
+                    param->logStatus = 1; //Setting 1 returns response as false
+                }
                 return IARM_RESULT_SUCCESS;
             });
 
@@ -125,24 +119,13 @@ TEST_F(LoggingPreferencesInitializedEventTest, enableKeystrokeMask)
 {
     Core::Event onKeystrokeMaskEnabledChange(false, true);
 
-    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
-        .WillOnce(
+    ON_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .WillByDefault(
             [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
-                EXPECT_TRUE(strcmp(methodName, IARM_BUS_SYSMGR_API_GetKeyCodeLoggingPref) == 0);
-                auto* param = static_cast<IARM_BUS_SYSMGR_KEYCodeLoggingInfo_Param_t*>(arg);
-                param->logStatus = 1;
-                return IARM_RESULT_SUCCESS;
-            })
-        .WillOnce(
-            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
-                EXPECT_TRUE(strcmp(methodName, IARM_BUS_SYSMGR_API_GetKeyCodeLoggingPref) == 0);
-                auto* param = static_cast<IARM_BUS_SYSMGR_KEYCodeLoggingInfo_Param_t*>(arg);
-                param->logStatus = 1;
-                return IARM_RESULT_SUCCESS;
-            })
-        .WillOnce(
-            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
-                EXPECT_TRUE(strcmp(methodName, IARM_BUS_SYSMGR_API_SetKeyCodeLoggingPref) == 0);
+                if (strcmp(methodName, IARM_BUS_SYSMGR_API_GetKeyCodeLoggingPref) == 0) {
+                    auto* param = static_cast<IARM_BUS_SYSMGR_KEYCodeLoggingInfo_Param_t*>(arg);
+                    param->logStatus = 1;
+                }
                 return IARM_RESULT_SUCCESS;
             });
     EXPECT_CALL(service, Submit(::testing::_, ::testing::_))
@@ -180,17 +163,13 @@ TEST_F(LoggingPreferencesInitializedEventTest, disbleKeystrokeMask)
 {
     Core::Event onKeystrokeMaskEnabledChange(false, true);
 
-    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
-        .WillOnce(
+    ON_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .WillByDefault(
             [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
-                EXPECT_TRUE(strcmp(methodName, IARM_BUS_SYSMGR_API_GetKeyCodeLoggingPref) == 0);
-                auto* param = static_cast<IARM_BUS_SYSMGR_KEYCodeLoggingInfo_Param_t*>(arg);
-                param->logStatus = 0;
-                return IARM_RESULT_SUCCESS;
-            })
-        .WillOnce(
-            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
-                EXPECT_TRUE(strcmp(methodName, IARM_BUS_SYSMGR_API_SetKeyCodeLoggingPref) == 0);
+                if (strcmp(methodName, IARM_BUS_SYSMGR_API_GetKeyCodeLoggingPref) == 0) {
+                    auto* param = static_cast<IARM_BUS_SYSMGR_KEYCodeLoggingInfo_Param_t*>(arg);
+                    param->logStatus = 0;
+                }
                 return IARM_RESULT_SUCCESS;
             });
     EXPECT_CALL(service, Submit(::testing::_, ::testing::_))
@@ -223,28 +202,16 @@ TEST_F(LoggingPreferencesInitializedEventTest, disbleKeystrokeMask)
 
 TEST_F(LoggingPreferencesInitializedTest, errorCases)
 {
-    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
-        .WillOnce(
+    ON_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .WillByDefault(
             [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
-                EXPECT_TRUE(strcmp(methodName, IARM_BUS_SYSMGR_API_GetKeyCodeLoggingPref) == 0);
-                return IARM_RESULT_IPCCORE_FAIL;
-            })
-        .WillOnce(
-            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
-                EXPECT_TRUE(strcmp(methodName, IARM_BUS_SYSMGR_API_GetKeyCodeLoggingPref) == 0);
-                return IARM_RESULT_IPCCORE_FAIL;
-            })
-        .WillOnce(
-            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
-                EXPECT_TRUE(strcmp(methodName, IARM_BUS_SYSMGR_API_GetKeyCodeLoggingPref) == 0);
-                auto* param = static_cast<IARM_BUS_SYSMGR_KEYCodeLoggingInfo_Param_t*>(arg);
-                param->logStatus = 0;
+                if (strcmp(methodName, IARM_BUS_SYSMGR_API_GetKeyCodeLoggingPref) == 0) {
+                    return IARM_RESULT_IPCCORE_FAIL;
+                } else if (strcmp(methodName, IARM_BUS_SYSMGR_API_GetKeyCodeLoggingPref) == 0) {
+                    auto* param = static_cast<IARM_BUS_SYSMGR_KEYCodeLoggingInfo_Param_t*>(arg);
+                    param->logStatus = 0;
+                }
                 return IARM_RESULT_SUCCESS;
-            })
-        .WillOnce(
-            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
-                EXPECT_TRUE(strcmp(methodName, IARM_BUS_SYSMGR_API_SetKeyCodeLoggingPref) == 0);
-                return IARM_RESULT_IPCCORE_FAIL;
             });
 
     EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("isKeystrokeMaskEnabled"), _T("{}"), response));

--- a/Tests/tests/test_SecurityAgent.cpp
+++ b/Tests/tests/test_SecurityAgent.cpp
@@ -97,8 +97,6 @@ protected:
             .WillByDefault(::testing::Return(proxyStubPath));
         ON_CALL(service, Callsign())
             .WillByDefault(::testing::Return(callSign));
-        ON_CALL(service, Version())
-            .WillByDefault(::testing::Return(string()));
 
         EXPECT_EQ(string(""), plugin->Initialize(&service));
     }

--- a/Tests/tests/test_Timer.cpp
+++ b/Tests/tests/test_Timer.cpp
@@ -52,13 +52,6 @@ protected:
     {
         IarmBus::getInstance().impl = &iarmBusImplMock;
 
-        ON_CALL(iarmBusImplMock, IARM_Bus_IsConnected(::testing::_, ::testing::_))
-            .WillByDefault(::testing::Invoke(
-                [](const char*, int* isRegistered) {
-                    *isRegistered = 1;
-                    return IARM_RESULT_SUCCESS;
-                }));
-
         EXPECT_EQ(string(""), plugin->Initialize(nullptr));
     }
     virtual ~TimerInitializedTest() override


### PR DESCRIPTION
- Add default expectations for IarmBusImplMock.
- Remove expectations for implementation-specific details.
- Remove blank expectations.