### PR TITLE
RDK-38099:Update_Examples_to_remove_version

### DIFF
--- a/Tools/json_generator/generator_json.py
+++ b/Tools/json_generator/generator_json.py
@@ -2149,12 +2149,12 @@ def CreateDocument(schema, path):
             MdHeader("Example", 3)
 
             if is_notification:
-                method = "client.events.1." + method
+                method = "client.events." + method
             elif is_property:
-                method = "%s.1.%s%s" % (classname, method, ("@" + props["index"]["example"])
+                method = "%s.%s%s" % (classname, method, ("@" + props["index"]["example"])
                                         if "index" in props and "example" in props["index"] else "")
             else:
-                method = "%s.1.%s" % (classname, method)
+                method = "%s.%s" % (classname, method)
             if "id" in props and "example" in props["id"]:
                 method = props["id"]["example"] + "." + method
             parameters = props["params"] if "params" in props else None

--- a/docs/api/AVInputPlugin.md
+++ b/docs/api/AVInputPlugin.md
@@ -1,70 +1,32 @@
 <!-- Generated automatically, DO NOT EDIT! -->
-<a name="head.AVInput_Plugin"></a>
+<a name="AVInput_Plugin"></a>
 # AVInput Plugin
 
 **Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/AVInput/CHANGELOG.md)**
 
-**Status: :black_circle::black_circle::black_circle:**
-
-org.rdk.AVInput plugin for Thunder framework.
+A org.rdk.AVInput plugin for Thunder framework.
 
 ### Table of Contents
 
-- [Introduction](#head.Introduction)
-- [Description](#head.Description)
-- [Configuration](#head.Configuration)
-- [Methods](#head.Methods)
-- [Notifications](#head.Notifications)
+- [Abbreviation, Acronyms and Terms](#Abbreviation,_Acronyms_and_Terms)
+- [Description](#Description)
+- [Configuration](#Configuration)
+- [Methods](#Methods)
+- [Notifications](#Notifications)
 
-<a name="head.Introduction"></a>
-# Introduction
+<a name="Abbreviation,_Acronyms_and_Terms"></a>
+# Abbreviation, Acronyms and Terms
 
-<a name="head.Scope"></a>
-## Scope
+[[Refer to this link](userguide/aat.md)]
 
-This document describes purpose and functionality of the org.rdk.AVInput plugin. It includes detailed specification about its configuration, methods provided and notifications sent.
-
-<a name="head.Case_Sensitivity"></a>
-## Case Sensitivity
-
-All identifiers of the interfaces described in this document are case-sensitive. Thus, unless stated otherwise, all keywords, entities, properties, relations and actions should be treated as such.
-
-<a name="head.Acronyms,_Abbreviations_and_Terms"></a>
-## Acronyms, Abbreviations and Terms
-
-The table below provides and overview of acronyms used in this document and their definitions.
-
-| Acronym | Description |
-| :-------- | :-------- |
-| <a name="acronym.API">API</a> | Application Programming Interface |
-| <a name="acronym.HTTP">HTTP</a> | Hypertext Transfer Protocol |
-| <a name="acronym.JSON">JSON</a> | JavaScript Object Notation; a data interchange format |
-| <a name="acronym.JSON-RPC">JSON-RPC</a> | A remote procedure call protocol encoded in JSON |
-
-The table below provides and overview of terms and abbreviations used in this document and their definitions.
-
-| Term | Description |
-| :-------- | :-------- |
-| <a name="term.callsign">callsign</a> | The name given to an instance of a plugin. One plugin can be instantiated multiple times, but each instance the instance name, callsign, must be unique. |
-
-<a name="head.References"></a>
-## References
-
-| Ref ID | Description |
-| :-------- | :-------- |
-| <a name="ref.HTTP">[HTTP](http://www.w3.org/Protocols)</a> | HTTP specification |
-| <a name="ref.JSON-RPC">[JSON-RPC](https://www.jsonrpc.org/specification)</a> | JSON-RPC 2.0 specification |
-| <a name="ref.JSON">[JSON](http://www.json.org/)</a> | JSON specification |
-| <a name="ref.Thunder">[Thunder](https://github.com/WebPlatformForEmbedded/Thunder/blob/master/doc/WPE%20-%20API%20-%20WPEFramework.docx)</a> | Thunder API Reference |
-
-<a name="head.Description"></a>
+<a name="Description"></a>
 # Description
 
 The `AVInput` plugin allows you to control the Hdmi and Composite input source on a device.
 
-The plugin is designed to be loaded and executed within the Thunder framework. For more information about the framework refer to [[Thunder](#ref.Thunder)].
+The plugin is designed to be loaded and executed within the Thunder framework. For more information about the framework refer to [[Thunder](#Thunder)].
 
-<a name="head.Configuration"></a>
+<a name="Configuration"></a>
 # Configuration
 
 The table below lists configuration options of the plugin.
@@ -76,7 +38,7 @@ The table below lists configuration options of the plugin.
 | locator | string | Library name: *libWPEFrameworkAVInput.so* |
 | autostart | boolean | Determines if the plugin shall be started automatically along with the framework |
 
-<a name="head.Methods"></a>
+<a name="Methods"></a>
 # Methods
 
 The following methods are provided by the org.rdk.AVInput plugin:
@@ -85,25 +47,25 @@ AVInput interface methods:
 
 | Method | Description |
 | :-------- | :-------- |
-| [contentProtected](#method.contentProtected) | Returns `true` if the content coming in the HDMI input is protected; otherwise, it returns `false` |
-| [currentVideoMode](#method.currentVideoMode) | Returns a string encoding the video mode being supplied by the device currently attached to the HDMI input |
-| [numberOfInputs](#method.numberOfInputs) | Returns an integer that specifies the number of available inputs |
-| [getInputDevices](#method.getInputDevices) | Returns an array of available HDMI/Composite Input ports |
-| [getEdidVersion](#method.getEdidVersion) | Returns the EDID version |
-| [getSPD](#method.getSPD) | Returns the Source Data Product Descriptor (SPD) infoFrame packet information for the specified HDMI Input device |
-| [getRawSPD](#method.getRawSPD) | Returns the Source Data Product Descriptor (SPD) infoFrame packet information for the specified HDMI Input device as raw bits |
-| [readEDID](#method.readEDID) | Returns the current EDID value |
-| [startInput](#method.startInput) | Activates the specified HDMI/Composite Input port as the primary video source |
-| [stopInput](#method.stopInput) | Deactivates the HDMI/Composite Input port currently selected as the primary video source |
-| [setEdidVersion](#method.setEdidVersion) | Sets an HDMI EDID version |
-| [setVideoRectangle](#method.setVideoRectangle) | Sets an HDMI/Composite Input video window |
-| [writeEDID](#method.writeEDID) | Changes a current EDID value |
-| [getSupportedGameFeatures](#method.getSupportedGameFeatures) | Returns the list of supported game features |
-| [getGameFeatureStatus](#method.getGameFeatureStatus) | Returns the Game Feature Status |
+| [contentProtected](#contentProtected) | Returns `true` if the content coming in the HDMI input is protected; otherwise, it returns `false` |
+| [currentVideoMode](#currentVideoMode) | Returns a string encoding the video mode being supplied by the device currently attached to the HDMI input |
+| [numberOfInputs](#numberOfInputs) | Returns an integer that specifies the number of available inputs |
+| [getInputDevices](#getInputDevices) | Returns an array of available HDMI/Composite Input ports |
+| [getEdidVersion](#getEdidVersion) | Returns the EDID version |
+| [getSPD](#getSPD) | Returns the Source Data Product Descriptor (SPD) infoFrame packet information for the specified HDMI Input device |
+| [getRawSPD](#getRawSPD) | Returns the Source Data Product Descriptor (SPD) infoFrame packet information for the specified HDMI Input device as raw bits |
+| [readEDID](#readEDID) | Returns the current EDID value |
+| [startInput](#startInput) | Activates the specified HDMI/Composite Input port as the primary video source |
+| [stopInput](#stopInput) | Deactivates the HDMI/Composite Input port currently selected as the primary video source |
+| [setEdidVersion](#setEdidVersion) | Sets an HDMI EDID version |
+| [setVideoRectangle](#setVideoRectangle) | Sets an HDMI/Composite Input video window |
+| [writeEDID](#writeEDID) | Changes a current EDID value |
+| [getSupportedGameFeatures](#getSupportedGameFeatures) | Returns the list of supported game features |
+| [getGameFeatureStatus](#getGameFeatureStatus) | Returns the Game Feature Status |
 
 
-<a name="method.contentProtected"></a>
-## *contentProtected [<sup>method</sup>](#head.Methods)*
+<a name="contentProtected"></a>
+## *contentProtected*
 
 Returns `true` if the content coming in the HDMI input is protected; otherwise, it returns `false`. If the content is protected, then it is only presented if the component and composite outputs of the box are disabled.
 
@@ -129,7 +91,7 @@ Returns `true` if the content coming in the HDMI input is protected; otherwise, 
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.AVInput.1.contentProtected",
+    "method": "org.rdk.AVInput.contentProtected",
     "params": {}
 }
 ```
@@ -147,8 +109,8 @@ Returns `true` if the content coming in the HDMI input is protected; otherwise, 
 }
 ```
 
-<a name="method.currentVideoMode"></a>
-## *currentVideoMode [<sup>method</sup>](#head.Methods)*
+<a name="currentVideoMode"></a>
+## *currentVideoMode*
 
 Returns a string encoding the video mode being supplied by the device currently attached to the HDMI input. The format of the string is the same format used for the `resolutionName` parameter of the XRE `setResolution` messages. HDMI input is presentable if its resolution is less than or equal to the current Parker display resolution. 
  
@@ -179,7 +141,7 @@ Returns a string encoding the video mode being supplied by the device currently 
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.AVInput.1.currentVideoMode",
+    "method": "org.rdk.AVInput.currentVideoMode",
     "params": {}
 }
 ```
@@ -198,8 +160,8 @@ Returns a string encoding the video mode being supplied by the device currently 
 }
 ```
 
-<a name="method.numberOfInputs"></a>
-## *numberOfInputs [<sup>method</sup>](#head.Methods)*
+<a name="numberOfInputs"></a>
+## *numberOfInputs*
 
 Returns an integer that specifies the number of available inputs. For example, a value of `2` indicates that there are two available inputs that can be selected using `avin://input0` and `avin://input1`. 
  
@@ -230,7 +192,7 @@ Returns an integer that specifies the number of available inputs. For example, a
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.AVInput.1.numberOfInputs",
+    "method": "org.rdk.AVInput.numberOfInputs",
     "params": {}
 }
 ```
@@ -249,8 +211,8 @@ Returns an integer that specifies the number of available inputs. For example, a
 }
 ```
 
-<a name="method.getInputDevices"></a>
-## *getInputDevices [<sup>method</sup>](#head.Methods)*
+<a name="getInputDevices"></a>
+## *getInputDevices*
 
 Returns an array of available HDMI/Composite Input ports.
  
@@ -290,7 +252,7 @@ No Events.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.AVInput.1.getInputDevices",
+    "method": "org.rdk.AVInput.getInputDevices",
     "params": {
         "typeOfInput": "HDMI"
     }
@@ -315,8 +277,8 @@ No Events.
 }
 ```
 
-<a name="method.getEdidVersion"></a>
-## *getEdidVersion [<sup>method</sup>](#head.Methods)*
+<a name="getEdidVersion"></a>
+## *getEdidVersion*
 
 Returns the EDID version.
  
@@ -353,7 +315,7 @@ No Events.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.AVInput.1.getEdidVersion",
+    "method": "org.rdk.AVInput.getEdidVersion",
     "params": {
         "portId": 0
     }
@@ -372,8 +334,8 @@ No Events.
 }
 ```
 
-<a name="method.getSPD"></a>
-## *getSPD [<sup>method</sup>](#head.Methods)*
+<a name="getSPD"></a>
+## *getSPD*
 
 Returns the Source Data Product Descriptor (SPD) infoFrame packet information for the specified HDMI Input device. The SPD infoFrame packet includes vendor name, product description, and source information.
  
@@ -410,7 +372,7 @@ No Events.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.AVInput.1.getSPD",
+    "method": "org.rdk.AVInput.getSPD",
     "params": {
         "portId": 0
     }
@@ -429,8 +391,8 @@ No Events.
 }
 ```
 
-<a name="method.getRawSPD"></a>
-## *getRawSPD [<sup>method</sup>](#head.Methods)*
+<a name="getRawSPD"></a>
+## *getRawSPD*
 
 Returns the Source Data Product Descriptor (SPD) infoFrame packet information for the specified HDMI Input device as raw bits.
  
@@ -467,7 +429,7 @@ No Events.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.AVInput.1.getRawSPD",
+    "method": "org.rdk.AVInput.getRawSPD",
     "params": {
         "portId": 0
     }
@@ -486,8 +448,8 @@ No Events.
 }
 ```
 
-<a name="method.readEDID"></a>
-## *readEDID [<sup>method</sup>](#head.Methods)*
+<a name="readEDID"></a>
+## *readEDID*
 
 Returns the current EDID value.
  
@@ -524,7 +486,7 @@ No Events.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.AVInput.1.readEDID",
+    "method": "org.rdk.AVInput.readEDID",
     "params": {
         "portId": 0
     }
@@ -543,8 +505,8 @@ No Events.
 }
 ```
 
-<a name="method.startInput"></a>
-## *startInput [<sup>method</sup>](#head.Methods)*
+<a name="startInput"></a>
+## *startInput*
 
 Activates the specified HDMI/Composite Input port as the primary video source.
  
@@ -554,7 +516,7 @@ Activates the specified HDMI/Composite Input port as the primary video source.
 | `onInputStatusChanged` | Triggers the event when HDMI/Composite Input source is activated and Input status changes to `started` | 
 | `onSignalChanged` | Triggers the event when HDMI/Composite Input signal changes (must be one of the following:noSignal, unstableSignal, notSupportedSignal, stableSignal).
 
-Also see: [onInputStatusChanged](#event.onInputStatusChanged), [onSignalChanged](#event.onSignalChanged)
+Also see: [onInputStatusChanged](#onInputStatusChanged), [onSignalChanged](#onSignalChanged)
 
 ### Parameters
 
@@ -585,7 +547,7 @@ Also see: [onInputStatusChanged](#event.onInputStatusChanged), [onSignalChanged]
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.AVInput.1.startInput",
+    "method": "org.rdk.AVInput.startInput",
     "params": {
         "portId": 0,
         "typeOfInput": "HDMI"
@@ -603,8 +565,8 @@ Also see: [onInputStatusChanged](#event.onInputStatusChanged), [onSignalChanged]
 }
 ```
 
-<a name="method.stopInput"></a>
-## *stopInput [<sup>method</sup>](#head.Methods)*
+<a name="stopInput"></a>
+## *stopInput*
 
 Deactivates the HDMI/Composite Input port currently selected as the primary video source.
  
@@ -613,7 +575,7 @@ Deactivates the HDMI/Composite Input port currently selected as the primary vide
 | :----------- | :----------- | 
 | `onInputStatusChanged` | Triggers the event when HDMI/Composite Input source is deactivated and Input status changes to `stopped`.
 
-Also see: [onInputStatusChanged](#event.onInputStatusChanged)
+Also see: [onInputStatusChanged](#onInputStatusChanged)
 
 ### Parameters
 
@@ -643,7 +605,7 @@ Also see: [onInputStatusChanged](#event.onInputStatusChanged)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.AVInput.1.stopInput",
+    "method": "org.rdk.AVInput.stopInput",
     "params": {
         "typeOfInput": "HDMI"
     }
@@ -660,8 +622,8 @@ Also see: [onInputStatusChanged](#event.onInputStatusChanged)
 }
 ```
 
-<a name="method.setEdidVersion"></a>
-## *setEdidVersion [<sup>method</sup>](#head.Methods)*
+<a name="setEdidVersion"></a>
+## *setEdidVersion*
 
 Sets an HDMI EDID version.
  
@@ -698,7 +660,7 @@ No Events.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.AVInput.1.setEdidVersion",
+    "method": "org.rdk.AVInput.setEdidVersion",
     "params": {
         "portId": 0,
         "edidVersion": "HDMI2.0"
@@ -716,8 +678,8 @@ No Events.
 }
 ```
 
-<a name="method.setVideoRectangle"></a>
-## *setVideoRectangle [<sup>method</sup>](#head.Methods)*
+<a name="setVideoRectangle"></a>
+## *setVideoRectangle*
 
 Sets an HDMI/Composite Input video window.
  
@@ -757,7 +719,7 @@ No Events.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.AVInput.1.setVideoRectangle",
+    "method": "org.rdk.AVInput.setVideoRectangle",
     "params": {
         "x": 0,
         "y": 0,
@@ -778,8 +740,8 @@ No Events.
 }
 ```
 
-<a name="method.writeEDID"></a>
-## *writeEDID [<sup>method</sup>](#head.Methods)*
+<a name="writeEDID"></a>
+## *writeEDID*
 
 Changes a current EDID value.
  
@@ -815,7 +777,7 @@ No Events.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.AVInput.1.writeEDID",
+    "method": "org.rdk.AVInput.writeEDID",
     "params": {
         "portId": 0,
         "message": "EDID"
@@ -833,8 +795,8 @@ No Events.
 }
 ```
 
-<a name="method.getSupportedGameFeatures"></a>
-## *getSupportedGameFeatures [<sup>method</sup>](#head.Methods)*
+<a name="getSupportedGameFeatures"></a>
+## *getSupportedGameFeatures*
 
 Returns the list of supported game features.
  
@@ -868,7 +830,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.AVInput.1.getSupportedGameFeatures"
+    "method": "org.rdk.AVInput.getSupportedGameFeatures"
 }
 ```
 
@@ -886,8 +848,8 @@ This method takes no parameters.
 }
 ```
 
-<a name="method.getGameFeatureStatus"></a>
-## *getGameFeatureStatus [<sup>method</sup>](#head.Methods)*
+<a name="getGameFeatureStatus"></a>
+## *getGameFeatureStatus*
 
 Returns the Game Feature Status. For example: ALLM
  
@@ -924,7 +886,7 @@ No Events.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.AVInput.1.getGameFeatureStatus",
+    "method": "org.rdk.AVInput.getGameFeatureStatus",
     "params": {
         "portId": 0,
         "gameFeature": "ALLM"
@@ -944,10 +906,10 @@ No Events.
 }
 ```
 
-<a name="head.Notifications"></a>
+<a name="Notifications"></a>
 # Notifications
 
-Notifications are autonomous events, triggered by the internals of the implementation, and broadcasted via JSON-RPC to all registered observers. Refer to [[Thunder](#ref.Thunder)] for information on how to register for a notification.
+Notifications are autonomous events, triggered by the internals of the implementation, and broadcasted via JSON-RPC to all registered observers. Refer to [[Thunder](#Thunder)] for information on how to register for a notification.
 
 The following events are provided by the org.rdk.AVInput plugin:
 
@@ -955,15 +917,15 @@ AVInput interface events:
 
 | Event | Description |
 | :-------- | :-------- |
-| [onDevicesChanged](#event.onDevicesChanged) | Triggered whenever a new HDMI/Composite device is connected to an HDMI/Composite Input |
-| [onInputStatusChanged](#event.onInputStatusChanged) | Triggered whenever the status changes for an HDMI/Composite Input |
-| [onSignalChanged](#event.onSignalChanged) | Triggered whenever the signal status changes for an HDMI/Composite Input |
-| [videoStreamInfoUpdate](#event.videoStreamInfoUpdate) | Triggered whenever there is an update in HDMI Input video stream info |
-| [gameFeatureStatusUpdate](#event.gameFeatureStatusUpdate) | Triggered whenever game feature(ALLM) status changes for an HDMI Input |
+| [onDevicesChanged](#onDevicesChanged) | Triggered whenever a new HDMI/Composite device is connected to an HDMI/Composite Input |
+| [onInputStatusChanged](#onInputStatusChanged) | Triggered whenever the status changes for an HDMI/Composite Input |
+| [onSignalChanged](#onSignalChanged) | Triggered whenever the signal status changes for an HDMI/Composite Input |
+| [videoStreamInfoUpdate](#videoStreamInfoUpdate) | Triggered whenever there is an update in HDMI Input video stream info |
+| [gameFeatureStatusUpdate](#gameFeatureStatusUpdate) | Triggered whenever game feature(ALLM) status changes for an HDMI Input |
 
 
-<a name="event.onDevicesChanged"></a>
-## *onDevicesChanged [<sup>event</sup>](#head.Notifications)*
+<a name="onDevicesChanged"></a>
+## *onDevicesChanged*
 
 Triggered whenever a new HDMI/Composite device is connected to an HDMI/Composite Input.
 
@@ -983,7 +945,7 @@ Triggered whenever a new HDMI/Composite device is connected to an HDMI/Composite
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onDevicesChanged",
+    "method": "client.events.onDevicesChanged",
     "params": {
         "devices": [
             {
@@ -996,8 +958,8 @@ Triggered whenever a new HDMI/Composite device is connected to an HDMI/Composite
 }
 ```
 
-<a name="event.onInputStatusChanged"></a>
-## *onInputStatusChanged [<sup>event</sup>](#head.Notifications)*
+<a name="onInputStatusChanged"></a>
+## *onInputStatusChanged*
 
 Triggered whenever the status changes for an HDMI/Composite Input.
 
@@ -1015,7 +977,7 @@ Triggered whenever the status changes for an HDMI/Composite Input.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onInputStatusChanged",
+    "method": "client.events.onInputStatusChanged",
     "params": {
         "id": 0,
         "locator": "hdmiin://localhost/deviceid/0",
@@ -1024,8 +986,8 @@ Triggered whenever the status changes for an HDMI/Composite Input.
 }
 ```
 
-<a name="event.onSignalChanged"></a>
-## *onSignalChanged [<sup>event</sup>](#head.Notifications)*
+<a name="onSignalChanged"></a>
+## *onSignalChanged*
 
 Triggered whenever the signal status changes for an HDMI/Composite Input.
 
@@ -1043,7 +1005,7 @@ Triggered whenever the signal status changes for an HDMI/Composite Input.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onSignalChanged",
+    "method": "client.events.onSignalChanged",
     "params": {
         "id": 0,
         "locator": "hdmiin://localhost/deviceid/0",
@@ -1052,8 +1014,8 @@ Triggered whenever the signal status changes for an HDMI/Composite Input.
 }
 ```
 
-<a name="event.videoStreamInfoUpdate"></a>
-## *videoStreamInfoUpdate [<sup>event</sup>](#head.Notifications)*
+<a name="videoStreamInfoUpdate"></a>
+## *videoStreamInfoUpdate*
 
 Triggered whenever there is an update in HDMI Input video stream info.
 
@@ -1075,7 +1037,7 @@ Triggered whenever there is an update in HDMI Input video stream info.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.videoStreamInfoUpdate",
+    "method": "client.events.videoStreamInfoUpdate",
     "params": {
         "id": 0,
         "locator": "hdmiin://localhost/deviceid/0",
@@ -1088,8 +1050,8 @@ Triggered whenever there is an update in HDMI Input video stream info.
 }
 ```
 
-<a name="event.gameFeatureStatusUpdate"></a>
-## *gameFeatureStatusUpdate [<sup>event</sup>](#head.Notifications)*
+<a name="gameFeatureStatusUpdate"></a>
+## *gameFeatureStatusUpdate*
 
 Triggered whenever game feature(ALLM) status changes for an HDMI Input.
 
@@ -1107,7 +1069,7 @@ Triggered whenever game feature(ALLM) status changes for an HDMI Input.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.gameFeatureStatusUpdate",
+    "method": "client.events.gameFeatureStatusUpdate",
     "params": {
         "id": 0,
         "gameFeature": "ALLM",

--- a/docs/api/ActivityMonitorPlugin.md
+++ b/docs/api/ActivityMonitorPlugin.md
@@ -95,7 +95,7 @@ Also see: [onCPUThresholdOccurred](#onCPUThresholdOccurred), [onMemoryThresholdO
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.ActivityMonitor.1.enableMonitoring",
+    "method": "org.rdk.ActivityMonitor.enableMonitoring",
     "params": {
         "config": [
             {
@@ -153,7 +153,7 @@ No events.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.ActivityMonitor.1.disableMonitoring",
+    "method": "org.rdk.ActivityMonitor.disableMonitoring",
     "params": {}
 }
 ```
@@ -205,7 +205,7 @@ No events.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.ActivityMonitor.1.getApplicationMemoryUsage",
+    "method": "org.rdk.ActivityMonitor.getApplicationMemoryUsage",
     "params": {
         "pid": 6763
     }
@@ -265,7 +265,7 @@ No events.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.ActivityMonitor.1.getAllMemoryUsage",
+    "method": "org.rdk.ActivityMonitor.getAllMemoryUsage",
     "params": {}
 }
 ```
@@ -324,7 +324,7 @@ Triggered when an application exceeds the given memory threshold.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onMemoryThresholdOccurred",
+    "method": "client.events.onMemoryThresholdOccurred",
     "params": {
         "appPid": 6763,
         "threshold": "exceeded",
@@ -352,7 +352,7 @@ Triggered when an application exceeds the `cpuThresholdPercent` value for a dura
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onCPUThresholdOccurred",
+    "method": "client.events.onCPUThresholdOccurred",
     "params": {
         "appPid": 6763,
         "threshold": "exceeded",

--- a/docs/api/BluetoothPlugin.md
+++ b/docs/api/BluetoothPlugin.md
@@ -108,7 +108,7 @@ Also see: [onStatuschanged](#onStatuschanged)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Bluetooth.1.connect",
+    "method": "org.rdk.Bluetooth.connect",
     "params": {
         "deviceID": "61579454946360",
         "deviceType": "TV",
@@ -157,7 +157,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Bluetooth.1.disable"
+    "method": "org.rdk.Bluetooth.disable"
 }
 ```
 
@@ -208,7 +208,7 @@ Also see: [onStatusChanged](#onStatusChanged)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Bluetooth.1.disconnect",
+    "method": "org.rdk.Bluetooth.disconnect",
     "params": {
         "deviceID": "61579454946360",
         "deviceType": "TV"
@@ -256,7 +256,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Bluetooth.1.enable"
+    "method": "org.rdk.Bluetooth.enable"
 }
 ```
 
@@ -311,7 +311,7 @@ Provides information on the currently playing song/audio from an external source
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Bluetooth.1.getAudioInfo",
+    "method": "org.rdk.Bluetooth.getAudioInfo",
     "params": {
         "deviceID": "61579454946360"
     }
@@ -373,7 +373,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Bluetooth.1.getConnectedDevices"
+    "method": "org.rdk.Bluetooth.getConnectedDevices"
 }
 ```
 
@@ -437,7 +437,7 @@ Returns information for the given device ID.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Bluetooth.1.getDeviceInfo",
+    "method": "org.rdk.Bluetooth.getDeviceInfo",
     "params": {
         "deviceID": "61579454946360"
     }
@@ -501,7 +501,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Bluetooth.1.getDiscoveredDevices"
+    "method": "org.rdk.Bluetooth.getDiscoveredDevices"
 }
 ```
 
@@ -555,7 +555,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Bluetooth.1.getName"
+    "method": "org.rdk.Bluetooth.getName"
 }
 ```
 
@@ -606,7 +606,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Bluetooth.1.getPairedDevices"
+    "method": "org.rdk.Bluetooth.getPairedDevices"
 }
 ```
 
@@ -659,7 +659,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Bluetooth.1.isDiscoverable"
+    "method": "org.rdk.Bluetooth.isDiscoverable"
 }
 ```
 
@@ -711,7 +711,7 @@ Also see: [onStatusChanged](#onStatusChanged), [onRequestFailed](#onRequestFaile
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Bluetooth.1.pair",
+    "method": "org.rdk.Bluetooth.pair",
     "params": {
         "deviceID": "61579454946360"
     }
@@ -763,7 +763,7 @@ Provides the ability to respond the client Bluetooth  For example, this device c
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Bluetooth.1.respondToEvent",
+    "method": "org.rdk.Bluetooth.respondToEvent",
     "params": {
         "deviceID": "61579454946360",
         "eventType": "onPairingRequest",
@@ -816,7 +816,7 @@ Provides control over the connected source. Requests can have one of the followi
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Bluetooth.1.sendAudioPlaybackCommand",
+    "method": "org.rdk.Bluetooth.sendAudioPlaybackCommand",
     "params": {
         "deviceID": "61579454946360",
         "command": "PLAY"
@@ -868,7 +868,7 @@ Sets the primary or secondary audio-out to the given Bluetooth device.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Bluetooth.1.setAudioStream",
+    "method": "org.rdk.Bluetooth.setAudioStream",
     "params": {
         "deviceID": "61579454946360",
         "audioStreamName": "PRIMARY"
@@ -920,7 +920,7 @@ When true, this device can be discovered by other Bluetooth devices. When false,
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Bluetooth.1.setDiscoverable",
+    "method": "org.rdk.Bluetooth.setDiscoverable",
     "params": {
         "timeout": 5,
         "discoverable": true
@@ -971,7 +971,7 @@ Sets the name of this device as seen by other Bluetooth devices.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Bluetooth.1.setName",
+    "method": "org.rdk.Bluetooth.setName",
     "params": {
         "name": "RDK Bluetooth Device"
     }
@@ -1040,7 +1040,7 @@ Also see: [onStatusChanged](#onStatusChanged), [onDiscoveredDevice](#onDiscovere
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Bluetooth.1.startScan",
+    "method": "org.rdk.Bluetooth.startScan",
     "params": {
         "timeout": 5,
         "profile": "SMARTPHONE, HEADSET"
@@ -1092,7 +1092,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Bluetooth.1.stopScan"
+    "method": "org.rdk.Bluetooth.stopScan"
 }
 ```
 
@@ -1142,7 +1142,7 @@ Also see: [onStatusChanged](#onStatusChanged)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Bluetooth.1.unpair",
+    "method": "org.rdk.Bluetooth.unpair",
     "params": {
         "deviceID": "61579454946360"
     }
@@ -1196,7 +1196,7 @@ Gets the volume information of the given Bluetooth device ID.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Bluetooth.1.getDeviceVolumeMuteInfo",
+    "method": "org.rdk.Bluetooth.getDeviceVolumeMuteInfo",
     "params": {
         "deviceID": "61579454946360",
         "deviceProfile": "SMARTPHONE"
@@ -1261,7 +1261,7 @@ Also see: [onDeviceMediaStatus](#onDeviceMediaStatus)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Bluetooth.1.setDeviceVolumeMuteInfo",
+    "method": "org.rdk.Bluetooth.setDeviceVolumeMuteInfo",
     "params": {
         "deviceID": "61579454946360",
         "deviceProfile": "SMARTPHONE",
@@ -1312,7 +1312,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Bluetooth.1.getApiVersionNumber"
+    "method": "org.rdk.Bluetooth.getApiVersionNumber"
 }
 ```
 
@@ -1376,7 +1376,7 @@ Triggered when a connection is requested by third party device that has already 
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onConnectionRequest",
+    "method": "client.events.onConnectionRequest",
     "params": {
         "deviceID": "61579454946360",
         "name": "[TV] UE32J5530",
@@ -1411,7 +1411,7 @@ Triggered during device discovery when a new device is discovered or a discovere
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onDiscoveredDevice",
+    "method": "client.events.onDiscoveredDevice",
     "params": {
         "deviceID": "61579454946360",
         "discoveryType": "DISCOVERED",
@@ -1450,7 +1450,7 @@ Triggered when pairing is requested by a third party device that supports A2DP p
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onPairingRequest",
+    "method": "client.events.onPairingRequest",
     "params": {
         "deviceID": "61579454946360",
         "name": "[TV] UE32J5530",
@@ -1484,7 +1484,7 @@ Triggered when playback is interrupted or changed. Note that there is no resume 
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onPlaybackChange",
+    "method": "client.events.onPlaybackChange",
     "params": {
         "action": "started",
         "deviceID": "61579454946360",
@@ -1518,7 +1518,7 @@ Triggered whenever the user plays a new track or when the music player selects a
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onPlaybackNewTrack",
+    "method": "client.events.onPlaybackNewTrack",
     "params": {
         "deviceID": "61579454946360",
         "album": "Spacebound Apes",
@@ -1551,7 +1551,7 @@ Triggered in one second intervals as long as the status of the playback is playi
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onPlaybackProgress",
+    "method": "client.events.onPlaybackProgress",
     "params": {
         "deviceID": "61579454946360",
         "position": "217000",
@@ -1582,7 +1582,7 @@ Triggered when playback is requested by third party device that has already been
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onPlaybackRequest",
+    "method": "client.events.onPlaybackRequest",
     "params": {
         "deviceID": "61579454946360",
         "name": "[TV] UE32J5530",
@@ -1618,7 +1618,7 @@ Triggered when the previous request to pair or connect failed. In absence of a f
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onRequestFailed",
+    "method": "client.events.onRequestFailed",
     "params": {
         "newStatus": "DISCOVERY_COMPLETED",
         "deviceID": "61579454946360",
@@ -1660,7 +1660,7 @@ Triggered when the Bluetooth functionality status changes. Supported statuses ar
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onStatusChanged",
+    "method": "client.events.onStatusChanged",
     "params": {
         "newStatus": "DISCOVERY_COMPLETED",
         "deviceID": "61579454946360",
@@ -1695,7 +1695,7 @@ Triggered when the new device got discovered.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onDeviceFound",
+    "method": "client.events.onDeviceFound",
     "params": {
         "deviceID": "61579454946360",
         "name": "[TV] UE32J5530",
@@ -1727,7 +1727,7 @@ Triggered when any discovered device lost or out of range.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onDeviceLost",
+    "method": "client.events.onDeviceLost",
     "params": {
         "deviceID": "61579454946360",
         "name": "[TV] UE32J5530",
@@ -1765,7 +1765,7 @@ Triggered when any change occurs to Device Media like volume or mute. Supported 
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onDeviceMediaStatus",
+    "method": "client.events.onDeviceMediaStatus",
     "params": {
         "deviceID": "61579454946360",
         "name": "[TV] UE32J5530",

--- a/docs/api/CompositeInputPlugin.md
+++ b/docs/api/CompositeInputPlugin.md
@@ -86,7 +86,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.CompositeInput.1.getCompositeInputDevices"
+    "method": "org.rdk.CompositeInput.getCompositeInputDevices"
 }
 ```
 
@@ -143,7 +143,7 @@ No Events.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.CompositeInput.1.setVideoRectangle",
+    "method": "org.rdk.CompositeInput.setVideoRectangle",
     "params": {
         "x": 900,
         "y": 500,
@@ -200,7 +200,7 @@ Also see: [onInputStatusChanged](#onInputStatusChanged), [onSignalChanged](#onSi
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.CompositeInput.1.startCompositeInput",
+    "method": "org.rdk.CompositeInput.startCompositeInput",
     "params": {
         "portId": 0
     }
@@ -250,7 +250,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.CompositeInput.1.stopCompositeInput"
+    "method": "org.rdk.CompositeInput.stopCompositeInput"
 }
 ```
 
@@ -303,7 +303,7 @@ Triggered when the composite input device changes.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onDevicesChanged",
+    "method": "client.events.onDevicesChanged",
     "params": {
         "devices": [
             {
@@ -335,7 +335,7 @@ Triggered when the status of the composite input changes.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onInputStatusChanged",
+    "method": "client.events.onInputStatusChanged",
     "params": {
         "id": 0,
         "locator": "cvbsin://localhost/deviceid/0",
@@ -363,7 +363,7 @@ Triggered when the status of the composite input signal changes.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onSignalChanged",
+    "method": "client.events.onSignalChanged",
     "params": {
         "id": 0,
         "locator": "cvbsin://localhost/deviceid/0",

--- a/docs/api/ContinueWatchingPlugin.md
+++ b/docs/api/ContinueWatchingPlugin.md
@@ -78,7 +78,7 @@ Deletes the stored tokens for a particular application.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.ContinueWatching.1.deleteApplicationToken",
+    "method": "org.rdk.ContinueWatching.deleteApplicationToken",
     "params": {
         "applicationName": "netflix"
     }
@@ -128,7 +128,7 @@ Retrieves the tokens for a particular application.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.ContinueWatching.1.getApplicationToken",
+    "method": "org.rdk.ContinueWatching.getApplicationToken",
     "params": {
         "applicationName": "netflix"
     }
@@ -183,7 +183,7 @@ Sets the given tokens for an application.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.ContinueWatching.1.setApplicationToken",
+    "method": "org.rdk.ContinueWatching.setApplicationToken",
     "params": {
         "applicationName": "netflix",
         "application_token": {

--- a/docs/api/ControlServicePlugin.md
+++ b/docs/api/ControlServicePlugin.md
@@ -92,7 +92,7 @@ Checks if the Control Manager can search for the remote.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.ControlService.1.canFindMyRemote",
+    "method": "org.rdk.ControlService.canFindMyRemote",
     "params": {}
 }
 ```
@@ -141,7 +141,7 @@ Checks Rf4ce chip connectivity status.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.ControlService.1.checkRf4ceChipConnectivity",
+    "method": "org.rdk.ControlService.checkRf4ceChipConnectivity",
     "params": {}
 }
 ```
@@ -191,7 +191,7 @@ Leaves pairing mode.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.ControlService.1.endPairingMode",
+    "method": "org.rdk.ControlService.endPairingMode",
     "params": {}
 }
 ```
@@ -245,7 +245,7 @@ Also see: [onControl](#onControl)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.ControlService.1.findLastUsedRemote",
+    "method": "org.rdk.ControlService.findLastUsedRemote",
     "params": {
         "timeOutPeriod": 20
     }
@@ -389,7 +389,7 @@ Returns all remote data.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.ControlService.1.getAllRemoteData",
+    "method": "org.rdk.ControlService.getAllRemoteData",
     "params": {}
 }
 ```
@@ -539,7 +539,7 @@ Returns last key press source data. The data, if any, is returned as part of the
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.ControlService.1.getLastKeypressSource",
+    "method": "org.rdk.ControlService.getLastKeypressSource",
     "params": {}
 }
 ```
@@ -670,7 +670,7 @@ Returns all remote data for the last paired remote. The data, if any, is returne
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.ControlService.1.getLastPairedRemoteData",
+    "method": "org.rdk.ControlService.getLastPairedRemoteData",
     "params": {}
 }
 ```
@@ -796,7 +796,7 @@ Gets quirks.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.ControlService.1.getQuirks",
+    "method": "org.rdk.ControlService.getQuirks",
     "params": {}
 }
 ```
@@ -923,7 +923,7 @@ Returns all remote data for the specified remote. The data, if any, is returned 
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.ControlService.1.getSingleRemoteData",
+    "method": "org.rdk.ControlService.getSingleRemoteData",
     "params": {
         "remoteId": 1
     }
@@ -1058,7 +1058,7 @@ Returns remote setting values.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.ControlService.1.getValues",
+    "method": "org.rdk.ControlService.getValues",
     "params": {}
 }
 ```
@@ -1122,7 +1122,7 @@ Sets remote setting values.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.ControlService.1.setValues",
+    "method": "org.rdk.ControlService.setValues",
     "params": {
         "enableASB": false,
         "enableOpenChime": false,
@@ -1181,7 +1181,7 @@ Enters pairing mode.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.ControlService.1.startPairingMode",
+    "method": "org.rdk.ControlService.startPairingMode",
     "params": {
         "pairingMode": 0,
         "restrictPairing": 0
@@ -1241,7 +1241,7 @@ Triggered on control manager events.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onControl",
+    "method": "client.events.onControl",
     "params": {
         "remoteId": 1,
         "eventValue": 0,
@@ -1272,7 +1272,7 @@ Triggered on control manager configuration complete
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onXRConfigurationComplete",
+    "method": "client.events.onXRConfigurationComplete",
     "params": {
         "remoteId": 1,
         "remoteType": "XR11",
@@ -1304,7 +1304,7 @@ Triggered on control manager validation/pairing key press
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onXRPairingStart",
+    "method": "client.events.onXRPairingStart",
     "params": {
         "remoteId": 1,
         "remoteType": "XR11",
@@ -1342,7 +1342,7 @@ Validation status codes:
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onXRValidationComplete",
+    "method": "client.events.onXRValidationComplete",
     "params": {
         "remoteId": 1,
         "remoteType": "XR11",
@@ -1374,7 +1374,7 @@ Triggered on control manager events.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onXRValidationUpdate",
+    "method": "client.events.onXRValidationUpdate",
     "params": {
         "remoteId": 1,
         "remoteType": "XR11",

--- a/docs/api/DTVPlugin.md
+++ b/docs/api/DTVPlugin.md
@@ -99,7 +99,7 @@ Add a new LNB to the database.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DTV.1.addLnb",
+    "method": "DTV.addLnb",
     "params": {
         "name": "Universal",
         "type": "single",
@@ -161,7 +161,7 @@ Add a new satellite to the database.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DTV.1.addSatellite",
+    "method": "DTV.addSatellite",
     "params": {
         "name": "Astra 28.2E",
         "longitude": 282,
@@ -235,7 +235,7 @@ Also see: [searchstatus](#searchstatus), [serviceupdated](#serviceupdated)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DTV.1.startServiceSearch",
+    "method": "DTV.startServiceSearch",
     "params": {
         "tunertype": "none",
         "searchtype": "frequency",
@@ -307,7 +307,7 @@ Finishes a service search.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DTV.1.finishServiceSearch",
+    "method": "DTV.finishServiceSearch",
     "params": {
         "tunertype": "none",
         "savechanges": true
@@ -364,7 +364,7 @@ Also see: [serviceupdated](#serviceupdated), [eventchanged](#eventchanged), [vid
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DTV.1.startPlaying",
+    "method": "DTV.startPlaying",
     "params": {
         "dvburi": "2.2041.9212",
         "lcn": 0,
@@ -412,7 +412,7 @@ Stops playing the specified service.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DTV.1.stopPlaying",
+    "method": "DTV.stopPlaying",
     "params": 0
 }
 ```
@@ -474,7 +474,7 @@ Provides access to the number of country configurations available.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DTV.1.numberOfCountries"
+    "method": "DTV.numberOfCountries"
 }
 ```
 
@@ -512,7 +512,7 @@ Provides access to the array containing the name and 3 character ISO country cod
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DTV.1.countryList"
+    "method": "DTV.countryList"
 }
 ```
 
@@ -550,7 +550,7 @@ Provides access to the country configuration using the ISO 3-character country c
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DTV.1.country"
+    "method": "DTV.country"
 }
 ```
 
@@ -570,7 +570,7 @@ Provides access to the country configuration using the ISO 3-character country c
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DTV.1.country",
+    "method": "DTV.country",
     "params": 6775410
 }
 ```
@@ -621,7 +621,7 @@ Provides access to the array of LNBs defined in the database.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DTV.1.lnbList"
+    "method": "DTV.lnbList"
 }
 ```
 
@@ -677,7 +677,7 @@ Provides access to the array of satellites defined in the database.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DTV.1.satelliteList"
+    "method": "DTV.satelliteList"
 }
 ```
 
@@ -718,7 +718,7 @@ Provides access to the total number of services in the service database.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DTV.1.numberOfServices"
+    "method": "DTV.numberOfServices"
 }
 ```
 
@@ -766,7 +766,7 @@ Provides access to the list of services for the given type of tuner, transport (
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DTV.1.serviceList@dvbs or 9018.4161"
+    "method": "DTV.serviceList@dvbs or 9018.4161"
 }
 ```
 
@@ -826,7 +826,7 @@ Provides access to the information for the given service as defined by its DVB t
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DTV.1.serviceInfo@9018.4161.1001"
+    "method": "DTV.serviceInfo@9018.4161.1001"
 }
 ```
 
@@ -896,7 +896,7 @@ Provides access to the (Version 2) array of components for the given service def
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DTV.1.serviceComponents@9018.4161.1001"
+    "method": "DTV.serviceComponents@9018.4161.1001"
 }
 ```
 
@@ -985,7 +985,7 @@ Provides access to the information for the given transport as defined by its DVB
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DTV.1.transportInfo@9018.4161"
+    "method": "DTV.transportInfo@9018.4161"
 }
 ```
 
@@ -1073,7 +1073,7 @@ Provides access to the now and next events (EITp/f) for the given service.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DTV.1.nowNextEvents@9018.4161.1001"
+    "method": "DTV.nowNextEvents@9018.4161.1001"
 }
 ```
 
@@ -1151,7 +1151,7 @@ Provides access to the events which are scheduled (EITsched) for the given servi
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DTV.1.scheduleEvents@9018.4161.1001:12345000,12346000"
+    "method": "DTV.scheduleEvents@9018.4161.1001:12345000,12346000"
 }
 ```
 
@@ -1208,7 +1208,7 @@ Provides access to the extended event info for the given service and event ID (v
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DTV.1.extendedEventInfo@9018.4161.1001:3012"
+    "method": "DTV.extendedEventInfo@9018.4161.1001:3012"
 }
 ```
 
@@ -1258,7 +1258,7 @@ Provides access to the information related to the play handle defined by the ind
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DTV.1.status@0"
+    "method": "DTV.status@0"
 }
 ```
 
@@ -1304,7 +1304,7 @@ Provides access to the strength and quality of the currently tuned signal for th
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DTV.1.signalInfo@0"
+    "method": "DTV.signalInfo@0"
 }
 ```
 
@@ -1387,7 +1387,7 @@ Triggered during the course of a service search.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.searchstatus",
+    "method": "client.events.searchstatus",
     "params": {
         "handle": 0,
         "eventtype": "ServiceSearchStatus",
@@ -1453,7 +1453,7 @@ Triggered during the course of a service search.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.serviceupdated",
+    "method": "client.events.serviceupdated",
     "params": {
         "eventtype": "ServiceSearchStatus",
         "service": {
@@ -1500,7 +1500,7 @@ Triggered during the course of a service search.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.serviceadded",
+    "method": "client.events.serviceadded",
     "params": {
         "eventtype": "ServiceSearchStatus",
         "service": {
@@ -1547,7 +1547,7 @@ Triggered during the course of a service search.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.servicedeleted",
+    "method": "client.events.servicedeleted",
     "params": {
         "eventtype": "ServiceSearchStatus",
         "service": {
@@ -1594,7 +1594,7 @@ Triggered during the course of a service search.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.videochanged",
+    "method": "client.events.videochanged",
     "params": {
         "eventtype": "ServiceSearchStatus",
         "service": {
@@ -1641,7 +1641,7 @@ Triggered during the course of a service search.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.audiochanged",
+    "method": "client.events.audiochanged",
     "params": {
         "eventtype": "ServiceSearchStatus",
         "service": {
@@ -1688,7 +1688,7 @@ Triggered during the course of a service search.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.subtitleschanged",
+    "method": "client.events.subtitleschanged",
     "params": {
         "eventtype": "ServiceSearchStatus",
         "service": {
@@ -1747,7 +1747,7 @@ Triggered during the course of a service search.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.eventchanged",
+    "method": "client.events.eventchanged",
     "params": {
         "eventtype": "ServiceSearchStatus",
         "service": {

--- a/docs/api/DataCapturePlugin.md
+++ b/docs/api/DataCapturePlugin.md
@@ -87,7 +87,7 @@ Return Values:
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.dataCapture.1.enableAudioCapture",
+    "method": "org.rdk.dataCapture.enableAudioCapture",
     "params": {
         "bufferMaxDuration": 6
     }
@@ -150,7 +150,7 @@ Also see: [onAudioClipReady](#onAudioClipReady)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.dataCapture.1.getAudioClip",
+    "method": "org.rdk.dataCapture.getAudioClip",
     "params": {
         "clipRequest": {
             "stream": "primary",
@@ -208,7 +208,7 @@ Indicates whether an audio clip succeeded or failed to upload.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onAudioClipReady",
+    "method": "client.events.onAudioClipReady",
     "params": {
         "fileName": "acm-songid0",
         "status": true,

--- a/docs/api/DeviceDiagnosticsPlugin.md
+++ b/docs/api/DeviceDiagnosticsPlugin.md
@@ -89,7 +89,7 @@ No events.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DeviceDiagnostics.1.getConfiguration",
+    "method": "org.rdk.DeviceDiagnostics.getConfiguration",
     "params": {
         "names": [
             "Device.X_CISCO_COM_LED.RedPwm"
@@ -146,7 +146,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DeviceDiagnostics.1.getMilestones"
+    "method": "org.rdk.DeviceDiagnostics.getMilestones"
 }
 ```
 
@@ -181,6 +181,13 @@ Log marker string to rdk milestones log.
 | params | object |  |
 | params.marker | string | Milestone marker string |
 
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.success | boolean | Whether the request succeeded |
+
 ### Example
 
 #### Request
@@ -189,9 +196,105 @@ Log marker string to rdk milestones log.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DeviceDiagnostics.1.logMilestone",
+    "method": "org.rdk.DeviceDiagnostics.logMilestone",
     "params": {
         "marker": "..."
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "success": true
+    }
+}
+```
+
+<a name="getAVDecoderStatus"></a>
+## *getAVDecoderStatus*
+
+Gets the most active status of audio/video decoder/pipeline. This API doesn't track individual pipelines. It will aggregate and report the pipeline status, and the pipeline states are prioritized from High to Low (`ACTIVE`, `PAUSED`, and `IDLE`). Therefore, if any of the pipelines is in active state, then `getAVDecoderStatus` will return `ACTIVE`. If none of the pipelines are active but one is in a paused state, then `getAVDecoderStatus` will return `PAUSED`, and if all the pipelines are idle only then, `IDLE` will be returned.
+ 
+### Events 
+ 
+No events.
+
+### Parameters
+
+This method takes no parameters.
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.AVDecoderStatus | string | The status. If AV decoder status is not supported, the default state will always be IDLE. (must be one of the following: *ACTIVE*, *PAUSED*, *IDLE*) |
+| result.success | boolean | Whether the request succeeded |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.DeviceDiagnostics.getAVDecoderStatus"
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "AVDecoderStatus": "ACTIVE",
+        "success": true
+    }
+}
+```
+
+<a name="Notifications"></a>
+# Notifications
+
+Notifications are autonomous events, triggered by the internals of the implementation, and broadcasted via JSON-RPC to all registered observers. Refer to [[Thunder](#Thunder)] for information on how to register for a notification.
+
+The following events are provided by the org.rdk.DeviceDiagnostics plugin:
+
+DeviceDiagnostics interface events:
+
+| Event | Description |
+| :-------- | :-------- |
+| [onAVDecoderStatusChanged](#onAVDecoderStatusChanged) | Triggered when the most active status of audio/video decoder/pipeline changes |
+
+
+<a name="onAVDecoderStatusChanged"></a>
+## *onAVDecoderStatusChanged*
+
+Triggered when the most active status of audio/video decoder/pipeline changes.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.AVDecoderStatus | string | The status. If AV decoder status is not supported, the default state will always be IDLE. (must be one of the following: *ACTIVE*, *PAUSED*, *IDLE*) |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.onAVDecoderStatusChanged",
+    "params": {
+        "AVDecoderStatus": "ACTIVE"
     }
 }
 ```

--- a/docs/api/DeviceIdentificationPlugin.md
+++ b/docs/api/DeviceIdentificationPlugin.md
@@ -73,7 +73,7 @@ Provides access to the device platform specific information.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DeviceIdentification.1.deviceidentification"
+    "method": "DeviceIdentification.deviceidentification"
 }
 ```
 

--- a/docs/api/DeviceInfoPlugin.md
+++ b/docs/api/DeviceInfoPlugin.md
@@ -89,7 +89,7 @@ Supported resolutions on the selected video display port.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DeviceInfo.1.supportedresolutions",
+    "method": "DeviceInfo.supportedresolutions",
     "params": {
         "videoDisplay": "HDMI0"
     }
@@ -143,7 +143,7 @@ Default resolution on the selected video display port.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DeviceInfo.1.defaultresolution",
+    "method": "DeviceInfo.defaultresolution",
     "params": {
         "videoDisplay": "HDMI0"
     }
@@ -195,7 +195,7 @@ Supported HDCP version on the selected video display port.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DeviceInfo.1.supportedhdcp",
+    "method": "DeviceInfo.supportedhdcp",
     "params": {
         "videoDisplay": "HDMI0"
     }
@@ -248,7 +248,7 @@ Audio capabilities for the specified audio port.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DeviceInfo.1.audiocapabilities",
+    "method": "DeviceInfo.audiocapabilities",
     "params": {
         "audioPort": "HDMI0"
     }
@@ -303,7 +303,7 @@ MS12 audio capabilities for the specified audio port.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DeviceInfo.1.ms12capabilities",
+    "method": "DeviceInfo.ms12capabilities",
     "params": {
         "audioPort": "HDMI0"
     }
@@ -358,7 +358,7 @@ Supported MS12 audio profiles for the specified audio port.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DeviceInfo.1.supportedms12audioprofiles",
+    "method": "DeviceInfo.supportedms12audioprofiles",
     "params": {
         "audioPort": "HDMI0"
     }
@@ -438,7 +438,7 @@ Provides access to the system general information.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DeviceInfo.1.systeminfo"
+    "method": "DeviceInfo.systeminfo"
 }
 ```
 
@@ -494,7 +494,7 @@ Provides access to the network interface addresses.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DeviceInfo.1.addresses"
+    "method": "DeviceInfo.addresses"
 }
 ```
 
@@ -538,7 +538,7 @@ Provides access to the socket information.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DeviceInfo.1.socketinfo"
+    "method": "DeviceInfo.socketinfo"
 }
 ```
 
@@ -585,7 +585,7 @@ Provides access to the versions maintained in version.txt.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DeviceInfo.1.firmwareversion"
+    "method": "DeviceInfo.firmwareversion"
 }
 ```
 
@@ -632,7 +632,7 @@ Provides access to the serial number set by manufacturer.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DeviceInfo.1.serialnumber"
+    "method": "DeviceInfo.serialnumber"
 }
 ```
 
@@ -676,7 +676,7 @@ Provides access to the device model number or SKU.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DeviceInfo.1.modelid"
+    "method": "DeviceInfo.modelid"
 }
 ```
 
@@ -720,7 +720,7 @@ Provides access to the device manufacturer.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DeviceInfo.1.make"
+    "method": "DeviceInfo.make"
 }
 ```
 
@@ -764,7 +764,7 @@ Provides access to the friendly device model name.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DeviceInfo.1.modelname"
+    "method": "DeviceInfo.modelname"
 }
 ```
 
@@ -808,7 +808,7 @@ Provides access to the device type.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DeviceInfo.1.devicetype"
+    "method": "DeviceInfo.devicetype"
 }
 ```
 
@@ -852,7 +852,7 @@ Provides access to the partner ID or distributor ID for device.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DeviceInfo.1.distributorid"
+    "method": "DeviceInfo.distributorid"
 }
 ```
 
@@ -897,7 +897,7 @@ Provides access to the audio ports supported on the device (all ports that are p
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DeviceInfo.1.supportedaudioports"
+    "method": "DeviceInfo.supportedaudioports"
 }
 ```
 
@@ -944,7 +944,7 @@ Provides access to the video ports supported on the device (all ports that are p
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DeviceInfo.1.supportedvideodisplays"
+    "method": "DeviceInfo.supportedvideodisplays"
 }
 ```
 
@@ -990,7 +990,7 @@ Provides access to the EDID of the host.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DeviceInfo.1.hostedid"
+    "method": "DeviceInfo.hostedid"
 }
 ```
 

--- a/docs/api/DisplayInfoPlugin.md
+++ b/docs/api/DisplayInfoPlugin.md
@@ -81,7 +81,7 @@ Returns the TV's Extended Display Identification Data (EDID).
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DisplayInfo.1.edid",
+    "method": "DisplayInfo.edid",
     "params": {
         "length": 0
     }
@@ -124,7 +124,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DisplayInfo.1.widthincentimeters"
+    "method": "DisplayInfo.widthincentimeters"
 }
 ```
 
@@ -161,7 +161,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DisplayInfo.1.heightincentimeters"
+    "method": "DisplayInfo.heightincentimeters"
 }
 ```
 
@@ -225,7 +225,7 @@ Provides access to the total GPU DRAM memory (in bytes).
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DisplayInfo.1.totalgpuram"
+    "method": "DisplayInfo.totalgpuram"
 }
 ```
 
@@ -260,7 +260,7 @@ Provides access to the free GPU DRAM memory (in bytes).
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DisplayInfo.1.freegpuram"
+    "method": "DisplayInfo.freegpuram"
 }
 ```
 
@@ -295,7 +295,7 @@ Provides access to the current audio passthrough status on HDMI.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DisplayInfo.1.isaudiopassthrough"
+    "method": "DisplayInfo.isaudiopassthrough"
 }
 ```
 
@@ -330,7 +330,7 @@ Provides access to the current HDMI connection status.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DisplayInfo.1.connected"
+    "method": "DisplayInfo.connected"
 }
 ```
 
@@ -365,7 +365,7 @@ Provides access to the horizontal resolution of the TV.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DisplayInfo.1.width"
+    "method": "DisplayInfo.width"
 }
 ```
 
@@ -400,7 +400,7 @@ Provides access to the vertical resolution of the TV.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DisplayInfo.1.height"
+    "method": "DisplayInfo.height"
 }
 ```
 
@@ -435,7 +435,7 @@ Provides access to the vertical Frequency.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DisplayInfo.1.verticalfreq"
+    "method": "DisplayInfo.verticalfreq"
 }
 ```
 
@@ -470,7 +470,7 @@ Provides access to the HDCP protocol used for transmission.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DisplayInfo.1.hdcpprotection"
+    "method": "DisplayInfo.hdcpprotection"
 }
 ```
 
@@ -505,7 +505,7 @@ Provides access to the video output port on the STB used for connecting to the T
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DisplayInfo.1.portname"
+    "method": "DisplayInfo.portname"
 }
 ```
 
@@ -540,7 +540,7 @@ Provides access to the HDR formats supported by the TV.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DisplayInfo.1.tvcapabilities"
+    "method": "DisplayInfo.tvcapabilities"
 }
 ```
 
@@ -575,7 +575,7 @@ Provides access to the HDR formats supported by the STB.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DisplayInfo.1.stbcapabilities"
+    "method": "DisplayInfo.stbcapabilities"
 }
 ```
 
@@ -610,7 +610,7 @@ Provides access to the HDR format in use.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DisplayInfo.1.hdrsetting"
+    "method": "DisplayInfo.hdrsetting"
 }
 ```
 
@@ -645,7 +645,7 @@ Provides access to the display color space (chroma subsampling format).
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DisplayInfo.1.colorspace"
+    "method": "DisplayInfo.colorspace"
 }
 ```
 
@@ -680,7 +680,7 @@ Provides access to the display frame rate.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DisplayInfo.1.framerate"
+    "method": "DisplayInfo.framerate"
 }
 ```
 
@@ -715,7 +715,7 @@ Provides access to the display colour depth.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DisplayInfo.1.colourdepth"
+    "method": "DisplayInfo.colourdepth"
 }
 ```
 
@@ -750,7 +750,7 @@ Provides access to the display quantization range.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DisplayInfo.1.quantizationrange"
+    "method": "DisplayInfo.quantizationrange"
 }
 ```
 
@@ -785,7 +785,7 @@ Provides access to the display colorimetry.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DisplayInfo.1.colorimetry"
+    "method": "DisplayInfo.colorimetry"
 }
 ```
 
@@ -820,7 +820,7 @@ Provides access to the display Electro Optical Transfer Function (EOTF).
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "DisplayInfo.1.eotf"
+    "method": "DisplayInfo.eotf"
 }
 ```
 
@@ -865,7 +865,7 @@ Triggered when the connection changes or is updated.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.updated",
+    "method": "client.events.updated",
     "params": {
         "event": "HdmiChange"
     }

--- a/docs/api/DisplaySettingsPlugin.md
+++ b/docs/api/DisplaySettingsPlugin.md
@@ -159,7 +159,7 @@ Enables or disables Surround Decoder capability. The Surround Decoder is an upmi
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.enableSurroundDecoder",
+    "method": "org.rdk.DisplaySettings.enableSurroundDecoder",
     "params": {
         "audioPort": "SPEAKER0",
         "surroundDecoderEnable": true
@@ -211,7 +211,7 @@ Returns `true` if the STB HDMI output is currently connected to the active input
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.getActiveInput",
+    "method": "org.rdk.DisplaySettings.getActiveInput",
     "params": {
         "videoDisplay": "HDMI0"
     }
@@ -263,7 +263,7 @@ Returns the audio delay (in ms) on the selected audio port. If the `audioPort` a
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.getAudioDelay",
+    "method": "org.rdk.DisplaySettings.getAudioDelay",
     "params": {
         "audioPort": "HDMI0"
     }
@@ -315,7 +315,7 @@ Returns the audio delay offset (in ms) on the selected audio port. If the `audio
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.getAudioDelayOffset",
+    "method": "org.rdk.DisplaySettings.getAudioDelayOffset",
     "params": {
         "audioPort": "HDMI0"
     }
@@ -366,7 +366,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.getAudioFormat"
+    "method": "org.rdk.DisplaySettings.getAudioFormat"
 }
 ```
 
@@ -419,7 +419,7 @@ Returns the current status of the Bass Enhancer settings.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.getBassEnhancer",
+    "method": "org.rdk.DisplaySettings.getBassEnhancer",
     "params": {
         "audioPort": "SPEAKER0"
     }
@@ -470,7 +470,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.getConnectedAudioPorts"
+    "method": "org.rdk.DisplaySettings.getConnectedAudioPorts"
 }
 ```
 
@@ -519,7 +519,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.getConnectedVideoDisplays"
+    "method": "org.rdk.DisplaySettings.getConnectedVideoDisplays"
 }
 ```
 
@@ -571,7 +571,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.getCurrentOutputSettings"
+    "method": "org.rdk.DisplaySettings.getCurrentOutputSettings"
 }
 ```
 
@@ -624,7 +624,7 @@ Returns the current resolution on the selected video display port.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.getCurrentResolution",
+    "method": "org.rdk.DisplaySettings.getCurrentResolution",
     "params": {
         "videoDisplay": "HDMI0"
     }
@@ -673,7 +673,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.getDefaultResolution"
+    "method": "org.rdk.DisplaySettings.getDefaultResolution"
 }
 ```
 
@@ -723,7 +723,7 @@ Returns the current Dialog Enhancer level (port HDMI0).
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.getDialogEnhancement",
+    "method": "org.rdk.DisplaySettings.getDialogEnhancement",
     "params": {
         "audioPort": "SPEAKER0"
     }
@@ -773,7 +773,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.getDolbyVolumeMode"
+    "method": "org.rdk.DisplaySettings.getDolbyVolumeMode"
 }
 ```
 
@@ -822,7 +822,7 @@ Returns the current Dynamic Range Control mode.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.getDRCMode",
+    "method": "org.rdk.DisplaySettings.getDRCMode",
     "params": {
         "audioPort": "SPEAKER0"
     }
@@ -874,7 +874,7 @@ Returns the current Dynamic Range Control mode.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.getEnableAudioPort",
+    "method": "org.rdk.DisplaySettings.getEnableAudioPort",
     "params": {
         "audioPort": "HDMI0"
     }
@@ -926,7 +926,7 @@ Returns the current gain value.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.getGain",
+    "method": "org.rdk.DisplaySettings.getGain",
     "params": {
         "audioPort": "SPEAKER0"
     }
@@ -979,7 +979,7 @@ Returns the current Graphic Equalizer Mode setting (port HDMI0).
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.getGraphicEqualizerMode",
+    "method": "org.rdk.DisplaySettings.getGraphicEqualizerMode",
     "params": {
         "audioPort": "SPEAKER0"
     }
@@ -1033,7 +1033,7 @@ Returns the current Intelligent Equalizer Mode setting (port HDMI0).
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.getIntelligentEqualizerMode",
+    "method": "org.rdk.DisplaySettings.getIntelligentEqualizerMode",
     "params": {
         "audioPort": "SPEAKER0"
     }
@@ -1086,7 +1086,7 @@ Returns the current status of Media Intelligence Steering settings.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.getMISteering",
+    "method": "org.rdk.DisplaySettings.getMISteering",
     "params": {
         "audioPort": "SPEAKER0"
     }
@@ -1139,7 +1139,7 @@ Returns the current audio compression settings.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.getMS12AudioCompression",
+    "method": "org.rdk.DisplaySettings.getMS12AudioCompression",
     "params": {
         "audioPort": "SPEAKER0"
     }
@@ -1192,7 +1192,7 @@ Returns the current MS12 audio profile settings.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.getMS12AudioProfile",
+    "method": "org.rdk.DisplaySettings.getMS12AudioProfile",
     "params": {
         "audioPort": "SPEAKER0"
     }
@@ -1244,7 +1244,7 @@ Returns whether audio is muted on a given port.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.getMuted",
+    "method": "org.rdk.DisplaySettings.getMuted",
     "params": {
         "audioPort": "SPEAKER0"
     }
@@ -1297,7 +1297,7 @@ Returns the current color depth on the selected video display port.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.getPreferredColorDepth",
+    "method": "org.rdk.DisplaySettings.getPreferredColorDepth",
     "params": {
         "videoDisplay": "HDMI0",
         "persist": true
@@ -1351,7 +1351,7 @@ Returns the set-top audio capabilities for the specified audio port.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.getSettopAudioCapabilities",
+    "method": "org.rdk.DisplaySettings.getSettopAudioCapabilities",
     "params": {
         "audioPort": "SPEAKER0"
     }
@@ -1404,7 +1404,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.getSettopHDRSupport"
+    "method": "org.rdk.DisplaySettings.getSettopHDRSupport"
 }
 ```
 
@@ -1457,7 +1457,7 @@ Returns the set-top MS12 audio capabilities for the specified audio port.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.getSettopMS12Capabilities",
+    "method": "org.rdk.DisplaySettings.getSettopMS12Capabilities",
     "params": {
         "audioPort": "SPEAKER0"
     }
@@ -1508,7 +1508,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.getSinkAtmosCapability"
+    "method": "org.rdk.DisplaySettings.getSinkAtmosCapability"
 }
 ```
 
@@ -1557,7 +1557,7 @@ Returns the sound mode for the incoming video display. If the argument is `Null`
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.getSoundMode",
+    "method": "org.rdk.DisplaySettings.getSoundMode",
     "params": {
         "audioPort": "SPEAKER0"
     }
@@ -1615,7 +1615,7 @@ For **Auto** mode in DS5, this API has the following extra specification:
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.getSupportedAudioModes",
+    "method": "org.rdk.DisplaySettings.getSupportedAudioModes",
     "params": {
         "audioPort": "SPEAKER0"
     }
@@ -1667,7 +1667,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.getSupportedAudioPorts"
+    "method": "org.rdk.DisplaySettings.getSupportedAudioPorts"
 }
 ```
 
@@ -1719,7 +1719,7 @@ Returns list of platform supported MS12 audio profiles for the specified audio p
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.getSupportedMS12AudioProfiles",
+    "method": "org.rdk.DisplaySettings.getSupportedMS12AudioProfiles",
     "params": {
         "audioPort": "SPEAKER0"
     }
@@ -1774,7 +1774,7 @@ Returns supported resolutions on the selected video display port (both TV and ST
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.getSupportedResolutions",
+    "method": "org.rdk.DisplaySettings.getSupportedResolutions",
     "params": {
         "videoDisplay": "HDMI0"
     }
@@ -1826,7 +1826,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.getSupportedSettopResolutions"
+    "method": "org.rdk.DisplaySettings.getSupportedSettopResolutions"
 }
 ```
 
@@ -1878,7 +1878,7 @@ Returns supported TV resolutions on the selected video display port.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.getSupportedTvResolutions",
+    "method": "org.rdk.DisplaySettings.getSupportedTvResolutions",
     "params": {
         "videoDisplay": "HDMI0"
     }
@@ -1930,7 +1930,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.getSupportedVideoDisplays"
+    "method": "org.rdk.DisplaySettings.getSupportedVideoDisplays"
 }
 ```
 
@@ -1982,7 +1982,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.getSurroundVirtualizer",
+    "method": "org.rdk.DisplaySettings.getSurroundVirtualizer",
     "params": {
         "audioPort": "SPEAKER0"
     }
@@ -2037,7 +2037,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.getTVHDRCapabilities"
+    "method": "org.rdk.DisplaySettings.getTVHDRCapabilities"
 }
 ```
 
@@ -2085,7 +2085,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.getTvHDRSupport"
+    "method": "org.rdk.DisplaySettings.getTvHDRSupport"
 }
 ```
 
@@ -2136,7 +2136,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.getVideoFormat"
+    "method": "org.rdk.DisplaySettings.getVideoFormat"
 }
 ```
 
@@ -2189,7 +2189,7 @@ Returns video port status in standby mode (failure if the port name is missing).
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.getVideoPortStatusInStandby",
+    "method": "org.rdk.DisplaySettings.getVideoPortStatusInStandby",
     "params": {
         "portName": "HDMI0"
     }
@@ -2242,7 +2242,7 @@ Returns the current volume level.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.getVolumeLevel",
+    "method": "org.rdk.DisplaySettings.getVolumeLevel",
     "params": {
         "audioPort": "SPEAKER0"
     }
@@ -2295,7 +2295,7 @@ Returns the current volume level.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.getVolumeLeveller",
+    "method": "org.rdk.DisplaySettings.getVolumeLeveller",
     "params": {
         "audioPort": "SPEAKER0"
     }
@@ -2345,7 +2345,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.getZoomSetting"
+    "method": "org.rdk.DisplaySettings.getZoomSetting"
 }
 ```
 
@@ -2391,7 +2391,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.isConnectedDeviceRepeater"
+    "method": "org.rdk.DisplaySettings.isConnectedDeviceRepeater"
 }
 ```
 
@@ -2440,7 +2440,7 @@ Returns the current status of Surround Decoder.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.isSurroundDecoderEnabled",
+    "method": "org.rdk.DisplaySettings.isSurroundDecoderEnabled",
     "params": {
         "audioPort": "SPEAKER0"
     }
@@ -2489,7 +2489,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.readEDID"
+    "method": "org.rdk.DisplaySettings.readEDID"
 }
 ```
 
@@ -2535,7 +2535,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.readHostEDID"
+    "method": "org.rdk.DisplaySettings.readHostEDID"
 }
 ```
 
@@ -2583,7 +2583,7 @@ Resets the dialog enhancer level to its default bassboost value.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.resetBassEnhancer",
+    "method": "org.rdk.DisplaySettings.resetBassEnhancer",
     "params": {
         "audioPort": "SPEAKER0"
     }
@@ -2633,7 +2633,7 @@ Resets the dialog enhancer level to its default enhancer level.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.resetDialogEnhancement",
+    "method": "org.rdk.DisplaySettings.resetDialogEnhancement",
     "params": {
         "audioPort": "SPEAKER0"
     }
@@ -2683,7 +2683,7 @@ Resets the surround virtualizer to its default boost value.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.resetSurroundVirtualizer",
+    "method": "org.rdk.DisplaySettings.resetSurroundVirtualizer",
     "params": {
         "audioPort": "SPEAKER0"
     }
@@ -2733,7 +2733,7 @@ Resets the Volume Leveller level to default volume value.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.resetVolumeLeveller",
+    "method": "org.rdk.DisplaySettings.resetVolumeLeveller",
     "params": {
         "audioPort": "SPEAKER0"
     }
@@ -2783,7 +2783,7 @@ Sets ATMOS audio output mode (on HDMI0).
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.setAudioAtmosOutputMode",
+    "method": "org.rdk.DisplaySettings.setAudioAtmosOutputMode",
     "params": {
         "enable": true
     }
@@ -2834,7 +2834,7 @@ Sets the audio delay (in ms) on the selected audio port. If the `audioPort` argu
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.setAudioDelay",
+    "method": "org.rdk.DisplaySettings.setAudioDelay",
     "params": {
         "audioPort": "HDMI0",
         "audioDelay": "0"
@@ -2886,7 +2886,7 @@ Sets the audio delay offset (in ms) on the selected audio port. If the `audioPor
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.setAudioDelayOffset",
+    "method": "org.rdk.DisplaySettings.setAudioDelayOffset",
     "params": {
         "audioPort": "HDMI0",
         "audioDelayOffset": "0"
@@ -2938,7 +2938,7 @@ Sets the Bass Enhancer. Bass Enhancer provides the consumer a single control to 
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.setBassEnhancer",
+    "method": "org.rdk.DisplaySettings.setBassEnhancer",
     "params": {
         "audioPort": "SPEAKER0",
         "bassBoost": 50
@@ -2996,7 +2996,7 @@ Also see: [resolutionPreChange](#resolutionPreChange), [resolutionChanged](#reso
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.setCurrentResolution",
+    "method": "org.rdk.DisplaySettings.setCurrentResolution",
     "params": {
         "videoDisplay": "HDMI0",
         "resolution": "1080p",
@@ -3050,7 +3050,7 @@ Sets the Dialog Enhancer level.A dialog enhancer boosts the speech audio separat
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.setDialogEnhancement",
+    "method": "org.rdk.DisplaySettings.setDialogEnhancement",
     "params": {
         "audioPort": "SPEAKER0",
         "enhancerlevel": 0
@@ -3101,7 +3101,7 @@ Enables or disables Dolby Volume mode on audio track (audio output port HDMI0).
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.setDolbyVolumeMode",
+    "method": "org.rdk.DisplaySettings.setDolbyVolumeMode",
     "params": {
         "dolbyVolumeMode": true
     }
@@ -3152,7 +3152,7 @@ Sets the Dynamic Range Control (DRC) setting. DRC is a compression control appli
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.setDRCMode",
+    "method": "org.rdk.DisplaySettings.setDRCMode",
     "params": {
         "audioPort": "SPEAKER0",
         "DRCMode": 1
@@ -3204,7 +3204,7 @@ Enable or disable the specified audio port based on the input audio port name. T
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.setEnableAudioPort",
+    "method": "org.rdk.DisplaySettings.setEnableAudioPort",
     "params": {
         "audioPort": "HDMI0",
         "enable": true
@@ -3255,7 +3255,7 @@ Enables or disables the force HDR mode. If enabled, the HDR format that is curre
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.setForceHDRMode",
+    "method": "org.rdk.DisplaySettings.setForceHDRMode",
     "params": {
         "hdr_mode": true
     }
@@ -3306,7 +3306,7 @@ Adjusts the gain on a specific port.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.setGain",
+    "method": "org.rdk.DisplaySettings.setGain",
     "params": {
         "audioPort": "SPEAKER0",
         "gain": 10.0
@@ -3358,7 +3358,7 @@ Sets the Graphic Equalizer Mode. The Graphic Equalizer is a multi-band equalizer
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.setGraphicEqualizerMode",
+    "method": "org.rdk.DisplaySettings.setGraphicEqualizerMode",
     "params": {
         "audioPort": "SPEAKER0",
         "graphicEqualizerMode": 2
@@ -3410,7 +3410,7 @@ Sets the Intelligent Equalizer Mode (port HDMI0). An Intelligent Equalizer conti
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.setIntelligentEqualizerMode",
+    "method": "org.rdk.DisplaySettings.setIntelligentEqualizerMode",
     "params": {
         "audioPort": "SPEAKER0",
         "intelligentEqualizerMode": 2
@@ -3462,7 +3462,7 @@ Enables or Disables Media Intelligent Steering. Media Intelligence analyzes audi
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.setMISteering",
+    "method": "org.rdk.DisplaySettings.setMISteering",
     "params": {
         "audioPort": "SPEAKER0",
         "MISteeringEnable": true
@@ -3514,7 +3514,7 @@ Sets the audio dynamic range compression level (port HDMI0).
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.setMS12AudioCompression",
+    "method": "org.rdk.DisplaySettings.setMS12AudioCompression",
     "params": {
         "audioPort": "SPEAKER0",
         "compresionLevel": 5
@@ -3566,7 +3566,7 @@ Sets the selected MS12 audio profile.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.setMS12AudioProfile",
+    "method": "org.rdk.DisplaySettings.setMS12AudioProfile",
     "params": {
         "audioPort": "SPEAKER0",
         "ms12AudioProfile": "Game"
@@ -3617,7 +3617,7 @@ Overrides individual MS12 audio settings in order to optimize the customer exper
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.setMS12ProfileSettingsOverride",
+    "method": "org.rdk.DisplaySettings.setMS12ProfileSettingsOverride",
     "params": {
         "audioPort": "SPEAKER0",
         "operation": "...",
@@ -3672,7 +3672,7 @@ Mutes or unmutes audio on a specific port.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.setMuted",
+    "method": "org.rdk.DisplaySettings.setMuted",
     "params": {
         "audioPort": "SPEAKER0",
         "muted": true
@@ -3722,7 +3722,7 @@ Sets the current color depth for the videoDisplay.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.setPreferredColorDepth",
+    "method": "org.rdk.DisplaySettings.setPreferredColorDepth",
     "params": {
         "videoDisplay": "HDMI0",
         "colorDepth": "12 Bit",
@@ -3785,7 +3785,7 @@ Possible values:
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.setScartParameter",
+    "method": "org.rdk.DisplaySettings.setScartParameter",
     "params": {
         "scartParameter": "aspect_ratio",
         "scartParameterData": "4x3"
@@ -3838,7 +3838,7 @@ Sets the current sound mode for the corresponding video display. If the `audioPo
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.setSoundMode",
+    "method": "org.rdk.DisplaySettings.setSoundMode",
     "params": {
         "audioPort": "HDMI0",
         "soundMode": "STEREO",
@@ -3892,7 +3892,7 @@ Sets the current sound mode for the corresponding video display. If the `audioPo
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.setSurroundVirtualizer",
+    "method": "org.rdk.DisplaySettings.setSurroundVirtualizer",
     "params": {
         "audioPort": "SPEAKER0",
         "mode": 1,
@@ -3946,7 +3946,7 @@ Sets the specified video port status to be used in standby mode (failure if the 
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.setVideoPortStatusInStandby",
+    "method": "org.rdk.DisplaySettings.setVideoPortStatusInStandby",
     "params": {
         "portName": "HDMI0",
         "enabled": true
@@ -3999,7 +3999,7 @@ Adjusts the Volume Level on a specific port.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.setVolumeLevel",
+    "method": "org.rdk.DisplaySettings.setVolumeLevel",
     "params": {
         "audioPort": "SPEAKER0",
         "volumeLevel": 50
@@ -4052,7 +4052,7 @@ Adjusts the Volume Level on a specific port.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.setVolumeLeveller",
+    "method": "org.rdk.DisplaySettings.setVolumeLeveller",
     "params": {
         "audioPort": "SPEAKER0",
         "mode": 1,
@@ -4105,7 +4105,7 @@ Sets the current zoom value.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.setZoomSetting",
+    "method": "org.rdk.DisplaySettings.setZoomSetting",
     "params": {
         "zoomSetting": "FULL"
     }
@@ -4154,7 +4154,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.DisplaySettings.1.getColorDepthCapabilities"
+    "method": "org.rdk.DisplaySettings.getColorDepthCapabilities"
 }
 ```
 
@@ -4211,7 +4211,7 @@ Triggered on active input change (RxSense).
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.activeInputChanged",
+    "method": "client.events.activeInputChanged",
     "params": {
         "activeInput": true
     }
@@ -4237,7 +4237,7 @@ Triggered when the configured audio format changes.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.audioFormatChanged",
+    "method": "client.events.audioFormatChanged",
     "params": {
         "supportedAudioFormat": [
             "`NONE`, `PCM`, `DOLBY AC3`, `DOLBY EAC3`, `DOLBY AC4`, `DOLBY MAT', 'DOLBY TRUEHD', 'DOLBY EAC3 ATMOS', 'DOLBY TRUEHD ATMOS', 'DOLBY MAT ATMOS', 'DOLBY AC4 ATMOS'"
@@ -4265,7 +4265,7 @@ Triggered when the connected audio port is updated.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.connectedAudioPortUpdated",
+    "method": "client.events.connectedAudioPortUpdated",
     "params": {
         "HotpluggedAudioPort": "HDMI_ARC0",
         "isConnected": "connected"
@@ -4291,7 +4291,7 @@ Triggered when the connected video display is updated and returns the connected 
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.connectedVideoDisplaysUpdated",
+    "method": "client.events.connectedVideoDisplaysUpdated",
     "params": {
         "connectedVideoDisplays": [
             "HDMI0"
@@ -4320,7 +4320,7 @@ Triggered when the resolution is changed by the user and returns the current res
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.resolutionChanged",
+    "method": "client.events.resolutionChanged",
     "params": {
         "width": 1920,
         "height": 1080,
@@ -4344,7 +4344,7 @@ This event carries no parameters.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.resolutionPreChange"
+    "method": "client.events.resolutionPreChange"
 }
 ```
 
@@ -4366,7 +4366,7 @@ Triggered when the zoom setting changes and returns the zoom setting values for 
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.zoomSettingUpdated",
+    "method": "client.events.zoomSettingUpdated",
     "params": {
         "zoomSetting": "FULL",
         "videoDisplayType": "HDMI0"
@@ -4393,7 +4393,7 @@ Triggered when the video format of connected video port changes and returns the 
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.videoFormatChanged",
+    "method": "client.events.videoFormatChanged",
     "params": {
         "supportedVideoFormat": [
             "`SDR`, `HDR10`, `HLG`, `DV`, `Technicolor Prime`"

--- a/docs/api/FireboltMediaPlayerPlugin.md
+++ b/docs/api/FireboltMediaPlayerPlugin.md
@@ -89,7 +89,7 @@ Initiates a new AAMP player instance suitable for playback of IP feeds. If a pla
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.FireboltMediaPlayer.1.create",
+    "method": "org.rdk.FireboltMediaPlayer.create",
     "params": {
         "id": "MainPlayer"
     }
@@ -137,7 +137,7 @@ For complete list of configuration properties, see:https://wiki.rdkcentral.com/d
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.FireboltMediaPlayer.1.initConfig",
+    "method": "org.rdk.FireboltMediaPlayer.initConfig",
     "params": {
         "initialBitrate": 3000000
     }
@@ -185,7 +185,7 @@ Associates a specified URL with a player instance.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.FireboltMediaPlayer.1.load",
+    "method": "org.rdk.FireboltMediaPlayer.load",
     "params": {
         "id": "MainPlayer",
         "url": "https://cpetestutility.stb.r53.xcal.tv/VideoTestStream/main.m3u8",
@@ -233,7 +233,7 @@ Pauses streaming content that is associated with the specified player instance. 
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.FireboltMediaPlayer.1.pause",
+    "method": "org.rdk.FireboltMediaPlayer.pause",
     "params": {
         "id": "MainPlayer"
     }
@@ -279,7 +279,7 @@ Begins or resumes streaming content that is associated with the specified player
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.FireboltMediaPlayer.1.play",
+    "method": "org.rdk.FireboltMediaPlayer.play",
     "params": {
         "id": "MainPlayer"
     }
@@ -325,7 +325,7 @@ Decreases the ref-count of the player. The player gets destroyed when the ref-co
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.FireboltMediaPlayer.1.release",
+    "method": "org.rdk.FireboltMediaPlayer.release",
     "params": {
         "id": "MainPlayer"
     }
@@ -372,7 +372,7 @@ Moves the media to a specific position.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.FireboltMediaPlayer.1.seek",
+    "method": "org.rdk.FireboltMediaPlayer.seek",
     "params": {
         "id": "MainPlayer",
         "positionSec": 30
@@ -422,7 +422,7 @@ Modifies the default configuration of the DRM used by AAMP.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.FireboltMediaPlayer.1.setDRMConfig",
+    "method": "org.rdk.FireboltMediaPlayer.setDRMConfig",
     "params": {
         "id": "MainPlayer",
         "com.microsoft.playready": "http://test.playready.microsoft.com/service/rightsmanager.asmx",
@@ -471,7 +471,7 @@ Stops streaming content.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.FireboltMediaPlayer.1.stop",
+    "method": "org.rdk.FireboltMediaPlayer.stop",
     "params": {
         "id": "MainPlayer"
     }
@@ -522,7 +522,7 @@ Triggered when the media stream starts.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onMediaStreamEvent",
+    "method": "client.events.onMediaStreamEvent",
     "params": {
         "id": "MainPlayer",
         "parametersJson": {}

--- a/docs/api/FrameRatePlugin.md
+++ b/docs/api/FrameRatePlugin.md
@@ -86,7 +86,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.FrameRate.1.getDisplayFrameRate"
+    "method": "org.rdk.FrameRate.getDisplayFrameRate"
 }
 ```
 
@@ -132,7 +132,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.FrameRate.1.getFrmMode"
+    "method": "org.rdk.FrameRate.getFrmMode"
 }
 ```
 
@@ -180,7 +180,7 @@ Sets the FPS data collection interval.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.FrameRate.1.setCollectionFrequency",
+    "method": "org.rdk.FrameRate.setCollectionFrequency",
     "params": {
         "frequency": 1000
     }
@@ -234,7 +234,7 @@ Also see: [onDisplayFrameRateChanging](#onDisplayFrameRateChanging), [onDisplayF
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.FrameRate.1.setDisplayFrameRate",
+    "method": "org.rdk.FrameRate.setDisplayFrameRate",
     "params": {
         "framerate": "3840x2160px48"
     }
@@ -284,7 +284,7 @@ Also see: [onDisplayFrameRateChanging](#onDisplayFrameRateChanging), [onDisplayF
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.FrameRate.1.setFrmMode",
+    "method": "org.rdk.FrameRate.setFrmMode",
     "params": {
         "frmmode": 0
     }
@@ -334,7 +334,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.FrameRate.1.startFpsCollection"
+    "method": "org.rdk.FrameRate.startFpsCollection"
 }
 ```
 
@@ -381,7 +381,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.FrameRate.1.stopFpsCollection"
+    "method": "org.rdk.FrameRate.stopFpsCollection"
 }
 ```
 
@@ -428,7 +428,7 @@ Updates Fps values.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.FrameRate.1.updateFps",
+    "method": "org.rdk.FrameRate.updateFps",
     "params": {
         "newFpsValue": 60
     }
@@ -477,7 +477,7 @@ This event carries no parameters.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onDisplayFrameRateChanging"
+    "method": "client.events.onDisplayFrameRateChanging"
 }
 ```
 
@@ -495,7 +495,7 @@ This event carries no parameters.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onDisplayFrameRateChanged"
+    "method": "client.events.onDisplayFrameRateChanged"
 }
 ```
 
@@ -518,7 +518,7 @@ Triggered at the end of each interval as defined by the `setCollectionFrequency`
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onFpsEvent",
+    "method": "client.events.onFpsEvent",
     "params": {
         "average": 0,
         "min": 0,

--- a/docs/api/FrontPanelPlugin.md
+++ b/docs/api/FrontPanelPlugin.md
@@ -90,7 +90,7 @@ Get the brightness of the specified LED or FrontPanel.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.FrontPanel.1.getBrightness",
+    "method": "org.rdk.FrontPanel.getBrightness",
     "params": {
         "index": "power_led"
     }
@@ -135,7 +135,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.FrontPanel.1.getClockBrightness"
+    "method": "org.rdk.FrontPanel.getClockBrightness"
 }
 ```
 
@@ -187,7 +187,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.FrontPanel.1.getFrontPanelLights"
+    "method": "org.rdk.FrontPanel.getFrontPanelLights"
 }
 ```
 
@@ -243,7 +243,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.FrontPanel.1.getPreferences"
+    "method": "org.rdk.FrontPanel.getPreferences"
 }
 ```
 
@@ -286,7 +286,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.FrontPanel.1.is24HourClock"
+    "method": "org.rdk.FrontPanel.is24HourClock"
 }
 ```
 
@@ -330,7 +330,7 @@ Switches the specified LED off.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.FrontPanel.1.powerLedOff",
+    "method": "org.rdk.FrontPanel.powerLedOff",
     "params": {
         "index": "power_led"
     }
@@ -376,7 +376,7 @@ Switches the specified LED indicator on. The LED must be powered on prior to set
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.FrontPanel.1.powerLedOn",
+    "method": "org.rdk.FrontPanel.powerLedOn",
     "params": {
         "index": "power_led"
     }
@@ -422,7 +422,7 @@ Sets the clock mode to either 12 or 24 hour.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.FrontPanel.1.set24HourClock",
+    "method": "org.rdk.FrontPanel.set24HourClock",
     "params": {
         "is24Hour": false
     }
@@ -479,7 +479,7 @@ Sets a blinking pattern for a particular LED indicator.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.FrontPanel.1.setBlink",
+    "method": "org.rdk.FrontPanel.setBlink",
     "params": {
         "blinkInfo": {
             "ledIndicator": "power_led",
@@ -539,7 +539,7 @@ Sets the brightness of the specified LED indicator. If no indicator is specified
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.FrontPanel.1.setBrightness",
+    "method": "org.rdk.FrontPanel.setBrightness",
     "params": {
         "brightness": 50,
         "index": "power_led"
@@ -586,7 +586,7 @@ Sets the clock brightness.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.FrontPanel.1.setClockBrightness",
+    "method": "org.rdk.FrontPanel.setClockBrightness",
     "params": {
         "brightness": 50
     }
@@ -633,7 +633,7 @@ Allows you to set a test pattern on the STB clock (`88 88`).
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.FrontPanel.1.setClockTestPattern",
+    "method": "org.rdk.FrontPanel.setClockTestPattern",
     "params": {
         "show": true,
         "timeInterval": 4
@@ -685,7 +685,7 @@ Set preferences for the specified Front Panel LED indicator. Data are not valida
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.FrontPanel.1.setLED",
+    "method": "org.rdk.FrontPanel.setLED",
     "params": {
         "ledIndicator": "power_led",
         "brightness": 50,
@@ -736,7 +736,7 @@ Sets preferences for Front Panel LED indicators which are saved to `/opt/fp_serv
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.FrontPanel.1.setPreferences",
+    "method": "org.rdk.FrontPanel.setPreferences",
     "params": {
         "preferences": {}
     }

--- a/docs/api/HdcpProfilePlugin.md
+++ b/docs/api/HdcpProfilePlugin.md
@@ -94,7 +94,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdcpProfile.1.getHDCPStatus"
+    "method": "org.rdk.HdcpProfile.getHDCPStatus"
 }
 ```
 
@@ -149,7 +149,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdcpProfile.1.getSettopHDCPSupport"
+    "method": "org.rdk.HdcpProfile.getSettopHDCPSupport"
 }
 ```
 
@@ -205,7 +205,7 @@ Triggered if HDMI was connected or disconnected upon receiving `onHdmiOutputHotP
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onDisplayConnectionChanged",
+    "method": "client.events.onDisplayConnectionChanged",
     "params": {
         "HDCPStatus": {
             "isConnected": false,

--- a/docs/api/HdmiCecPlugin.md
+++ b/docs/api/HdmiCecPlugin.md
@@ -86,7 +86,7 @@ Gets the active source status of the device.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiCec.1.getActiveSourceStatus",
+    "method": "org.rdk.HdmiCec.getActiveSourceStatus",
     "params": {
         "status": true
     }
@@ -138,7 +138,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiCec.1.getCECAddresses"
+    "method": "org.rdk.HdmiCec.getCECAddresses"
 }
 ```
 
@@ -195,7 +195,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiCec.1.getDeviceList"
+    "method": "org.rdk.HdmiCec.getDeviceList"
 }
 ```
 
@@ -248,7 +248,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiCec.1.getEnabled"
+    "method": "org.rdk.HdmiCec.getEnabled"
 }
 ```
 
@@ -299,7 +299,7 @@ Also see: [onMessage](#onMessage)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiCec.1.sendMessage",
+    "method": "org.rdk.HdmiCec.sendMessage",
     "params": {
         "message": "1234567890"
     }
@@ -349,7 +349,7 @@ Enables or disables HDMI-CEC driver.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiCec.1.setEnabled",
+    "method": "org.rdk.HdmiCec.setEnabled",
     "params": {
         "enabled": false
     }
@@ -406,7 +406,7 @@ Triggered when the address of the host CEC device has changed.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.cecAddressesChanged",
+    "method": "client.events.cecAddressesChanged",
     "params": {
         "CECAddresses": {
             "physicalAddress": [
@@ -434,7 +434,7 @@ Triggered when device active source status changes.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onActiveSourceStatusUpdated",
+    "method": "client.events.onActiveSourceStatusUpdated",
     "params": {
         "status": true
     }
@@ -458,7 +458,7 @@ Triggered when an HDMI cable is physically connected to the HDMI port on a TV, o
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onDeviceAdded",
+    "method": "client.events.onDeviceAdded",
     "params": {
         "logicalAddress": 0
     }
@@ -482,7 +482,7 @@ Triggered when device information changes (vendorID, osdName).
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onDeviceInfoUpdated",
+    "method": "client.events.onDeviceInfoUpdated",
     "params": {
         "logicalAddress": 0
     }
@@ -506,7 +506,7 @@ Triggered when HDMI cable is physically removed from the HDMI port on a TV or th
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onDeviceRemoved",
+    "method": "client.events.onDeviceRemoved",
     "params": {
         "logicalAddress": 0
     }
@@ -530,7 +530,7 @@ Triggered when a message is sent from an HDMI device.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onMessage",
+    "method": "client.events.onMessage",
     "params": {
         "message": "1234567890"
     }

--- a/docs/api/HdmiCecSinkPlugin.md
+++ b/docs/api/HdmiCecSinkPlugin.md
@@ -109,7 +109,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiCecSink.1.getActiveRoute"
+    "method": "org.rdk.HdmiCecSink.getActiveRoute"
 }
 ```
 
@@ -174,7 +174,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiCecSink.1.getActiveSource"
+    "method": "org.rdk.HdmiCecSink.getActiveSource"
 }
 ```
 
@@ -228,7 +228,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiCecSink.1.getAudioDeviceConnectedStatus"
+    "method": "org.rdk.HdmiCecSink.getAudioDeviceConnectedStatus"
 }
 ```
 
@@ -284,7 +284,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiCecSink.1.getDeviceList"
+    "method": "org.rdk.HdmiCecSink.getDeviceList"
 }
 ```
 
@@ -342,7 +342,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiCecSink.1.getEnabled"
+    "method": "org.rdk.HdmiCecSink.getEnabled"
 }
 ```
 
@@ -388,7 +388,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiCecSink.1.getOSDName"
+    "method": "org.rdk.HdmiCecSink.getOSDName"
 }
 ```
 
@@ -434,7 +434,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiCecSink.1.getVendorId"
+    "method": "org.rdk.HdmiCecSink.getVendorId"
 }
 ```
 
@@ -480,7 +480,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiCecSink.1.printDeviceList"
+    "method": "org.rdk.HdmiCecSink.printDeviceList"
 }
 ```
 
@@ -530,7 +530,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiCecSink.1.requestActiveSource"
+    "method": "org.rdk.HdmiCecSink.requestActiveSource"
 }
 ```
 
@@ -577,7 +577,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiCecSink.1.requestShortAudioDescriptor"
+    "method": "org.rdk.HdmiCecSink.requestShortAudioDescriptor"
 }
 ```
 
@@ -624,7 +624,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiCecSink.1.sendAudioDevicePowerOnMessage"
+    "method": "org.rdk.HdmiCecSink.sendAudioDevicePowerOnMessage"
 }
 ```
 
@@ -671,7 +671,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiCecSink.1.sendGetAudioStatusMessage"
+    "method": "org.rdk.HdmiCecSink.sendGetAudioStatusMessage"
 }
 ```
 
@@ -719,7 +719,7 @@ Sends the CEC \<User Control Pressed\> message when TV remote key is pressed.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiCecSink.1.sendKeyPressEvent",
+    "method": "org.rdk.HdmiCecSink.sendKeyPressEvent",
     "params": {
         "logicalAddress": 4,
         "keyCode": 65
@@ -767,7 +767,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiCecSink.1.sendStandbyMessage"
+    "method": "org.rdk.HdmiCecSink.sendStandbyMessage"
 }
 ```
 
@@ -814,7 +814,7 @@ Sets the source device to active (`setStreamPath`). The source wakes from standb
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiCecSink.1.setActivePath",
+    "method": "org.rdk.HdmiCecSink.setActivePath",
     "params": {
         "activePath": "1.0.0.0"
     }
@@ -861,7 +861,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiCecSink.1.setActiveSource"
+    "method": "org.rdk.HdmiCecSink.setActiveSource"
 }
 ```
 
@@ -911,7 +911,7 @@ Also see: [reportCecEnabledEvent](#reportCecEnabledEvent)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiCecSink.1.setEnabled",
+    "method": "org.rdk.HdmiCecSink.setEnabled",
     "params": {
         "enabled": false
     }
@@ -961,7 +961,7 @@ Updates the internal data structure with the new menu Language and also broadcas
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiCecSink.1.setMenuLanguage",
+    "method": "org.rdk.HdmiCecSink.setMenuLanguage",
     "params": {
         "language": "chi"
     }
@@ -1011,7 +1011,7 @@ Sets the OSD Name used by host device.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiCecSink.1.setOSDName",
+    "method": "org.rdk.HdmiCecSink.setOSDName",
     "params": {
         "name": "Fire TV Stick"
     }
@@ -1062,7 +1062,7 @@ Changes routing while switching between HDMI inputs and TV.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiCecSink.1.setRoutingChange",
+    "method": "org.rdk.HdmiCecSink.setRoutingChange",
     "params": {
         "oldPort": "HDMI0",
         "newPort": "TV"
@@ -1115,7 +1115,7 @@ Also see: [arcInitiationEvent](#arcInitiationEvent), [arcTerminationEvent](#arcT
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiCecSink.1.setupARCRouting",
+    "method": "org.rdk.HdmiCecSink.setupARCRouting",
     "params": {
         "enabled": true
     }
@@ -1165,7 +1165,7 @@ Sets a vendor ID used by host device.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiCecSink.1.setVendorId",
+    "method": "org.rdk.HdmiCecSink.setVendorId",
     "params": {
         "vendorid": "0019fc"
     }
@@ -1230,7 +1230,7 @@ Triggered when routing though the HDMI ARC port is successfully established.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.arcInitiationEvent",
+    "method": "client.events.arcInitiationEvent",
     "params": {
         "status": "success"
     }
@@ -1254,7 +1254,7 @@ Triggered when routing though the HDMI ARC port terminates.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.arcTerminationEvent",
+    "method": "client.events.arcTerminationEvent",
     "params": {
         "status": "success"
     }
@@ -1279,7 +1279,7 @@ Triggered with the active source device changes.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onActiveSourceChange",
+    "method": "client.events.onActiveSourceChange",
     "params": {
         "logicalAddress": 4,
         "physicalAddress": "1.0.0.0"
@@ -1304,7 +1304,7 @@ Triggered when an HDMI cable is physically connected to the HDMI port on a TV, o
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onDeviceAdded",
+    "method": "client.events.onDeviceAdded",
     "params": {
         "logicalAddress": 4
     }
@@ -1328,7 +1328,7 @@ Triggered when device information changes (physicalAddress, deviceType, vendorID
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onDeviceInfoUpdated",
+    "method": "client.events.onDeviceInfoUpdated",
     "params": {
         "logicalAddress": 4
     }
@@ -1352,7 +1352,7 @@ Triggered when HDMI cable is physically removed from the HDMI port on a TV or th
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onDeviceRemoved",
+    "method": "client.events.onDeviceRemoved",
     "params": {
         "logicalAddress": 4
     }
@@ -1376,7 +1376,7 @@ Triggered when an \<Image View ON\> CEC message is received from the source devi
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onImageViewOnMsg",
+    "method": "client.events.onImageViewOnMsg",
     "params": {
         "logicalAddress": 4
     }
@@ -1401,7 +1401,7 @@ Triggered when the source is no longer active.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onInActiveSource",
+    "method": "client.events.onInActiveSource",
     "params": {
         "logicalAddress": 4,
         "physicalAddress": "1.0.0.0"
@@ -1426,7 +1426,7 @@ Triggered when a \<Text View ON\> CEC message is received from the source device
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onTextViewOnMsg",
+    "method": "client.events.onTextViewOnMsg",
     "params": {
         "logicalAddress": 4
     }
@@ -1450,7 +1450,7 @@ Triggered when the TV is in standby mode and it receives \<Image View ON\>/ \<Te
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onWakeupFromStandby",
+    "method": "client.events.onWakeupFromStandby",
     "params": {
         "logicalAddress": 4
     }
@@ -1475,7 +1475,7 @@ Triggered when an audio device is added or removed.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.reportAudioDeviceConnectedStatus",
+    "method": "client.events.reportAudioDeviceConnectedStatus",
     "params": {
         "status": "success",
         "audioDeviceConnected": "true"
@@ -1501,7 +1501,7 @@ Triggered when CEC \<Report Audio Status\> message of device is received.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.reportAudioStatusEvent",
+    "method": "client.events.reportAudioStatusEvent",
     "params": {
         "muteStatus": 0,
         "volumeLevel": 28
@@ -1526,7 +1526,7 @@ Triggered when the HDMI-CEC is enabled.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.reportCecEnabledEvent",
+    "method": "client.events.reportCecEnabledEvent",
     "params": {
         "cecEnable": "true"
     }
@@ -1550,7 +1550,7 @@ Triggered when CEC \<Set System Audio Mode\> message of device is received.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.setSystemAudioModeEvent",
+    "method": "client.events.setSystemAudioModeEvent",
     "params": {
         "audioMode": "On"
     }
@@ -1575,7 +1575,7 @@ Triggered when SAD is received from the connected audio device. See `requestShor
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.shortAudiodesciptorEvent",
+    "method": "client.events.shortAudiodesciptorEvent",
     "params": {
         "ShortAudioDescriptor": [
             [
@@ -1605,7 +1605,7 @@ Triggered when the source device changes status to `STANDBY`.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.standbyMessageReceived",
+    "method": "client.events.standbyMessageReceived",
     "params": {
         "logicalAddress": 4
     }

--- a/docs/api/HdmiCec_2Plugin.md
+++ b/docs/api/HdmiCec_2Plugin.md
@@ -93,7 +93,7 @@ Gets the active source status of the device.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiCec_2.1.getActiveSourceStatus",
+    "method": "org.rdk.HdmiCec_2.getActiveSourceStatus",
     "params": {
         "status": true
     }
@@ -146,7 +146,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiCec_2.1.getDeviceList"
+    "method": "org.rdk.HdmiCec_2.getDeviceList"
 }
 ```
 
@@ -199,7 +199,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiCec_2.1.getEnabled"
+    "method": "org.rdk.HdmiCec_2.getEnabled"
 }
 ```
 
@@ -245,7 +245,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiCec_2.1.getOSDName"
+    "method": "org.rdk.HdmiCec_2.getOSDName"
 }
 ```
 
@@ -291,7 +291,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiCec_2.1.getOTPEnabled"
+    "method": "org.rdk.HdmiCec_2.getOTPEnabled"
 }
 ```
 
@@ -337,7 +337,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiCec_2.1.getVendorId"
+    "method": "org.rdk.HdmiCec_2.getVendorId"
 }
 ```
 
@@ -382,7 +382,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiCec_2.1.performOTPAction"
+    "method": "org.rdk.HdmiCec_2.performOTPAction"
 }
 ```
 
@@ -430,7 +430,7 @@ Sends the CEC \<User Control Pressed\> message when TV remote key is pressed.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiCec_2.1.sendKeyPressEvent",
+    "method": "org.rdk.HdmiCec_2.sendKeyPressEvent",
     "params": {
         "logicalAddress": 0,
         "keyCode": 65
@@ -478,7 +478,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiCec_2.1.sendStandbyMessage"
+    "method": "org.rdk.HdmiCec_2.sendStandbyMessage"
 }
 ```
 
@@ -525,7 +525,7 @@ Enables or disables HDMI-CEC driver.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiCec_2.1.setEnabled",
+    "method": "org.rdk.HdmiCec_2.setEnabled",
     "params": {
         "enabled": false
     }
@@ -575,7 +575,7 @@ Sets the OSD name of the application.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiCec_2.1.setOSDName",
+    "method": "org.rdk.HdmiCec_2.setOSDName",
     "params": {
         "name": "Sky TV"
     }
@@ -625,7 +625,7 @@ Enables or disables HDMI-CEC OTP option.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiCec_2.1.setOTPEnabled",
+    "method": "org.rdk.HdmiCec_2.setOTPEnabled",
     "params": {
         "enabled": false
     }
@@ -675,7 +675,7 @@ Sets the vendor ID of the application.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiCec_2.1.setVendorId",
+    "method": "org.rdk.HdmiCec_2.setVendorId",
     "params": {
         "vendorid": "0x0019FB"
     }
@@ -729,7 +729,7 @@ Triggered when the device active source status changes.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onActiveSourceStatusUpdated",
+    "method": "client.events.onActiveSourceStatusUpdated",
     "params": {
         "status": true
     }
@@ -753,7 +753,7 @@ Triggered when an HDMI cable is physically connected to the HDMI port on a TV, o
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onDeviceAdded",
+    "method": "client.events.onDeviceAdded",
     "params": {
         "logicalAddress": 0
     }
@@ -777,7 +777,7 @@ Triggered when device system information is updated (vendorID, osdName).
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onDeviceInfoUpdated",
+    "method": "client.events.onDeviceInfoUpdated",
     "params": {
         "logicalAddress": 0
     }
@@ -801,7 +801,7 @@ Triggered when HDMI cable is physically removed from the HDMI port on a TV or th
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onDeviceRemoved",
+    "method": "client.events.onDeviceRemoved",
     "params": {
         "logicalAddress": 0
     }
@@ -825,7 +825,7 @@ Triggered when the source device changes status to `STANDBY`.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.standbyMessageReceived",
+    "method": "client.events.standbyMessageReceived",
     "params": {
         "logicalAddress": 0
     }

--- a/docs/api/HdmiInputPlugin.md
+++ b/docs/api/HdmiInputPlugin.md
@@ -94,7 +94,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiInput.1.getHDMIInputDevices"
+    "method": "org.rdk.HdmiInput.getHDMIInputDevices"
 }
 ```
 
@@ -149,7 +149,7 @@ No Events.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiInput.1.getEdidVersion",
+    "method": "org.rdk.HdmiInput.getEdidVersion",
     "params": {
         "portId": "0"
     }
@@ -201,7 +201,7 @@ No Events.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiInput.1.getHDMISPD",
+    "method": "org.rdk.HdmiInput.getHDMISPD",
     "params": {
         "portId": "0"
     }
@@ -253,7 +253,7 @@ No Events.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiInput.1.getRawHDMISPD",
+    "method": "org.rdk.HdmiInput.getRawHDMISPD",
     "params": {
         "portId": "0"
     }
@@ -305,7 +305,7 @@ No Events.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiInput.1.readEDID",
+    "method": "org.rdk.HdmiInput.readEDID",
     "params": {
         "deviceId": 0
     }
@@ -360,7 +360,7 @@ Also see: [onInputStatusChanged](#onInputStatusChanged), [onSignalChanged](#onSi
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiInput.1.startHdmiInput",
+    "method": "org.rdk.HdmiInput.startHdmiInput",
     "params": {
         "portId": "0"
     }
@@ -410,7 +410,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiInput.1.stopHdmiInput"
+    "method": "org.rdk.HdmiInput.stopHdmiInput"
 }
 ```
 
@@ -458,7 +458,7 @@ No Events.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiInput.1.setEdidVersion",
+    "method": "org.rdk.HdmiInput.setEdidVersion",
     "params": {
         "portId": "0",
         "edidVersion": "HDMI2.0"
@@ -512,7 +512,7 @@ No Events.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiInput.1.setVideoRectangle",
+    "method": "org.rdk.HdmiInput.setVideoRectangle",
     "params": {
         "x": 0,
         "y": 0,
@@ -566,7 +566,7 @@ No Events.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiInput.1.writeEDID",
+    "method": "org.rdk.HdmiInput.writeEDID",
     "params": {
         "deviceId": 0,
         "message": "EDID"
@@ -615,7 +615,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiInput.1.getSupportedGameFeatures"
+    "method": "org.rdk.HdmiInput.getSupportedGameFeatures"
 }
 ```
 
@@ -665,7 +665,7 @@ No Events.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.HdmiInput.1.getHdmiGameFeatureStatus",
+    "method": "org.rdk.HdmiInput.getHdmiGameFeatureStatus",
     "params": {
         "portId": "0",
         "gameFeature": "ALLM"
@@ -725,7 +725,7 @@ Triggered whenever a new HDMI device is connected to an HDMI Input.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onDevicesChanged",
+    "method": "client.events.onDevicesChanged",
     "params": {
         "devices": [
             {
@@ -757,7 +757,7 @@ Triggered whenever the status changes for an HDMI Input.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onInputStatusChanged",
+    "method": "client.events.onInputStatusChanged",
     "params": {
         "id": 0,
         "locator": "hdmiin://localhost/deviceid/0",
@@ -785,7 +785,7 @@ Triggered whenever the signal status changes for an HDMI Input.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onSignalChanged",
+    "method": "client.events.onSignalChanged",
     "params": {
         "id": 0,
         "locator": "hdmiin://localhost/deviceid/0",
@@ -817,7 +817,7 @@ Triggered whenever there is an update in HDMI Input video stream info.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.videoStreamInfoUpdate",
+    "method": "client.events.videoStreamInfoUpdate",
     "params": {
         "id": 0,
         "locator": "hdmiin://localhost/deviceid/0",
@@ -849,7 +849,7 @@ Triggered whenever game feature(ALLM) status changes for an HDMI Input.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.hdmiGameFeatureStatusUpdate",
+    "method": "client.events.hdmiGameFeatureStatusUpdate",
     "params": {
         "portId": "0",
         "gameFeature": "ALLM",

--- a/docs/api/LinearPlaybackControlPlugin.md
+++ b/docs/api/LinearPlaybackControlPlugin.md
@@ -76,7 +76,7 @@ Provides access to the current channel.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "LinearPlaybackControl.1.channel@0"
+    "method": "LinearPlaybackControl.channel@0"
 }
 ```
 
@@ -98,7 +98,7 @@ Provides access to the current channel.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "LinearPlaybackControl.1.channel@0",
+    "method": "LinearPlaybackControl.channel@0",
     "params": {
         "channel": "chan_select"
     }
@@ -145,7 +145,7 @@ Provides access to the TSB seek position offset, from live position, in seconds.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "LinearPlaybackControl.1.seek@0"
+    "method": "LinearPlaybackControl.seek@0"
 }
 ```
 
@@ -167,7 +167,7 @@ Provides access to the TSB seek position offset, from live position, in seconds.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "LinearPlaybackControl.1.seek@0",
+    "method": "LinearPlaybackControl.seek@0",
     "params": {
         "seekPosInSeconds": 0
     }
@@ -214,7 +214,7 @@ Provides access to the trick play speed and direction.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "LinearPlaybackControl.1.trickPlay@0"
+    "method": "LinearPlaybackControl.trickPlay@0"
 }
 ```
 
@@ -236,7 +236,7 @@ Provides access to the trick play speed and direction.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "LinearPlaybackControl.1.trickPlay@0",
+    "method": "LinearPlaybackControl.trickPlay@0",
     "params": {
         "speed": -4
     }
@@ -290,7 +290,7 @@ Provides access to the current TSB status information containing buffer size, se
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "LinearPlaybackControl.1.status@0"
+    "method": "LinearPlaybackControl.status@0"
 }
 ```
 
@@ -340,7 +340,7 @@ Provides access to the tracing enable/disable flag.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "LinearPlaybackControl.1.tracing"
+    "method": "LinearPlaybackControl.tracing"
 }
 ```
 
@@ -362,7 +362,7 @@ Provides access to the tracing enable/disable flag.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "LinearPlaybackControl.1.tracing",
+    "method": "LinearPlaybackControl.tracing",
     "params": {
         "tracing": true
     }
@@ -411,7 +411,7 @@ Indicates that the trick play speed has changed.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.speedchanged",
+    "method": "client.events.speedchanged",
     "params": {
         "speed": -4,
         "muxId": 0

--- a/docs/api/LocationSyncPlugin.md
+++ b/docs/api/LocationSyncPlugin.md
@@ -92,7 +92,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "LocationSync.1.sync"
+    "method": "LocationSync.sync"
 }
 ```
 
@@ -144,7 +144,7 @@ Provides access to the location information.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "LocationSync.1.location"
+    "method": "LocationSync.location"
 }
 ```
 
@@ -192,7 +192,7 @@ This event carries no parameters.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.locationchange"
+    "method": "client.events.locationchange"
 }
 ```
 

--- a/docs/api/LoggingPreferencesPlugin.md
+++ b/docs/api/LoggingPreferencesPlugin.md
@@ -80,7 +80,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.LoggingPreferences.1.isKeystrokeMaskEnabled"
+    "method": "org.rdk.LoggingPreferences.isKeystrokeMaskEnabled"
 }
 ```
 
@@ -131,7 +131,7 @@ Also see: [onKeystrokeMaskEnabledChange](#onKeystrokeMaskEnabledChange)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.LoggingPreferences.1.setKeystrokeMaskEnabled",
+    "method": "org.rdk.LoggingPreferences.setKeystrokeMaskEnabled",
     "params": {
         "keystrokeMaskEnabled": false
     }
@@ -181,7 +181,7 @@ Triggered when the keystroke mask is changed.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onKeystrokeMaskEnabledChange",
+    "method": "client.events.onKeystrokeMaskEnabledChange",
     "params": {
         "keystrokeMaskEnabled": false
     }

--- a/docs/api/MaintenanceManagerPlugin.md
+++ b/docs/api/MaintenanceManagerPlugin.md
@@ -93,7 +93,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.MaintenanceManager.1.getMaintenanceActivityStatus"
+    "method": "org.rdk.MaintenanceManager.getMaintenanceActivityStatus"
 }
 ```
 
@@ -142,7 +142,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.MaintenanceManager.1.getMaintenanceStartTime"
+    "method": "org.rdk.MaintenanceManager.getMaintenanceStartTime"
 }
 ```
 
@@ -196,7 +196,7 @@ Sets the maintenance mode and software upgrade opt-out mode.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.MaintenanceManager.1.setMaintenanceMode",
+    "method": "org.rdk.MaintenanceManager.setMaintenanceMode",
     "params": {
         "maintenanceMode": "BACKGROUND",
         "optOut": "ENFORCE_OPTOUT"
@@ -247,7 +247,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.MaintenanceManager.1.startMaintenance"
+    "method": "org.rdk.MaintenanceManager.startMaintenance"
 }
 ```
 
@@ -294,7 +294,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.MaintenanceManager.1.stopMaintenance"
+    "method": "org.rdk.MaintenanceManager.stopMaintenance"
 }
 ```
 
@@ -340,7 +340,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.MaintenanceManager.1.getMaintenanceMode"
+    "method": "org.rdk.MaintenanceManager.getMaintenanceMode"
 }
 ```
 
@@ -389,7 +389,7 @@ Triggered when the maintenance manager status changes. See `getMaintenanceActivi
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onMaintenanceStatusChange",
+    "method": "client.events.onMaintenanceStatusChange",
     "params": {
         "maintenanceStatus": "MAINTENANCE_STARTED"
     }

--- a/docs/api/MessengerPlugin.md
+++ b/docs/api/MessengerPlugin.md
@@ -97,7 +97,7 @@ Also see: [userupdate](#userupdate)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "Messenger.1.join",
+    "method": "Messenger.join",
     "params": {
         "user": "Bob",
         "room": "Lounge",
@@ -159,7 +159,7 @@ Also see: [userupdate](#userupdate)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "Messenger.1.leave",
+    "method": "Messenger.leave",
     "params": {
         "roomid": "1e217990dd1cd4f66124"
     }
@@ -215,7 +215,7 @@ Also see: [message](#message)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "Messenger.1.send",
+    "method": "Messenger.send",
     "params": {
         "roomid": "1e217990dd1cd4f66124",
         "message": "Hello!"
@@ -272,7 +272,7 @@ Register to this event to be notified about room status updates. Immediately aft
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.roomupdate",
+    "method": "client.events.roomupdate",
     "params": {
         "room": "Lounge",
         "secure": "secure",
@@ -305,7 +305,7 @@ Register to this event to be notified about room status updates. Immediately aft
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "1e217990dd1cd4f66124.client.events.1.userupdate",
+    "method": "1e217990dd1cd4f66124.client.events.userupdate",
     "params": {
         "user": "Bob",
         "action": "joined"
@@ -337,7 +337,7 @@ Register to this event to be notified about new messages in a room.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "1e217990dd1cd4f66124.client.events.1.message",
+    "method": "1e217990dd1cd4f66124.client.events.message",
     "params": {
         "user": "Bob",
         "message": "Hello!"

--- a/docs/api/MonitorPlugin.md
+++ b/docs/api/MonitorPlugin.md
@@ -83,7 +83,7 @@ No Events.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "Monitor.1.restartlimits",
+    "method": "Monitor.restartlimits",
     "params": {
         "callsign": "WebServer",
         "restart": {
@@ -159,7 +159,7 @@ No Events.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "Monitor.1.resetstats",
+    "method": "Monitor.resetstats",
     "params": {
         "callsign": "WebServer"
     }
@@ -273,7 +273,7 @@ Provides access to the service statistics.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "Monitor.1.status@WebServer"
+    "method": "Monitor.status@WebServer"
 }
 ```
 
@@ -356,7 +356,7 @@ Signals an action taken by the Monitor.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.action",
+    "method": "client.events.action",
     "params": {
         "callsign": "WebServer",
         "action": "Deactivate",

--- a/docs/api/MotionDetectionPlugin.md
+++ b/docs/api/MotionDetectionPlugin.md
@@ -92,7 +92,7 @@ Enables a motion detector in the mode requested. This enables a single shot  Onc
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.MotionDetection.1.arm",
+    "method": "org.rdk.MotionDetection.arm",
     "params": {
         "index": "FP_MD",
         "mode": "0"
@@ -143,7 +143,7 @@ Disables the specified motion detector.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.MotionDetection.1.disarm",
+    "method": "org.rdk.MotionDetection.disarm",
     "params": {
         "index": "FP_MD"
     }
@@ -194,7 +194,7 @@ Returns the elapsed time since the last motion event occurred for the specified 
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.MotionDetection.1.getLastMotionEventElapsedTime",
+    "method": "org.rdk.MotionDetection.getLastMotionEventElapsedTime",
     "params": {
         "index": "FP_MD"
     }
@@ -255,7 +255,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.MotionDetection.1.getMotionDetectors"
+    "method": "org.rdk.MotionDetection.getMotionDetectors"
 }
 ```
 
@@ -318,7 +318,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.MotionDetection.1.getMotionEventsActivePeriod"
+    "method": "org.rdk.MotionDetection.getMotionEventsActivePeriod"
 }
 ```
 
@@ -372,7 +372,7 @@ Returns the no-motion period for the specified motion detector.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.MotionDetection.1.getNoMotionPeriod",
+    "method": "org.rdk.MotionDetection.getNoMotionPeriod",
     "params": {
         "index": "FP_MD"
     }
@@ -424,7 +424,7 @@ Returns the current sensitivity configuration for the specified motion detector.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.MotionDetection.1.getSensitivity",
+    "method": "org.rdk.MotionDetection.getSensitivity",
     "params": {
         "index": "FP_MD"
     }
@@ -476,7 +476,7 @@ Returns whether the specified motion detector is enabled.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.MotionDetection.1.isarmed",
+    "method": "org.rdk.MotionDetection.isarmed",
     "params": {
         "index": "FP_MD"
     }
@@ -533,7 +533,7 @@ Sets the period of time during the day when the motion sensor is active and dete
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.MotionDetection.1.setMotionEventsActivePeriod",
+    "method": "org.rdk.MotionDetection.setMotionEventsActivePeriod",
     "params": {
         "index": "FP_MD",
         "nowTime": 1234,
@@ -591,7 +591,7 @@ Sets the no-motion period, in seconds, for the specified motion detector. When a
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.MotionDetection.1.setNoMotionPeriod",
+    "method": "org.rdk.MotionDetection.setNoMotionPeriod",
     "params": {
         "index": "FP_MD",
         "period": "1800"
@@ -647,7 +647,7 @@ See `getMotionDetectors` to get the supported sensitivity mode.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.MotionDetection.1.setSensitivity",
+    "method": "org.rdk.MotionDetection.setSensitivity",
     "params": {
         "index": "FP_MD",
         "name": "low"
@@ -699,7 +699,7 @@ Triggered when a motion detector is enabled and either motion or no motion is de
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onMotionEvent",
+    "method": "client.events.onMotionEvent",
     "params": {
         "index": "FP_MD",
         "mode": "0"

--- a/docs/api/NetworkPlugin.md
+++ b/docs/api/NetworkPlugin.md
@@ -97,7 +97,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Network.1.getDefaultInterface"
+    "method": "org.rdk.Network.getDefaultInterface"
 }
 ```
 
@@ -148,7 +148,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Network.1.getInterfaces"
+    "method": "org.rdk.Network.getInterfaces"
 }
 ```
 
@@ -213,7 +213,7 @@ Gets the IP setting for the given interface.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Network.1.getIPSettings",
+    "method": "org.rdk.Network.getIPSettings",
     "params": {
         "interface": "WIFI",
         "ipversion": "IPv4"
@@ -272,7 +272,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Network.1.getNamedEndpoints"
+    "method": "org.rdk.Network.getNamedEndpoints"
 }
 ```
 
@@ -320,7 +320,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Network.1.getQuirks"
+    "method": "org.rdk.Network.getQuirks"
 }
 ```
 
@@ -366,7 +366,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Network.1.getStbIp"
+    "method": "org.rdk.Network.getStbIp"
 }
 ```
 
@@ -415,7 +415,7 @@ Gets the IP address of the default interface by address family.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Network.1.getSTBIPFamily",
+    "method": "org.rdk.Network.getSTBIPFamily",
     "params": {
         "family": "AF_INET"
     }
@@ -464,7 +464,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Network.1.isConnectedToInternet"
+    "method": "org.rdk.Network.isConnectedToInternet"
 }
 ```
 
@@ -513,7 +513,7 @@ Whether the specified interface is enabled.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Network.1.isInterfaceEnabled",
+    "method": "org.rdk.Network.isInterfaceEnabled",
     "params": {
         "interface": "WIFI"
     }
@@ -576,7 +576,7 @@ Pings the specified endpoint with the specified number of packets.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Network.1.ping",
+    "method": "org.rdk.Network.ping",
     "params": {
         "endpoint": "45.57.221.20",
         "packets": 10,
@@ -650,7 +650,7 @@ Pings the specified named endpoint with the specified number of packets. Only na
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Network.1.pingNamedEndpoint",
+    "method": "org.rdk.Network.pingNamedEndpoint",
     "params": {
         "endpointName": "CMTS",
         "packets": 10,
@@ -713,7 +713,7 @@ Sets the default list of endpoints used for a connectivity test. Maximum number 
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Network.1.setConnectivityTestEndpoints",
+    "method": "org.rdk.Network.setConnectivityTestEndpoints",
     "params": {
         "endpoints": [
             "xfinity.com:8080"
@@ -772,7 +772,7 @@ Also see: [onInterfaceStatusChanged](#onInterfaceStatusChanged), [onConnectionSt
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Network.1.setDefaultInterface",
+    "method": "org.rdk.Network.setDefaultInterface",
     "params": {
         "interface": "WIFI",
         "persist": true
@@ -828,7 +828,7 @@ Also see: [onInterfaceStatusChanged](#onInterfaceStatusChanged)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Network.1.setInterfaceEnabled",
+    "method": "org.rdk.Network.setInterfaceEnabled",
     "params": {
         "interface": "WIFI",
         "enabled": true,
@@ -891,7 +891,7 @@ Also see: [onIPAddressStatusChanged](#onIPAddressStatusChanged)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Network.1.setIPSettings",
+    "method": "org.rdk.Network.setIPSettings",
     "params": {
         "interface": "WIFI",
         "ipversion": "IPv4",
@@ -951,7 +951,7 @@ It allows either zero parameter or with only interface and ipv6 parameter to det
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Network.1.getPublicIP",
+    "method": "org.rdk.Network.getPublicIP",
     "params": {
         "iface": "WIFI",
         "ipv6": true
@@ -1007,7 +1007,7 @@ Set the Stun Endpoint used for getPublicIP.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Network.1.setStunEndPoint",
+    "method": "org.rdk.Network.setStunEndPoint",
     "params": {
         "server": "global.stun.twilio.com",
         "port": 3478,
@@ -1065,7 +1065,7 @@ Traces the specified endpoint with the specified number of packets using `tracer
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Network.1.trace",
+    "method": "org.rdk.Network.trace",
     "params": {
         "endpoint": "45.57.221.20",
         "packets": 10
@@ -1123,7 +1123,7 @@ Traces the specified named endpoint with the specified number of packets using `
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Network.1.traceNamedEndpoint",
+    "method": "org.rdk.Network.traceNamedEndpoint",
     "params": {
         "endpointName": "CMTS",
         "packets": 10
@@ -1181,7 +1181,7 @@ Triggered when an interface becomes enabled or disabled.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onInterfaceStatusChanged",
+    "method": "client.events.onInterfaceStatusChanged",
     "params": {
         "interface": "WIFI",
         "enabled": true
@@ -1207,7 +1207,7 @@ Triggered when a connection is made or lost.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onConnectionStatusChanged",
+    "method": "client.events.onConnectionStatusChanged",
     "params": {
         "interface": "WIFI",
         "status": "CONNECTED"
@@ -1235,7 +1235,7 @@ Triggered when an IP Address is assigned or lost.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onIPAddressStatusChanged",
+    "method": "client.events.onIPAddressStatusChanged",
     "params": {
         "interface": "WIFI",
         "ip6Address": "2001:0xx8:85a3:0000:0000:8x2x:0370:7334",
@@ -1263,7 +1263,7 @@ Triggered when the default interface changes, regardless if it's from a system o
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onDefaultInterfaceChanged",
+    "method": "client.events.onDefaultInterfaceChanged",
     "params": {
         "oldInterfaceName": "ETHERNET",
         "newInterfaceName": "WIFI"

--- a/docs/api/OCIContainerPlugin.md
+++ b/docs/api/OCIContainerPlugin.md
@@ -91,7 +91,7 @@ Executes a command inside a running container. The path to the executable must r
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.OCIContainer.1.executeCommand",
+    "method": "org.rdk.OCIContainer.executeCommand",
     "params": {
         "containerId": "com.bskyb.epgui",
         "options": "--cwd=PATH",
@@ -160,7 +160,7 @@ Gets information about a running container such as CPU, memory, and GPU usage (G
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.OCIContainer.1.getContainerInfo",
+    "method": "org.rdk.OCIContainer.getContainerInfo",
     "params": {
         "containerId": "com.bskyb.epgui"
     }
@@ -236,7 +236,7 @@ Gets the state of a currently running container.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.OCIContainer.1.getContainerState",
+    "method": "org.rdk.OCIContainer.getContainerState",
     "params": {
         "containerId": "com.bskyb.epgui"
     }
@@ -289,7 +289,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.OCIContainer.1.listContainers"
+    "method": "org.rdk.OCIContainer.listContainers"
 }
 ```
 
@@ -342,7 +342,7 @@ Pauses a currently running container.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.OCIContainer.1.pauseContainer",
+    "method": "org.rdk.OCIContainer.pauseContainer",
     "params": {
         "containerId": "com.bskyb.epgui"
     }
@@ -392,7 +392,7 @@ Resumes a previously paused container.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.OCIContainer.1.resumeContainer",
+    "method": "org.rdk.OCIContainer.resumeContainer",
     "params": {
         "containerId": "com.bskyb.epgui"
     }
@@ -451,7 +451,7 @@ Also see: [onContainerStarted](#onContainerStarted)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.OCIContainer.1.startContainer",
+    "method": "org.rdk.OCIContainer.startContainer",
     "params": {
         "containerId": "com.bskyb.epgui",
         "bundlePath": "/containers/myBundle",
@@ -515,7 +515,7 @@ Also see: [onContainerStarted](#onContainerStarted)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.OCIContainer.1.startContainerFromDobbySpec",
+    "method": "org.rdk.OCIContainer.startContainerFromDobbySpec",
     "params": {
         "containerId": "com.bskyb.epgui",
         "dobbySpec": "/containers/dobbySpec",
@@ -573,7 +573,7 @@ Also see: [onContainerStopped](#onContainerStopped)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.OCIContainer.1.stopContainer",
+    "method": "org.rdk.OCIContainer.stopContainer",
     "params": {
         "containerId": "com.bskyb.epgui",
         "force": true
@@ -626,7 +626,7 @@ Triggered when a new container has started running.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onContainerStarted",
+    "method": "client.events.onContainerStarted",
     "params": {
         "descriptor": 91,
         "name": "com.bskyb.epgui"
@@ -652,7 +652,7 @@ Triggered when the container has stopped running.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onContainerStopped",
+    "method": "client.events.onContainerStopped",
     "params": {
         "descriptor": 91,
         "name": "com.bskyb.epgui"

--- a/docs/api/OpenCDMiPlugin.md
+++ b/docs/api/OpenCDMiPlugin.md
@@ -86,7 +86,7 @@ Provides access to the supported DRM systems.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "OCDM.1.drms"
+    "method": "OCDM.drms"
 }
 ```
 
@@ -137,7 +137,7 @@ Provides access to the DRM key systems.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "OCDM.1.keysystems@PlayReady"
+    "method": "OCDM.keysystems@PlayReady"
 }
 ```
 

--- a/docs/api/PackagerPlugin.md
+++ b/docs/api/PackagerPlugin.md
@@ -84,7 +84,7 @@ Installs a package given by a name, a URL, or a file path.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "Packager.1.install",
+    "method": "Packager.install",
     "params": {
         "package": "wpeframework-plugin-netflix",
         "version": "1.0",
@@ -132,7 +132,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "Packager.1.synchronize"
+    "method": "Packager.synchronize"
 }
 ```
 

--- a/docs/api/PersistentStorePlugin.md
+++ b/docs/api/PersistentStorePlugin.md
@@ -89,7 +89,7 @@ Deletes a key from the specified namespace.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.PersistentStore.1.deleteKey",
+    "method": "org.rdk.PersistentStore.deleteKey",
     "params": {
         "namespace": "ns1",
         "key": "key1"
@@ -140,7 +140,7 @@ Deletes the specified namespace.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.PersistentStore.1.deleteNamespace",
+    "method": "org.rdk.PersistentStore.deleteNamespace",
     "params": {
         "namespace": "ns1"
     }
@@ -187,7 +187,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.PersistentStore.1.flushCache"
+    "method": "org.rdk.PersistentStore.flushCache"
 }
 ```
 
@@ -236,7 +236,7 @@ Returns the keys that are stored in the specified namespace.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.PersistentStore.1.getKeys",
+    "method": "org.rdk.PersistentStore.getKeys",
     "params": {
         "namespace": "ns1"
     }
@@ -288,7 +288,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.PersistentStore.1.getNamespaces"
+    "method": "org.rdk.PersistentStore.getNamespaces"
 }
 ```
 
@@ -338,7 +338,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.PersistentStore.1.getStorageSize"
+    "method": "org.rdk.PersistentStore.getStorageSize"
 }
 ```
 
@@ -391,7 +391,7 @@ Returns the value of a key from the specified namespace.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.PersistentStore.1.getValue",
+    "method": "org.rdk.PersistentStore.getValue",
     "params": {
         "namespace": "ns1",
         "key": "key1"
@@ -449,7 +449,7 @@ Also see: [onStorageExceeded](#onStorageExceeded), [onValueChanged](#onValueChan
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.PersistentStore.1.setValue",
+    "method": "org.rdk.PersistentStore.setValue",
     "params": {
         "namespace": "ns1",
         "key": "key1",
@@ -499,7 +499,7 @@ This event carries no parameters.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onStorageExceeded"
+    "method": "client.events.onStorageExceeded"
 }
 ```
 
@@ -522,7 +522,7 @@ Triggered whenever any of the values stored are changed using setValue.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onValueChanged",
+    "method": "client.events.onValueChanged",
     "params": {
         "namespace": "ns1",
         "key": "key1",

--- a/docs/api/PlayerInfoPlugin.md
+++ b/docs/api/PlayerInfoPlugin.md
@@ -80,7 +80,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "PlayerInfo.1.audiocodecs"
+    "method": "PlayerInfo.audiocodecs"
 }
 ```
 
@@ -124,7 +124,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "PlayerInfo.1.videocodecs"
+    "method": "PlayerInfo.videocodecs"
 }
 ```
 
@@ -183,7 +183,7 @@ Provides access to the player general information.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "PlayerInfo.1.playerinfo"
+    "method": "PlayerInfo.playerinfo"
 }
 ```
 
@@ -225,7 +225,7 @@ Provides access to the current configured video output port resolution.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "PlayerInfo.1.resolution"
+    "method": "PlayerInfo.resolution"
 }
 ```
 
@@ -260,7 +260,7 @@ Provides access to the check for Loudness Equivalence in the platform.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "PlayerInfo.1.isaudioequivalenceenabled"
+    "method": "PlayerInfo.isaudioequivalenceenabled"
 }
 ```
 
@@ -295,7 +295,7 @@ Provides access to the atmos capabilities of Sink.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "PlayerInfo.1.dolby_atmosmetadata"
+    "method": "PlayerInfo.dolby_atmosmetadata"
 }
 ```
 
@@ -330,7 +330,7 @@ Provides access to the current sound mode.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "PlayerInfo.1.dolby_soundmode"
+    "method": "PlayerInfo.dolby_soundmode"
 }
 ```
 
@@ -365,7 +365,7 @@ Provides access to the audio output enablement for Atmos.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "PlayerInfo.1.dolby_enableatmosoutput",
+    "method": "PlayerInfo.dolby_enableatmosoutput",
     "params": false
 }
 ```
@@ -399,7 +399,7 @@ Provides access to the dolby mode.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "PlayerInfo.1.dolby_mode"
+    "method": "PlayerInfo.dolby_mode"
 }
 ```
 
@@ -419,7 +419,7 @@ Provides access to the dolby mode.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "PlayerInfo.1.dolby_mode",
+    "method": "PlayerInfo.dolby_mode",
     "params": "DigitalPcm"
 }
 ```
@@ -466,7 +466,7 @@ Triggered after the audio sound mode changes.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.dolby_audiomodechanged",
+    "method": "client.events.dolby_audiomodechanged",
     "params": {
         "mode": "Unknown",
         "enable": true

--- a/docs/api/RDKShellPlugin.md
+++ b/docs/api/RDKShellPlugin.md
@@ -165,7 +165,7 @@ Performs the set of animations.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.addAnimation",
+    "method": "org.rdk.RDKShell.addAnimation",
     "params": {
         "animations": [
             {
@@ -233,7 +233,7 @@ Adds a key intercept to the client application specified. The keys are specified
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.addKeyIntercept",
+    "method": "org.rdk.RDKShell.addKeyIntercept",
     "params": {
         "keyCode": 10,
         "modifiers": [
@@ -295,7 +295,7 @@ Adds the list of key intercepts.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.addKeyIntercepts",
+    "method": "org.rdk.RDKShell.addKeyIntercepts",
     "params": {
         "intercepts": [
             {
@@ -366,7 +366,7 @@ Adds a key listener to an application. The keys are bubbled up based on their z-
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.addKeyListener",
+    "method": "org.rdk.RDKShell.addKeyListener",
     "params": {
         "client": "org.rdk.Netflix",
         "callsign": "org.rdk.Netflix",
@@ -429,7 +429,7 @@ Adds the key metadata listeners.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.addKeyMetadataListener",
+    "method": "org.rdk.RDKShell.addKeyMetadataListener",
     "params": {
         "client": "searchanddiscovery",
         "callsign": "searchanddiscovery"
@@ -489,7 +489,7 @@ Adds the key metadata listeners.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.createDisplay",
+    "method": "org.rdk.RDKShell.createDisplay",
     "params": {
         "client": "org.rdk.Netflix",
         "callsign": "org.rdk.Netflix",
@@ -551,7 +551,7 @@ Also see: [onDestroyed](#onDestroyed)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.destroy",
+    "method": "org.rdk.RDKShell.destroy",
     "params": {
         "callsign": "Cobalt"
     }
@@ -601,7 +601,7 @@ Enables or disables inactivity reporting and events.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.enableInactivityReporting",
+    "method": "org.rdk.RDKShell.enableInactivityReporting",
     "params": {
         "enable": true
     }
@@ -651,7 +651,7 @@ Enables or disables key repeats.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.enableKeyRepeats",
+    "method": "org.rdk.RDKShell.enableKeyRepeats",
     "params": {
         "enable": true
     }
@@ -701,7 +701,7 @@ Enables or disables flushing all logs.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.enableLogsFlushing",
+    "method": "org.rdk.RDKShell.enableLogsFlushing",
     "params": {
         "enable": true
     }
@@ -753,7 +753,7 @@ Enables or disables a virtual display for the specified client.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.enableVirtualDisplay",
+    "method": "org.rdk.RDKShell.enableVirtualDisplay",
     "params": {
         "client": "org.rdk.Netflix",
         "callsign": "org.rdk.Netflix",
@@ -812,7 +812,7 @@ Triggers the key events (key press and release).
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.generateKey",
+    "method": "org.rdk.RDKShell.generateKey",
     "params": {
         "keys": [
             {
@@ -871,7 +871,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.getAvailableTypes"
+    "method": "org.rdk.RDKShell.getAvailableTypes"
 }
 ```
 
@@ -927,7 +927,7 @@ Gets the bounds of the specified client.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.getBounds",
+    "method": "org.rdk.RDKShell.getBounds",
     "params": {
         "client": "org.rdk.Netflix",
         "callsign": "org.rdk.Netflix"
@@ -983,7 +983,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.getClients"
+    "method": "org.rdk.RDKShell.getClients"
 }
 ```
 
@@ -1032,7 +1032,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.getCursorSize"
+    "method": "org.rdk.RDKShell.getCursorSize"
 }
 ```
 
@@ -1083,7 +1083,7 @@ Returns whether video hole punching is enabled or disabled for the specified cli
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.getHolePunch",
+    "method": "org.rdk.RDKShell.getHolePunch",
     "params": {
         "client": "org.rdk.Netflix",
         "callsign": "org.rdk.Netflix"
@@ -1133,7 +1133,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.getKeyRepeatsEnabled"
+    "method": "org.rdk.RDKShell.getKeyRepeatsEnabled"
 }
 ```
 
@@ -1182,7 +1182,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.getLastWakeupKey"
+    "method": "org.rdk.RDKShell.getLastWakeupKey"
 }
 ```
 
@@ -1232,7 +1232,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.getLogLevel"
+    "method": "org.rdk.RDKShell.getLogLevel"
 }
 ```
 
@@ -1278,7 +1278,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.getLogsFlushingEnabled"
+    "method": "org.rdk.RDKShell.getLogsFlushingEnabled"
 }
 ```
 
@@ -1327,7 +1327,7 @@ Gets the opacity of the specified client.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.getOpacity",
+    "method": "org.rdk.RDKShell.getOpacity",
     "params": {
         "client": "org.rdk.Netflix"
     }
@@ -1380,7 +1380,7 @@ Returns the scale of an application.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.getScale",
+    "method": "org.rdk.RDKShell.getScale",
     "params": {
         "client": "org.rdk.Netflix"
     }
@@ -1431,7 +1431,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.getScreenResolution"
+    "method": "org.rdk.RDKShell.getScreenResolution"
 }
 ```
 
@@ -1480,7 +1480,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.getScreenshot"
+    "method": "org.rdk.RDKShell.getScreenshot"
 }
 ```
 
@@ -1529,7 +1529,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.getState"
+    "method": "org.rdk.RDKShell.getState"
 }
 ```
 
@@ -1583,7 +1583,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.getSystemMemory"
+    "method": "org.rdk.RDKShell.getSystemMemory"
 }
 ```
 
@@ -1635,7 +1635,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.getSystemResourceInfo"
+    "method": "org.rdk.RDKShell.getSystemResourceInfo"
 }
 ```
 
@@ -1691,7 +1691,7 @@ Returns whether virtual display is enabled or disabled for the specified client.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.getVirtualDisplayEnabled",
+    "method": "org.rdk.RDKShell.getVirtualDisplayEnabled",
     "params": {
         "client": "org.rdk.Netflix",
         "callsign": "org.rdk.Netflix"
@@ -1746,7 +1746,7 @@ Returns the virtual display resolution for the specified client.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.getVirtualResolution",
+    "method": "org.rdk.RDKShell.getVirtualResolution",
     "params": {
         "client": "org.rdk.Netflix",
         "callsign": "org.rdk.Netflix"
@@ -1801,7 +1801,7 @@ Gets the visibility of the specified client.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.getVisibility",
+    "method": "org.rdk.RDKShell.getVisibility",
     "params": {
         "client": "org.rdk.Netflix",
         "callsign": "org.rdk.Netflix"
@@ -1852,7 +1852,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.getZOrder"
+    "method": "org.rdk.RDKShell.getZOrder"
 }
 ```
 
@@ -1902,7 +1902,7 @@ Hides/Unhides all the clients.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.hideAllClients",
+    "method": "org.rdk.RDKShell.hideAllClients",
     "params": {
         "hide": true
     }
@@ -1949,7 +1949,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.hideCursor"
+    "method": "org.rdk.RDKShell.hideCursor"
 }
 ```
 
@@ -1993,7 +1993,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.hideFullScreenImage"
+    "method": "org.rdk.RDKShell.hideFullScreenImage"
 }
 ```
 
@@ -2037,7 +2037,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.hideSplashLogo"
+    "method": "org.rdk.RDKShell.hideSplashLogo"
 }
 ```
 
@@ -2080,7 +2080,7 @@ Blocks user key inputs.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.ignoreKeyInputs",
+    "method": "org.rdk.RDKShell.ignoreKeyInputs",
     "params": {
         "ignore": false
     }
@@ -2132,7 +2132,7 @@ Injects the keys.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.injectKey",
+    "method": "org.rdk.RDKShell.injectKey",
     "params": {
         "keycode": 10,
         "modifiers": [
@@ -2186,7 +2186,7 @@ Kills the specified client.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.kill",
+    "method": "org.rdk.RDKShell.kill",
     "params": {
         "client": "org.rdk.Netflix",
         "callsign": "org.rdk.Netflix"
@@ -2259,7 +2259,7 @@ Also see: [onLaunched](#onLaunched)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.launch",
+    "method": "org.rdk.RDKShell.launch",
     "params": {
         "callsign": "Cobalt",
         "type": "HtmlApp",
@@ -2335,7 +2335,7 @@ Also see: [onApplicationLaunched](#onApplicationLaunched)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.launchApplication",
+    "method": "org.rdk.RDKShell.launchApplication",
     "params": {
         "client": "HtmlApp",
         "uri": "https://x1box-app.xumo.com/3.0.70/index.html%22",
@@ -2386,7 +2386,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.launchResidentApp"
+    "method": "org.rdk.RDKShell.launchResidentApp"
 }
 ```
 
@@ -2434,7 +2434,7 @@ Moves the specified client behind the specified target client.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.moveBehind",
+    "method": "org.rdk.RDKShell.moveBehind",
     "params": {
         "client": "org.rdk.Netflix",
         "target": "org.rdk.RDKBrowser2"
@@ -2486,7 +2486,7 @@ Moves the specified client to the back or bottom of the Z order.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.moveToBack",
+    "method": "org.rdk.RDKShell.moveToBack",
     "params": {
         "client": "org.rdk.Netflix",
         "callsign": "org.rdk.Netflix"
@@ -2538,7 +2538,7 @@ Moves the specified client to the front or top of the Z order.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.moveToFront",
+    "method": "org.rdk.RDKShell.moveToFront",
     "params": {
         "client": "org.rdk.Netflix",
         "callsign": "org.rdk.Netflix"
@@ -2586,7 +2586,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.removeAllKeyIntercepts"
+    "method": "org.rdk.RDKShell.removeAllKeyIntercepts"
 }
 ```
 
@@ -2630,7 +2630,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.removeAllKeyListeners"
+    "method": "org.rdk.RDKShell.removeAllKeyListeners"
 }
 ```
 
@@ -2678,7 +2678,7 @@ Removes the current animation for the specified client.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.removeAnimation",
+    "method": "org.rdk.RDKShell.removeAnimation",
     "params": {
         "client": "org.rdk.Netflix",
         "callsign": "org.rdk.Netflix"
@@ -2732,7 +2732,7 @@ Removes a key intercept.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.removeKeyIntercept",
+    "method": "org.rdk.RDKShell.removeKeyIntercept",
     "params": {
         "keyCode": 10,
         "modifiers": [
@@ -2792,7 +2792,7 @@ Removes a key listener for an application.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.removeKeyListener",
+    "method": "org.rdk.RDKShell.removeKeyListener",
     "params": {
         "client": "org.rdk.Netflix",
         "callsign": "org.rdk.Netflix",
@@ -2852,7 +2852,7 @@ Removes the key metadata listeners.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.removeKeyMetadataListener",
+    "method": "org.rdk.RDKShell.removeKeyMetadataListener",
     "params": {
         "client": "searchanddiscovery",
         "callsign": "searchanddiscovery"
@@ -2900,7 +2900,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.resetInactivityTime"
+    "method": "org.rdk.RDKShell.resetInactivityTime"
 }
 ```
 
@@ -2950,7 +2950,7 @@ Also see: [onApplicationResumed](#onApplicationResumed)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.resumeApplication",
+    "method": "org.rdk.RDKShell.resumeApplication",
     "params": {
         "client": "HtmlApp"
     }
@@ -3005,7 +3005,7 @@ Scales the specified client to fit the current bounds.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.scaleToFit",
+    "method": "org.rdk.RDKShell.scaleToFit",
     "params": {
         "client": "org.rdk.Netflix",
         "callsign": "org.rdk.Netflix",
@@ -3065,7 +3065,7 @@ Sets the bounds of the specified client.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.setBounds",
+    "method": "org.rdk.RDKShell.setBounds",
     "params": {
         "client": "org.rdk.Netflix",
         "callsign": "org.rdk.Netflix",
@@ -3121,7 +3121,7 @@ Sets the cursor size.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.setCursorSize",
+    "method": "org.rdk.RDKShell.setCursorSize",
     "params": {
         "width": 255,
         "height": 255
@@ -3173,7 +3173,7 @@ Sets focus to the specified client.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.setFocus",
+    "method": "org.rdk.RDKShell.setFocus",
     "params": {
         "client": "org.rdk.Netflix",
         "callsign": "org.rdk.Netflix"
@@ -3226,7 +3226,7 @@ Enables or disables video hole punching for the specified client.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.setHolePunch",
+    "method": "org.rdk.RDKShell.setHolePunch",
     "params": {
         "client": "org.rdk.Netflix",
         "callsign": "org.rdk.Netflix",
@@ -3281,7 +3281,7 @@ Also see: [onUserInactivity](#onUserInactivity)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.setInactivityInterval",
+    "method": "org.rdk.RDKShell.setInactivityInterval",
     "params": {
         "interval": 15
     }
@@ -3331,7 +3331,7 @@ Sets the logging level.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.setLogLevel",
+    "method": "org.rdk.RDKShell.setLogLevel",
     "params": {
         "logLevel": "INFO"
     }
@@ -3384,7 +3384,7 @@ Enables or disables RAM memory monitoring on the device. Upon enabling, triggers
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.setMemoryMonitor",
+    "method": "org.rdk.RDKShell.setMemoryMonitor",
     "params": {
         "enable": true,
         "interval": 300,
@@ -3438,7 +3438,7 @@ Sets the opacity of the specified client.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.setOpacity",
+    "method": "org.rdk.RDKShell.setOpacity",
     "params": {
         "client": "org.rdk.Netflix",
         "opacity": 100
@@ -3492,7 +3492,7 @@ Scales an application.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.setScale",
+    "method": "org.rdk.RDKShell.setScale",
     "params": {
         "client": "org.rdk.Netflix",
         "callsign": "org.rdk.Netflix",
@@ -3546,7 +3546,7 @@ Sets the screen resolution.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.setScreenResolution",
+    "method": "org.rdk.RDKShell.setScreenResolution",
     "params": {
         "w": 1920,
         "h": 1080
@@ -3599,7 +3599,7 @@ Sets whether the specified client appears above all other clients on the display
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.setTopmost",
+    "method": "org.rdk.RDKShell.setTopmost",
     "params": {
         "client": "org.rdk.Netflix",
         "topmost": true,
@@ -3653,7 +3653,7 @@ Sets the virtual resolution for the specified client.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.setVirtualResolution",
+    "method": "org.rdk.RDKShell.setVirtualResolution",
     "params": {
         "client": "org.rdk.Netflix",
         "width": 1920,
@@ -3707,7 +3707,7 @@ Sets whether the specified client should be visible.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.setVisibility",
+    "method": "org.rdk.RDKShell.setVisibility",
     "params": {
         "client": "org.rdk.Netflix",
         "callsign": "org.rdk.Netflix",
@@ -3756,7 +3756,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.showCursor"
+    "method": "org.rdk.RDKShell.showCursor"
 }
 ```
 
@@ -3803,7 +3803,7 @@ Shows the Full Screen Image.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.showFullScreenImage",
+    "method": "org.rdk.RDKShell.showFullScreenImage",
     "params": {
         "path": "/tmp/netflix.png"
     }
@@ -3853,7 +3853,7 @@ Displays the splash screen.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.showSplashLogo",
+    "method": "org.rdk.RDKShell.showSplashLogo",
     "params": {
         "displayTime": 5
     }
@@ -3903,7 +3903,7 @@ Sets whether a watermark shows on the display.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.showWatermark",
+    "method": "org.rdk.RDKShell.showWatermark",
     "params": {
         "show": true
     }
@@ -3956,7 +3956,7 @@ Also see: [onSuspended](#onSuspended)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.suspend",
+    "method": "org.rdk.RDKShell.suspend",
     "params": {
         "callsign": "Cobalt"
     }
@@ -4009,7 +4009,7 @@ Also see: [onApplicationSuspended](#onApplicationSuspended)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RDKShell.1.suspendApplication",
+    "method": "org.rdk.RDKShell.suspendApplication",
     "params": {
         "client": "HtmlApp"
     }
@@ -4079,7 +4079,7 @@ Triggered when an application is activated.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onApplicationActivated",
+    "method": "client.events.onApplicationActivated",
     "params": {
         "client": "org.rdk.Netflix"
     }
@@ -4103,7 +4103,7 @@ Triggered when a connection to an application succeeds.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onApplicationConnected",
+    "method": "client.events.onApplicationConnected",
     "params": {
         "client": "org.rdk.Netflix"
     }
@@ -4127,7 +4127,7 @@ Triggered when an attempt to disconnect from an application succeeds.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onApplicationDisconnected",
+    "method": "client.events.onApplicationDisconnected",
     "params": {
         "client": "org.rdk.Netflix"
     }
@@ -4151,7 +4151,7 @@ Triggered when the first frame of an application is loaded.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onApplicationFirstFrame",
+    "method": "client.events.onApplicationFirstFrame",
     "params": {
         "client": "org.rdk.Netflix"
     }
@@ -4175,7 +4175,7 @@ Triggered when an application launches successfully.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onApplicationLaunched",
+    "method": "client.events.onApplicationLaunched",
     "params": {
         "client": "org.rdk.Netflix"
     }
@@ -4199,7 +4199,7 @@ Triggered when an application resumes from a suspended state.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onApplicationResumed",
+    "method": "client.events.onApplicationResumed",
     "params": {
         "client": "org.rdk.Netflix"
     }
@@ -4223,7 +4223,7 @@ Triggered when an application is suspended.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onApplicationSuspended",
+    "method": "client.events.onApplicationSuspended",
     "params": {
         "client": "org.rdk.Netflix"
     }
@@ -4247,7 +4247,7 @@ Triggered when an application terminates.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onApplicationTerminated",
+    "method": "client.events.onApplicationTerminated",
     "params": {
         "client": "org.rdk.Netflix"
     }
@@ -4271,7 +4271,7 @@ Triggered when a runtime is destroyed.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onDestroyed",
+    "method": "client.events.onDestroyed",
     "params": {
         "client": "org.rdk.Netflix"
     }
@@ -4295,7 +4295,7 @@ Triggered when the RAM memory on the device exceeds the configured `criticallyLo
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onDeviceCriticallyLowRamWarning",
+    "method": "client.events.onDeviceCriticallyLowRamWarning",
     "params": {
         "ram": 65536
     }
@@ -4319,7 +4319,7 @@ Triggered when the RAM memory on the device no longer exceeds the configured `cr
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onDeviceCriticallyLowRamWarningCleared",
+    "method": "client.events.onDeviceCriticallyLowRamWarningCleared",
     "params": {
         "ram": 65536
     }
@@ -4343,7 +4343,7 @@ Triggered when the RAM memory on the device exceeds the configured `lowRam` thre
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onDeviceLowRamWarning",
+    "method": "client.events.onDeviceLowRamWarning",
     "params": {
         "ram": 65536
     }
@@ -4367,7 +4367,7 @@ Triggered when the RAM memory on the device no longer exceeds the configured `lo
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onDeviceLowRamWarningCleared",
+    "method": "client.events.onDeviceLowRamWarningCleared",
     "params": {
         "ram": 65536
     }
@@ -4392,7 +4392,7 @@ Triggered when a runtime is launched.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onLaunched",
+    "method": "client.events.onLaunched",
     "params": {
         "client": "org.rdk.Netflix",
         "launchType": "create"
@@ -4417,7 +4417,7 @@ Triggered when a runtime is suspended.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onSuspended",
+    "method": "client.events.onSuspended",
     "params": {
         "client": "org.rdk.Netflix"
     }
@@ -4441,7 +4441,7 @@ Triggered when a device has been inactive for a period of time. This event is br
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onUserInactivity",
+    "method": "client.events.onUserInactivity",
     "params": {
         "minutes": 5
     }
@@ -4465,7 +4465,7 @@ Triggered when an application is set to be destroyed.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onWillDestroy",
+    "method": "client.events.onWillDestroy",
     "params": {
         "callsign": "Cobalt"
     }
@@ -4489,7 +4489,7 @@ Triggered when a plugin is suspended.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onPluginSuspended",
+    "method": "client.events.onPluginSuspended",
     "params": {
         "client": "searchanddiscovery"
     }
@@ -4513,7 +4513,7 @@ Triggered when a screenshot is captured successfully using `getScreenshot`
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onScreenshotComplete",
+    "method": "client.events.onScreenshotComplete",
     "params": {
         "imageData": "AAAAAAAAAA"
     }
@@ -4537,7 +4537,7 @@ Triggered when the focused client is blurred.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onBlur",
+    "method": "client.events.onBlur",
     "params": {
         "client": "searchanddiscovery"
     }
@@ -4561,7 +4561,7 @@ Triggered when a client is set to focus.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onFocus",
+    "method": "client.events.onFocus",
     "params": {
         "client": "HtmlApp"
     }

--- a/docs/api/RemoteActionMappingPlugin.md
+++ b/docs/api/RemoteActionMappingPlugin.md
@@ -90,7 +90,7 @@ Cancels downloading IR and five digit codes from the IRRF database.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RemoteActionMapping.1.cancelCodeDownload",
+    "method": "org.rdk.RemoteActionMapping.cancelCodeDownload",
     "params": {
         "deviceID": 1
     }
@@ -147,7 +147,7 @@ Clears an action mapping for the specified keys.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RemoteActionMapping.1.clearKeyActionMapping",
+    "method": "org.rdk.RemoteActionMapping.clearKeyActionMapping",
     "params": {
         "deviceID": 1,
         "keymapType": 1,
@@ -203,7 +203,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RemoteActionMapping.1.getApiVersionNumber"
+    "method": "org.rdk.RemoteActionMapping.getApiVersionNumber"
 }
 ```
 
@@ -261,7 +261,7 @@ Returns the mapping of all action keys.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RemoteActionMapping.1.getFullKeyActionMapping",
+    "method": "org.rdk.RemoteActionMapping.getFullKeyActionMapping",
     "params": {
         "deviceID": 1,
         "keymapType": 1
@@ -329,7 +329,7 @@ Returns a hard-coded list of key names.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RemoteActionMapping.1.getKeymap",
+    "method": "org.rdk.RemoteActionMapping.getKeymap",
     "params": {
         "deviceID": 1,
         "keymapType": 1
@@ -386,7 +386,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RemoteActionMapping.1.getLastUsedDeviceID"
+    "method": "org.rdk.RemoteActionMapping.getLastUsedDeviceID"
 }
 ```
 
@@ -448,7 +448,7 @@ Returns the mapping for a single action key.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RemoteActionMapping.1.getSingleKeyActionMapping",
+    "method": "org.rdk.RemoteActionMapping.getSingleKeyActionMapping",
     "params": {
         "deviceID": 1,
         "keymapType": 1,
@@ -518,7 +518,7 @@ Also see: [onFiveDigitCodeLoad](#onFiveDigitCodeLoad)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RemoteActionMapping.1.setFiveDigitCode",
+    "method": "org.rdk.RemoteActionMapping.setFiveDigitCode",
     "params": {
         "deviceID": 1,
         "tvFiveDigitCode": 12345,
@@ -585,7 +585,7 @@ Also see: [onIRCodeLoad](#onIRCodeLoad)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.RemoteActionMapping.1.setKeyActionMapping",
+    "method": "org.rdk.RemoteActionMapping.setKeyActionMapping",
     "params": {
         "deviceID": 1,
         "keymapType": 1,
@@ -652,7 +652,7 @@ Triggered when new five digit codes are loaded.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onFiveDigitCodeLoad",
+    "method": "client.events.onFiveDigitCodeLoad",
     "params": {
         "deviceID": 1,
         "tvLoadStatus": 0,
@@ -683,7 +683,7 @@ Triggered when new IR codes are loaded.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onIRCodeLoad",
+    "method": "client.events.onIRCodeLoad",
     "params": {
         "deviceID": 1,
         "keyNames": [

--- a/docs/api/ScreenCapturePlugin.md
+++ b/docs/api/ScreenCapturePlugin.md
@@ -90,7 +90,7 @@ Also see: [uploadComplete](#uploadComplete)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.ScreenCapture.1.uploadScreenCapture",
+    "method": "org.rdk.ScreenCapture.uploadScreenCapture",
     "params": {
         "url": "http://server/cgi-bin/upload.cgi",
         "callGUID": "12345"
@@ -143,7 +143,7 @@ Triggered after uploading a screen capture.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.uploadComplete",
+    "method": "client.events.uploadComplete",
     "params": {
         "status": true,
         "message": "Success",

--- a/docs/api/SecurityAgentPlugin.md
+++ b/docs/api/SecurityAgentPlugin.md
@@ -88,7 +88,7 @@ Creates a signed JsonWeb token. On success, returns Signed JsonWeb token and on 
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "SecurityAgent.1.createtoken",
+    "method": "SecurityAgent.createtoken",
     "params": {
         "url": "https://test.comcast.com",
         "user": "Test",
@@ -136,7 +136,7 @@ Validates the token whether it is valid and properly signed.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "SecurityAgent.1.validate",
+    "method": "SecurityAgent.validate",
     "params": {
         "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICAgImpzb25ycGMiOiAiMi4wIiwgCiAgICAiaWQiOiAxMjM0NTY3ODkwLCAKICAgICJtZXRob2QiOiAiQ29udHJvbGxlci4xLmFjdGl2YXRlIiwgCiAgICAicGFyYW1zIjogewogICAgICAgICJjYWxsc2lnbiI6ICJTZWN1cml0eUFnZW50IgogICAgfQp9.lL40nTwRyBvMwiglZhl5_rB8ycY1uhAJRFx9pGATMRQ"
     }

--- a/docs/api/StateObserverPlugin.md
+++ b/docs/api/StateObserverPlugin.md
@@ -85,7 +85,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "com.comcast.StateObserver.1.getApiVersionNumber"
+    "method": "com.comcast.StateObserver.getApiVersionNumber"
 }
 ```
 
@@ -131,7 +131,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "com.comcast.StateObserver.1.getName"
+    "method": "com.comcast.StateObserver.getName"
 }
 ```
 
@@ -178,7 +178,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "com.comcast.StateObserver.1.getRegisteredPropertyNames"
+    "method": "com.comcast.StateObserver.getRegisteredPropertyNames"
 }
 ```
 
@@ -243,7 +243,7 @@ Returns the values and errors for the specified properties.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "com.comcast.StateObserver.1.getValues",
+    "method": "com.comcast.StateObserver.getValues",
     "params": {
         "propertyNames": [
             "com.comcast.channel_map"
@@ -308,7 +308,7 @@ Register a listener on the specified properties for value change notifications. 
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "com.comcast.StateObserver.1.registerListeners",
+    "method": "com.comcast.StateObserver.registerListeners",
     "params": {
         "propertyNames": [
             "com.comcast.channel_map"
@@ -367,7 +367,7 @@ Sets the API version number.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "com.comcast.StateObserver.1.setApiVersionNumber",
+    "method": "com.comcast.StateObserver.setApiVersionNumber",
     "params": {
         "version": 1
     }
@@ -418,7 +418,7 @@ Removes the listeners on the specified properties. The properties are removed fr
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "com.comcast.StateObserver.1.unregisterListeners",
+    "method": "com.comcast.StateObserver.unregisterListeners",
     "params": {
         "propertyNames": [
             "com.comcast.channel_map"
@@ -472,7 +472,7 @@ Triggered whenever a device property value changes. A handler function is called
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.propertyChanged",
+    "method": "client.events.propertyChanged",
     "params": {
         "propertyName": "com.comcast.channel_map",
         "value": 2,

--- a/docs/api/SystemAudioPlayerPlugin.md
+++ b/docs/api/SystemAudioPlayerPlugin.md
@@ -96,7 +96,7 @@ Closes the system audio player with the specified ID. The `SystemAudioPlayer` pl
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.SystemAudioPlayer.1.close",
+    "method": "org.rdk.SystemAudioPlayer.close",
     "params": {
         "id": 1
     }
@@ -157,7 +157,7 @@ Configures playback for a PCM audio source (audio/x-raw) on the specified player
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.SystemAudioPlayer.1.config",
+    "method": "org.rdk.SystemAudioPlayer.config",
     "params": {
         "id": 1,
         "pcmconfig": {
@@ -223,7 +223,7 @@ Gets the session ID from the provided the URL. The session is the ID returned in
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.SystemAudioPlayer.1.getPlayerSessionId",
+    "method": "org.rdk.SystemAudioPlayer.getPlayerSessionId",
     "params": {
         "url": "http://localhost:50050/nuanceEve/tts?voice=ava&language=en-US&rate=50&text=SETTINGS"
     }
@@ -274,7 +274,7 @@ Checks if playback is in progress.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.SystemAudioPlayer.1.isspeaking",
+    "method": "org.rdk.SystemAudioPlayer.isspeaking",
     "params": {
         "id": 1
     }
@@ -331,7 +331,7 @@ Also See: [close](#close).
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.SystemAudioPlayer.1.open",
+    "method": "org.rdk.SystemAudioPlayer.open",
     "params": {
         "audiotype": "pcm",
         "sourcetype": "websocket",
@@ -387,7 +387,7 @@ Also see: [onsapevents](#onsapevents)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.SystemAudioPlayer.1.pause",
+    "method": "org.rdk.SystemAudioPlayer.pause",
     "params": {
         "id": 1
     }
@@ -444,7 +444,7 @@ Also see: [onsapevents](#onsapevents)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.SystemAudioPlayer.1.play",
+    "method": "org.rdk.SystemAudioPlayer.play",
     "params": {
         "id": 1,
         "url": "http://localhost:50050/nuanceEve/tts?voice=ava&language=en-US&rate=50&text=SETTINGS"
@@ -499,7 +499,7 @@ Also see: [onsapevents](#onsapevents)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.SystemAudioPlayer.1.playbuffer",
+    "method": "org.rdk.SystemAudioPlayer.playbuffer",
     "params": {
         "id": 1,
         "data": "180"
@@ -553,7 +553,7 @@ Also see: [onsapevents](#onsapevents)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.SystemAudioPlayer.1.resume",
+    "method": "org.rdk.SystemAudioPlayer.resume",
     "params": {
         "id": 1
     }
@@ -605,7 +605,7 @@ Sets the audio level on the specified player. The `SystemAudioPlayer` plugin can
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.SystemAudioPlayer.1.setMixerLevels",
+    "method": "org.rdk.SystemAudioPlayer.setMixerLevels",
     "params": {
         "id": 1,
         "primaryVolume": "20",
@@ -662,7 +662,7 @@ Sets the smart volume audio control on the specified player. The plugin can cont
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.SystemAudioPlayer.1.setSmartVolControl",
+    "method": "org.rdk.SystemAudioPlayer.setSmartVolControl",
     "params": {
         "id": 1,
         "enable": true,
@@ -717,7 +717,7 @@ Stops playback on the specified player.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.SystemAudioPlayer.1.stop",
+    "method": "org.rdk.SystemAudioPlayer.stop",
     "params": {
         "id": 1
     }
@@ -781,7 +781,7 @@ The following events are supported.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onsapevents",
+    "method": "client.events.onsapevents",
     "params": {
         "id": 1,
         "event": "PLAYBACK_STARTED"

--- a/docs/api/SystemPlugin.md
+++ b/docs/api/SystemPlugin.md
@@ -149,7 +149,7 @@ Checks if a key is present in the cache.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.cacheContains",
+    "method": "org.rdk.System.cacheContains",
     "params": {
         "key": "sampleKey"
     }
@@ -196,7 +196,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.clearLastDeepSleepReason"
+    "method": "org.rdk.System.clearLastDeepSleepReason"
 }
 ```
 
@@ -244,7 +244,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.deletePersistentPath",
+    "method": "org.rdk.System.deletePersistentPath",
     "params": {
         "callsign": "HtmlApp",
         "type": "HtmlApp"
@@ -295,7 +295,7 @@ Enables (or disables) Moca support for the platform.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.enableMoca",
+    "method": "org.rdk.System.enableMoca",
     "params": {
         "value": true
     }
@@ -345,7 +345,7 @@ Enables (or disables) XRE Connection Retention option.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.enableXREConnectionRetention",
+    "method": "org.rdk.System.enableXREConnectionRetention",
     "params": {
         "enable": true
     }
@@ -395,7 +395,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.fireFirmwarePendingReboot"
+    "method": "org.rdk.System.fireFirmwarePendingReboot"
 }
 ```
 
@@ -441,7 +441,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.getAvailableStandbyModes"
+    "method": "org.rdk.System.getAvailableStandbyModes"
 }
 ```
 
@@ -494,7 +494,7 @@ Gets the value of a key in the cache.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.getCachedValue",
+    "method": "org.rdk.System.getCachedValue",
     "params": {
         "key": "sampleKey"
     }
@@ -543,7 +543,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.getCoreTemperature"
+    "method": "org.rdk.System.getCoreTemperature"
 }
 ```
 
@@ -600,7 +600,7 @@ Collects device details. Sample keys include:
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.getDeviceInfo",
+    "method": "org.rdk.System.getDeviceInfo",
     "params": {
         "params": [
             "estb_mac"
@@ -654,7 +654,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.getDownloadedFirmwareInfo"
+    "method": "org.rdk.System.getDownloadedFirmwareInfo"
 }
 ```
 
@@ -703,7 +703,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.getFirmwareDownloadPercent"
+    "method": "org.rdk.System.getFirmwareDownloadPercent"
 }
 ```
 
@@ -755,7 +755,7 @@ Also see: [onFirmwareUpdateInfoReceived](#onFirmwareUpdateInfoReceived)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.getFirmwareUpdateInfo",
+    "method": "org.rdk.System.getFirmwareUpdateInfo",
     "params": {
         "GUID": "1234abcd"
     }
@@ -804,7 +804,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.getFirmwareUpdateState"
+    "method": "org.rdk.System.getFirmwareUpdateState"
 }
 ```
 
@@ -850,7 +850,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.getLastDeepSleepReason"
+    "method": "org.rdk.System.getLastDeepSleepReason"
 }
 ```
 
@@ -896,7 +896,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.getLastFirmwareFailureReason"
+    "method": "org.rdk.System.getLastFirmwareFailureReason"
 }
 ```
 
@@ -942,7 +942,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.getLastWakeupKeyCode"
+    "method": "org.rdk.System.getLastWakeupKeyCode"
 }
 ```
 
@@ -994,7 +994,7 @@ Also see: [onMacAddressesRetreived](#onMacAddressesRetreived)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.getMacAddresses",
+    "method": "org.rdk.System.getMacAddresses",
     "params": {
         "GUID": "1234abcd"
     }
@@ -1043,7 +1043,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.getMfgSerialNumber"
+    "method": "org.rdk.System.getMfgSerialNumber"
 }
 ```
 
@@ -1092,7 +1092,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.getMilestones"
+    "method": "org.rdk.System.getMilestones"
 }
 ```
 
@@ -1142,7 +1142,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.getMode"
+    "method": "org.rdk.System.getMode"
 }
 ```
 
@@ -1191,7 +1191,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.getNetworkStandbyMode"
+    "method": "org.rdk.System.getNetworkStandbyMode"
 }
 ```
 
@@ -1237,7 +1237,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.getOvertempGraceInterval"
+    "method": "org.rdk.System.getOvertempGraceInterval"
 }
 ```
 
@@ -1309,7 +1309,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.getPlatformConfiguration",
+    "method": "org.rdk.System.getPlatformConfiguration",
     "params": {
         "query": "..."
     }
@@ -1386,7 +1386,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.getPowerState"
+    "method": "org.rdk.System.getPowerState"
 }
 ```
 
@@ -1432,7 +1432,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.getPowerStateBeforeReboot"
+    "method": "org.rdk.System.getPowerStateBeforeReboot"
 }
 ```
 
@@ -1478,7 +1478,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.getPowerStateIsManagedByDevice"
+    "method": "org.rdk.System.getPowerStateIsManagedByDevice"
 }
 ```
 
@@ -1524,7 +1524,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.getPreferredStandbyMode"
+    "method": "org.rdk.System.getPreferredStandbyMode"
 }
 ```
 
@@ -1574,7 +1574,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.getPreviousRebootInfo"
+    "method": "org.rdk.System.getPreviousRebootInfo"
 }
 ```
 
@@ -1629,7 +1629,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.getPreviousRebootInfo2"
+    "method": "org.rdk.System.getPreviousRebootInfo2"
 }
 ```
 
@@ -1681,7 +1681,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.getPreviousRebootReason"
+    "method": "org.rdk.System.getPreviousRebootReason"
 }
 ```
 
@@ -1732,7 +1732,7 @@ Returns information that is related to RDK Feature Control (RFC) configurations.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.getRFCConfig",
+    "method": "org.rdk.System.getRFCConfig",
     "params": {
         "rfcList": [
             "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.AccountInfo.AccountID"
@@ -1785,7 +1785,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.getSerialNumber"
+    "method": "org.rdk.System.getSerialNumber"
 }
 ```
 
@@ -1834,7 +1834,7 @@ Queries device state information of various properties.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.getStateInfo",
+    "method": "org.rdk.System.getStateInfo",
     "params": {
         "param": "com.comcast.channel_map"
     }
@@ -1883,7 +1883,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.getStoreDemoLink"
+    "method": "org.rdk.System.getStoreDemoLink"
 }
 ```
 
@@ -1931,7 +1931,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.getSystemVersions"
+    "method": "org.rdk.System.getSystemVersions"
 }
 ```
 
@@ -1982,7 +1982,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.getTemperatureThresholds"
+    "method": "org.rdk.System.getTemperatureThresholds"
 }
 ```
 
@@ -2033,7 +2033,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.getTerritory"
+    "method": "org.rdk.System.getTerritory"
 }
 ```
 
@@ -2085,7 +2085,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.getTimeZones"
+    "method": "org.rdk.System.getTimeZones"
 }
 ```
 
@@ -2139,7 +2139,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.getTimeZoneDST"
+    "method": "org.rdk.System.getTimeZoneDST"
 }
 ```
 
@@ -2185,7 +2185,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.getWakeupReason"
+    "method": "org.rdk.System.getWakeupReason"
 }
 ```
 
@@ -2235,7 +2235,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.getXconfParams"
+    "method": "org.rdk.System.getXconfParams"
 }
 ```
 
@@ -2286,7 +2286,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.hasRebootBeenRequested"
+    "method": "org.rdk.System.hasRebootBeenRequested"
 }
 ```
 
@@ -2334,7 +2334,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.isGzEnabled"
+    "method": "org.rdk.System.isGzEnabled"
 }
 ```
 
@@ -2380,7 +2380,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.isOptOutTelemetry"
+    "method": "org.rdk.System.isOptOutTelemetry"
 }
 ```
 
@@ -2426,7 +2426,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.queryMocaStatus"
+    "method": "org.rdk.System.queryMocaStatus"
 }
 ```
 
@@ -2478,7 +2478,7 @@ Also see: [onRebootRequest](#onRebootRequest)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.reboot",
+    "method": "org.rdk.System.reboot",
     "params": {
         "rebootReason": "FIRMWARE_FAILURE"
     }
@@ -2531,7 +2531,7 @@ Removes the cache key.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.removeCacheKey",
+    "method": "org.rdk.System.removeCacheKey",
     "params": {
         "key": "sampleKey"
     }
@@ -2579,7 +2579,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.requestSystemUptime"
+    "method": "org.rdk.System.requestSystemUptime"
 }
 ```
 
@@ -2626,7 +2626,7 @@ Sets the boot loader pattern mode in MFR.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.setBootLoaderPattern",
+    "method": "org.rdk.System.setBootLoaderPattern",
     "params": {
         "pattern": "NORMAL"
     }
@@ -2679,7 +2679,7 @@ Sets the value for a key in the cache.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.setCachedValue",
+    "method": "org.rdk.System.setCachedValue",
     "params": {
         "key": "sampleKey",
         "value": 4343.3434
@@ -2730,7 +2730,7 @@ Sets the deep sleep timeout period.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.setDeepSleepTimer",
+    "method": "org.rdk.System.setDeepSleepTimer",
     "params": {
         "seconds": 3
     }
@@ -2780,7 +2780,7 @@ Sets the deep sleep timeout period.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.setFirmwareAutoReboot",
+    "method": "org.rdk.System.setFirmwareAutoReboot",
     "params": {
         "enable": true
     }
@@ -2830,7 +2830,7 @@ Sets the deep sleep timeout period.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.setFirmwareRebootDelay",
+    "method": "org.rdk.System.setFirmwareRebootDelay",
     "params": {
         "delaySeconds": 60
     }
@@ -2882,7 +2882,7 @@ Enables or disables GZ.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.setGzEnabled",
+    "method": "org.rdk.System.setGzEnabled",
     "params": {
         "enabled": false
     }
@@ -2940,7 +2940,7 @@ Also see: [onSystemModeChanged](#onSystemModeChanged)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.setMode",
+    "method": "org.rdk.System.setMode",
     "params": {
         "modeInfo": {
             "mode": "NORMAL",
@@ -2993,7 +2993,7 @@ Enables or disables the network standby mode of the device. If network standby i
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.setNetworkStandbyMode",
+    "method": "org.rdk.System.setNetworkStandbyMode",
     "params": {
         "nwStandby": false
     }
@@ -3043,7 +3043,7 @@ Sets the telemetry opt-out status.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.setOptOutTelemetry",
+    "method": "org.rdk.System.setOptOutTelemetry",
     "params": {
         "Opt-Out": false
     }
@@ -3093,7 +3093,7 @@ Sets the over-temperature grace interval value. Not supported on all devices.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.setOvertempGraceInterval",
+    "method": "org.rdk.System.setOvertempGraceInterval",
     "params": {
         "graceInterval": "600"
     }
@@ -3147,7 +3147,7 @@ Also see: [onSystemPowerStateChanged](#onSystemPowerStateChanged)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.setPowerState",
+    "method": "org.rdk.System.setPowerState",
     "params": {
         "powerState": "ON",
         "standbyReason": "APIUnitTest"
@@ -3198,7 +3198,7 @@ Sets and persists the preferred standby mode. See [getAvailableStandbyModes](#ge
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.setPreferredStandbyMode",
+    "method": "org.rdk.System.setPreferredStandbyMode",
     "params": {
         "standbyMode": "DEEP_SLEEP"
     }
@@ -3250,7 +3250,7 @@ Sets the temperature threshold values. Not supported on all devices.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.setTemperatureThresholds",
+    "method": "org.rdk.System.setTemperatureThresholds",
     "params": {
         "thresholds": {
             "WARN": "100.000000",
@@ -3304,7 +3304,7 @@ Sets the system territory and region.Territory is a ISO-3166-1 alpha-3 standard 
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.setTerritory",
+    "method": "org.rdk.System.setTerritory",
     "params": {
         "territory": "USA",
         "region": "US-NY"
@@ -3355,7 +3355,7 @@ Sets the system time zone. See `getTimeZones` to get a list of available timezon
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.setTimeZoneDST",
+    "method": "org.rdk.System.setTimeZoneDST",
     "params": {
         "timeZone": "America/New_York"
     }
@@ -3406,7 +3406,7 @@ Sets the wakeup source configuration.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.setWakeupSrcConfiguration",
+    "method": "org.rdk.System.setWakeupSrcConfiguration",
     "params": {
         "wakeupSrc": "3",
         "config": "1"
@@ -3454,7 +3454,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.updateFirmware"
+    "method": "org.rdk.System.updateFirmware"
 }
 ```
 
@@ -3501,7 +3501,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.System.1.uploadLogs",
+    "method": "org.rdk.System.uploadLogs",
     "params": {
         "url": "https://ssr.ccp.xcal.tv/cgi-bin/rdkb_snmp.cgi"
     }
@@ -3561,7 +3561,7 @@ SystemServices interface events:
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onFirmwarePendingReboot",
+    "method": "client.events.onFirmwarePendingReboot",
     "params": {
         "fireFirmwarePendingReboot": 3,
         "success": true
@@ -3597,7 +3597,7 @@ Update details are:
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onFirmwareUpdateInfoReceived",
+    "method": "client.events.onFirmwareUpdateInfoReceived",
     "params": {
         "status": 0,
         "responseString": "...",
@@ -3635,7 +3635,7 @@ State details are:
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onFirmwareUpdateStateChange",
+    "method": "client.events.onFirmwareUpdateStateChange",
     "params": {
         "firmwareUpdateStateChange": 5
     }
@@ -3667,7 +3667,7 @@ Triggered when the `getMacAddresses` asynchronous method is invoked.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onMacAddressesRetreived",
+    "method": "client.events.onMacAddressesRetreived",
     "params": {
         "ecm_mac": "A8:11:XX:FD:0C:XX",
         "estb_mac": "A8:11:XX:FD:0C:XX",
@@ -3699,7 +3699,7 @@ Triggered when the network standby mode setting changes.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onNetworkStandbyModeChanged",
+    "method": "client.events.onNetworkStandbyModeChanged",
     "params": {
         "nwStandby": true
     }
@@ -3724,7 +3724,7 @@ Triggered when an application invokes the reboot
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onRebootRequest",
+    "method": "client.events.onRebootRequest",
     "params": {
         "requestedApp": "SystemPlugin",
         "rebootReason": "FIRMWARE_FAILURE"
@@ -3746,7 +3746,7 @@ This event carries no parameters.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onSystemClockSet"
+    "method": "client.events.onSystemClockSet"
 }
 ```
 
@@ -3767,7 +3767,7 @@ Triggered when the device operating mode changes.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onSystemModeChanged",
+    "method": "client.events.onSystemModeChanged",
     "params": {
         "mode": "NORMAL"
     }
@@ -3792,7 +3792,7 @@ Triggered when the power manager detects a device power state change.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onSystemPowerStateChanged",
+    "method": "client.events.onSystemPowerStateChanged",
     "params": {
         "powerState": "ON",
         "currentPowerState": "ON"
@@ -3819,7 +3819,7 @@ Triggered when the device temperature changes beyond the `WARN` or `MAX` limits 
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onTemperatureThresholdChanged",
+    "method": "client.events.onTemperatureThresholdChanged",
     "params": {
         "thresholdType": "MAX",
         "exceeded": true,

--- a/docs/api/TelemetryPlugin.md
+++ b/docs/api/TelemetryPlugin.md
@@ -77,7 +77,7 @@ Sets the status of telemetry reporting.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Telemetry.1.setReportProfileStatus",
+    "method": "org.rdk.Telemetry.setReportProfileStatus",
     "params": {
         "status": "STARTED"
     }
@@ -124,7 +124,7 @@ Logs an application
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Telemetry.1.logApplicationEvent",
+    "method": "org.rdk.Telemetry.logApplicationEvent",
     "params": {
         "eventName": "...",
         "eventValue": "..."

--- a/docs/api/TextToSpeechPlugin.md
+++ b/docs/api/TextToSpeechPlugin.md
@@ -97,7 +97,7 @@ Also see: [onspeechinterrupted](#onspeechinterrupted)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.TextToSpeech.1.cancel",
+    "method": "org.rdk.TextToSpeech.cancel",
     "params": {
         "speechid": 1
     }
@@ -153,7 +153,7 @@ Also see: [onttsstatechanged](#onttsstatechanged), [onspeechinterrupted](#onspee
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.TextToSpeech.1.enabletts",
+    "method": "org.rdk.TextToSpeech.enabletts",
     "params": {
         "enabletts": true
     }
@@ -202,7 +202,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.TextToSpeech.1.getapiversion"
+    "method": "org.rdk.TextToSpeech.getapiversion"
 }
 ```
 
@@ -252,7 +252,7 @@ No Events.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.TextToSpeech.1.getspeechstate",
+    "method": "org.rdk.TextToSpeech.getspeechstate",
     "params": {
         "speechid": 1
     }
@@ -308,7 +308,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.TextToSpeech.1.getttsconfiguration"
+    "method": "org.rdk.TextToSpeech.getttsconfiguration"
 }
 ```
 
@@ -364,7 +364,7 @@ No Events.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.TextToSpeech.1.isspeaking",
+    "method": "org.rdk.TextToSpeech.isspeaking",
     "params": {
         "speechid": 1
     }
@@ -415,7 +415,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.TextToSpeech.1.isttsenabled"
+    "method": "org.rdk.TextToSpeech.isttsenabled"
 }
 ```
 
@@ -466,7 +466,7 @@ No Events.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.TextToSpeech.1.listvoices",
+    "method": "org.rdk.TextToSpeech.listvoices",
     "params": {
         "language": "en-US"
     }
@@ -522,7 +522,7 @@ Also see: [onspeechpause](#onspeechpause)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.TextToSpeech.1.pause",
+    "method": "org.rdk.TextToSpeech.pause",
     "params": {
         "speechid": 1
     }
@@ -577,7 +577,7 @@ Also see: [onspeechresume](#onspeechresume)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.TextToSpeech.1.resume",
+    "method": "org.rdk.TextToSpeech.resume",
     "params": {
         "speechid": 1
     }
@@ -643,7 +643,7 @@ Also see: [onvoicechanged](#onvoicechanged)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.TextToSpeech.1.setttsconfiguration",
+    "method": "org.rdk.TextToSpeech.setttsconfiguration",
     "params": {
         "ttsendpoint": "http://url_for_the_text_to_speech_processing_unit",
         "ttsendpointsecured": "https://url_for_the_text_to_speech_processing_unit",
@@ -718,7 +718,7 @@ Also see: [onwillspeak](#onwillspeak), [onspeechstart](#onspeechstart), [onspeec
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.TextToSpeech.1.speak",
+    "method": "org.rdk.TextToSpeech.speak",
     "params": {
         "text": "speech_1",
         "callsign": "WebApp"
@@ -774,7 +774,7 @@ No Events.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.TextToSpeech.1.setACL",
+    "method": "org.rdk.TextToSpeech.setACL",
     "params": {
         "accesslist": [
             {
@@ -838,7 +838,7 @@ Triggered when a network error occurs while fetching the audio from the endpoint
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onnetworkerror",
+    "method": "client.events.onnetworkerror",
     "params": {
         "speechid": 1
     }
@@ -862,7 +862,7 @@ Triggered when an error occurs during playback including pipeline failures.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onplaybackerror",
+    "method": "client.events.onplaybackerror",
     "params": {
         "speechid": 1
     }
@@ -887,7 +887,7 @@ Triggered when the speech completes.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onspeechcomplete",
+    "method": "client.events.onspeechcomplete",
     "params": {
         "speechid": 1,
         "text": "speech_1"
@@ -912,7 +912,7 @@ Triggered when the current speech is interrupted either by a next speech request
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onspeechinterrupted",
+    "method": "client.events.onspeechinterrupted",
     "params": {
         "speechid": 1
     }
@@ -936,7 +936,7 @@ Triggered when the ongoing speech pauses.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onspeechpause",
+    "method": "client.events.onspeechpause",
     "params": {
         "speechid": 1
     }
@@ -960,7 +960,7 @@ Triggered when any paused speech resumes.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onspeechresume",
+    "method": "client.events.onspeechresume",
     "params": {
         "speechid": 1
     }
@@ -985,7 +985,7 @@ Triggered when the speech start.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onspeechstart",
+    "method": "client.events.onspeechstart",
     "params": {
         "speechid": 1,
         "text": "speech_1"
@@ -1010,7 +1010,7 @@ Triggered when TTS is enabled or disabled.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onttsstatechanged",
+    "method": "client.events.onttsstatechanged",
     "params": {
         "state": true
     }
@@ -1034,7 +1034,7 @@ Triggered when the configured voice changes.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onvoicechanged",
+    "method": "client.events.onvoicechanged",
     "params": {
         "voice": "carol"
     }
@@ -1059,7 +1059,7 @@ Triggered when the text to speech conversion is about to start. It provides the 
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onwillspeak",
+    "method": "client.events.onwillspeak",
     "params": {
         "speechid": 1,
         "text": "speech_1"

--- a/docs/api/TimerPlugin.md
+++ b/docs/api/TimerPlugin.md
@@ -86,7 +86,7 @@ No Events.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Timer.1.cancel",
+    "method": "org.rdk.Timer.cancel",
     "params": {
         "timerID": 0
     }
@@ -141,7 +141,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Timer.1.getTimers"
+    "method": "org.rdk.Timer.getTimers"
 }
 ```
 
@@ -203,7 +203,7 @@ No Events.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Timer.1.getTimerStatus",
+    "method": "org.rdk.Timer.getTimerStatus",
     "params": {
         "timerId": 0
     }
@@ -258,7 +258,7 @@ No Events.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Timer.1.resume",
+    "method": "org.rdk.Timer.resume",
     "params": {
         "timerID": 0
     }
@@ -317,7 +317,7 @@ Also see: [timerExpired](#timerExpired), [timerExpiryReminder](#timerExpiryRemin
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Timer.1.startTimer",
+    "method": "org.rdk.Timer.startTimer",
     "params": {
         "interval": 1.2,
         "mode": "WAKE",
@@ -371,7 +371,7 @@ No Events.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Timer.1.suspend",
+    "method": "org.rdk.Timer.suspend",
     "params": {
         "timerID": 0
     }
@@ -424,7 +424,7 @@ Triggered when a timer expires.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.timerExpired",
+    "method": "client.events.timerExpired",
     "params": {
         "timerId": 0,
         "mode": "WAKE",
@@ -452,7 +452,7 @@ Triggered before a timer actually expires. It is triggered only when a non-zero 
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.timerExpiryReminder",
+    "method": "client.events.timerExpiryReminder",
     "params": {
         "timerId": 0,
         "mode": "WAKE",

--- a/docs/api/TraceControlPlugin.md
+++ b/docs/api/TraceControlPlugin.md
@@ -89,7 +89,7 @@ Sets traces. Enables or disables all or select category traces for the specified
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "TraceControl.1.set",
+    "method": "TraceControl.set",
     "params": {
         "module": "Plugin_Monitor",
         "category": "Information",
@@ -148,7 +148,7 @@ Retrieves the actual trace status information for the specified module and categ
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "TraceControl.1.status",
+    "method": "TraceControl.status",
     "params": {
         "module": "Plugin_Monitor",
         "category": "Information"

--- a/docs/api/UsbAccessPlugin.md
+++ b/docs/api/UsbAccessPlugin.md
@@ -85,7 +85,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.UsbAccess.1.clearLink"
+    "method": "org.rdk.UsbAccess.clearLink"
 }
 ```
 
@@ -132,7 +132,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.UsbAccess.1.createLink"
+    "method": "org.rdk.UsbAccess.createLink"
 }
 ```
 
@@ -181,7 +181,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.UsbAccess.1.getAvailableFirmwareFiles"
+    "method": "org.rdk.UsbAccess.getAvailableFirmwareFiles"
 }
 ```
 
@@ -236,7 +236,7 @@ Gets a list of files and folders from the specified directory or path.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.UsbAccess.1.getFileList",
+    "method": "org.rdk.UsbAccess.getFileList",
     "params": {
         "path": "..."
     }
@@ -292,7 +292,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.UsbAccess.1.getMounted"
+    "method": "org.rdk.UsbAccess.getMounted"
 }
 ```
 
@@ -343,7 +343,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.UsbAccess.1.updateFirmware",
+    "method": "org.rdk.UsbAccess.updateFirmware",
     "params": {
         "fileName": "/tmp/usbmnts/sda/this_is_test.bin"
     }
@@ -394,7 +394,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.UsbAccess.1.ArchiveLogs"
+    "method": "org.rdk.UsbAccess.ArchiveLogs"
 }
 ```
 
@@ -443,7 +443,7 @@ UsbAccess interface events:
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onUSBMountChanged",
+    "method": "client.events.onUSBMountChanged",
     "params": {
         "mounted": true,
         "device": "/dev/sda1"
@@ -469,7 +469,7 @@ UsbAccess interface events:
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onArchiveLogs",
+    "method": "client.events.onArchiveLogs",
     "params": {
         "error": "none",
         "success": true

--- a/docs/api/UserPreferencesPlugin.md
+++ b/docs/api/UserPreferencesPlugin.md
@@ -75,7 +75,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.UserPreferences.1.getUILanguage"
+    "method": "org.rdk.UserPreferences.getUILanguage"
 }
 ```
 
@@ -119,7 +119,7 @@ Sets the preferred user interface language.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.UserPreferences.1.setUILanguage",
+    "method": "org.rdk.UserPreferences.setUILanguage",
     "params": {
         "ui_language": "US_en"
     }

--- a/docs/api/VoiceControlPlugin.md
+++ b/docs/api/VoiceControlPlugin.md
@@ -108,7 +108,7 @@ Configures the RDK's voice stack. NOTE: The URL Scheme determines which API prot
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.VoiceControl.1.configureVoice",
+    "method": "org.rdk.VoiceControl.configureVoice",
     "params": {
         "urlAll": "ws://voiceserver.com/voice/ptt",
         "urlPtt": "vrng://vrex-next-gen-api.vrexcore.net/vrex/speech/websocket",
@@ -176,7 +176,7 @@ Sends a message to the Voice Server. The specification of this message is not in
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.VoiceControl.1.sendVoiceMessage",
+    "method": "org.rdk.VoiceControl.sendVoiceMessage",
     "params": {
         "msgType": "ars",
         "trx": "1b11359e-23fe-4f2f-9ba8-cc19b87203cf",
@@ -231,7 +231,7 @@ Sets the application metadata in the INIT message that gets sent to the Voice Se
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.VoiceControl.1.setVoiceInit",
+    "method": "org.rdk.VoiceControl.setVoiceInit",
     "params": {
         "capabilities": [
             "PRV"
@@ -295,7 +295,7 @@ Also see: [onSessionBegin](#onSessionBegin), [onStreamBegin](#onStreamBegin), [o
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.VoiceControl.1.voiceSessionByText",
+    "method": "org.rdk.VoiceControl.voiceSessionByText",
     "params": {
         "transcription": "Watch Comedy Central",
         "type": "PTT"
@@ -356,7 +356,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.VoiceControl.1.voiceSessionTypes"
+    "method": "org.rdk.VoiceControl.voiceSessionTypes"
 }
 ```
 
@@ -415,7 +415,7 @@ Also see: [onSessionBegin](#onSessionBegin), [onStreamBegin](#onStreamBegin), [o
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.VoiceControl.1.voiceSessionRequest",
+    "method": "org.rdk.VoiceControl.voiceSessionRequest",
     "params": {
         "transcription": "Watch Comedy Central",
         "type": "ptt_transcription"
@@ -466,7 +466,7 @@ Terminates a voice session using the specified session identifier.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.VoiceControl.1.voiceSessionTerminate",
+    "method": "org.rdk.VoiceControl.voiceSessionTerminate",
     "params": {
         "sessionId": "1b11359e-23fe-4f2f-9ba8-cc19b87203cf"
     }
@@ -525,7 +525,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.VoiceControl.1.voiceStatus"
+    "method": "org.rdk.VoiceControl.voiceStatus"
 }
 ```
 
@@ -595,7 +595,7 @@ Triggered when a keyword verification result is received.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onKeywordVerification",
+    "method": "client.events.onKeywordVerification",
     "params": {
         "remoteId": 1,
         "sessionId": "1b11359e-23fe-4f2f-9ba8-cc19b87203cf",
@@ -625,7 +625,7 @@ Triggered when a message is received from the Voice Server. The `params` value i
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onServerMessage",
+    "method": "client.events.onServerMessage",
     "params": {
         "maskPii": true,
         "msgType": "ars",
@@ -656,7 +656,7 @@ Triggered when a voice session begins.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onSessionBegin",
+    "method": "client.events.onSessionBegin",
     "params": {
         "remoteId": 1,
         "sessionId": "1b11359e-23fe-4f2f-9ba8-cc19b87203cf",
@@ -702,7 +702,7 @@ Triggered when the interaction with the server has concluded.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onSessionEnd",
+    "method": "client.events.onSessionEnd",
     "params": {
         "serverStats": {
             "dnsTime": 1.0,
@@ -751,7 +751,7 @@ Triggered when a device starts streaming voice data to the RDK. This event is op
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onStreamBegin",
+    "method": "client.events.onStreamBegin",
     "params": {
         "remoteId": 1,
         "sessionId": "1b11359e-23fe-4f2f-9ba8-cc19b87203cf"
@@ -778,7 +778,7 @@ Triggered when the device has stopped streaming audio.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onStreamEnd",
+    "method": "client.events.onStreamEnd",
     "params": {
         "remoteId": 1,
         "sessionId": "1b11359e-23fe-4f2f-9ba8-cc19b87203cf",

--- a/docs/api/WarehousePlugin.md
+++ b/docs/api/WarehousePlugin.md
@@ -85,7 +85,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Warehouse.1.executeHardwareTest"
+    "method": "org.rdk.Warehouse.executeHardwareTest"
 }
 ```
 
@@ -141,7 +141,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Warehouse.1.getDeviceInfo"
+    "method": "org.rdk.Warehouse.getDeviceInfo"
 }
 ```
 
@@ -200,7 +200,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Warehouse.1.getHardwareTestResults",
+    "method": "org.rdk.Warehouse.getHardwareTestResults",
     "params": {
         "testResults": "Timezone: NA 2021-04-15 10:35:06 Test execution start, remote trigger ver. 0011 2021-04-15 10:35:10 Test result: Audio/Video Decoder:PASSED 2021-04-15 10:35:06 Test result: Dynamic RAM:PASSED 2021-04-15 10:35:06 Test result: Flash Memory:PASSED 2021-04-15 10:35:06 Test result: HDMI Output:PASSED 2021-04-15 10:35:38 Test result: IR Remote Interface:WARNING_IR_Not_Detected 2021-04-15 10:35:06 Test result: Bluetooth:PASSED 2021-04-15 10:35:06 Test result: SD Card:PASSED 2021-04-15 10:35:06 Test result: WAN:PASSED 2021-04-15 10:35:38 Test execution completed:PASSED"
     }
@@ -251,7 +251,7 @@ Invokes the internal reset script, which reboots the Warehouse service (`/reboot
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Warehouse.1.internalReset",
+    "method": "org.rdk.Warehouse.internalReset",
     "params": {
         "passPhrase": "FOR TEST PURPOSES ONLY"
     }
@@ -302,7 +302,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Warehouse.1.isClean"
+    "method": "org.rdk.Warehouse.isClean"
 }
 ```
 
@@ -351,7 +351,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Warehouse.1.lightReset"
+    "method": "org.rdk.Warehouse.lightReset"
 }
 ```
 
@@ -404,7 +404,7 @@ Also see: [resetDone](#resetDone)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Warehouse.1.resetDevice",
+    "method": "org.rdk.Warehouse.resetDevice",
     "params": {
         "suppressReboot": true,
         "resetType": "WAREHOUSE"
@@ -457,7 +457,7 @@ Sets the state of the front panel LEDs to indicate the download state of the STB
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Warehouse.1.setFrontPanelState",
+    "method": "org.rdk.Warehouse.setFrontPanelState",
     "params": {
         "state": 1
     }
@@ -509,7 +509,7 @@ Notifies subscribers about the status of the warehouse reset operation.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.resetDone",
+    "method": "client.events.resetDone",
     "params": {
         "success": true,
         "error": "..."

--- a/docs/api/WebKitBrowserPlugin.md
+++ b/docs/api/WebKitBrowserPlugin.md
@@ -107,7 +107,7 @@ Sends a legacy `$badger`
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "WebKitBrowser.1.bridgeevent",
+    "method": "WebKitBrowser.bridgeevent",
     "params": "..."
 }
 ```
@@ -151,7 +151,7 @@ A response for legacy `$badger`.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "WebKitBrowser.1.bridgereply",
+    "method": "WebKitBrowser.bridgereply",
     "params": "..."
 }
 ```
@@ -202,7 +202,7 @@ Removes the contents of a directory recursively from the persistent storage.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "WebKitBrowser.1.delete",
+    "method": "WebKitBrowser.delete",
     "params": {
         "path": ".cache/wpe/disk-cache"
     }
@@ -260,7 +260,7 @@ Provides access to the current number of frames-per-second the browser is render
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "WebKitBrowser.1.fps"
+    "method": "WebKitBrowser.fps"
 }
 ```
 
@@ -304,7 +304,7 @@ Use this property to send on all requests that the browser makes.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "WebKitBrowser.1.headers"
+    "method": "WebKitBrowser.headers"
 }
 ```
 
@@ -329,7 +329,7 @@ Use this property to send on all requests that the browser makes.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "WebKitBrowser.1.headers",
+    "method": "WebKitBrowser.headers",
     "params": [
         {
             "name": "X-Forwarded-For",
@@ -382,7 +382,7 @@ Use this property to accept HTTP cookie policy.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "WebKitBrowser.1.httpcookieacceptpolicy"
+    "method": "WebKitBrowser.httpcookieacceptpolicy"
 }
 ```
 
@@ -402,7 +402,7 @@ Use this property to accept HTTP cookie policy.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "WebKitBrowser.1.httpcookieacceptpolicy",
+    "method": "WebKitBrowser.httpcookieacceptpolicy",
     "params": "always"
 }
 ```
@@ -445,7 +445,7 @@ Use this property to return User preferred languages.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "WebKitBrowser.1.languages"
+    "method": "WebKitBrowser.languages"
 }
 ```
 
@@ -467,7 +467,7 @@ Use this property to return User preferred languages.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "WebKitBrowser.1.languages",
+    "method": "WebKitBrowser.languages",
     "params": [
         "en-US"
     ]
@@ -511,7 +511,7 @@ Use this property to return Local storage availability.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "WebKitBrowser.1.localstorageenabled"
+    "method": "WebKitBrowser.localstorageenabled"
 }
 ```
 
@@ -531,7 +531,7 @@ Use this property to return Local storage availability.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "WebKitBrowser.1.localstorageenabled",
+    "method": "WebKitBrowser.localstorageenabled",
     "params": false
 }
 ```
@@ -576,7 +576,7 @@ Also see: [statechange](#statechange)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "WebKitBrowser.1.state"
+    "method": "WebKitBrowser.state"
 }
 ```
 
@@ -596,7 +596,7 @@ Also see: [statechange](#statechange)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "WebKitBrowser.1.state",
+    "method": "WebKitBrowser.state",
     "params": "resumed"
 }
 ```
@@ -649,7 +649,7 @@ Also see: [urlchange](#urlchange)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "WebKitBrowser.1.url"
+    "method": "WebKitBrowser.url"
 }
 ```
 
@@ -669,7 +669,7 @@ Also see: [urlchange](#urlchange)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "WebKitBrowser.1.url",
+    "method": "WebKitBrowser.url",
     "params": "https://www.google.com"
 }
 ```
@@ -711,7 +711,7 @@ Use this property to return `UserAgent` string used by the browser.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "WebKitBrowser.1.useragent"
+    "method": "WebKitBrowser.useragent"
 }
 ```
 
@@ -731,7 +731,7 @@ Use this property to return `UserAgent` string used by the browser.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "WebKitBrowser.1.useragent",
+    "method": "WebKitBrowser.useragent",
     "params": "Mozilla/5.0 (Linux; x86_64 GNU/Linux) AppleWebKit/601.1 (KHTML, like Gecko) Version/8.0 Safari/601.1 WP"
 }
 ```
@@ -782,7 +782,7 @@ Also see: [visibilitychange](#visibilitychange)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "WebKitBrowser.1.visibility"
+    "method": "WebKitBrowser.visibility"
 }
 ```
 
@@ -802,7 +802,7 @@ Also see: [visibilitychange](#visibilitychange)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "WebKitBrowser.1.visibility",
+    "method": "WebKitBrowser.visibility",
     "params": "visible"
 }
 ```
@@ -853,7 +853,7 @@ A Base64 encoded JSON message from legacy `$badger` bridge.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.bridgequery",
+    "method": "client.events.bridgequery",
     "params": "..."
 }
 ```
@@ -875,7 +875,7 @@ Triggered when the browser fails to load a page.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.loadfailed",
+    "method": "client.events.loadfailed",
     "params": {
         "url": "https://example.com"
     }
@@ -900,7 +900,7 @@ Triggered when the initial HTML document has been completely loaded and parsed.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.loadfinished",
+    "method": "client.events.loadfinished",
     "params": {
         "url": "https://example.com",
         "httpstatus": 200
@@ -922,7 +922,7 @@ This event carries no parameters.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.pageclosure"
+    "method": "client.events.pageclosure"
 }
 ```
 
@@ -943,7 +943,7 @@ Triggered when the state of the service changes.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.statechange",
+    "method": "client.events.statechange",
     "params": {
         "suspended": false
     }
@@ -968,7 +968,7 @@ Triggered when the URL changes in the browser.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.urlchange",
+    "method": "client.events.urlchange",
     "params": {
         "url": "https://example.com",
         "loaded": false
@@ -993,7 +993,7 @@ Triggered when the browser visibility changes.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.visibilitychange",
+    "method": "client.events.visibilitychange",
     "params": {
         "hidden": false
     }

--- a/docs/api/WifiPlugin.md
+++ b/docs/api/WifiPlugin.md
@@ -99,7 +99,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Wifi.1.cancelWPSPairing"
+    "method": "org.rdk.Wifi.cancelWPSPairing"
 }
 ```
 
@@ -148,7 +148,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Wifi.1.clearSSID"
+    "method": "org.rdk.Wifi.clearSSID"
 }
 ```
 
@@ -202,7 +202,7 @@ Also see: [onWIFIStateChanged](#onWIFIStateChanged), [onError](#onError)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Wifi.1.connect",
+    "method": "org.rdk.Wifi.connect",
     "params": {
         "ssid": "123412341234",
         "passphrase": "password",
@@ -255,7 +255,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Wifi.1.disconnect"
+    "method": "org.rdk.Wifi.disconnect"
 }
 ```
 
@@ -307,7 +307,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Wifi.1.getConnectedSSID"
+    "method": "org.rdk.Wifi.getConnectedSSID"
 }
 ```
 
@@ -367,7 +367,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Wifi.1.getCurrentState"
+    "method": "org.rdk.Wifi.getCurrentState"
 }
 ```
 
@@ -413,7 +413,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Wifi.1.getPairedSSID"
+    "method": "org.rdk.Wifi.getPairedSSID"
 }
 ```
 
@@ -460,7 +460,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Wifi.1.getPairedSSIDInfo"
+    "method": "org.rdk.Wifi.getPairedSSIDInfo"
 }
 ```
 
@@ -522,7 +522,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Wifi.1.getSupportedSecurityModes"
+    "method": "org.rdk.Wifi.getSupportedSecurityModes"
 }
 ```
 
@@ -595,7 +595,7 @@ Also see: [onWIFIStateChanged](#onWIFIStateChanged), [onError](#onError)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Wifi.1.initiateWPSPairing",
+    "method": "org.rdk.Wifi.initiateWPSPairing",
     "params": {
         "method": "PIN",
         "wps_pin": "88888888"
@@ -646,7 +646,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Wifi.1.isPaired"
+    "method": "org.rdk.Wifi.isPaired"
 }
 ```
 
@@ -692,7 +692,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Wifi.1.isSignalThresholdChangeEnabled"
+    "method": "org.rdk.Wifi.isSignalThresholdChangeEnabled"
 }
 ```
 
@@ -743,7 +743,7 @@ Saves the SSID, passphrase, and security mode for future sessions. If an SSID wa
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Wifi.1.saveSSID",
+    "method": "org.rdk.Wifi.saveSSID",
     "params": {
         "ssid": "123412341234",
         "passphrase": "password",
@@ -796,7 +796,7 @@ Enables or disables the Wifi adapter for this device.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Wifi.1.setEnabled",
+    "method": "org.rdk.Wifi.setEnabled",
     "params": {
         "enable": true
     }
@@ -850,7 +850,7 @@ Also see: [onWifiSignalThresholdChanged](#onWifiSignalThresholdChanged)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Wifi.1.setSignalThresholdChangeEnabled",
+    "method": "org.rdk.Wifi.setSignalThresholdChangeEnabled",
     "params": {
         "enabled": true,
         "interval": 2000
@@ -907,7 +907,7 @@ Also see: [onAvailableSSIDs](#onAvailableSSIDs)
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Wifi.1.startScan",
+    "method": "org.rdk.Wifi.startScan",
     "params": {
         "incremental": false,
         "ssid": "...",
@@ -957,7 +957,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Wifi.1.stopScan"
+    "method": "org.rdk.Wifi.stopScan"
 }
 ```
 
@@ -1009,7 +1009,7 @@ Triggered when the Wifi state changes. See `getCurrentState` for a list of valid
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onWIFIStateChanged",
+    "method": "client.events.onWIFIStateChanged",
     "params": {
         "state": 2,
         "isLNF": false
@@ -1043,7 +1043,7 @@ Triggered when a recoverable unexpected Wifi error occurs.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onError",
+    "method": "client.events.onError",
     "params": {
         "code": 2
     }
@@ -1064,7 +1064,7 @@ This event carries no parameters.
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onSSIDsChanged"
+    "method": "client.events.onSSIDsChanged"
 }
 ```
 
@@ -1086,7 +1086,7 @@ Triggered at intervals specified in the `setSignalThresholdChangeEnabled` method
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onWifiSignalThresholdChanged",
+    "method": "client.events.onWifiSignalThresholdChanged",
     "params": {
         "signalStrength": "-27.000000",
         "strength": "Excellent"
@@ -1117,7 +1117,7 @@ Triggered when the `scan` method is called and SSIDs are obtained. The event con
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onAvailableSSIDs",
+    "method": "client.events.onAvailableSSIDs",
     "params": {
         "ssids": [
             {

--- a/docs/api/XCastPlugin.md
+++ b/docs/api/XCastPlugin.md
@@ -54,7 +54,6 @@ XCast interface methods:
 | [getStandbyBehavior](#getStandbyBehavior) | Gets the expected xcast behavior in standby mode |
 | [onApplicationStateChanged](#onApplicationStateChanged) | Provides notification whenever an application changes state due to user activity, an internal error, or other reasons |
 | [registerApplications](#registerApplications) | Registers an application |
-| [unregisterApplications](#unregisterApplications) | Unregisters an application |
 | [setEnabled](#setEnabled) | Enables or disables xcast |
 | [setFriendlyName](#setFriendlyName) | Sets the friendly name of device |
 | [setStandbyBehavior](#setStandbyBehavior) | Sets the expected xcast behavior in standby mode |
@@ -89,7 +88,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Xcast.1.getApiVersionNumber"
+    "method": "org.rdk.Xcast.getApiVersionNumber"
 }
 ```
 
@@ -135,7 +134,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Xcast.1.getEnabled"
+    "method": "org.rdk.Xcast.getEnabled"
 }
 ```
 
@@ -181,7 +180,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Xcast.1.getFriendlyName"
+    "method": "org.rdk.Xcast.getFriendlyName"
 }
 ```
 
@@ -227,7 +226,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Xcast.1.getProtocolVersion"
+    "method": "org.rdk.Xcast.getProtocolVersion"
 }
 ```
 
@@ -273,7 +272,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Xcast.1.getStandbyBehavior"
+    "method": "org.rdk.Xcast.getStandbyBehavior"
 }
 ```
 
@@ -334,7 +333,7 @@ The following table provides a client error mapping example:
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Xcast.1.onApplicationStateChanged",
+    "method": "org.rdk.Xcast.onApplicationStateChanged",
     "params": {
         "applicationName": "NetflixApp",
         "state": "running",
@@ -359,7 +358,7 @@ The following table provides a client error mapping example:
 <a name="registerApplications"></a>
 ## *registerApplications*
 
-This API allows application to whitelist the apps, which support dial service with xcast service. Application can register single or multiple apps by passing application list. Calling this api again, with a new set of APP names, will append those APPs to the existing whitelist. Passing an existing whitelisted APP name, with a modified property value, will update the curresponding field in the APP whitelist.
+Registers an application. This allows to whitelist the apps which support dial service. To dynamically update the app list, same API should be called with the updated list.
   
 ### Events 
 
@@ -379,132 +378,17 @@ This API allows application to whitelist the apps, which support dial service wi
 | result | object |  |
 | result.success | boolean | Whether the request succeeded |
 
-### Example 1
-Following call will register NetflixApp to the dial dynamic list.
+### Example
+
 #### Request
 
 ```json
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Xcast.1.registerApplications",
+    "method": "org.rdk.Xcast.registerApplications",
     "params": {
-        "applications": {
-            "names":["Netflix"],
-            "cors":[".netflix.com"]
-         }
-    }
-}
-```
-
-#### Response
-
-```json
-{
-    "jsonrpc": "2.0",
-    "id": 42,
-    "result": {
-        "success": true
-    }
-}
-```
-### Example 2
-Following call will update the existing NetflixApp properties in the dial dynamic APP list and insert the new applications YouTube, YouTubeKids and YouTubeTV.
-#### Request
-
-```json
-{
-    "jsonrpc":"2.0",
-    "id":"3",
-    "method": "org.rdk.Xcast.1.registerApplications",
-    "params":{
-        "applications":[{
-               "names":["Netflix"],
-               "cors":[".netflix.com"],
-               "properties":{"allowStop" :true}
-           }, 
-           {
-               "names":["YouTube", "YouTubeKids", "YouTubeTV"],
-               "cors":[".youtube.com"],
-               "properties":{"allowStop" :true}
-           }]
-    }
-}
-```
-
-#### Response
-
-```json
-{
-    "jsonrpc": "2.0",
-    "id": 42,
-    "result": {
-        "success": true
-    }
-}
-```
-
-<a name="unregisterApplications"></a>
-## *unregisterApplications*
-
-This API will remove the specified APP names from the existing whitelist. This API call will simply ignore the request and return success, if specified apps are not present in the whitelist. Invoking this API, with the empty list, will clear the whitelist and wont allow any of the applications to cast.
-  
-### Events 
-
- No Events.
-
-### Parameters
-
-| Name | Type | Description |
-| :-------- | :-------- | :-------- |
-| params | object |  |
-| params.applications | string | The application name to register |
-
-### Result
-
-| Name | Type | Description |
-| :-------- | :-------- | :-------- |
-| result | object |  |
-| result.success | boolean | Whether the request succeeded |
-
-### Example 1
-Following call will remove NetflixApp and YouTubeKids from gdial whitelistied applications.
-#### Request
-
-```json
-{
-    "jsonrpc": "2.0",
-    "id": 42,
-    "method": "org.rdk.Xcast.1.unregisterApplications",
-    "params": {
-        "applications": ["NetflixApp", "YouTubeKids"]
-    }
-}
-```
-
-#### Response
-
-```json
-{
-    "jsonrpc": "2.0",
-    "id": 42,
-    "result": {
-        "success": true
-    }
-}
-```
-
-### Example 1
-Following call will clear the gdial application whitelist. Once this call is invoked, it wont be able to cast any of the aaplications using XCast.
-#### Request
-
-```json
-{
-    "jsonrpc": "2.0",
-    "id": 42,
-    "method": "org.rdk.Xcast.1.unregisterApplications",
-    "params": {
-        "applications": []
+        "applications": "NetflixApp"
     }
 }
 ```
@@ -552,7 +436,7 @@ Enables or disables xcast.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Xcast.1.setEnabled",
+    "method": "org.rdk.Xcast.setEnabled",
     "params": {
         "enabled": true
     }
@@ -602,7 +486,7 @@ Sets the friendly name of device. It allows an application to override the defau
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Xcast.1.setFriendlyName",
+    "method": "org.rdk.Xcast.setFriendlyName",
     "params": {
         "friendlyname": "xdial"
     }
@@ -652,7 +536,7 @@ Sets the expected xcast behavior in standby mode. It allows an application to ov
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Xcast.1.setStandbyBehavior",
+    "method": "org.rdk.Xcast.setStandbyBehavior",
     "params": {
         "standbybehavior": "active"
     }
@@ -708,7 +592,7 @@ Upon hiding the application, the resident application is responsible for calling
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onApplicationHideRequest",
+    "method": "client.events.onApplicationHideRequest",
     "params": {
         "applicationName": "NetflixApp",
         "applicationId": "1234"
@@ -736,7 +620,7 @@ Upon launching the application, the resident application is responsible for call
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onApplicationLaunchRequest",
+    "method": "client.events.onApplicationLaunchRequest",
     "params": {
         "applicationName": "NetflixApp",
         "parameters": {
@@ -765,7 +649,7 @@ Upon resuming the application, the resident application is responsible for calli
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onApplicationResumeRequest",
+    "method": "client.events.onApplicationResumeRequest",
     "params": {
         "applicationName": "NetflixApp",
         "applicationId": "1234"
@@ -792,7 +676,7 @@ The resident application is responsible for calling the `onApplicationStateChang
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onApplicationStateRequest",
+    "method": "client.events.onApplicationStateRequest",
     "params": {
         "applicationName": "NetflixApp",
         "applicationId": "1234"
@@ -819,7 +703,7 @@ Upon stopping the application, the resident application is responsible for calli
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.1.onApplicationStopRequest",
+    "method": "client.events.onApplicationStopRequest",
     "params": {
         "applicationName": "NetflixApp",
         "applicationId": "1234"


### PR DESCRIPTION
"RDK-38099 : Update Examples in RDKServices to not include version in method name"

Reason for change:
RDK-38099 : All the examples in RDKServices documentation are updated to remove the version since we want clients to call the API without specifying the version.

Test Procedure: Executed and verified by generating api documentation in docsify
Risks: Create None
Signed-off-by: Rekha Jayaram "[Rekha_Jayaram3@comcast.com](mailto:Rekha_Jayaram3@comcast.com)"

Jira link :
https://ccp.sys.comcast.net/browse/RDK-38099
