### PR TITLE
DELIA-57833 - Fix Warnings in RDKServices and enable warnings as error

### DIFF
--- a/Warehouse/CMakeLists.txt
+++ b/Warehouse/CMakeLists.txt
@@ -31,7 +31,6 @@ set_target_properties(${MODULE_NAME} PROPERTIES
         CXX_STANDARD_REQUIRED YES)
 
 target_compile_definitions(${MODULE_NAME} PRIVATE MODULE_NAME=Plugin_${PLUGIN_NAME})
-target_compile_options(${MODULE_NAME} PRIVATE -Wno-error=attribute-warning)
 
 find_package(DS)
 if (DS_FOUND)


### PR DESCRIPTION
Removed -Wno-error=attribute-warning from Warehous/CMakeLists.txt,as this is causing problems for PACEXID, Ciscoxid, XG1V3 builds.

Signed-off-by: svemur170 <srikanth_vemuri@comcast.com>