### PR TITLE
RDK-35406 : XCAST unregisterApplications API

### DIFF
--- a/XCast/RtXcastConnector.cpp
+++ b/XCast/RtXcastConnector.cpp
@@ -31,6 +31,7 @@ using namespace WPEFramework;
 #define LOCATE_CAST_FINAL_TIMEOUT_IN_MILLIS  60000  //60 seconds
 #define EVENT_LOOP_ITERATION_IN_100MS     100000
 
+
 static rtObjectRef xdialCastObj = NULL;
 RtXcastConnector * RtXcastConnector::_instance = nullptr;
 
@@ -258,7 +259,6 @@ bool RtXcastConnector::initialize()
     rtError err;
     rtRemoteEnvironment* env = rtEnvironmentGetGlobal();
     err = rtRemoteInit(env);
-    
     if(err != RT_OK){
         LOGINFO("Xcastservice: rtRemoteInit failed : Reason %s", rtStrError(err));
     }
@@ -334,53 +334,6 @@ void RtXcastConnector::updateFriendlyName(string friendlyname)
         LOGINFO(" xdialCastObj is NULL ");
 }
 
-void RtXcastConnector::clearAppLaunchParamList (){
-   for (RegAppLaunchParams regAppLaunchParam : m_appLaunchParamList) {
-       if (NULL != regAppLaunchParam.appName) {
-           free (regAppLaunchParam.appName);
-           regAppLaunchParam.appName = NULL;
-       }
-       if (NULL != regAppLaunchParam.query) {
-           free (regAppLaunchParam.query);
-           regAppLaunchParam.query = NULL;
-       }
-       if (NULL != regAppLaunchParam.payload) {
-           free (regAppLaunchParam.payload);
-           regAppLaunchParam.payload = NULL;
-       }
-    }
-    m_appLaunchParamList.clear();
-}
-
-bool RtXcastConnector::getEntryFromAppLaunchParamList (const char* appName, RegAppLaunchParams* reqParam){
-    bool isEntryFound = false;
-    for (RegAppLaunchParams regAppLaunchParam : m_appLaunchParamList) {
-        if (0 == strcmp (regAppLaunchParam.appName, appName)) {
-            isEntryFound = true;
-            int iNameLen = strlen (regAppLaunchParam.appName);
-            reqParam->appName = (char*) malloc (iNameLen+1);
-            memset (reqParam->appName, '\0', iNameLen+1);
-            strcpy (reqParam->appName, regAppLaunchParam.appName);
-
-            if (regAppLaunchParam.query) {
-                int iQueryLen = strlen (regAppLaunchParam.query);
-                reqParam->query = (char*) malloc (iQueryLen+1);
-                memset (reqParam->query, '\0', iQueryLen+1);
-                strcpy (reqParam->query, regAppLaunchParam.query);
-            }
-
-            if (regAppLaunchParam.payload) {
-                int iPayLoad = strlen (regAppLaunchParam.payload);
-                reqParam->payload = (char*) malloc (iPayLoad+1);
-                memset (reqParam->payload, '\0', iPayLoad+1);
-                strcpy (reqParam->payload, regAppLaunchParam.payload);
-            }
-            break;
-        }
-    }
-    return isEntryFound;
-}
-
 string RtXcastConnector::getProtocolVersion(void)
 {
     LOGINFO("XcastService::getProtocolVersion ");
@@ -398,199 +351,47 @@ string RtXcastConnector::getProtocolVersion(void)
     return strVersion.cString();
 }
 
-void RtXcastConnector::registerApplications(string strApps)
+void RtXcastConnector::registerApplications(std::vector<DynamicAppConfig*>& appConfigList)
 {
     LOGINFO("XcastService::registerApplications");
 
-    cJSON *itrApp = NULL;
+    rtArrayObject *appReqList = new rtArrayObject;
+    for (DynamicAppConfig* pDynamicAppConfig : appConfigList) {
+        //populate the rtParam here
+        rtObjectRef appReq = new rtMapObject;
 
-    cJSON *jNames = NULL;
-    cJSON *itrName = NULL;
+        rtArrayObject *appNameList = new rtArrayObject;
+        appNameList->pushBack (pDynamicAppConfig->appName);
+        appReq.set ("Names", rtValue(appNameList));
 
-    cJSON *jPrefixes = NULL;
-    cJSON *itrPrefix = NULL;
-
-    cJSON *jCors = NULL;
-    cJSON *itrCor = NULL;
-
-    cJSON *jProperties = NULL;
-    cJSON *jAllowStop = NULL;
-
-    cJSON *jLaunchParam = NULL;
-    cJSON *jQuery = NULL;
-    cJSON *jPayload = NULL;
-    if (!strApps.empty()) {
-        cJSON *applications = cJSON_Parse(strApps.c_str());
-        if (!cJSON_IsArray(applications)) {
-            LOGINFO ("applications array passed: %s", strApps.c_str());
-            LOGINFO ("\nInvalid applications array exititng\n");
-            cJSON_Delete(applications);
-            return;
+        if ('\0' != pDynamicAppConfig->prefixes[0]) {
+            rtArrayObject *appPrefixes = new rtArrayObject;
+            appPrefixes->pushBack (pDynamicAppConfig->prefixes);
+            appReq.set ("prefixes", rtValue(appPrefixes));
         }
 
-        /* iterate over ints */
-        LOGINFO("Applications:\n");
-        int iIndex = 0;
-        rtArrayObject *appReqList = new rtArrayObject;
-
-        /*Clear all existing launch param*/
-        clearAppLaunchParamList ();
-
-        cJSON_ArrayForEach(itrApp, applications) {
-            LOGINFO("Application: %d \n", iIndex);
-            if (!cJSON_IsObject(itrApp)) {
-                LOGINFO ("\nInvalid appliaction format at index. Skipping%d\n", iIndex);
-                continue;
-            }
-            rtObjectRef appReq = new rtMapObject;
-            jNames = cJSON_GetObjectItem(itrApp, "names");
-            if (!cJSON_IsArray(jNames)) {
-                LOGINFO ("\nInvalid names format at application index %d. Skipping the application\n", iIndex);
-                continue;
-            }
-            else {
-                rtArrayObject *appNameList = new rtArrayObject;
-                cJSON_ArrayForEach(itrName, jNames) {
-                    if (!cJSON_IsString(itrName)) {
-                        LOGINFO ("\nInvalid name format at application index. Skipping%d\n", iIndex);
-                        continue;
-                    }
-                    LOGINFO("%s, ", itrName->valuestring);
-                    appNameList->pushBack (itrName->valuestring);
-                }
-                appReq.set ("Names", rtValue(appNameList));
-                LOGINFO("\n");
-            }
-
-            jPrefixes = cJSON_GetObjectItem(itrApp, "prefixes");
-            if (!cJSON_IsArray(jPrefixes)) {
-                LOGINFO ("\nInvalid prefixes format at application index %d\n", iIndex);
-            }
-            else {
-                rtArrayObject *appPrefixes = new rtArrayObject;
-                cJSON_ArrayForEach(itrPrefix, jPrefixes) {
-                    if (!cJSON_IsString(itrPrefix)) {
-                        LOGINFO ("\nInvalid prefix format at application index. Skipping%d\n", iIndex);
-                        continue;
-                    }
-                    LOGINFO("%s, ", itrPrefix->valuestring);
-                    appPrefixes->pushBack (itrPrefix->valuestring);
-                }
-                appReq.set ("prefixes", rtValue(appPrefixes));
-                LOGINFO("\n");
-            }
-
-            jCors = cJSON_GetObjectItem(itrApp, "cors");
-            if (!cJSON_IsArray(jCors)) {
-                LOGINFO ("\nInvalid cors format at application index %d. Skipping the application\n", iIndex);
-                continue;
-            }
-            else {
-                rtArrayObject *appCors = new rtArrayObject;
-                cJSON_ArrayForEach(itrCor, jCors) {
-                    if (!cJSON_IsString(itrCor)) {
-                        LOGINFO ("\nInvalid cor format at application index. Skipping%d\n", iIndex);
-                        continue;
-                    }
-                    LOGINFO("%s, ", itrCor->valuestring);
-                    appCors->pushBack (itrCor->valuestring);
-                }
-                appReq.set ("cors", rtValue(appCors));
-                LOGINFO("\n");
-            }
-
-            jProperties = cJSON_GetObjectItem(itrApp, "properties");
-            if (!cJSON_IsObject(jProperties)) {
-                LOGINFO ("\nInvalid property format at application index %d\n", iIndex);
-            }
-            else {
-                rtObjectRef appProp = new rtMapObject;
-                jAllowStop = cJSON_GetObjectItem(jProperties, "allowStop");
-                if (!cJSON_IsBool(jAllowStop)) {
-                    LOGINFO ("\nInvalid allowStop format at application index %d\n", iIndex);
-                }
-                else {
-                    LOGINFO("allowStop: %d", jAllowStop->valueint);
-                    appProp.set("allowStop",jAllowStop->valueint);
-                    LOGINFO("\n");
-                }
-                appReq.set ("properties", rtValue(appProp));
-            }
-
-            jLaunchParam = cJSON_GetObjectItem(itrApp, "launchParameters");
-            if (!cJSON_IsObject(jLaunchParam)) {
-                LOGINFO ("\nInvalid Launch param format at application index %d\n", iIndex);
-            }
-            else {
-                jQuery = cJSON_GetObjectItem(jLaunchParam, "query");
-                if (!cJSON_IsString(jQuery)) {
-                    LOGINFO ("\nInvalid query format at application index %d\n", iIndex);
-                }
-                else {
-                    LOGINFO("query: %s, ", jQuery->valuestring);
-                }
-                jPayload = cJSON_GetObjectItem(jLaunchParam, "payload");
-                if (!cJSON_IsString(jPayload)) {
-                    LOGINFO ("\nInvalid payload format at application index %d\n", iIndex);
-                }
-                else {
-                    LOGINFO("payload: %s", jPayload->valuestring);
-                    LOGINFO("\n");
-                }
-                //Set launchParameters in list for later usage
-                rtObjectRef appNames;
-                int err = appReq.get ("Names", appNames);
-                if(err == RT_OK) {
-                    for(int i = 0 ; i< 25; i ++) {
-                        rtString appName;
-                        err = appNames.get(i,appName);
-                        if(err == RT_OK) {
-                            RegAppLaunchParams reqAppLaunchParams;
-
-                            int iNameLen = strlen (appName.cString());
-                            reqAppLaunchParams.appName = (char*) malloc (iNameLen+1);
-                            memset (reqAppLaunchParams.appName, '\0', iNameLen+1);
-                            strcpy (reqAppLaunchParams.appName, appName.cString());
-                            LOGINFO("reqAppLaunchParams.appName:%s iNameLen:%d appName:%s", reqAppLaunchParams.appName, iNameLen, appName.cString());
-
-                            if (cJSON_IsString(jQuery)) {
-                                int iQueryLen = strlen (jQuery->valuestring);
-                                reqAppLaunchParams.query = (char*) malloc (iQueryLen+1);
-                                memset (reqAppLaunchParams.query, '\0', iQueryLen+1);
-                                strcpy (reqAppLaunchParams.query, jQuery->valuestring);
-                                LOGINFO("reqAppLaunchParams.query:%s iQueryLen:%d jQuery:%s", reqAppLaunchParams.query, iQueryLen, jQuery->valuestring);
-                            }
-
-                            if (cJSON_IsString(jPayload)) {
-                                int iPayLoadLen = strlen (jPayload->valuestring);
-                                reqAppLaunchParams.payload = (char*) malloc (iPayLoadLen+1);
-                                memset (reqAppLaunchParams.payload, '\0', iPayLoadLen+1);
-                                strcpy (reqAppLaunchParams.payload, jPayload->valuestring);
-                                LOGINFO("reqAppLaunchParams.payload:%s iPayLoadLen:%d jPayload:%s", reqAppLaunchParams.payload, iPayLoadLen, jPayload->valuestring);
-                            }
-                            m_appLaunchParamList.push_back (reqAppLaunchParams);
-                        }
-                    }
-                }
-            }
-            iIndex++;
-            appReqList->pushBack(rtValue(appReq));
+        if ('\0' != pDynamicAppConfig->cors[0]) {
+            rtArrayObject *appCors = new rtArrayObject;
+            appCors->pushBack (pDynamicAppConfig->cors);
+            appReq.set ("cors", rtValue(appCors));
         }
-        LOGINFO("\n");
 
-        cJSON_Delete(applications);
+        rtObjectRef appProp = new rtMapObject;
+        appProp.set("allowStop",pDynamicAppConfig->allowStop);
+        appReq.set ("properties", rtValue(appProp));
 
-        if(xdialCastObj != NULL)
-        {
-	        LOGINFO("%s:%d xdialCastObj Not NULL strApps:%s", __FUNCTION__, __LINE__, strApps.c_str());
-            int ret = xdialCastObj.send("onRegisterApplications", appReqList);
-            LOGINFO("XcastService send onRegisterApplications ret:%d",ret);
-        }
-        else
-            LOGINFO(" xdialCastObj is NULL ");
+        appReqList->pushBack(rtValue(appReq));
     }
-}
 
+    if(xdialCastObj != NULL)
+    {
+        LOGINFO("%s:%d xdialCastObj Not NULL", __FUNCTION__, __LINE__);
+        int ret = xdialCastObj.send("onRegisterApplications", appReqList);
+        LOGINFO("XcastService send onRegisterApplications ret:%d",ret);
+    }
+    else
+        LOGINFO(" xdialCastObj is NULL ");
+}
 
 RtXcastConnector * RtXcastConnector::getInstance()
 {

--- a/XCast/RtXcastConnector.h
+++ b/XCast/RtXcastConnector.h
@@ -26,13 +26,9 @@
 #include <rtObject.h>
 #include <rtError.h>
 #include "RtNotifier.h"
+#include "XCastCommon.h"
 using namespace std;
 
-typedef struct _RegAppLaunchParams {
-    char *appName = NULL;
-    char *query = NULL;
-    char *payload = NULL;
-}RegAppLaunchParams;
 
 /**
  * This is the connector class for interacting with xdial client using rtRemote.
@@ -42,8 +38,6 @@ protected:
     RtXcastConnector():m_runEventThread(true){
         }
 public:
-    std::list<RegAppLaunchParams> m_appLaunchParamList;
-
     virtual ~RtXcastConnector();
     /**
      * Initialize rtRemote communication with rtDial server
@@ -72,7 +66,7 @@ public:
      *@param friendlyname - friendlyname
      */
     void updateFriendlyName(string friendlyname);
-    void registerApplications (string strApps);
+    void registerApplications (std::vector<DynamicAppConfig*>& appConfigList);
     string  getProtocolVersion(void);
     /**
      *Request the single instance of this class
@@ -83,7 +77,6 @@ public:
      */
     int connectToRemoteService();
     bool IsDynamicAppListEnabled();
-    bool getEntryFromAppLaunchParamList (const char* appName, RegAppLaunchParams* reqParam);
     
     void setService(RtNotifier * service){
         m_observer = service;
@@ -98,9 +91,9 @@ private:
     mutex m_threadlock;
     // Boolean event thread exit condition
     bool m_runEventThread;
+    bool m_IsDefaultDynamicAppListEnabled;
     // Member function to handle RT messages.
     void processRtMessages();
-    void clearAppLaunchParamList ();
     bool IsAppEnabled(char* strAppName);
 
     // Class level contracts

--- a/XCast/XCast.cpp
+++ b/XCast/XCast.cpp
@@ -49,16 +49,13 @@ using namespace std;
 #define METHOD_GET_PROTOCOLVERSION "getProtocolVersion"
 
 #define METHOD_REG_APPLICATIONS "registerApplications"
+#define METHOD_UNREG_APPLICATIONS "unregisterApplications"
 
 #define LOCATE_CAST_FIRST_TIMEOUT_IN_MILLIS  5000  //5 seconds
 #define LOCATE_CAST_SECOND_TIMEOUT_IN_MILLIS 15000  //15 seconds
 #define LOCATE_CAST_THIRD_TIMEOUT_IN_MILLIS  30000  //30 seconds
 #define LOCATE_CAST_FINAL_TIMEOUT_IN_MILLIS  60000  //60 seconds
 
-/*
- * The maximum DIAL payload accepted per the DIAL 1.6.1 specification.
- */
-#define DIAL_MAX_PAYLOAD (4096)
 
 /*
  * The maximum additionalDataUrl length
@@ -96,12 +93,11 @@ bool XCast::m_xcastEnable= false;
 string XCast::m_friendlyName = "";
 bool XCast::m_standbyBehavior = false;
 bool XCast::m_enableStatus = false;
-string strDyAppConfig = "";
 
 IARM_Bus_PWRMgr_PowerState_t XCast::m_powerState = IARM_BUS_PWRMGR_POWERSTATE_STANDBY;
 
 XCast::XCast() : PluginHost::JSONRPC()
-, m_apiVersionNumber(1)
+, m_apiVersionNumber(1), m_isDynamicRegistrationsRequired(false)
 {
     InitializeIARM();
     XCast::checkRFCServiceStatus();
@@ -117,6 +113,7 @@ XCast::XCast() : PluginHost::JSONRPC()
         Register(METHOD_GET_FRIENDLYNAME, &XCast::getFriendlyName, this);
         Register(METHOD_SET_FRIENDLYNAME, &XCast::setFriendlyName, this);
         Register(METHOD_REG_APPLICATIONS, &XCast::registerApplications, this);
+        Register(METHOD_UNREG_APPLICATIONS, &XCast::unregisterApplications, this);
         Register(METHOD_GET_PROTOCOLVERSION, &XCast::getProtocolVersion, this);
         
         m_locateCastTimer.connect( bind( &XCast::onLocateCastTimer, this ));
@@ -356,9 +353,355 @@ uint32_t XCast::getProtocolVersion(const JsonObject& parameters, JsonObject& res
     returnResponse(true);
 }
 
+bool XCast::getEntryFromAppLaunchParamList (const char* appName, DynamicAppConfig& retAppConfig){
+    bool isEntryFound = false;
+    {lock_guard<mutex> lck(m_appConfigMutex);
+        for (DynamicAppConfig* regAppLaunchParam : m_appConfigCache) {
+            if (0 == strcmp (regAppLaunchParam->appName, appName)) {
+                isEntryFound = true;
+                strcpy (retAppConfig.appName, regAppLaunchParam->appName);
+
+                if (regAppLaunchParam->query) {
+                    strcpy (retAppConfig.query, regAppLaunchParam->query);
+                }
+
+                if (regAppLaunchParam->payload) {
+                    strcpy (retAppConfig.payload, regAppLaunchParam->payload);
+                }
+                break;
+            }
+        }
+    }
+    return isEntryFound;
+}
+
+void XCast::dumpDynamicAppConfigCache(string strListName, std::vector<DynamicAppConfig*> appConfigList) {
+    LOGINFO("appConfigList count: %d", appConfigList.size());
+    /*Check if existing cache need to be updated*/
+    std::vector<int> entriesTodelete;
+    LOGINFO ("=================Current dynamic %s is:===========================", strListName.c_str());
+    for (DynamicAppConfig* pDynamicAppConfig : appConfigList) {
+        LOGINFO ("Apps: appName:%s, prefixes:%s, cors:%s, allowStop:%d, query:%s, payload:%s",
+                  pDynamicAppConfig->appName,
+                  pDynamicAppConfig->prefixes,
+                  pDynamicAppConfig->cors,
+                  pDynamicAppConfig->allowStop,
+                  pDynamicAppConfig->query,
+                  pDynamicAppConfig->payload);
+    }
+    LOGINFO ("=================================================================");
+}
+
+bool XCast::deleteFromDynamicAppCache(vector<string>& appsToDelete) {
+    bool ret = true;
+    {lock_guard<mutex> lck(m_appConfigMutex);
+        /*Check if existing cache need to be updated*/
+        std::vector<int> entriesTodelete;
+        for (string appNameToDelete : appsToDelete) {
+            bool found = false;
+            int index = 0;
+            for (DynamicAppConfig* pDynamicAppConfigOld : m_appConfigCache) {
+                if (0 == strcmp(pDynamicAppConfigOld->appName, appNameToDelete.c_str())){
+                    entriesTodelete.push_back(index);
+                    found = true;
+                    break;
+                }
+                index ++;
+            }
+            if (!found) {
+                LOGINFO("%s not existing in the dynamic cache", appNameToDelete.c_str());
+            }
+        }
+        std::sort(entriesTodelete.begin(), entriesTodelete.end(), std::greater<int>());
+        for (int indexToDelete : entriesTodelete) {
+            LOGINFO("Going to delete the entry: %d from m_appConfigCache size: %d", indexToDelete, m_appConfigCache.size());
+            //Delete the old unwanted item here.
+            DynamicAppConfig* pDynamicAppConfigOld = m_appConfigCache[indexToDelete];
+            m_appConfigCache.erase (m_appConfigCache.begin()+indexToDelete);
+            free (pDynamicAppConfigOld); pDynamicAppConfigOld = NULL;
+        }
+        entriesTodelete.clear();
+
+    }
+    //Even if requested app names not there return true.
+    return ret;
+}
+
+bool XCast::deleteFromDynamicAppCache(string strAppNames)
+{
+    bool ret = false;
+    cJSON *itrName = NULL;
+    if (!strAppNames.empty()) {
+        cJSON *applications = cJSON_Parse(strAppNames.c_str());
+        if (!cJSON_IsArray(applications)) {
+            LOGINFO ("deleteFromDynamicAppCache::applications array passed: %s", strAppNames.c_str());
+            LOGINFO ("deleteFromDynamicAppCache::Invalid applications array exititng");
+            cJSON_Delete(applications);
+            return ret;
+        }
+        int iIndex = 0;
+        vector<string> appsToDelete;
+        cJSON_ArrayForEach(itrName, applications) {
+            if (!cJSON_IsString(itrName)) {
+                LOGINFO ("Invalid name format at application index. Skipping%d", iIndex);
+                continue;
+            }
+            LOGINFO("App name to delete: %s, size:%d", itrName->valuestring, strlen (itrName->valuestring));
+            appsToDelete.push_back(string(itrName->valuestring));
+            iIndex++;
+        }
+        //If empty list is passed, dynamic cache is cleared. This will clear static list also
+        //Net result will be not app will be able to launch.
+        if(!appsToDelete.size()){
+            LOGINFO ("Empty unregister list is passed clearing the dynamic cache");
+            {lock_guard<mutex> lck(m_appConfigMutex);
+                m_appConfigCache.clear();
+            }
+        } else {
+            //Remove specified appl list from dynamic app cache
+            ret = deleteFromDynamicAppCache (appsToDelete);
+            appsToDelete.clear();
+        }
+        cJSON_Delete(applications);
+    }
+    return ret;
+}
+
+void XCast::updateDynamicAppCache(string strApps)
+{
+    LOGINFO("XcastService::UpdateDynamicAppCache");
+
+    cJSON *itrApp = NULL;
+
+    cJSON *jNames = NULL;
+    cJSON *itrName = NULL;
+
+    cJSON *jPrefixes = NULL;
+    cJSON *itrPrefix = NULL;
+
+    cJSON *jCors = NULL;
+    cJSON *itrCor = NULL;
+
+    cJSON *jProperties = NULL;
+    cJSON *jAllowStop = NULL;
+
+    cJSON *jLaunchParam = NULL;
+    cJSON *jQuery = NULL;
+    cJSON *jPayload = NULL;
+
+    std::vector <DynamicAppConfig*> appConfigList;
+    if (!strApps.empty()) {
+        cJSON *applications = cJSON_Parse(strApps.c_str());
+        if (!cJSON_IsArray(applications)) {
+            LOGINFO ("applications array passed: %s", strApps.c_str());
+            LOGINFO ("Invalid applications array exititng");
+            cJSON_Delete(applications);
+            return;
+        }
+
+        /* iterate over ints */
+        LOGINFO("Applications:");
+        int iIndex = 0;
+
+        cJSON_ArrayForEach(itrApp, applications) {
+            std::vector <DynamicAppConfig*> appConfigListTemp;
+            LOGINFO("Application: %d", iIndex);
+            if (!cJSON_IsObject(itrApp)) {
+                LOGINFO ("Invalid appliaction format at index. Skipping%d", iIndex);
+                continue;
+            }
+            jNames = cJSON_GetObjectItem(itrApp, "names");
+            if (!cJSON_IsArray(jNames)) {
+                LOGINFO ("Invalid names format at application index %d. Skipping the application", iIndex);
+                continue;
+            }
+            else {
+                cJSON_ArrayForEach(itrName, jNames) {
+                    if (!cJSON_IsString(itrName)) {
+                        LOGINFO ("Invalid name format at application index. Skipping%d", iIndex);
+                        continue;
+                    }
+                    LOGINFO("%s, size:%d", itrName->valuestring, strlen (itrName->valuestring));
+                    DynamicAppConfig* pDynamicAppConfig = (DynamicAppConfig*) malloc (sizeof(DynamicAppConfig));
+                    memset ((void*)pDynamicAppConfig, '0', sizeof(DynamicAppConfig));
+                    memset (pDynamicAppConfig->appName, '\0', sizeof(pDynamicAppConfig->appName));
+                    strcpy (pDynamicAppConfig->appName, itrName->valuestring);
+                    memset (pDynamicAppConfig->prefixes, '\0', sizeof(pDynamicAppConfig->prefixes));
+                    memset (pDynamicAppConfig->cors, '\0', sizeof(pDynamicAppConfig->cors));
+                    memset (pDynamicAppConfig->query, '\0', sizeof(pDynamicAppConfig->query));
+                    memset (pDynamicAppConfig->payload, '\0', sizeof(pDynamicAppConfig->payload));
+                    appConfigListTemp.push_back (pDynamicAppConfig);
+                }
+                LOGINFO("");
+            }
+
+            jPrefixes = cJSON_GetObjectItem(itrApp, "prefixes");
+            if (!cJSON_IsArray(jPrefixes)) {
+                LOGINFO ("Invalid prefixes format at application index %d", iIndex);
+            }
+            else {
+                cJSON_ArrayForEach(itrPrefix, jPrefixes) {
+                    if (!cJSON_IsString(itrPrefix)) {
+                        LOGINFO ("Invalid prefix format at application index. Skipping%d", iIndex);
+                        continue;
+                    }
+                    LOGINFO("%s, size:%d", itrPrefix->valuestring, strlen (itrPrefix->valuestring));
+                    for (DynamicAppConfig* pDynamicAppConfig : appConfigListTemp) {
+                        strcpy (pDynamicAppConfig->prefixes, itrPrefix->valuestring);
+                    }
+                }
+                LOGINFO("");
+            }
+
+            jCors = cJSON_GetObjectItem(itrApp, "cors");
+            if (!cJSON_IsArray(jCors)) {
+                LOGINFO ("Invalid cors format at application index %d. Skipping the application", iIndex);
+                continue;
+            }
+            else {
+                cJSON_ArrayForEach(itrCor, jCors) {
+                    if (!cJSON_IsString(itrCor)) {
+                        LOGINFO ("Invalid cor format at application index. Skipping%d", iIndex);
+                        continue;
+                    }
+                    LOGINFO("%s, size:%d", itrCor->valuestring, strlen (itrCor->valuestring));
+                    for (DynamicAppConfig* pDynamicAppConfig : appConfigListTemp) {
+                        strcpy (pDynamicAppConfig->cors, itrCor->valuestring);
+                    }
+                }
+                LOGINFO("");
+            }
+
+            jProperties = cJSON_GetObjectItem(itrApp, "properties");
+            if (!cJSON_IsObject(jProperties)) {
+                LOGINFO ("Invalid property format at application index %d", iIndex);
+            }
+            else {
+                jAllowStop = cJSON_GetObjectItem(jProperties, "allowStop");
+                if (!cJSON_IsBool(jAllowStop)) {
+                    LOGINFO ("Invalid allowStop format at application index %d", iIndex);
+                }
+                else {
+                    LOGINFO("allowStop: %d", jAllowStop->valueint);
+                    for (DynamicAppConfig* pDynamicAppConfig : appConfigListTemp) {
+                        pDynamicAppConfig->allowStop = jAllowStop->valueint;
+                    }
+                    LOGINFO("");
+                }
+            }
+
+            jLaunchParam = cJSON_GetObjectItem(itrApp, "launchParameters");
+            if (!cJSON_IsObject(jLaunchParam)) {
+                LOGINFO ("Invalid Launch param format at application index %d", iIndex);
+            }
+            else {
+                jQuery = cJSON_GetObjectItem(jLaunchParam, "query");
+                if (!cJSON_IsString(jQuery)) {
+                    LOGINFO ("Invalid query format at application index %d", iIndex);
+                }
+                else {
+                    LOGINFO("query: %s, size:%d", jQuery->valuestring, strlen (jQuery->valuestring));
+                }
+                jPayload = cJSON_GetObjectItem(jLaunchParam, "payload");
+                if (!cJSON_IsString(jPayload)) {
+                    LOGINFO ("Invalid payload format at application index %d", iIndex);
+                }
+                else {
+                    LOGINFO("payload: %s, size:%d", jPayload->valuestring, strlen (jPayload->valuestring));
+                    LOGINFO("");
+                }
+                //Set launchParameters in list for later usage
+                for (DynamicAppConfig* pDynamicAppConfig : appConfigListTemp) {
+                    if (cJSON_IsString(jQuery)) {
+                        strcpy (pDynamicAppConfig->query, jQuery->valuestring);
+                    }
+                    if (cJSON_IsString(jPayload)) {
+                        strcpy (pDynamicAppConfig->payload, jPayload->valuestring);
+                    }
+                }
+
+            }
+            for (DynamicAppConfig* pDynamicAppConfig : appConfigListTemp) {
+                appConfigList.push_back(pDynamicAppConfig);
+            }
+            appConfigListTemp.clear();
+            iIndex++;
+        }
+        LOGINFO("");
+        dumpDynamicAppConfigCache(string("appConfigList"), appConfigList);
+        vector<string> appsToDelete;
+        for (DynamicAppConfig* pDynamicAppConfig : appConfigList) {
+            appsToDelete.push_back(string(pDynamicAppConfig->appName));
+        }
+        deleteFromDynamicAppCache (appsToDelete);
+
+        LOGINFO("appConfigList count: %d", appConfigList.size());
+        //Update the new entries here.
+        {lock_guard<mutex> lck(m_appConfigMutex);
+            for (DynamicAppConfig* pDynamicAppConfig : appConfigList) {
+                m_appConfigCache.push_back(pDynamicAppConfig);
+            }
+            LOGINFO("m_appConfigCache count: %d", m_appConfigCache.size());
+        }
+        //Clear the tempopary list here
+        appsToDelete.clear();
+        appConfigList.clear();
+        cJSON_Delete(applications);
+    }
+    dumpDynamicAppConfigCache(string("m_appConfigCache"), m_appConfigCache);
+    return;
+}
+
 uint32_t XCast::registerApplications(const JsonObject& parameters, JsonObject& response)
 {
     LOGINFO("XcastService::registerApplications \n ");
+    bool hasAppReq = parameters.HasLabel("applications");
+    if (hasAppReq) {
+       LOGINFO ("\nInput string is:%s\n", parameters["applications"].String().c_str());
+
+       if(_rtConnector)
+       {
+           LOGINFO("%s:%d _rtConnector Not NULL", __FUNCTION__, __LINE__);
+           if(_rtConnector->IsDynamicAppListEnabled()) {
+               /*Disable cast service before registering Applications*/
+               _rtConnector->enableCastService(m_friendlyName,false);
+
+               m_isDynamicRegistrationsRequired = true;
+               //Register dynamic application list to app cache map
+               updateDynamicAppCache(parameters["applications"].String());
+               std::vector<DynamicAppConfig*> appConfigList;
+               {lock_guard<mutex> lck(m_appConfigMutex);
+                   appConfigList = m_appConfigCache;
+               }
+               dumpDynamicAppConfigCache(string("m_appConfigCache"), appConfigList);
+               //Pass the dynamic cache to xdial process
+               _rtConnector->registerApplications (m_appConfigCache);
+
+               /*Reenabling cast service after registering Applications*/
+               if (m_xcastEnable && ( (m_standbyBehavior == true) || ((m_standbyBehavior == false)&&(m_powerState == IARM_BUS_PWRMGR_POWERSTATE_ON)) ) ) {
+                   LOGINFO("Enable CastService  m_xcastEnable: %d m_standbyBehavior: %d m_powerState:%d", m_xcastEnable, m_standbyBehavior, m_powerState);
+                   _rtConnector->enableCastService(m_friendlyName,true);
+               }
+               else {
+                   LOGINFO("CastService not enabled m_xcastEnable: %d m_standbyBehavior: %d m_powerState:%d", m_xcastEnable, m_standbyBehavior, m_powerState);
+               }
+               returnResponse(true);
+           }
+           else {
+               returnResponse(false);
+           }
+       }
+       else
+           returnResponse(false);
+    }
+    else {
+        returnResponse(false);
+    }
+}
+
+uint32_t XCast::unregisterApplications(const JsonObject& parameters, JsonObject& response)
+{
+    LOGINFO("XcastService::unregisterApplications \n ");
     bool hasAppReq = parameters.HasLabel("applications");
     if (hasAppReq) {
        LOGINFO ("\nInput string is:%s\n", parameters["applications"].String().c_str());
@@ -369,11 +712,17 @@ uint32_t XCast::registerApplications(const JsonObject& parameters, JsonObject& r
            if(_rtConnector->IsDynamicAppListEnabled()) {
                /*Disable cast service before registering Applications*/
                _rtConnector->enableCastService(m_friendlyName,false);
+               m_isDynamicRegistrationsRequired = true;
+               //Remove app names from cache map
+               bool ret = deleteFromDynamicAppCache (parameters["applications"].String());
+               std::vector<DynamicAppConfig*> appConfigList;
+               {lock_guard<mutex> lck(m_appConfigMutex);
+                   appConfigList = m_appConfigCache;
+               }
+               dumpDynamicAppConfigCache(string("m_appConfigCache"), appConfigList);
+               //Pass the dynamic cache to xdial process
+               _rtConnector->registerApplications (appConfigList);
 
-               _rtConnector->registerApplications (parameters["applications"].String());
-
-               /*Save the config*/
-               strDyAppConfig.assign(parameters["applications"].String());
                /*Reenabling cast service after registering Applications*/
                if (m_xcastEnable && ( (m_standbyBehavior == true) || ((m_standbyBehavior == false)&&(m_powerState == IARM_BUS_PWRMGR_POWERSTATE_ON)) ) ) {
                    LOGINFO("Enable CastService  m_xcastEnable: %d m_standbyBehavior: %d m_powerState:%d", m_xcastEnable, m_standbyBehavior, m_powerState);
@@ -382,7 +731,7 @@ uint32_t XCast::registerApplications(const JsonObject& parameters, JsonObject& r
                else {
                    LOGINFO("CastService not enabled m_xcastEnable: %d m_standbyBehavior: %d m_powerState:%d", m_xcastEnable, m_standbyBehavior, m_powerState);
                }
-               returnResponse(true);
+               returnResponse(ret);
            }
            else {
                returnResponse(false);
@@ -428,17 +777,23 @@ void XCast::onLocateCastTimer()
     locateCastObjectRetryCount = 0;
     m_locateCastTimer.stop();
 
-    if ((!strDyAppConfig.empty()) && (NULL != _rtConnector)) {
-        if (_rtConnector->IsDynamicAppListEnabled()) {
-            LOGINFO("XCast::onLocateCastTimer : strDyAppConfig: %s", strDyAppConfig.c_str());
-            _rtConnector->registerApplications (strDyAppConfig);
+    if (NULL != _rtConnector) {
+        if (_rtConnector->IsDynamicAppListEnabled() && m_isDynamicRegistrationsRequired) {
+
+            std::vector<DynamicAppConfig*> appConfigList;
+            {lock_guard<mutex> lck(m_appConfigMutex);
+                appConfigList = m_appConfigCache;
+            }
+            dumpDynamicAppConfigCache(string("m_appConfigCache"), appConfigList);
+            LOGINFO("XCast::onLocateCastTimer : calling registerApplications");
+            _rtConnector->registerApplications (appConfigList);
         }
         else {
             LOGINFO("XCast::onLocateCastTimer : DynamicAppList not enabled");
         }
     }
     else {
-        LOGINFO("XCast::onLocateCastTimer : strDyAppConfig: %s _rtConnector: %p", strDyAppConfig.c_str(), _rtConnector);
+        LOGINFO("XCast::onLocateCastTimer :_rtConnector: %p",  _rtConnector);
     }
     if (m_xcastEnable && ( (m_standbyBehavior == true) || ((m_standbyBehavior == false)&&(m_powerState == IARM_BUS_PWRMGR_POWERSTATE_ON)) ) ) {
         _rtConnector->enableCastService(m_friendlyName,true);
@@ -553,26 +908,26 @@ void XCast::onXcastApplicationLaunchRequestWithLaunchParam (string appName,
     char url[DIAL_MAX_PAYLOAD+DIAL_MAX_ADDITIONALURL+100] = {0,};
 
     if(_rtConnector) {
-        RegAppLaunchParams reqParam;
-        _rtConnector->getEntryFromAppLaunchParamList (appName.c_str(), &reqParam);
+        DynamicAppConfig appConfig{};
+        getEntryFromAppLaunchParamList (appName.c_str(), appConfig);
 
         /*Replacing with App requested payload and query*/
-        if (reqParam.query && reqParam.payload) {
+        if (('\0' != appConfig.query[0]) && ('\0' != appConfig.payload[0])) {
             getUrlFromAppLaunchParams (appName.c_str(),
-                               reqParam.payload,
-                               reqParam.query,
+                               appConfig.payload,
+                               appConfig.query,
                                strAddDataUrl.c_str(), url);
         }
-        else if(reqParam.payload){
+        else if(('\0' != appConfig.payload[0])){
             getUrlFromAppLaunchParams (appName.c_str(),
-                               reqParam.payload,
+                               appConfig.payload,
                                strQuery.c_str(),
                                strAddDataUrl.c_str(), url);
         }
-        else if(reqParam.query) {
+        else if(('\0' != appConfig.query[0])) {
             getUrlFromAppLaunchParams (appName.c_str(),
                                strPayLoad.c_str(),
-                               reqParam.query,
+                               appConfig.query,
                                strAddDataUrl.c_str(), url);
         }
         else {

--- a/XCast/XCast.h
+++ b/XCast/XCast.h
@@ -19,12 +19,18 @@
 
 #pragma once
 
+#include <iostream>
+#include <mutex>
+
 #include "tptimer.h"
 #include "Module.h"
 #include "RtNotifier.h"
 #include "libIBus.h"
 #include "libIBusDaemon.h"
 #include "pwrMgr.h"
+#include "XCastCommon.h"
+
+using namespace std;
 
 namespace WPEFramework {
 
@@ -58,6 +64,7 @@ private:
     uint32_t setFriendlyName(const JsonObject& parameters, JsonObject& response);
     uint32_t getFriendlyName(const JsonObject& parameters, JsonObject& response);
     uint32_t registerApplications(const JsonObject& parameters, JsonObject& response);
+    uint32_t unregisterApplications(const JsonObject& parameters, JsonObject& response);
     uint32_t getProtocolVersion(const JsonObject& parameters, JsonObject& response);
     //End methods
     
@@ -93,6 +100,9 @@ private:
     static bool m_xcastEnable;
     static IARM_Bus_PWRMgr_PowerState_t m_powerState;
     uint32_t m_apiVersionNumber;
+    bool m_isDynamicRegistrationsRequired;
+    mutex m_appConfigMutex;
+    std::vector<DynamicAppConfig*> m_appConfigCache;
     static string m_friendlyName;
     static bool m_standbyBehavior;
     static bool m_enableStatus;
@@ -103,6 +113,12 @@ private:
     //Internal methods
     void onLocateCastTimer();
     void getUrlFromAppLaunchParams (const char *app_name, const char *payload, const char *query_string, const char *additional_data_url, char *url);
+    bool getEntryFromAppLaunchParamList (const char* appName, DynamicAppConfig& retAppConfig);
+    void dumpDynamicAppConfigCache(string strListName, std::vector<DynamicAppConfig*> appConfigList);
+    bool deleteFromDynamicAppCache(string strAppNames);
+    bool deleteFromDynamicAppCache(vector<string>& appsToDelete);
+    void updateDynamicAppCache(string strApps);
+
     /**
      * Check whether the xdial service is allowed in this device.
      */

--- a/XCast/XCastCommon.h
+++ b/XCast/XCastCommon.h
@@ -1,0 +1,49 @@
+/**
+ * If not stated otherwise in this file or this component's LICENSE
+ * file the following copyright and licenses apply:
+ *
+ * Copyright 2020 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+#include <iostream>
+#include <cstring>
+
+#ifndef __XCAST_COMMON_H__
+#define __XCAST_COMMON_H__
+/*
+ * The maximum DIAL payload accepted per the DIAL 1.6.1 specification.
+ */
+#define DIAL_MAX_PAYLOAD (4096)
+
+
+typedef struct _DynamicAppConfig {
+    char appName[64];
+    char prefixes[128];
+    char cors[128];
+    int  allowStop = 0; //Default allowStop value is false
+    char query[2048];
+    char payload[DIAL_MAX_PAYLOAD+1];
+
+    public:
+       _DynamicAppConfig(){
+           memset (appName, '\0', sizeof(appName));
+           memset (prefixes, '\0', sizeof(prefixes));
+           memset (cors, '\0', sizeof(cors));
+           memset (query, '\0', sizeof(query));
+           memset (payload, '\0', sizeof(payload));
+       }
+}DynamicAppConfig;
+
+#endif

--- a/docs/api/XCastPlugin.md
+++ b/docs/api/XCastPlugin.md
@@ -54,6 +54,7 @@ XCast interface methods:
 | [getStandbyBehavior](#getStandbyBehavior) | Gets the expected xcast behavior in standby mode |
 | [onApplicationStateChanged](#onApplicationStateChanged) | Provides notification whenever an application changes state due to user activity, an internal error, or other reasons |
 | [registerApplications](#registerApplications) | Registers an application |
+| [unregisterApplications](#unregisterApplications) | Unregisters an application |
 | [setEnabled](#setEnabled) | Enables or disables xcast |
 | [setFriendlyName](#setFriendlyName) | Sets the friendly name of device |
 | [setStandbyBehavior](#setStandbyBehavior) | Sets the expected xcast behavior in standby mode |
@@ -358,7 +359,7 @@ The following table provides a client error mapping example:
 <a name="registerApplications"></a>
 ## *registerApplications*
 
-Registers an application. This allows to whitelist the apps which support dial service. To dynamically update the app list, same API should be called with the updated list.
+This API registers applications passed with XCast service. This allows to whitelist the apps which support dial service. Calling this api again, with a new set of APP names, will append those APP names to existing whitelist. Passing an existing whitelisted app, with a modified parameter value, will update the curresponding field in the whitelist.
   
 ### Events 
 
@@ -378,8 +379,8 @@ Registers an application. This allows to whitelist the apps which support dial s
 | result | object |  |
 | result.success | boolean | Whether the request succeeded |
 
-### Example
-
+### Example 1
+Following call will register NetflixApp to the gdisl dynamic list.
 #### Request
 
 ```json
@@ -388,7 +389,122 @@ Registers an application. This allows to whitelist the apps which support dial s
     "id": 42,
     "method": "org.rdk.Xcast.1.registerApplications",
     "params": {
-        "applications": "NetflixApp"
+        "applications": {
+            "names":["Netflix"],
+            "cors":[".netflix.com"]
+         }
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "success": true
+    }
+}
+```
+### Example 2
+Following call will update the existing NetflixApp properties to the gdisl dynamic list and insert new applications YouTube, YouTubeKids and YouTubeTV.
+#### Request
+
+```json
+{
+    "jsonrpc":"2.0",
+    "id":"3",
+    "method": "org.rdk.Xcast.1.registerApplications",
+    "params":{
+        "applications":[{
+               "names":["Netflix"],
+               "cors":[".netflix.com"],
+               "properties":{"allowStop" :true}
+           }, 
+           {
+               "names":["YouTube", "YouTubeKids", "YouTubeTV"],
+               "cors":[".youtube.com"],
+               "properties":{"allowStop" :true}
+           }]
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "success": true
+    }
+}
+```
+
+<a name="unregisterApplications"></a>
+## *unregisterApplications*
+
+This API will remove the specified APP names from the existing whitelist. This API call will simply ignore the request and return success, if specified apps are not present in the whitelist. Invoking this API, with the empty list, will clear the whitelist and wont allow any of the applications to cast.
+  
+### Events 
+
+ No Events.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.applications | string | The application name to register |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.success | boolean | Whether the request succeeded |
+
+### Example 1
+Following call will remove NetflixApp and YouTubeKids from gdial whitelistied applications.
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.Xcast.1.unregisterApplications",
+    "params": {
+        "applications": ["NetflixApp", "YouTubeKids"]
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "success": true
+    }
+}
+```
+
+### Example 1
+Following call will clear the gdial application whitelist. Once this call is invoked, it wont be able to cast any of the aaplications using XCast.
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.Xcast.1.unregisterApplications",
+    "params": {
+        "applications": []
     }
 }
 ```


### PR DESCRIPTION
Reason for change:
XCAST unregisterApplications API
Test Procedure: None
Risks: Low

Change-Id: Ifa45888f90c2490e9df9ba6230b90e6d2437a2db Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>