### PR TITLE
DELIA-57482: APIs should be available in all versions

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -140,7 +140,8 @@ namespace
 }
 #endif
 
-#define registerMethod(...) Register(__VA_ARGS__);GetHandler(2)->Register<JsonObject, JsonObject>(__VA_ARGS__)
+// TODO: remove this
+#define registerMethod(...) for (uint8_t i = 1; GetHandler(i); i++) GetHandler(i)->Register<JsonObject, JsonObject>(__VA_ARGS__)
 
 namespace WPEFramework {
 
@@ -2190,7 +2191,6 @@ namespace WPEFramework {
 	     JsonObject params;
 	     audioFormatToString(audioFormat, params);
              sendNotify("audioFormatChanged", params);
-        GetHandler(2)->Notify("audioFormatChanged", params);
 	}
 
 	void DisplaySettings::notifyVideoFormatChange(dsHDRStandard_t videoFormat)
@@ -2200,7 +2200,6 @@ namespace WPEFramework {
 
             params["supportedVideoFormat"] = getSupportedVideoFormats();
             sendNotify("videoFormatChanged", params);
-        GetHandler(2)->Notify("videoFormatChanged", params);
         }
 
         void DisplaySettings::notifyAssociatedAudioMixingChange(bool mixing)
@@ -2208,7 +2207,6 @@ namespace WPEFramework {
              JsonObject params;
              params["mixing"] = mixing;
              sendNotify("associatedAudioMixingChanged", params);
-            GetHandler(2)->Notify("associatedAudioMixingChanged", params);
         }
 
         void DisplaySettings::notifyFaderControlChange(bool mixerbalance)
@@ -2216,7 +2214,6 @@ namespace WPEFramework {
              JsonObject params;
              params["mixerBalance"] = mixerbalance;
              sendNotify("faderControlChanged", params);
-            GetHandler(2)->Notify("faderControlChanged", params);
         }
 
         void DisplaySettings::notifyPrimaryLanguageChange(std::string pLang)
@@ -2224,7 +2221,6 @@ namespace WPEFramework {
              JsonObject params;
              params["primaryLanguage"] = pLang;
              sendNotify("primaryLanguageChanged", params);
-            GetHandler(2)->Notify("primaryLanguageChanged", params);
         }
 
         void DisplaySettings::notifySecondaryLanguageChange(std::string sLang)
@@ -2232,7 +2228,6 @@ namespace WPEFramework {
              JsonObject params;
              params["secondaryLanguage"] = sLang;
              sendNotify("secondaryLanguageChanged", params);
-            GetHandler(2)->Notify("secondaryLanguageChanged", params);
         }
 
         uint32_t DisplaySettings::getBassEnhancer(const JsonObject& parameters, JsonObject& response)
@@ -5257,7 +5252,6 @@ namespace WPEFramework {
         void DisplaySettings::resolutionPreChange()
         {
             sendNotify("resolutionPreChange", JsonObject());
-            GetHandler(2)->Notify("resolutionPreChange", JsonObject());
         }
 
         void DisplaySettings::resolutionChanged(int width, int height)
@@ -5293,7 +5287,6 @@ namespace WPEFramework {
                         params["videoDisplayType"] = display;
                         params["resolution"] = resolution;
                         sendNotify("resolutionChanged", params);
-                        GetHandler(2)->Notify("resolutionChanged", params);
                         return;
                     }
                     else if (!firstResolutionSet)
@@ -5313,7 +5306,6 @@ namespace WPEFramework {
                 params["videoDisplayType"] = firstDisplay;
                 params["resolution"] = firstResolution;
                 sendNotify("resolutionChanged", params);
-                GetHandler(2)->Notify("resolutionChanged", params);
             }
         }
 
@@ -5324,7 +5316,6 @@ namespace WPEFramework {
             params["zoomSetting"] = zoomSetting;
             params["videoDisplayType"] = "all";
             sendNotify("zoomSettingUpdated", params);
-            GetHandler(2)->Notify("zoomSettingUpdated", params);
         }
 
         void DisplaySettings::activeInputChanged(bool activeInput)
@@ -5332,7 +5323,6 @@ namespace WPEFramework {
             JsonObject params;
             params["activeInput"] = activeInput;
             sendNotify("activeInputChanged", params);
-            GetHandler(2)->Notify("activeInputChanged", params);
         }
 
         void DisplaySettings::connectedVideoDisplaysUpdated(int hdmiHotPlugEvent)
@@ -5356,7 +5346,6 @@ namespace WPEFramework {
                 JsonObject params;
                 params["connectedVideoDisplays"] = connectedDisplays;
                 sendNotify("connectedVideoDisplaysUpdated", params);
-                GetHandler(2)->Notify("connectedVideoDisplaysUpdated", params);
             }
             previousStatus = hdmiHotPlugEvent;
         }
@@ -5394,7 +5383,6 @@ namespace WPEFramework {
             }
             LOGWARN ("Thunder sends notification %s audio port hotplug status %s", sPortName.c_str(), sPortStatus.c_str());
             sendNotify("connectedAudioPortUpdated", params);
-            GetHandler(2)->Notify("connectedAudioPortUpdated", params);
         }
 
         //End events

--- a/FrameRate/FrameRate.cpp
+++ b/FrameRate/FrameRate.cpp
@@ -46,6 +46,9 @@
 #define DEFAULT_MIN_FPS_VALUE 60
 #define DEFAULT_MAX_FPS_VALUE -1
 
+// TODO: remove this
+#define registerMethod(...) for (uint8_t i = 1; GetHandler(i); i++) GetHandler(i)->Register<JsonObject, JsonObject>(__VA_ARGS__)
+
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
 #define API_VERSION_NUMBER_PATCH 0
@@ -80,39 +83,21 @@ namespace WPEFramework
         {
             FrameRate::_instance = this;
 
-            Register(METHOD_SET_COLLECTION_FREQUENCY, &FrameRate::setCollectionFrequencyWrapper, this);
-            Register(METHOD_START_FPS_COLLECTION, &FrameRate::startFpsCollectionWrapper, this);
-            Register(METHOD_STOP_FPS_COLLECTION, &FrameRate::stopFpsCollectionWrapper, this);
-            Register(METHOD_UPDATE_FPS_COLLECTION, &FrameRate::updateFpsWrapper, this);
-
             CreateHandler({2});
-            GetHandler(2)->Register<JsonObject, JsonObject>(METHOD_SET_COLLECTION_FREQUENCY, &FrameRate::setCollectionFrequencyWrapper, this);
-            GetHandler(2)->Register<JsonObject, JsonObject>(METHOD_START_FPS_COLLECTION, &FrameRate::startFpsCollectionWrapper, this);
-            GetHandler(2)->Register<JsonObject, JsonObject>(METHOD_STOP_FPS_COLLECTION, &FrameRate::stopFpsCollectionWrapper, this);
-            GetHandler(2)->Register<JsonObject, JsonObject>(METHOD_UPDATE_FPS_COLLECTION, &FrameRate::updateFpsWrapper, this);
-            GetHandler(2)->Register<JsonObject, JsonObject>(METHOD_SET_FRAME_MODE, &FrameRate::setFrmMode, this);
-            GetHandler(2)->Register<JsonObject, JsonObject>(METHOD_GET_FRAME_MODE, &FrameRate::getFrmMode, this);
-            GetHandler(2)->Register<JsonObject, JsonObject>(METHOD_GET_DISPLAY_FRAME_RATE, &FrameRate::getDisplayFrameRate, this);
-            GetHandler(2)->Register<JsonObject, JsonObject>(METHOD_SET_DISPLAY_FRAME_RATE, &FrameRate::setDisplayFrameRate, this);
+            registerMethod(METHOD_SET_COLLECTION_FREQUENCY, &FrameRate::setCollectionFrequencyWrapper, this);
+            registerMethod(METHOD_START_FPS_COLLECTION, &FrameRate::startFpsCollectionWrapper, this);
+            registerMethod(METHOD_STOP_FPS_COLLECTION, &FrameRate::stopFpsCollectionWrapper, this);
+            registerMethod(METHOD_UPDATE_FPS_COLLECTION, &FrameRate::updateFpsWrapper, this);
+            registerMethod(METHOD_SET_FRAME_MODE, &FrameRate::setFrmMode, this);
+            registerMethod(METHOD_GET_FRAME_MODE, &FrameRate::getFrmMode, this);
+            registerMethod(METHOD_GET_DISPLAY_FRAME_RATE, &FrameRate::getDisplayFrameRate, this);
+            registerMethod(METHOD_SET_DISPLAY_FRAME_RATE, &FrameRate::setDisplayFrameRate, this);
 
             m_reportFpsTimer.connect( std::bind( &FrameRate::onReportFpsTimer, this ) );
         }
 
         FrameRate::~FrameRate()
         {
-            Unregister(METHOD_SET_COLLECTION_FREQUENCY);
-            Unregister(METHOD_START_FPS_COLLECTION);
-            Unregister(METHOD_STOP_FPS_COLLECTION);
-            Unregister(METHOD_UPDATE_FPS_COLLECTION);
-
-            GetHandler(2)->Unregister(METHOD_SET_COLLECTION_FREQUENCY);
-            GetHandler(2)->Unregister(METHOD_START_FPS_COLLECTION);
-            GetHandler(2)->Unregister(METHOD_STOP_FPS_COLLECTION);
-            GetHandler(2)->Unregister(METHOD_UPDATE_FPS_COLLECTION);
-            GetHandler(2)->Unregister(METHOD_SET_FRAME_MODE);
-            GetHandler(2)->Unregister(METHOD_GET_FRAME_MODE);
-            GetHandler(2)->Unregister(METHOD_GET_DISPLAY_FRAME_RATE);
-            GetHandler(2)->Unregister(METHOD_SET_DISPLAY_FRAME_RATE);
         }
 
 	const string FrameRate::Initialize(PluginHost::IShell * /* service */)
@@ -435,8 +420,6 @@ namespace WPEFramework
             params["max"] = maxFps;
             
             sendNotify(EVENT_FPS_UPDATE, params);
-
-            GetHandler(2)->Notify(EVENT_FPS_UPDATE, params);
         }
         
         void FrameRate::onReportFpsTimer()
@@ -481,8 +464,6 @@ namespace WPEFramework
         void FrameRate::frameRatePreChange()
         {
             sendNotify(EVENT_FRAMERATE_PRECHANGE, JsonObject());
-
-            GetHandler(2)->Notify(EVENT_FRAMERATE_PRECHANGE, JsonObject());
         }
 
         void FrameRate::FrameRatePostChange(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
@@ -496,8 +477,6 @@ namespace WPEFramework
         void FrameRate::frameRatePostChange()
         {
             sendNotify(EVENT_FRAMERATE_POSTCHANGE, JsonObject());
-
-            GetHandler(2)->Notify(EVENT_FRAMERATE_POSTCHANGE, JsonObject());
         }
 
         

--- a/HdmiInput/HdmiInput.cpp
+++ b/HdmiInput/HdmiInput.cpp
@@ -52,6 +52,9 @@
 #define HDMIINPUT_EVENT_ON_VIDEO_MODE_UPDATED "videoStreamInfoUpdate"
 #define HDMIINPUT_EVENT_ON_GAME_FEATURE_STATUS_CHANGED "hdmiGameFeatureStatusUpdate"
 
+// TODO: remove this
+#define registerMethod(...) for (uint8_t i = 1; GetHandler(i); i++) GetHandler(i)->Register<JsonObject, JsonObject>(__VA_ARGS__)
+
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
 #define API_VERSION_NUMBER_PATCH 0
@@ -89,27 +92,19 @@ namespace WPEFramework
 
             CreateHandler({2});
 
-            Register(HDMIINPUT_METHOD_GET_HDMI_INPUT_DEVICES, &HdmiInput::getHDMIInputDevicesWrapper, this);
-            Register(HDMIINPUT_METHOD_WRITE_EDID, &HdmiInput::writeEDIDWrapper, this);
-            Register(HDMIINPUT_METHOD_READ_EDID, &HdmiInput::readEDIDWrapper, this);
-            GetHandler(2)->Register<JsonObject, JsonObject>(HDMIINPUT_METHOD_READ_RAWHDMISPD, &HdmiInput::getRawHDMISPDWrapper, this);
-            GetHandler(2)->Register<JsonObject, JsonObject>(HDMIINPUT_METHOD_READ_HDMISPD, &HdmiInput::getHDMISPDWrapper, this);
-            GetHandler(2)->Register<JsonObject, JsonObject>(HDMIINPUT_METHOD_SET_EDID_VERSION, &HdmiInput::setEdidVersionWrapper, this);
-            GetHandler(2)->Register<JsonObject, JsonObject>(HDMIINPUT_METHOD_GET_EDID_VERSION, &HdmiInput::getEdidVersionWrapper, this);
-            Register(HDMIINPUT_METHOD_START_HDMI_INPUT, &HdmiInput::startHdmiInput, this);
-            Register(HDMIINPUT_METHOD_STOP_HDMI_INPUT, &HdmiInput::stopHdmiInput, this);
-            Register(HDMIINPUT_METHOD_SCALE_HDMI_INPUT, &HdmiInput::setVideoRectangleWrapper, this);
+            registerMethod(HDMIINPUT_METHOD_GET_HDMI_INPUT_DEVICES, &HdmiInput::getHDMIInputDevicesWrapper, this);
+            registerMethod(HDMIINPUT_METHOD_WRITE_EDID, &HdmiInput::writeEDIDWrapper, this);
+            registerMethod(HDMIINPUT_METHOD_READ_EDID, &HdmiInput::readEDIDWrapper, this);
+            registerMethod(HDMIINPUT_METHOD_READ_RAWHDMISPD, &HdmiInput::getRawHDMISPDWrapper, this);
+            registerMethod(HDMIINPUT_METHOD_READ_HDMISPD, &HdmiInput::getHDMISPDWrapper, this);
+            registerMethod(HDMIINPUT_METHOD_SET_EDID_VERSION, &HdmiInput::setEdidVersionWrapper, this);
+            registerMethod(HDMIINPUT_METHOD_GET_EDID_VERSION, &HdmiInput::getEdidVersionWrapper, this);
+            registerMethod(HDMIINPUT_METHOD_START_HDMI_INPUT, &HdmiInput::startHdmiInput, this);
+            registerMethod(HDMIINPUT_METHOD_STOP_HDMI_INPUT, &HdmiInput::stopHdmiInput, this);
+            registerMethod(HDMIINPUT_METHOD_SCALE_HDMI_INPUT, &HdmiInput::setVideoRectangleWrapper, this);
 
-            GetHandler(2)->Register<JsonObject, JsonObject>(HDMIINPUT_METHOD_GET_HDMI_INPUT_DEVICES, &HdmiInput::getHDMIInputDevicesWrapper, this);
-            GetHandler(2)->Register<JsonObject, JsonObject>(HDMIINPUT_METHOD_WRITE_EDID, &HdmiInput::writeEDIDWrapper, this);
-            GetHandler(2)->Register<JsonObject, JsonObject>(HDMIINPUT_METHOD_READ_EDID, &HdmiInput::readEDIDWrapper, this);
-            GetHandler(2)->Register<JsonObject, JsonObject>(HDMIINPUT_METHOD_START_HDMI_INPUT, &HdmiInput::startHdmiInput, this);
-            GetHandler(2)->Register<JsonObject, JsonObject>(HDMIINPUT_METHOD_STOP_HDMI_INPUT, &HdmiInput::stopHdmiInput, this);
-            GetHandler(2)->Register<JsonObject, JsonObject>(HDMIINPUT_METHOD_SCALE_HDMI_INPUT, &HdmiInput::setVideoRectangleWrapper, this);
-            Register(HDMIINPUT_METHOD_SUPPORTED_GAME_FEATURES, &HdmiInput::getSupportedGameFeatures, this);
-            GetHandler(2)->Register<JsonObject, JsonObject>(HDMIINPUT_METHOD_SUPPORTED_GAME_FEATURES, &HdmiInput::getSupportedGameFeatures, this);
-            Register(HDMIINPUT_METHOD_GAME_FEATURE_STATUS, &HdmiInput::getHdmiGameFeatureStatusWrapper, this);
-            GetHandler(2)->Register<JsonObject, JsonObject>(HDMIINPUT_METHOD_GAME_FEATURE_STATUS, &HdmiInput::getHdmiGameFeatureStatusWrapper, this);
+            registerMethod(HDMIINPUT_METHOD_SUPPORTED_GAME_FEATURES, &HdmiInput::getSupportedGameFeatures, this);
+            registerMethod(HDMIINPUT_METHOD_GAME_FEATURE_STATUS, &HdmiInput::getHdmiGameFeatureStatusWrapper, this);
         }
 
         HdmiInput::~HdmiInput()
@@ -415,7 +410,6 @@ namespace WPEFramework
             JsonObject params;
             params["devices"] = getHDMIInputDevices();
             sendNotify(HDMIINPUT_EVENT_ON_DEVICES_CHANGED, params);
-            GetHandler(2)->Notify(HDMIINPUT_EVENT_ON_DEVICES_CHANGED, params);
         }
 
         /**
@@ -458,7 +452,6 @@ namespace WPEFramework
             }
 
             sendNotify(HDMIINPUT_EVENT_ON_SIGNAL_CHANGED, params);
-            GetHandler(2)->Notify(HDMIINPUT_EVENT_ON_SIGNAL_CHANGED, params);
         }
 
         /**
@@ -486,7 +479,6 @@ namespace WPEFramework
             }
 
             sendNotify(HDMIINPUT_EVENT_ON_STATUS_CHANGED, params);
-            GetHandler(2)->Notify(HDMIINPUT_EVENT_ON_STATUS_CHANGED, params);
         }
 
         /**
@@ -593,7 +585,6 @@ namespace WPEFramework
             }
 
             sendNotify(HDMIINPUT_EVENT_ON_VIDEO_MODE_UPDATED, params);
-            GetHandler(2)->Notify(HDMIINPUT_EVENT_ON_VIDEO_MODE_UPDATED, params);
         }
 
         void HdmiInput::dsHdmiEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
@@ -690,7 +681,6 @@ namespace WPEFramework
             params["mode"] = allm_mode;
 
             sendNotify(HDMIINPUT_EVENT_ON_GAME_FEATURE_STATUS_CHANGED, params);
-            GetHandler(2)->Notify(HDMIINPUT_EVENT_ON_GAME_FEATURE_STATUS_CHANGED, params);
         }
 
         uint32_t HdmiInput::getSupportedGameFeatures(const JsonObject& parameters, JsonObject& response)

--- a/Network/Network.cpp
+++ b/Network/Network.cpp
@@ -61,6 +61,9 @@ using namespace std;
 #define IARM_BUS_NETSRVMGR_API_isAvailable "isAvailable"
 #define IARM_BUS_NETSRVMGR_API_getPublicIP "getPublicIP"
 
+// TODO: remove this
+#define registerMethod(...) for (uint8_t i = 1; GetHandler(i); i++) GetHandler(i)->Register<JsonObject, JsonObject>(__VA_ARGS__)
+
 typedef enum _NetworkManager_EventId_t {
     IARM_BUS_NETWORK_MANAGER_EVENT_SET_INTERFACE_ENABLED=50,
     IARM_BUS_NETWORK_MANAGER_EVENT_SET_INTERFACE_CONTROL_PERSISTENCE,
@@ -160,36 +163,36 @@ namespace WPEFramework
             CreateHandler({2});
 
             // Quirk
-            Register("getQuirks", &Network::getQuirks, this);
+            registerMethod("getQuirks", &Network::getQuirks, this);
 
             // Network_API_Version_1
-            Register("getInterfaces", &Network::getInterfaces, this);
-            Register("isInterfaceEnabled", &Network::isInterfaceEnabled, this);
-            Register("setInterfaceEnabled", &Network::setInterfaceEnabled, this);
-            Register("getDefaultInterface", &Network::getDefaultInterface, this);
-            Register("setDefaultInterface", &Network::setDefaultInterface, this);
+            registerMethod("getInterfaces", &Network::getInterfaces, this);
+            registerMethod("isInterfaceEnabled", &Network::isInterfaceEnabled, this);
+            registerMethod("setInterfaceEnabled", &Network::setInterfaceEnabled, this);
+            registerMethod("getDefaultInterface", &Network::getDefaultInterface, this);
+            registerMethod("setDefaultInterface", &Network::setDefaultInterface, this);
 
-            Register("getStbIp", &Network::getStbIp, this);
+            registerMethod("getStbIp", &Network::getStbIp, this);
 
-            Register("trace", &Network::trace, this);
-            Register("traceNamedEndpoint", &Network::traceNamedEndpoint, this);
+            registerMethod("trace", &Network::trace, this);
+            registerMethod("traceNamedEndpoint", &Network::traceNamedEndpoint, this);
 
-            Register("getNamedEndpoints", &Network::getNamedEndpoints, this);
+            registerMethod("getNamedEndpoints", &Network::getNamedEndpoints, this);
 
-            Register("ping",              &Network::ping, this);
-            Register("pingNamedEndpoint", &Network::pingNamedEndpoint, this);
+            registerMethod("ping",              &Network::ping, this);
+            registerMethod("pingNamedEndpoint", &Network::pingNamedEndpoint, this);
 
             Register("setIPSettings", &Network::setIPSettings, this);
             GetHandler(2)->Register<JsonObject, JsonObject>("setIPSettings", &Network::setIPSettings2, this);
             Register("getIPSettings", &Network::getIPSettings, this);
             GetHandler(2)->Register<JsonObject, JsonObject>("getIPSettings", &Network::getIPSettings2, this);
 
-            Register("getSTBIPFamily", &Network::getSTBIPFamily, this);
-            Register("isConnectedToInternet", &Network::isConnectedToInternet, this);
-            Register("setConnectivityTestEndpoints", &Network::setConnectivityTestEndpoints, this);
+            registerMethod("getSTBIPFamily", &Network::getSTBIPFamily, this);
+            registerMethod("isConnectedToInternet", &Network::isConnectedToInternet, this);
+            registerMethod("setConnectivityTestEndpoints", &Network::setConnectivityTestEndpoints, this);
 
-            Register("getPublicIP", &Network::getPublicIP, this);
-            Register("setStunEndPoint", &Network::setStunEndPoint, this);
+            registerMethod("getPublicIP", &Network::getPublicIP, this);
+            registerMethod("setStunEndPoint", &Network::setStunEndPoint, this);
 
             const char * script1 = R"(grep DEVICE_TYPE /etc/device.properties | cut -d "=" -f2 | tr -d '\n')";
             m_isHybridDevice = Utils::cRunScript(script1).substr();
@@ -1356,7 +1359,6 @@ namespace WPEFramework
             params["enabled"] = enabled;
             m_useInterfacesCache = false;
             sendNotify("onInterfaceStatusChanged", params);
-            GetHandler(2)->Notify("onInterfaceStatusChanged", params);
         }
 
         void Network::onInterfaceConnectionStatusChanged(string interface, bool connected)
@@ -1374,7 +1376,6 @@ namespace WPEFramework
             m_defIpversionCache = "";
             m_defInterfaceCache = "";
             sendNotify("onConnectionStatusChanged", params);
-            GetHandler(2)->Notify("onConnectionStatusChanged", params);
         }
 
         void Network::onInterfaceIPAddressChanged(string interface, string ipv6Addr, string ipv4Addr, bool acquired)
@@ -1408,7 +1409,6 @@ namespace WPEFramework
             }
             params["status"] = string (acquired ? "ACQUIRED" : "LOST");
             sendNotify("onIPAddressStatusChanged", params);
-            GetHandler(2)->Notify("onIPAddressStatusChanged", params);
         }
 
         void Network::onDefaultInterfaceChanged(string oldInterface, string newInterface)
@@ -1425,7 +1425,6 @@ namespace WPEFramework
             m_defIpversionCache = "";
             m_defInterfaceCache = m_netUtils.getInterfaceDescription(newInterface);
             sendNotify("onDefaultInterfaceChanged", params);
-            GetHandler(2)->Notify("onDefaultInterfaceChanged", params);
         }
 
         void Network::eventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len)

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -251,7 +251,8 @@ bool setPowerState(std::string powerState)
 
 #endif /* defined(USE_IARMBUS) || defined(USE_IARM_BUS) */
 
-#define registerMethod(...) Register(__VA_ARGS__);GetHandler(2)->Register<JsonObject, JsonObject>(__VA_ARGS__)
+// TODO: remove this
+#define registerMethod(...) for (uint8_t i = 1; GetHandler(i); i++) GetHandler(i)->Register<JsonObject, JsonObject>(__VA_ARGS__)
 
 /**
  * @brief WPEFramework class for SystemServices
@@ -424,25 +425,27 @@ namespace WPEFramework {
 #endif //ENABLE_SET_WAKEUP_SRC_CONFIG
 
             // version 2 APIs
-            GetHandler(2)->Register<JsonObject, JsonObject>(_T("getTimeZones"), &SystemServices::getTimeZones, this);
+            registerMethod(_T("getTimeZones"), &SystemServices::getTimeZones, this);
 #ifdef ENABLE_DEEP_SLEEP
-            GetHandler(2)->Register<JsonObject, JsonObject>(_T("getWakeupReason"),&SystemServices::getWakeupReason, this);
-            GetHandler(2)->Register<JsonObject, JsonObject>(_T("getLastWakeupKeyCode"), &SystemServices::getLastWakeupKeyCode, this);
+            registerMethod(_T("getWakeupReason"), &SystemServices::getWakeupReason, this);
+            registerMethod(_T("getLastWakeupKeyCode"), &SystemServices::getLastWakeupKeyCode, this);
 #endif
-            GetHandler(2)->Register<JsonObject, JsonObject>("uploadLogs", &SystemServices::uploadLogs, this);
+            registerMethod("uploadLogs", &SystemServices::uploadLogs, this);
 
             registerMethod("getPowerStateBeforeReboot", &SystemServices::getPowerStateBeforeReboot,
                     this);
-            GetHandler(2)->Register<JsonObject, JsonObject>("getLastFirmwareFailureReason", &SystemServices::getLastFirmwareFailureReason, this);
+            registerMethod("getLastFirmwareFailureReason", &SystemServices::getLastFirmwareFailureReason, this);
             registerMethod("setOptOutTelemetry", &SystemServices::setOptOutTelemetry, this);
             registerMethod("isOptOutTelemetry", &SystemServices::isOptOutTelemetry, this);
-            GetHandler(2)->Register<JsonObject, JsonObject>("fireFirmwarePendingReboot", &SystemServices::fireFirmwarePendingReboot, this);
-            GetHandler(2)->Register<JsonObject, JsonObject>("setFirmwareRebootDelay", &SystemServices::setFirmwareRebootDelay, this);
-            GetHandler(2)->Register<JsonObject, JsonObject>("setFirmwareAutoReboot", &SystemServices::setFirmwareAutoReboot, this);
+            registerMethod("fireFirmwarePendingReboot", &SystemServices::fireFirmwarePendingReboot, this);
+            registerMethod("setFirmwareRebootDelay", &SystemServices::setFirmwareRebootDelay, this);
+            registerMethod("setFirmwareAutoReboot", &SystemServices::setFirmwareAutoReboot, this);
 #ifdef ENABLE_SYSTEM_GET_STORE_DEMO_LINK
-            GetHandler(2)->Register<JsonObject, JsonObject>("getStoreDemoLink", &SystemServices::getStoreDemoLink, this);
+            registerMethod("getStoreDemoLink", &SystemServices::getStoreDemoLink, this);
 #endif
-            GetHandler(2)->Register<JsonObject, JsonObject>("deletePersistentPath", &SystemServices::deletePersistentPath, this);
+            registerMethod("deletePersistentPath", &SystemServices::deletePersistentPath, this);
+            Register<JsonObject, PlatformCaps>("getPlatformConfiguration",
+                &SystemServices::getPlatformConfiguration, this);
             GetHandler(2)->Register<JsonObject, PlatformCaps>("getPlatformConfiguration",
                 &SystemServices::getPlatformConfiguration, this);
 
@@ -553,7 +556,6 @@ namespace WPEFramework {
             response["sampleAPI"] = "Success";
             /* Kept for debug purpose/future reference. */
             sendNotify(EVT_ONSYSTEMSAMPLEEVENT, parameters);
-            GetHandler(2)->Notify(EVT_ONSYSTEMSAMPLEEVENT, parameters);
             returnResponse(true);
         }
 #endif /* DEBUG */
@@ -745,7 +747,6 @@ namespace WPEFramework {
             params["fireFirmwarePendingReboot"] = seconds;
             LOGINFO("Notifying onFirmwarePendingReboot received \n");
             sendNotify(EVT_ONFWPENDINGREBOOT, params);
-            GetHandler(2)->Notify(EVT_ONFWPENDINGREBOOT, params);
         }
 
         /***
@@ -763,7 +764,6 @@ namespace WPEFramework {
             params["currentPowerState"] = currentPowerState;
             LOGWARN("power state changed from '%s' to '%s'", currentPowerState.c_str(), powerState.c_str());
             sendNotify(EVT_ONSYSTEMPOWERSTATECHANGED, params);
-            GetHandler(2)->Notify(EVT_ONSYSTEMPOWERSTATECHANGED, params);
         }
 
         void SystemServices::onPwrMgrReboot(string requestedApp, string rebootReason)
@@ -773,7 +773,6 @@ namespace WPEFramework {
             params["rebootReason"] = rebootReason;
 
             sendNotify(EVT_ONREBOOTREQUEST, params);
-            GetHandler(2)->Notify(EVT_ONREBOOTREQUEST, params);
         }
 
         void SystemServices::onNetorkModeChanged(bool bNetworkStandbyMode)
@@ -783,7 +782,6 @@ namespace WPEFramework {
             JsonObject params;
             params["nwStandby"] = bNetworkStandbyMode;
             sendNotify(EVT_ONNETWORKSTANDBYMODECHANGED , params);
-            GetHandler(2)->Notify(EVT_ONNETWORKSTANDBYMODECHANGED , params);
         }
 
         /**
@@ -1131,7 +1129,6 @@ namespace WPEFramework {
             params["mode"] = mode;
             LOGINFO("mode changed to '%s'\n", mode.c_str());
             sendNotify(EVT_ONSYSTEMMODECHANGED, params);
-            GetHandler(2)->Notify(EVT_ONSYSTEMMODECHANGED, params);
         }
 
         /***
@@ -1411,7 +1408,6 @@ namespace WPEFramework {
             params.ToString(jsonLog);
             LOGWARN("result: %s\n", jsonLog.c_str());
             sendNotify(EVT_ONFIRMWAREUPDATEINFORECEIVED, params);
-            GetHandler(2)->Notify(EVT_ONFIRMWAREUPDATEINFORECEIVED, params);
         }
 
         /***
@@ -2116,7 +2112,6 @@ namespace WPEFramework {
             params["firmwareUpdateStateChange"] = (int)firmwareUpdateState;
             LOGINFO("New firmwareUpdateState = %d\n", (int)firmwareUpdateState);
             sendNotify(EVT_ONFIRMWAREUPDATESTATECHANGED, params);
-            GetHandler(2)->Notify(EVT_ONFIRMWAREUPDATESTATECHANGED, params);
         }
 
         /***
@@ -2127,7 +2122,6 @@ namespace WPEFramework {
         {
             JsonObject params;
             sendNotify(EVT_ON_SYSTEM_CLOCK_SET, params);
-            GetHandler(2)->Notify(EVT_ON_SYSTEM_CLOCK_SET, params);
         }
 
         /***
@@ -2223,7 +2217,6 @@ namespace WPEFramework {
             LOGWARN("thresholdType = %s exceed = %d temperature = %f\n",
                     thresholdType.c_str(), exceed, temperature);
             sendNotify(EVT_ONTEMPERATURETHRESHOLDCHANGED, params);
-            GetHandler(2)->Notify(EVT_ONTEMPERATURETHRESHOLDCHANGED, params);
         }
 
         /***
@@ -4034,7 +4027,6 @@ namespace WPEFramework {
             params["rebootReason"] = reason;
             LOGINFO("Notifying onRebootRequest\n");
             sendNotify(EVT_ONREBOOTREQUEST, params);
-            GetHandler(2)->Notify(EVT_ONREBOOTREQUEST, params);
         }
 
         /***

--- a/Tests/tests/test_FrameRate.cpp
+++ b/Tests/tests/test_FrameRate.cpp
@@ -15,14 +15,12 @@ class FrameRateTest : public ::testing::Test {
 protected:
     Core::ProxyType<Plugin::FrameRate> plugin;
     Core::JSONRPC::Handler& handler;
-    Core::JSONRPC::Handler& handlerV2;
     Core::JSONRPC::Connection connection;
     string response;
 
     FrameRateTest()
         : plugin(Core::ProxyType<Plugin::FrameRate>::Create())
         , handler(*(plugin))
-        , handlerV2(*(plugin->GetHandler(2)))
         , connection(1, 0)
     {
     }
@@ -114,14 +112,10 @@ TEST_F(FrameRateTest, RegisteredMethods)
     EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("startFpsCollection")));
     EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("stopFpsCollection")));
     EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("updateFps")));
-    EXPECT_EQ(Core::ERROR_NONE, handlerV2.Exists(_T("setCollectionFrequency")));
-    EXPECT_EQ(Core::ERROR_NONE, handlerV2.Exists(_T("startFpsCollection")));
-    EXPECT_EQ(Core::ERROR_NONE, handlerV2.Exists(_T("stopFpsCollection")));
-    EXPECT_EQ(Core::ERROR_NONE, handlerV2.Exists(_T("updateFps")));
-    EXPECT_EQ(Core::ERROR_NONE, handlerV2.Exists(_T("setFrmMode")));
-    EXPECT_EQ(Core::ERROR_NONE, handlerV2.Exists(_T("getFrmMode")));
-    EXPECT_EQ(Core::ERROR_NONE, handlerV2.Exists(_T("getDisplayFrameRate")));
-    EXPECT_EQ(Core::ERROR_NONE, handlerV2.Exists(_T("setDisplayFrameRate")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("setFrmMode")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("getFrmMode")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("getDisplayFrameRate")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("setDisplayFrameRate")));
 }
 
 TEST_F(FrameRateTest, setCollectionFrequency_startFpsCollection_stopFpsCollection_updateFps)
@@ -145,7 +139,7 @@ TEST_F(FrameRateDsTest, setFrmMode)
                 return 0;
             }));
 
-    EXPECT_EQ(Core::ERROR_NONE, handlerV2.Invoke(connection, _T("setFrmMode"), _T("{\"frmmode\":0}"), response));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("setFrmMode"), _T("{\"frmmode\":0}"), response));
     EXPECT_EQ(response, string("{\"success\":true}"));
 }
 
@@ -158,7 +152,7 @@ TEST_F(FrameRateDsTest, getFrmMode)
                 return 0;
             }));
 
-    EXPECT_EQ(Core::ERROR_NONE, handlerV2.Invoke(connection, _T("getFrmMode"), _T("{}"), response));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getFrmMode"), _T("{}"), response));
     EXPECT_EQ(response, string("{\"auto-frm-mode\":0,\"success\":true}"));
 }
 
@@ -171,7 +165,7 @@ TEST_F(FrameRateDsTest, setDisplayFrameRate)
                 return 0;
             }));
 
-    EXPECT_EQ(Core::ERROR_NONE, handlerV2.Invoke(connection, _T("setDisplayFrameRate"), _T("{\"framerate\":\"3840x2160px48\"}"), response));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("setDisplayFrameRate"), _T("{\"framerate\":\"3840x2160px48\"}"), response));
     EXPECT_EQ(response, string("{\"success\":true}"));
 }
 
@@ -185,7 +179,7 @@ TEST_F(FrameRateDsTest, getDisplayFrameRate)
                 return 0;
             }));
 
-    EXPECT_EQ(Core::ERROR_NONE, handlerV2.Invoke(connection, _T("getDisplayFrameRate"), _T("{}"), response));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getDisplayFrameRate"), _T("{}"), response));
     EXPECT_EQ(response, string("{\"framerate\":\"3840x2160px48\",\"success\":true}"));
 }
 

--- a/Tests/tests/test_SystemServices.cpp
+++ b/Tests/tests/test_SystemServices.cpp
@@ -48,7 +48,6 @@ class SystemServicesTest : public::SystemInitializeTest
     protected:
 	    Core::ProxyType<Plugin::SystemServices> systemplugin;
 	    Core::JSONRPC::Handler& handler;
-	    Core::JSONRPC::Handler& handlerV2;
 	    Core::JSONRPC::Connection connection;
 	    string response;
  
@@ -56,7 +55,6 @@ class SystemServicesTest : public::SystemInitializeTest
 		    :SystemInitializeTest()
     		    ,systemplugin(Core::ProxyType<Plugin::SystemServices>::Create())
     		    ,handler(*systemplugin)
-    		    ,handlerV2(*(systemplugin->GetHandler(2)))
     		    ,connection(1,0)
     {
     }
@@ -67,10 +65,10 @@ class SystemServicesTest : public::SystemInitializeTest
 TEST_F(SystemServicesTest, RegisterMethods)
 {
 	EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("requestSystemUptime")));
-	EXPECT_EQ(Core::ERROR_NONE, handlerV2.Exists(_T("fireFirmwarePendingReboot")));
-	EXPECT_EQ(Core::ERROR_NONE, handlerV2.Exists(_T("setFirmwareAutoReboot")));
-	EXPECT_EQ(Core::ERROR_NONE, handlerV2.Exists(_T("setFirmwareRebootDelay")));
-	EXPECT_EQ(Core::ERROR_NONE, handlerV2.Exists(_T("getLastFirmwareFailureReason")));
+	EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("fireFirmwarePendingReboot")));
+	EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("setFirmwareAutoReboot")));
+	EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("setFirmwareRebootDelay")));
+	EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("getLastFirmwareFailureReason")));
 	EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("getDownloadedFirmwareInfo")));
 	EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("getFirmwareDownloadPercent")));
 	EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("getFirmwareUpdateState")));
@@ -109,7 +107,7 @@ TEST_F(SystemServicesTest, PendingReboot)
 		return WDMP_SUCCESS;
 	}));
 	
-	EXPECT_EQ(Core::ERROR_NONE, handlerV2.Invoke(connection, _T("fireFirmwarePendingReboot"), _T("{}"),response));
+	EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("fireFirmwarePendingReboot"), _T("{}"),response));
 	EXPECT_EQ(response,string("{\"success\":true}"));
 }
 
@@ -124,7 +122,7 @@ TEST_F(SystemServicesTest, AutoReboot)
                 return WDMP_SUCCESS;
         }));
 
-    	EXPECT_EQ(Core::ERROR_NONE, handlerV2.Invoke(connection, _T("setFirmwareAutoReboot"), _T("{\"enable\":true}"),response));
+    	EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("setFirmwareAutoReboot"), _T("{\"enable\":true}"),response));
     	EXPECT_EQ(response,string("{\"success\":true}"));
 }
 
@@ -138,7 +136,7 @@ TEST_F(SystemServicesTest, RebootDelay)
                 EXPECT_EQ(strcmp(pcParameterName, "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.AutoReboot.fwDelayReboot"), 0);
                 return WDMP_SUCCESS;
 		}));
-    	EXPECT_EQ(Core::ERROR_NONE, handlerV2.Invoke(connection, _T("setFirmwareRebootDelay"), _T("{\"delaySeconds\":10}"),response));
+    	EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("setFirmwareRebootDelay"), _T("{\"delaySeconds\":10}"),response));
     	EXPECT_EQ(response,string("{\"success\":true}"));
 }
 
@@ -153,7 +151,7 @@ TEST_F(SystemServicesTest, Firmware)
 
 	file.close();
 
-	EXPECT_EQ(Core::ERROR_NONE, handlerV2.Invoke(connection, _T("getLastFirmwareFailureReason"), _T("{}"),response));
+	EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getLastFirmwareFailureReason"), _T("{}"),response));
     	EXPECT_EQ(response,string("{\"failReason\":\"None\",\"success\":true}"));
 
 	EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getDownloadedFirmwareInfo"), _T("{}"),response));

--- a/Tests/tests/test_UsbAccess.cpp
+++ b/Tests/tests/test_UsbAccess.cpp
@@ -11,14 +11,12 @@ class UsbAccessTest : public ::testing::Test {
 protected:
     Core::ProxyType<Plugin::UsbAccess> plugin;
     Core::JSONRPC::Handler& handler;
-    Core::JSONRPC::Handler& handlerV2;
     Core::JSONRPC::Connection connection;
     string response;
 
     UsbAccessTest()
         : plugin(Core::ProxyType<Plugin::UsbAccess>::Create())
         , handler(*(plugin))
-        , handlerV2(*(plugin->GetHandler(2)))
         , connection(1, 0)
     {
     }
@@ -29,13 +27,10 @@ TEST_F(UsbAccessTest, RegisteredMethods)
     EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("getFileList")));
     EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("createLink")));
     EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("clearLink")));
-    EXPECT_EQ(Core::ERROR_NONE, handlerV2.Exists(_T("getFileList")));
-    EXPECT_EQ(Core::ERROR_NONE, handlerV2.Exists(_T("createLink")));
-    EXPECT_EQ(Core::ERROR_NONE, handlerV2.Exists(_T("clearLink")));
-    EXPECT_EQ(Core::ERROR_NONE, handlerV2.Exists(_T("getAvailableFirmwareFiles")));
-    EXPECT_EQ(Core::ERROR_NONE, handlerV2.Exists(_T("getMounted")));
-    EXPECT_EQ(Core::ERROR_NONE, handlerV2.Exists(_T("updateFirmware")));
-    EXPECT_EQ(Core::ERROR_NONE, handlerV2.Exists(_T("ArchiveLogs")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("getAvailableFirmwareFiles")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("getMounted")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("updateFirmware")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("ArchiveLogs")));
 }
 
 TEST_F(UsbAccessTest, UpdateFirmware)
@@ -55,10 +50,10 @@ TEST_F(UsbAccessTest, UpdateFirmware)
                 return 0;
             }));
 
-    EXPECT_EQ(Core::ERROR_NONE, handlerV2.Invoke(connection, _T("updateFirmware"), _T("{\"fileName\":\"/tmp;reboot;/my.bin\"}"), response));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("updateFirmware"), _T("{\"fileName\":\"/tmp;reboot;/my.bin\"}"), response));
     EXPECT_EQ(response, string("{\"success\":true}"));
 
-    EXPECT_EQ(Core::ERROR_GENERAL, handlerV2.Invoke(connection, _T("updateFirmware"), _T("{\"fileName\":\"/tmp\';reboot;/my.bin\"}"), response));
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("updateFirmware"), _T("{\"fileName\":\"/tmp\';reboot;/my.bin\"}"), response));
 
     Udev::getInstance().impl = nullptr;
     Wraps::getInstance().impl = nullptr;

--- a/UsbAccess/UsbAccess.cpp
+++ b/UsbAccess/UsbAccess.cpp
@@ -43,6 +43,9 @@ const WPEFramework::Plugin::UsbAccess::ArchiveLogsErrorMap WPEFramework::Plugin:
         {WritingError, "Writing Error"}
 };
 
+// TODO: remove this
+#define registerMethod(...) for (uint8_t i = 1; GetHandler(i); i++) GetHandler(i)->Register<JsonObject, JsonObject>(__VA_ARGS__)
+
 namespace WPEFramework {
 
 namespace {
@@ -137,18 +140,14 @@ namespace Plugin {
     {
         UsbAccess::_instance = this;
 
-        Register(_T("getFileList"), &UsbAccess::getFileListWrapper, this);
-        Register(_T("createLink"), &UsbAccess::createLinkWrapper, this);
-        Register(_T("clearLink"), &UsbAccess::clearLinkWrapper, this);
-
         CreateHandler({2});
-        GetHandler(2)->Register<JsonObject, JsonObject>(_T("getFileList"), &UsbAccess::getFileListWrapper, this);
-        GetHandler(2)->Register<JsonObject, JsonObject>(_T("createLink"), &UsbAccess::createLinkWrapper, this);
-        GetHandler(2)->Register<JsonObject, JsonObject>(_T("clearLink"), &UsbAccess::clearLinkWrapper, this);
-        GetHandler(2)->Register<JsonObject, JsonObject>(_T("getAvailableFirmwareFiles"), &UsbAccess::getAvailableFirmwareFilesWrapper, this);
-        GetHandler(2)->Register<JsonObject, JsonObject>(_T("getMounted"), &UsbAccess::getMountedWrapper, this);
-        GetHandler(2)->Register<JsonObject, JsonObject>(_T("updateFirmware"), &UsbAccess::updateFirmware, this);
-        GetHandler(2)->Register<JsonObject, JsonObject>(_T("ArchiveLogs"), &UsbAccess::archiveLogs, this);
+        registerMethod(_T("getFileList"), &UsbAccess::getFileListWrapper, this);
+        registerMethod(_T("createLink"), &UsbAccess::createLinkWrapper, this);
+        registerMethod(_T("clearLink"), &UsbAccess::clearLinkWrapper, this);
+        registerMethod(_T("getAvailableFirmwareFiles"), &UsbAccess::getAvailableFirmwareFilesWrapper, this);
+        registerMethod(_T("getMounted"), &UsbAccess::getMountedWrapper, this);
+        registerMethod(_T("updateFirmware"), &UsbAccess::updateFirmware, this);
+        registerMethod(_T("ArchiveLogs"), &UsbAccess::archiveLogs, this);
     }
 
     UsbAccess::~UsbAccess()
@@ -157,18 +156,6 @@ namespace Plugin {
 
         if (archiveLogsThread.joinable())
             archiveLogsThread.join();
-
-        Unregister(_T("getFileList"));
-        Unregister(_T("createLink"));
-        Unregister(_T("clearLink"));
-
-        GetHandler(2)->Unregister(_T("getFileList"));
-        GetHandler(2)->Unregister(_T("createLink"));
-        GetHandler(2)->Unregister(_T("clearLink"));
-        GetHandler(2)->Unregister(_T("getAvailableFirmwareFiles"));
-        GetHandler(2)->Unregister(_T("getMounted"));
-        GetHandler(2)->Unregister(_T("updateFirmware"));
-        GetHandler(2)->Unregister(_T("ArchiveLogs"));
     }
 
     const string UsbAccess::Initialize(PluginHost::IShell * /* service */)
@@ -389,8 +376,6 @@ namespace Plugin {
         params["error"] = it->second;
         params["success"] = (error == None);
         sendNotify(EVT_ON_ARCHIVE_LOGS.c_str(), params);
-
-        GetHandler(2)->Notify(EVT_ON_ARCHIVE_LOGS.c_str(), params);
     }
 
     // iarm
@@ -453,8 +438,6 @@ namespace Plugin {
         params["mounted"] = mounted;
         params["device"] = device;
         sendNotify(EVT_ON_USB_MOUNT_CHANGED.c_str(), params);
-
-        GetHandler(2)->Notify(EVT_ON_USB_MOUNT_CHANGED.c_str(), params);
     }
 
     // internal methods

--- a/Warehouse/Warehouse.cpp
+++ b/Warehouse/Warehouse.cpp
@@ -81,6 +81,9 @@
 #define FRONT_PANEL_FAILED 3
 #define FRONT_PANEL_INTERVAL 5000
 
+// TODO: remove this
+#define registerMethod(...) for (uint8_t i = 1; GetHandler(i); i++) GetHandler(i)->Register<JsonObject, JsonObject>(__VA_ARGS__)
+
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
 #define API_VERSION_NUMBER_PATCH 0
@@ -151,19 +154,14 @@ namespace WPEFramework
             m_isPwrMgr2RFCEnabled = false;
             CreateHandler({2});
 
-            Register(WAREHOUSE_METHOD_RESET_DEVICE, &Warehouse::resetDeviceWrapper, this);
-            Register(WAREHOUSE_METHOD_GET_DEVICE_INFO, &Warehouse::getDeviceInfoWrapper, this);
-            Register(WAREHOUSE_METHOD_SET_FRONT_PANEL_STATE, &Warehouse::setFrontPanelStateWrapper, this);
-            Register(WAREHOUSE_METHOD_INTERNAL_RESET, &Warehouse::internalResetWrapper, this);
-            Register(WAREHOUSE_METHOD_LIGHT_RESET, &Warehouse::lightResetWrapper, this);
-            Register(WAREHOUSE_METHOD_IS_CLEAN, &Warehouse::isCleanWrapper, this);
-            GetHandler(2)->Register<JsonObject, JsonObject>(WAREHOUSE_METHOD_EXECUTE_HARDWARE_TEST, &Warehouse::executeHardwareTestWrapper, this);
-            GetHandler(2)->Register<JsonObject, JsonObject>(WAREHOUSE_METHOD_GET_HARDWARE_TEST_RESULTS, &Warehouse::getHardwareTestResultsWrapper, this);
-            GetHandler(2)->Register<JsonObject, JsonObject>(WAREHOUSE_METHOD_RESET_DEVICE, &Warehouse::resetDeviceWrapper, this);
-            GetHandler(2)->Register<JsonObject, JsonObject>(WAREHOUSE_METHOD_SET_FRONT_PANEL_STATE, &Warehouse::setFrontPanelStateWrapper, this);
-            GetHandler(2)->Register<JsonObject, JsonObject>(WAREHOUSE_METHOD_INTERNAL_RESET, &Warehouse::internalResetWrapper, this);
-            GetHandler(2)->Register<JsonObject, JsonObject>(WAREHOUSE_METHOD_LIGHT_RESET, &Warehouse::lightResetWrapper, this);
-            GetHandler(2)->Register<JsonObject, JsonObject>(WAREHOUSE_METHOD_IS_CLEAN, &Warehouse::isCleanWrapper, this);
+            registerMethod(WAREHOUSE_METHOD_RESET_DEVICE, &Warehouse::resetDeviceWrapper, this);
+            registerMethod(WAREHOUSE_METHOD_GET_DEVICE_INFO, &Warehouse::getDeviceInfoWrapper, this);
+            registerMethod(WAREHOUSE_METHOD_SET_FRONT_PANEL_STATE, &Warehouse::setFrontPanelStateWrapper, this);
+            registerMethod(WAREHOUSE_METHOD_INTERNAL_RESET, &Warehouse::internalResetWrapper, this);
+            registerMethod(WAREHOUSE_METHOD_LIGHT_RESET, &Warehouse::lightResetWrapper, this);
+            registerMethod(WAREHOUSE_METHOD_IS_CLEAN, &Warehouse::isCleanWrapper, this);
+            registerMethod(WAREHOUSE_METHOD_EXECUTE_HARDWARE_TEST, &Warehouse::executeHardwareTestWrapper, this);
+            registerMethod(WAREHOUSE_METHOD_GET_HARDWARE_TEST_RESULTS, &Warehouse::getHardwareTestResultsWrapper, this);
             {
                 RFC_ParamData_t param = {0};
                 WDMP_STATUS status = getRFCParameter(NULL, RFC_PWRMGR2, &param);
@@ -424,7 +422,6 @@ namespace WPEFramework
                 params[PARAM_SUCCESS] = false;
                 params[PARAM_ERROR] = "exception in submitting request";
                 sendNotify(WAREHOUSE_EVT_RESET_DONE, params);
-                GetHandler(2)->Notify(WAREHOUSE_EVT_RESET_DONE, params);
             }
             catch(const std::exception& e)
             {
@@ -432,7 +429,6 @@ namespace WPEFramework
                 params[PARAM_SUCCESS] = false;
                 params[PARAM_ERROR] = "exception in submitting request";
                 sendNotify(WAREHOUSE_EVT_RESET_DONE, params);
-                GetHandler(2)->Notify(WAREHOUSE_EVT_RESET_DONE, params);
             }
 #else
             bool ok = false;
@@ -442,7 +438,6 @@ namespace WPEFramework
                 params[PARAM_ERROR] = "No IARMBUS";
 
             sendNotify(WAREHOUSE_EVT_RESET_DONE, params);
-            GetHandler(2)->Notify(WAREHOUSE_EVT_RESET_DONE, params);
 #endif
         }
 

--- a/WifiManager/WifiManager.cpp
+++ b/WifiManager/WifiManager.cpp
@@ -26,6 +26,9 @@
 
 #include "libIBus.h"
 
+// TODO: remove this
+#define registerMethod(...) for (uint8_t i = 1; GetHandler(i); i++) GetHandler(i)->Register<JsonObject, JsonObject>(__VA_ARGS__)
+
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
 #define API_VERSION_NUMBER_PATCH 0
@@ -34,28 +37,6 @@ namespace {
     using WPEFramework::Plugin::WifiManager;
     using WifiManagerConstMethod = uint32_t (WifiManager::*)(const JsonObject &parameters, JsonObject &response) const;
     using WifiManagerMethod = uint32_t (WifiManager::*)(const JsonObject &parameters, JsonObject &response);
-
-    std::vector<std::pair<const char*, WifiManagerMethod>> mutableMethods = {
-        {"stopScan", &WifiManager::stopScan},
-        {"setEnabled", &WifiManager::setEnabled},
-        {"connect", &WifiManager::connect},
-        {"disconnect", &WifiManager::disconnect},
-        {"cancelWPSPairing", &WifiManager::cancelWPSPairing},
-        {"saveSSID", &WifiManager::saveSSID},
-        {"clearSSID", &WifiManager::clearSSID},
-        {"setSignalThresholdChangeEnabled", &WifiManager::setSignalThresholdChangeEnabled},
-        {"getPairedSSID", &WifiManager::getPairedSSID},
-        {"getPairedSSIDInfo", &WifiManager::getPairedSSIDInfo},
-        {"isPaired", &WifiManager::isPaired},
-        {"getCurrentState", &WifiManager::getCurrentState},
-        {"getConnectedSSID", &WifiManager::getConnectedSSID},
-    };
-
-    std::vector<std::pair<const char*, WifiManagerConstMethod>> constMethods = {
-        {"getQuirks", &WifiManager::getQuirks},
-        {"startScan", &WifiManager::startScan},
-        {"isSignalThresholdChangeEnabled", &WifiManager::isSignalThresholdChangeEnabled}
-    };
 }
 
 namespace WPEFramework
@@ -85,21 +66,28 @@ namespace WPEFramework
         {
             CreateHandler({ 2 });
 
-            for (const auto& mapping : constMethods) {
-                Register(mapping.first, mapping.second, this);
-                GetHandler(2)->Register<JsonObject, JsonObject>(mapping.first, mapping.second, this);
-            }
-
-            for (const auto& mapping : mutableMethods) {
-                Register(mapping.first, mapping.second, this);
-                GetHandler(2)->Register<JsonObject, JsonObject>(mapping.first, mapping.second, this);
-            }
+            registerMethod("stopScan", &WifiManager::stopScan, this);
+            registerMethod("setEnabled", &WifiManager::setEnabled, this);
+            registerMethod("connect", &WifiManager::connect, this);
+            registerMethod("disconnect", &WifiManager::disconnect, this);
+            registerMethod("cancelWPSPairing", &WifiManager::cancelWPSPairing, this);
+            registerMethod("saveSSID", &WifiManager::saveSSID, this);
+            registerMethod("clearSSID", &WifiManager::clearSSID, this);
+            registerMethod("setSignalThresholdChangeEnabled", &WifiManager::setSignalThresholdChangeEnabled, this);
+            registerMethod("getPairedSSID", &WifiManager::getPairedSSID, this);
+            registerMethod("getPairedSSIDInfo", &WifiManager::getPairedSSIDInfo, this);
+            registerMethod("isPaired", &WifiManager::isPaired, this);
+            registerMethod("getCurrentState", &WifiManager::getCurrentState, this);
+            registerMethod("getConnectedSSID", &WifiManager::getConnectedSSID, this);
+            registerMethod("getQuirks", &WifiManager::getQuirks, this);
+            registerMethod("startScan", &WifiManager::startScan, this);
+            registerMethod("isSignalThresholdChangeEnabled", &WifiManager::isSignalThresholdChangeEnabled, this);
+            registerMethod("getSupportedSecurityModes", &WifiManager::getSupportedSecurityModes, this);
 
             /* Version 1 only API */
             Register("initiateWPSPairing", &WifiManager::initiateWPSPairing, this);
 
             /* Version 2 API */
-            GetHandler(2)->Register<JsonObject, JsonObject>("getSupportedSecurityModes", &WifiManager::getSupportedSecurityModes, this);
             GetHandler(2)->Register<JsonObject, JsonObject>("initiateWPSPairing", &WifiManager::initiateWPSPairing2, this);
         }
 
@@ -327,7 +315,6 @@ namespace WPEFramework
                 wifiWPS.updateWifiWPSCache(false);
             }
             sendNotify("onWIFIStateChanged", params);
-            GetHandler(2)->Notify("onWIFIStateChanged", params);
             if (state == WifiState::CONNECTED)
             {
                 wifiSignalThreshold.setSignalThresholdChangeEnabled(true);
@@ -348,7 +335,6 @@ namespace WPEFramework
             JsonObject params;
             params["code"] = static_cast<int>(code);
             sendNotify("onError", params);
-            GetHandler(2)->Notify("onError", params);
         }
 
         void WifiManager::onSSIDsChanged()
@@ -356,7 +342,6 @@ namespace WPEFramework
             wifiWPS.updateWifiWPSCache(false);
             wifiState.resetWifiStateConnectedCache(false);
             sendNotify("onSSIDsChanged", JsonObject());
-            GetHandler(2)->Notify("onSSIDsChanged", JsonObject());
         }
 
         void WifiManager::onWifiSignalThresholdChanged(float signalStrength, const std::string &strength)
@@ -378,7 +363,6 @@ namespace WPEFramework
         void WifiManager::onAvailableSSIDs(JsonObject const& ssids)
         {
             sendNotify("onAvailableSSIDs", ssids);
-            GetHandler(2)->Notify("onAvailableSSIDs", ssids);
         }
 
         /**

--- a/helpers/UtilsJsonRpc.h
+++ b/helpers/UtilsJsonRpc.h
@@ -43,17 +43,24 @@
         LOGERR("No argument '%s' or it has incorrect type", name); \
         returnResponse(false); \
     }
+
+/**
+ * DO NOT USE THIS.
+ *
+ * You should be capable of just using "Notify".
+ */
+
 #define sendNotify(event,params) { \
     std::string json; \
     params.ToString(json); \
     LOGINFO("Notify %s %s", event, json.c_str()); \
-    Notify(event,params); \
+    for (uint8_t i = 1; GetHandler(i); i++) GetHandler(i)->Notify(event,params); \
 }
 #define sendNotifyMaskParameters(event,params) { \
     std::string json; \
     params.ToString(json); \
     LOGINFO("Notify %s <***>", event); \
-    Notify(event,params); \
+    for (uint8_t i = 1; GetHandler(i); i++) GetHandler(i)->Notify(event,params); \
 }
 
 /**


### PR DESCRIPTION
Reason for change: APIs should be available in all versions or without version specified.

- Specially for the plugins which use Version 2 add macro registerMethod that registers to all handlers.
- Modify sendNotify macro to notify all handlers.
- Remove Version 2 from tests.

Test Procedure: None
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>