### PR TITLE
RDKTV-19363: WPEFramework Crash in WPEFramework::Plugin::MemoryInfo::…

### DIFF
--- a/ActivityMonitor/ActivityMonitor.cpp
+++ b/ActivityMonitor/ActivityMonitor.cpp
@@ -407,7 +407,11 @@ namespace WPEFramework
         long long unsigned int MemoryInfo::getTotalCpuUsage()
         {
             FILE *f = fopen("/proc/stat", "r");
-
+            if (f == NULL)
+            {
+                LOGERR("Could not open file /proc/stat in read mode");
+                return 0;
+            }
             std::vector <char> buf;
             buf.resize(1024);
 


### PR DESCRIPTION
…getTotalCpuUsage