### PR TITLE
Sprint 2208 delia 57501 2

### DIFF
--- a/ControlService/test/controlSvcTestClient.cpp
+++ b/ControlService/test/controlSvcTestClient.cpp
@@ -361,7 +361,7 @@ int main(int argc, char** argv)
     std::cout << "Using callsign: " << SYSSRV_CALLSIGN << std::endl;
 
     if (NULL == remoteObject) {
-        remoteObject = new JSONRPC::Client(_T(SYSSRV_CALLSIGN), _T(""), false, sToken);
+        remoteObject = new JSONRPC::LinkType<Core::JSON::IElement>(_T(SYSSRV_CALLSIGN), _T(""), false, sToken);
         if (NULL == remoteObject) {
             std::cout << "JSONRPC::Client initialization failed" << std::endl;
 
@@ -375,7 +375,7 @@ int main(int argc, char** argv)
                 JsonObject params;
                 params["callsign"] = SYSSRV_CALLSIGN;
                 JsonObject result;
-                ret = controllerClient.Invoke(2000, "activate", params, result);
+                ret = controllerClient.Invoke<JsonObject, JsonObject>(2000, "activate", params, result);
                 result.ToString(strres);
                 std::cout<<"\nstartup result : "<< strres <<"\n";
             }

--- a/HdmiCec/CMakeLists.txt
+++ b/HdmiCec/CMakeLists.txt
@@ -37,7 +37,7 @@ target_include_directories(${MODULE_NAME} PRIVATE ${CEC_INCLUDE_DIRS})
 target_include_directories(${MODULE_NAME} PRIVATE ${DS_INCLUDE_DIRS})
 
 target_link_libraries(${MODULE_NAME} PUBLIC ${NAMESPACE}Plugins::${NAMESPACE}Plugins ${IARMBUS_LIBRARIES} ${CEC_LIBRARIES} ${DS_LIBRARIES} )
-
+target_compile_options(${MODULE_NAME} PRIVATE -Wno-error=deprecated)
 
 install(TARGETS ${MODULE_NAME}
         DESTINATION lib/${STORAGE_DIRECTORY}/plugins)

--- a/HdmiCecSink/CMakeLists.txt
+++ b/HdmiCecSink/CMakeLists.txt
@@ -38,7 +38,7 @@ target_include_directories(${MODULE_NAME} PRIVATE ${CEC_INCLUDE_DIRS})
 target_include_directories(${MODULE_NAME} PRIVATE ${DS_INCLUDE_DIRS})
 
 target_link_libraries(${MODULE_NAME} PUBLIC ${NAMESPACE}Plugins::${NAMESPACE}Plugins ${IARMBUS_LIBRARIES} ${CEC_LIBRARIES} ${DS_LIBRARIES} )
-
+target_compile_options(${MODULE_NAME} PRIVATE -Wno-error=deprecated)
 
 install(TARGETS ${MODULE_NAME}
         DESTINATION lib/${STORAGE_DIRECTORY}/plugins)

--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -537,7 +537,7 @@ namespace WPEFramework {
                     api.append(requestName);
                     auto thunderController = getThunderControllerClient();
                     JsonObject joResult;
-                    thunderController->Invoke(RDKSHELL_THUNDER_TIMEOUT, api.c_str(), apiRequest.mRequest, joResult);
+                    thunderController->Invoke<JsonObject, JsonObject>(RDKSHELL_THUNDER_TIMEOUT, api.c_str(), apiRequest.mRequest, joResult);
                 } 
             });
             rdkshellRequestsThread.detach();
@@ -730,7 +730,7 @@ namespace WPEFramework {
                                   JsonObject request, response;
                                   std::cout << "about to launch factory app\n";
                                   request["resetagingtime"] = "true";
-                                  getThunderControllerClient("org.rdk.RDKShell.1")->Invoke(1, "launchFactoryApp", request, response);
+                                  getThunderControllerClient("org.rdk.RDKShell.1")->Invoke<JsonObject, JsonObject>(1, "launchFactoryApp", request, response);
                                 }
                             }
                         }
@@ -1420,7 +1420,7 @@ namespace WPEFramework {
                     std::cout << "invoking thunder api " << thunderApi << std::endl;
                     uint32_t status = 0;
                     JsonObject joResult;
-                    status = getThunderControllerClient()->Invoke(RDKSHELL_THUNDER_TIMEOUT, thunderApi.c_str(), apiParams, joResult);
+                    status = getThunderControllerClient()->Invoke<JsonObject, JsonObject>(RDKSHELL_THUNDER_TIMEOUT, thunderApi.c_str(), apiParams, joResult);
                     if (status > 0)
                     {
                         std::cout << "invoking thunder api " << thunderApi << " failed - " << status << std::endl;
@@ -1518,7 +1518,7 @@ namespace WPEFramework {
                     std::cout << "Received power state change to sleep " << std::endl;
                     JsonObject request, response;
                     request["visible"] = false;
-                    getThunderControllerClient("org.rdk.RDKShell.1")->Invoke(0, "launchResidentApp", request, response);
+                    getThunderControllerClient("org.rdk.RDKShell.1")->Invoke<JsonObject, JsonObject>(0, "launchResidentApp", request, response);
                 }
  
                 if ((prevState == "STANDBY" || prevState == "LIGHT_SLEEP" || prevState == "DEEP_SLEEP" || prevState == "OFF")
@@ -1527,7 +1527,7 @@ namespace WPEFramework {
                     JsonObject request, response;
                     request["callsign"] = "ResidentApp";
                     request["visible"] = true;
-                    getThunderControllerClient("org.rdk.RDKShell.1")->Invoke(0, "setVisibility", request, response);
+                    getThunderControllerClient("org.rdk.RDKShell.1")->Invoke<JsonObject, JsonObject>(0, "setVisibility", request, response);
 		    /*
                     gRdkShellMutex.lock();
                     CompositorController::getLastKeyPress(mLastWakeupKeyCode, mLastWakeupKeyModifiers, mLastWakeupKeyTimestamp);
@@ -1685,7 +1685,7 @@ namespace WPEFramework {
                         JsonObject activateParams;
                         activateParams.Set("callsign",callsign.c_str());
                         JsonObject activateResult;
-                        thunderController->Invoke(3500, "activate", activateParams, activateResult);
+                        thunderController->Invoke<JsonObject, JsonObject>(3500, "activate", activateParams, activateResult);
                     }
                     else
                     {
@@ -1709,7 +1709,7 @@ namespace WPEFramework {
                     {
                         // setting wait Time to 2 seconds
                         gRdkShellMutex.unlock();
-                        status = thunderController->Invoke(RDKSHELL_THUNDER_TIMEOUT, invoke.c_str(), actionObject["params"], joResult);
+                        status = thunderController->Invoke<JsonObject, JsonObject>(RDKSHELL_THUNDER_TIMEOUT, invoke.c_str(), actionObject["params"].Object(), joResult);
                         gRdkShellMutex.lock();
                     }
                     else
@@ -1718,7 +1718,7 @@ namespace WPEFramework {
                       joParams["params"] = JsonObject();
                       // setting wait Time to 2 seconds
                       gRdkShellMutex.unlock();
-                      status = thunderController->Invoke(RDKSHELL_THUNDER_TIMEOUT, invoke.c_str(), joParams, joResult);
+                      status = thunderController->Invoke<JsonObject, JsonObject>(RDKSHELL_THUNDER_TIMEOUT, invoke.c_str(), joParams, joResult);
                       gRdkShellMutex.lock();
                     }
                     if (status > 0)
@@ -1749,7 +1749,7 @@ namespace WPEFramework {
             joGetParams["params"] = JsonObject();
             std::string getPowerStateInvoke = "org.rdk.System.1.getPowerState";
             auto thunderController = getThunderControllerClient();
-            uint32_t status = thunderController->Invoke(5000, getPowerStateInvoke.c_str(), joGetParams, joGetResult);
+            uint32_t status = thunderController->Invoke<JsonObject, JsonObject>(5000, getPowerStateInvoke.c_str(), joGetParams, joGetResult);
 
             std::cout << "get power state status: " << status << std::endl;
 
@@ -1782,7 +1782,7 @@ namespace WPEFramework {
             std::string setPowerStateInvoke = "org.rdk.System.1.setPowerState";
 
             std::cout << "attempting to set the power state to " << newPowerState << std::endl;
-            status = thunderController->Invoke(5000, setPowerStateInvoke.c_str(), joSetParams, joSetResult);
+            status = thunderController->Invoke<JsonObject, JsonObject>(5000, setPowerStateInvoke.c_str(), joSetParams, joSetResult);
             std::cout << "get power state status second: " << status << std::endl;
             if (status > 0)
             {
@@ -4010,7 +4010,7 @@ namespace WPEFramework {
                 JsonObject joResult;
                 auto thunderController = getThunderControllerClient();
                 gDestroyMutex.lock();
-                uint32_t status = thunderController->Invoke(RDKSHELL_THUNDER_TIMEOUT, "deactivate", joParams, joResult);
+                uint32_t status = thunderController->Invoke<JsonObject, JsonObject>(RDKSHELL_THUNDER_TIMEOUT, "deactivate", joParams, joResult);
                 gDestroyMutex.unlock();
                 if (status > 0)
                 {
@@ -4651,7 +4651,7 @@ namespace WPEFramework {
                     std::string agingGetInvoke = "org.rdk.PersistentStore.1.getValue";
 
                     std::cout << "attempting to check aging flag \n";
-                    uint32_t status = getThunderControllerClient()->Invoke(RDKSHELL_THUNDER_TIMEOUT, agingGetInvoke.c_str(), joAgingParams, joAgingResult);
+                    uint32_t status = getThunderControllerClient()->Invoke<JsonObject, JsonObject>(RDKSHELL_THUNDER_TIMEOUT, agingGetInvoke.c_str(), joAgingParams, joAgingResult);
                     std::cout << "get status: " << status << std::endl;
 
                     if (status > 0)
@@ -4692,7 +4692,7 @@ namespace WPEFramework {
                     std::string agingSetInvoke = "org.rdk.PersistentStore.1.setValue";
 
                     std::cout << "attempting to set aging total time to 0 \n";
-                    uint32_t agingTotalTimeSetStatus = getThunderControllerClient()->Invoke(RDKSHELL_THUNDER_TIMEOUT, agingSetInvoke.c_str(), joAgingSetValueParams, joAgingSetValueResult);
+                    uint32_t agingTotalTimeSetStatus = getThunderControllerClient()->Invoke<JsonObject, JsonObject>(RDKSHELL_THUNDER_TIMEOUT, agingSetInvoke.c_str(), joAgingSetValueParams, joAgingSetValueResult);
                     std::cout << "aging total time set status: " <<  agingTotalTimeSetStatus << std::endl;
                 }
 
@@ -4731,7 +4731,7 @@ namespace WPEFramework {
                 std::string factoryModeSetInvoke = "org.rdk.PersistentStore.1.setValue";
 
                 std::cout << "attempting to set factory mode flag \n";
-                uint32_t setStatus = getThunderControllerClient()->Invoke(RDKSHELL_THUNDER_TIMEOUT, factoryModeSetInvoke.c_str(), joFactoryModeParams, joFactoryModeResult);
+                uint32_t setStatus = getThunderControllerClient()->Invoke<JsonObject, JsonObject>(RDKSHELL_THUNDER_TIMEOUT, factoryModeSetInvoke.c_str(), joFactoryModeParams, joFactoryModeResult);
                 std::cout << "set status: " << setStatus << std::endl;
 
                 JsonObject joFactoryExitParams;
@@ -4742,7 +4742,7 @@ namespace WPEFramework {
                 std::string factoryExitSetInvoke = "org.rdk.PersistentStore.1.setValue";
 
                 std::cout << "attempting to set factory allow exit flag \n";
-                uint32_t setExitStatus = getThunderControllerClient()->Invoke(RDKSHELL_THUNDER_TIMEOUT, factoryExitSetInvoke.c_str(), joFactoryExitParams, joFactoryExitResult);
+                uint32_t setExitStatus = getThunderControllerClient()->Invoke<JsonObject, JsonObject>(RDKSHELL_THUNDER_TIMEOUT, factoryExitSetInvoke.c_str(), joFactoryExitParams, joFactoryExitResult);
                 std::cout << "set status: " << setExitStatus << std::endl;
 
                 sFactoryAppLaunchStatus = COMPLETED;
@@ -4783,7 +4783,7 @@ namespace WPEFramework {
 
             std::cout << "attempting to check flag \n";
             auto thunderController = getThunderControllerClient();
-            uint32_t status = thunderController->Invoke(RDKSHELL_THUNDER_TIMEOUT, toFacGetInvoke.c_str(), joToFacParams, joToFacResult);
+            uint32_t status = thunderController->Invoke<JsonObject, JsonObject>(RDKSHELL_THUNDER_TIMEOUT, toFacGetInvoke.c_str(), joToFacParams, joToFacResult);
             std::cout << "get status: " << status << std::endl;
 
             if (status > 0)
@@ -4836,7 +4836,7 @@ namespace WPEFramework {
                 std::string agingGetInvoke = "org.rdk.PersistentStore.1.getValue";
 
                 std::cout << "attempting to check aging flag \n";
-                uint32_t agingStatus = getThunderControllerClient()->Invoke(RDKSHELL_THUNDER_TIMEOUT, agingGetInvoke.c_str(), joAgingParams, joAgingResult);
+                uint32_t agingStatus = getThunderControllerClient()->Invoke<JsonObject, JsonObject>(RDKSHELL_THUNDER_TIMEOUT, agingGetInvoke.c_str(), joAgingParams, joAgingResult);
                 std::cout << "aging get status: " << agingStatus << std::endl;
 
                 if (agingStatus == 0 && joAgingResult.HasLabel("value"))
@@ -4862,7 +4862,7 @@ namespace WPEFramework {
                 std::string factoryExitGetInvoke = "org.rdk.PersistentStore.1.getValue";
 
                 std::cout << "attempting to check factory exit flag\n";
-                uint32_t factoryExitStatus = getThunderControllerClient()->Invoke(RDKSHELL_THUNDER_TIMEOUT, factoryExitGetInvoke.c_str(), joExitParams, joExitResult);
+                uint32_t factoryExitStatus = getThunderControllerClient()->Invoke<JsonObject, JsonObject>(RDKSHELL_THUNDER_TIMEOUT, factoryExitGetInvoke.c_str(), joExitParams, joExitResult);
                 std::cout << "factory exit get status: " << factoryExitStatus << std::endl;
 
                 if (factoryExitStatus == 0 && joExitResult.HasLabel("value"))
@@ -4906,7 +4906,7 @@ namespace WPEFramework {
             std::string stopHdmiInvoke = "org.rdk.HdmiInput.1.stopHdmiInput";
 
             std::cout << "attempting to stop hdmi input \n";
-            uint32_t stopHdmiStatus = getThunderControllerClient()->Invoke(RDKSHELL_THUNDER_TIMEOUT, stopHdmiInvoke.c_str(), joStopHdmiParams, joStopHdmiResult);
+            uint32_t stopHdmiStatus = getThunderControllerClient()->Invoke<JsonObject, JsonObject>(RDKSHELL_THUNDER_TIMEOUT, stopHdmiInvoke.c_str(), joStopHdmiParams, joStopHdmiResult);
             std::cout << "stopHdmiStatus status: " << stopHdmiStatus << std::endl;
 
             sForceResidentAppLaunch = true;
@@ -4946,13 +4946,13 @@ namespace WPEFramework {
             JsonObject activateParams;
             activateParams.Set("callsign",callsign.c_str());
             JsonObject activateResult;
-            status = thunderController->Invoke(3500, "activate", activateParams, activateResult);
+            status = thunderController->Invoke<JsonObject, JsonObject>(3500, "activate", activateParams, activateResult);
 
             std::cout << "activate resident app status: " << status << std::endl;
             if (status > 0)
             {
                 std::cout << "trying status one more time...\n";
-                status = thunderController->Invoke(3500, "activate", activateParams, activateResult);
+                status = thunderController->Invoke<JsonObject, JsonObject>(3500, "activate", activateParams, activateResult);
                 std::cout << "activate resident app status: " << status << std::endl;
                 if (status > 0)
                 {
@@ -4990,7 +4990,7 @@ namespace WPEFramework {
             std::string factoryModeSetInvoke = "org.rdk.PersistentStore.1.setValue";
 
             std::cout << "attempting to set factory mode flag \n";
-            uint32_t setStatus = thunderController->Invoke(RDKSHELL_THUNDER_TIMEOUT, factoryModeSetInvoke.c_str(), joFactoryModeParams, joFactoryModeResult);
+            uint32_t setStatus = thunderController->Invoke<JsonObject, JsonObject>(RDKSHELL_THUNDER_TIMEOUT, factoryModeSetInvoke.c_str(), joFactoryModeParams, joFactoryModeResult);
             std::cout << "set status: " << setStatus << std::endl;
             sForceResidentAppLaunch = false;
             returnResponse(ret);
@@ -5064,7 +5064,7 @@ namespace WPEFramework {
             std::string agingGetInvoke = "org.rdk.PersistentStore.1.getValue";
 
             std::cout << "attempting to check aging state flag \n";
-            uint32_t status = getThunderControllerClient()->Invoke(RDKSHELL_THUNDER_TIMEOUT, agingGetInvoke.c_str(), joAgingParams, joAgingResult);
+            uint32_t status = getThunderControllerClient()->Invoke<JsonObject, JsonObject>(RDKSHELL_THUNDER_TIMEOUT, agingGetInvoke.c_str(), joAgingParams, joAgingResult);
             std::cout << "get status: " << status << std::endl;
 
             if (status > 0)
@@ -5091,7 +5091,7 @@ namespace WPEFramework {
             joAgingParams.Set("value","false");
             std::string agingSetInvoke = "org.rdk.PersistentStore.1.setValue";
             std::cout << "attempting to set check aging state flag to false\n";
-            status = getThunderControllerClient()->Invoke(RDKSHELL_THUNDER_TIMEOUT, agingSetInvoke.c_str(), joAgingParams, joAgingResult);
+            status = getThunderControllerClient()->Invoke<JsonObject, JsonObject>(RDKSHELL_THUNDER_TIMEOUT, agingSetInvoke.c_str(), joAgingParams, joAgingResult);
             std::cout << "set status: " << status << std::endl;
 
             JsonObject request, res;
@@ -5289,14 +5289,14 @@ namespace WPEFramework {
              serviceCallsign.append(".2");
              auto systemServiceConnection = RDKShell::getThunderControllerClient(serviceCallsign);
              JsonObject request, result;
-             uint32_t status = systemServiceConnection->Invoke(RDKSHELL_THUNDER_TIMEOUT, "getWakeupReason", request, result);
+             uint32_t status = systemServiceConnection->Invoke<JsonObject, JsonObject>(RDKSHELL_THUNDER_TIMEOUT, "getWakeupReason", request, result);
              if (Core::ERROR_NONE == status && result.HasLabel("wakeupReason"))
              {
                 std::string wakeupreason = result["wakeupReason"].String();
                 if(wakeupreason.compare("WAKEUP_REASON_IR") == 0)
                 {
                      JsonObject req, res;
-                     uint32_t status = systemServiceConnection->Invoke(RDKSHELL_THUNDER_TIMEOUT, "getLastWakeupKeyCode", req, res);
+                     uint32_t status = systemServiceConnection->Invoke<JsonObject, JsonObject>(RDKSHELL_THUNDER_TIMEOUT, "getLastWakeupKeyCode", req, res);
                      if (Core::ERROR_NONE == status && res.HasLabel("wakeupKeyCode"))
                      {
                          unsigned int key = res["wakeupKeyCode"].Number();
@@ -5320,7 +5320,7 @@ namespace WPEFramework {
 				JsonObject req, res, stat;
 				req.Set("netType",1);
 
-				uint32_t status = remoteControlConnection->Invoke(RDKSHELL_THUNDER_TIMEOUT, "getNetStatus", req, res);
+				uint32_t status = remoteControlConnection->Invoke<JsonObject, JsonObject>(RDKSHELL_THUNDER_TIMEOUT, "getNetStatus", req, res);
 				if (Core::ERROR_NONE == status && res.HasLabel("status"))
 				{
 					stat = res["status"].Object();

--- a/RemoteActionMapping/RamHelper.cpp
+++ b/RemoteActionMapping/RamHelper.cpp
@@ -1397,7 +1397,8 @@ namespace WPEFramework {
                     if (tvFiveDigitCode > 0)
                     {
                         memset((void*)codestr, 0, sizeof(codestr));
-                        snprintf(codestr, 6, "%05u", tvFiveDigitCode);
+                        volatile int codestr_sz = sizeof(codestr);
+                        snprintf(codestr, codestr_sz, "%05u", tvFiveDigitCode);
                         memcpy((void*)&ribRequest.data[1], (const void*)codestr, 6);
                         flags |= XRC_RIB_TARGET_STATUS_FLAGS_TV_CODE_PRESENT_BIT;
                         // Clear the Not Programmed and/or IRRF Database bits, if they were set.
@@ -1409,7 +1410,8 @@ namespace WPEFramework {
                     if (avrFiveDigitCode > 0)
                     {
                         memset((void*)codestr, 0, sizeof(codestr));
-                        snprintf(codestr, 6, "%05u", avrFiveDigitCode);
+                        volatile int codestr_sz = sizeof(codestr);
+                        snprintf(codestr, codestr_sz, "%05u", avrFiveDigitCode);
                         memcpy((void*)&ribRequest.data[7], (const void*)codestr, 6);
                         flags |= XRC_RIB_TARGET_STATUS_FLAGS_AVR_CODE_PRESENT_BIT;
                         // Clear the Not Programmed and/or IRRF Database bits, if they were set.

--- a/RemoteActionMapping/test/ramTestClient.cpp
+++ b/RemoteActionMapping/test/ramTestClient.cpp
@@ -543,7 +543,7 @@ int main(int argc, char** argv)
     std::cout << "Using callsign: " << SYSSRV_CALLSIGN << std::endl;
 
     if (NULL == remoteObject) {
-        remoteObject = new JSONRPC::Client(_T(SYSSRV_CALLSIGN), _T(""), false, sToken);
+        remoteObject = new JSONRPC::LinkType<Core::JSON::IElement>(_T(SYSSRV_CALLSIGN), _T(""), false, sToken);
         if (NULL == remoteObject) {
             std::cout << "JSONRPC::Client initialization failed" << std::endl;
 
@@ -557,7 +557,7 @@ int main(int argc, char** argv)
                 JsonObject params;
                 params["callsign"] = SYSSRV_CALLSIGN;
                 JsonObject result;
-                ret = controllerClient.Invoke(2000, "activate", params, result);
+                ret = controllerClient.Invoke<JsonObject, JsonObject>(2000, "activate", params, result);
                 result.ToString(strres);
                 std::cout<<"\nstartup result : "<< strres <<"\n";
             }

--- a/Warehouse/CMakeLists.txt
+++ b/Warehouse/CMakeLists.txt
@@ -31,6 +31,7 @@ set_target_properties(${MODULE_NAME} PROPERTIES
         CXX_STANDARD_REQUIRED YES)
 
 target_compile_definitions(${MODULE_NAME} PRIVATE MODULE_NAME=Plugin_${PLUGIN_NAME})
+target_compile_options(${MODULE_NAME} PRIVATE -Wno-error=attribute-warning)
 
 find_package(DS)
 if (DS_FOUND)


### PR DESCRIPTION
- Suppressed warnings "deprecated" for HdmiCec, HdmiCecSink: They use "recipe-sysroot/usr/include/ccec/include/ccec/Driver.hpp" header file which gives error as "error: dynamic exception specifications are deprecated in C++11" fir functions like "virtual void  open(void) throw(InvalidStateException, IOException) = 0;"

- Suppressed warnings "attribute-warning" for Warehouse: It uses system(). Since this rdkservices is open source, it cannot be replaced with v_secure_system().