### PR TITLE
RDKDEV-259 :Security agent : Bug fix in security agent plugin's configuration and url for token creation in injected bundle (v3)

### DIFF
--- a/SecurityAgent/SecurityAgent.config
+++ b/SecurityAgent/SecurityAgent.config
@@ -1,6 +1,7 @@
 set (autostart true)
+set(PLUGIN_SECURITYAGENT_ACL_FILE_NAME "acl.json" CACHE STRING "SecurityAgent ACL file name")
 
 map()
-    map(acl acl.json)
+    kv(acl ${PLUGIN_SECURITYAGENT_ACL_FILE_NAME})
 end()
 ans(configuration)

--- a/WebKitBrowser/InjectedBundle/SecurityAgent.cpp
+++ b/WebKitBrowser/InjectedBundle/SecurityAgent.cpp
@@ -46,6 +46,8 @@ namespace JavaScript {
                     uint8_t buffer[2 * 1024];
 
                     std::string url = WebKit::Utils::GetURL();
+                    //Formatting the url string to json for creating token
+                    url = "{\"url\":\"" + url + "\"}";
 
                     std::string tokenAsString;
                     if (url.length() < sizeof(buffer)) {


### PR DESCRIPTION
This commits adds the configuration of acl file name in Securityagent plugin.
Sets value of PLUGIN_SECURITYAGENT_ACL_FILE_NAME to acl if it is defined else set default file name acl.json also fixes the bug in the SecurityAgent.config file previously it used map instead of kv to pair acl with the acl file name.
Also formatting url to json for creating token, after decoding the token, securityagent plugin expecting "url" string with url while checking the url in the acl configuration file.

This PR is the rebased version of https://github.com/rdkcentral/rdkservices/pull/2636.

As mentioned in https://github.com/rdkcentral/rdkservices/pull/2636#discussion_r974094731, this is still needed taking into consideration the current implementation of the `SecurityAgent` plugin.