### PR TITLE
RDK-37578: More tests for System 

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -199,27 +199,19 @@ jobs:
         run: sudo apt update && sudo apt install -y valgrind
 
       - name: Set up files
-        run: |
-          sudo mkdir -p /opt/secure
-          sudo mkdir -p /opt/persistent
-          sudo mkdir -p /opt/secure/reboot
-          sudo mkdir -p /opt/secure/persistent
-          sudo mkdir -p /opt/secure/persistent/System
-          sudo mkdir -p /opt/logs
-          sudo mkdir -p /lib/rdk
-          sudo chmod -R 1777 /opt
-          sudo chmod -R 1777 /lib/rdk
-          sudo touch /opt/logs/rebootInfo.log
-          sudo touch /opt/persistent/previousreboot.info
-          sudo touch /opt/persistent/hardpower.info
-          sudo touch /opt/tmtryoptout
-          sudo touch /opt/fwdnldstatus.txt
-          sudo touch /etc/device.properties
-          sudo touch /etc/authService.conf
-          sudo touch /version.txt
-          sudo chmod 777 /etc/device.properties
-          sudo chmod 777 /etc/authService.conf
-          sudo chmod 777 /version.txt
+        run: >
+          sudo mkdir -p -m 777
+          /opt/persistent
+          /opt/secure /opt/secure/reboot /opt/secure/persistent /opt/secure/persistent/System
+          /opt/logs &&
+          sudo touch
+          /opt/standbyReason.txt /opt/tmtryoptout /opt/fwdnldstatus.txt
+          /etc/device.properties /etc/authService.conf
+          /version.txt &&
+          sudo chmod 777
+          /opt/standbyReason.txt /opt/tmtryoptout /opt/fwdnldstatus.txt
+          /etc/device.properties /etc/authService.conf
+          /version.txt
 
       - name: Run unit tests
         run: >


### PR DESCRIPTION
Reason for change:
- Tests for onFirmwareUpdateStateChange, onSystemClockSet, onTemperatureThresholdChanged, getTimeZones, getLastDeepSleepReason.
- Clean up 'Set up files' workflow to not chmod the whole /opt.

Comments:
- "getXconfParams" has no relation to Xconf. Should not test that.
- "getSerialNumber" should be deprecated in favor of "DeviceInfo.serialnumber". Should not test that.
- "getFirmwareDownloadPercent" uses system() to read file which looks incorrect. Should not test that.
- "getMacAddresses" group all Mac addresses in one API which looks incorrect. Should not test that.
- "getCachedValue", "setCachedValue", "cacheContains", "removeCacheKey" are deprecated. Should not test that.
- "clearLastDeepSleepReason" uses system() to delete file which looks incorrect. Should not test that.

Test Procedure: Unit tests
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>