### PR TITLE
RDK-37578: More tests for System

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -155,7 +155,7 @@ jobs:
           -I ${{github.workspace}}/rdkservices/Tests/headers/rdk/ds
           -I ${{github.workspace}}/rdkservices/Tests/headers/rdk/iarmbus
           -I ${{github.workspace}}/rdkservices/Tests/headers/rdk/iarmmgrs-hal
-          --coverage -Wall -Werror -Wno-unused-parameter -Wno-unused-result -Wl,-wrap,system
+          --coverage -Wall -Werror -Wno-unused-parameter -Wno-unused-result -Wl,-wrap,system -Wl,-wrap,popen
           -DENABLE_TELEMETRY_LOGGING
           -DUSE_IARMBUS
           -DENABLE_SYSTEM_GET_STORE_DEMO_LINK

--- a/Tests/headers/rdk/ds/sleepMode.hpp
+++ b/Tests/headers/rdk/ds/sleepMode.hpp
@@ -1,53 +1,44 @@
-
 #pragma once
-#include <vector>
+
 #include "list.hpp"
 
-#ifndef UNUSED
-#define UNUSED(x) (void)(x)
-#endif
-
 namespace device {
-    class SleepMode;
-    class SleepModeImpl {
-        public:
-            virtual ~SleepModeImpl() = default;
-            virtual SleepMode& getInstance(int id) = 0;
-            virtual SleepMode& getInstance(const std::string& name) = 0;
-            virtual List<SleepMode> getSleepModes() = 0;
-            virtual const std::string& toString() const;
-    };
+class SleepMode;
+class SleepModeImpl {
+public:
+    virtual ~SleepModeImpl() = default;
+    virtual List<SleepMode> getSleepModes() = 0;
+    virtual const std::string& toString() const = 0;
+};
 
-    class SleepMode /*: public DSConstant*/ {
-        public:
-            SleepModeImpl* impl;
+class SleepMode {
+public:
+    SleepModeImpl* impl;
 
-            static SleepMode& getInstance()
-            {
-                static SleepMode instance;
-                return instance;
-            }
+    static SleepMode& getInstance()
+    {
+        static SleepMode instance;
+        return instance;
+    }
 
-            static SleepMode& getInstance(int id)
-            {
-                UNUSED(id);
-                return getInstance();
-            }
+    static SleepMode& getInstance(int)
+    {
+        return getInstance();
+    }
 
-            static SleepMode& getInstance(const std::string& name)
-            {
-                UNUSED(name);
-                return getInstance();
-            }
+    static SleepMode& getInstance(const std::string&)
+    {
+        return getInstance();
+    }
 
-            List<SleepMode> getSleepModes()
-            {
-                return impl->getSleepModes();
-            }
+    List<SleepMode> getSleepModes()
+    {
+        return impl->getSleepModes();
+    }
 
-            const std::string& toString() const
-            {
-                return impl->toString();
-            }
-    };
+    const std::string& toString() const
+    {
+        return impl->toString();
+    }
+};
 }

--- a/Tests/mocks/WrapsMock.h
+++ b/Tests/mocks/WrapsMock.h
@@ -9,4 +9,5 @@ public:
     virtual ~WrapsImplMock() = default;
 
     MOCK_METHOD(int, system, (const char* command), (override));
+    MOCK_METHOD(FILE*, popen, (const char* command, const char* type), (override));
 };

--- a/Tests/mocks/devicesettings/SleepModeMock.h
+++ b/Tests/mocks/devicesettings/SleepModeMock.h
@@ -2,9 +2,11 @@
 
 #include <gmock/gmock.h>
 
+#include "sleepMode.hpp"
+
 class SleepModeMock : public device::SleepModeImpl {
 public:
     virtual ~SleepModeMock() = default;
-    MOCK_METHOD(List<SleepMode>, getSleepModes, (), (override));
-    MOCK_METHOD(onst std::string&, toString, (), (const, override));
+    MOCK_METHOD(device::List<device::SleepMode>, getSleepModes, (), (override));
+    MOCK_METHOD(const std::string&, toString, (), (const, override));
 };

--- a/Tests/source/Wraps.cpp
+++ b/Tests/source/Wraps.cpp
@@ -4,3 +4,8 @@ extern "C" int __wrap_system(const char* command)
 {
     return Wraps::getInstance().system(command);
 }
+
+extern "C" FILE* __wrap_popen(const char* command, const char* type)
+{
+    return Wraps::getInstance().popen(command, type);
+}

--- a/Tests/source/Wraps.h
+++ b/Tests/source/Wraps.h
@@ -1,10 +1,13 @@
 #pragma once
 
+#include <stdio.h>
+
 class WrapsImpl {
 public:
     virtual ~WrapsImpl() = default;
 
     virtual int system(const char* command) = 0;
+    virtual FILE* popen(const char* command, const char* type) = 0;
 };
 
 class Wraps {
@@ -20,5 +23,10 @@ public:
     static int system(const char* command)
     {
         return getInstance().impl->system(command);
+    }
+
+    static FILE* popen(const char* command, const char* type)
+    {
+        return getInstance().impl->popen(command, type);
     }
 };


### PR DESCRIPTION
Reason for change:
- Negative tests for setFirmwareRebootDelay, setFirmwareAutoReboot.
- Tests for enableMoca, queryMocaStatus, updateFirmware, getMode, setMode, setDeepSleepTimer, setNetworkStandbyMode, getNetworkStandbyMode, setPreferredStandbyMode, getPreferredStandbyMode, getAvailableStandbyModes, getWakeupReason, getLastWakeupKeyCode.

Comments:
- "reboot" uses kill via system() and checks Netflix shutdown via sleep(10); which looks incorrect. Should not test that.
- "getDeviceInfo" is too complex to understand or test. Should not test that.
- "getFirmwareUpdateInfo" uses system() to read file which looks incorrect. Should not test that.

Test Procedure: Unit tests
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>