### PR TITLE
AMLOGIC-3543: osdName is NA for connected HDMIs

### DIFF
--- a/HdmiCecSink/CHANGELOG.md
+++ b/HdmiCecSink/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.0.3]
+### Fixed
+- Fix for osdName is NA for connected HDMIs.
+ 
 ## [1.0.2]
 ### Fixed
 - Fix for resetting retry count for Physical address query.

--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -148,7 +148,7 @@ static int32_t HdmiArcPortID = -1;
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 2
+#define API_VERSION_NUMBER_PATCH 3
 
 namespace WPEFramework
 {

--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -2353,7 +2353,7 @@ namespace WPEFramework
 
 				case CECDeviceParams::REQUEST_OSD_NAME :	
 				{
-					_instance->smConnection->sendTo(LogicalAddress(logicalAddress), MessageEncoder().encode(GiveOSDName()), 200);
+					_instance->smConnection->sendTo(LogicalAddress(logicalAddress), MessageEncoder().encode(GiveOSDName()), 500);
 				}
 					break;
 


### PR DESCRIPTION
Reason for change: Give OSD Name write failure, reattempt is not happening. Increased timeout of GiveOsdName request to reattempt. Test Procedure: Refer ticket for test procedure.
Risks: Low
Signed-off-by: bp-ynagas047 <yeshwanth.nagaswamy@sky.uk>
(cherry picked from commit eba7078a4dc0b1ae711828e70fcef1dfe49d5e45)