### PR TITLE
RDK-37578: More tests for System

### DIFF
--- a/Tests/mocks/COMLinkMock.h
+++ b/Tests/mocks/COMLinkMock.h
@@ -1,0 +1,18 @@
+#ifndef RDKSERVICES_TESTS_MOCKS_COMLINKMOCK_H_
+#define RDKSERVICES_TESTS_MOCKS_COMLINKMOCK_H_
+
+#include <gmock/gmock.h>
+
+#include "Module.h"
+
+class COMLinkMock : public WPEFramework::PluginHost::IShell::ICOMLink {
+public:
+    virtual ~COMLinkMock() = default;
+
+    MOCK_METHOD(void, Register, (WPEFramework::RPC::IRemoteConnection::INotification*), (override));
+    MOCK_METHOD(void, Unregister, (WPEFramework::RPC::IRemoteConnection::INotification*), (override));
+    MOCK_METHOD(WPEFramework::RPC::IRemoteConnection*, RemoteConnection, (const uint32_t), (override));
+    MOCK_METHOD(void*, Instantiate, (const WPEFramework::RPC::Object&, const uint32_t, uint32_t&, const string&, const string&), (override));
+};
+
+#endif //RDKSERVICES_TESTS_MOCKS_COMLINKMOCK_H_

--- a/Tests/mocks/ServiceMock.h
+++ b/Tests/mocks/ServiceMock.h
@@ -24,7 +24,7 @@
 
 #include "Module.h"
 
-class ServiceMock : public WPEFramework::PluginHost::IShell::ICOMLink, public WPEFramework::PluginHost::IShell {
+class ServiceMock : public WPEFramework::PluginHost::IShell {
 public:
     virtual ~ServiceMock() = default;
 
@@ -64,10 +64,6 @@ public:
     MOCK_METHOD(uint32_t, Deactivate, (const reason), (override));
     MOCK_METHOD(uint32_t, Unavailable, (const reason), (override));
     MOCK_METHOD(reason, Reason, (), (const, override));
-    MOCK_METHOD(void, Register, (WPEFramework::RPC::IRemoteConnection::INotification*), (override));
-    MOCK_METHOD(void, Unregister, (WPEFramework::RPC::IRemoteConnection::INotification*), (override));
-    MOCK_METHOD(WPEFramework::RPC::IRemoteConnection*, RemoteConnection, (const uint32_t), (override));
-    MOCK_METHOD(void*, Instantiate, (const WPEFramework::RPC::Object&, const uint32_t, uint32_t&, const string&, const string&), (override));
     MOCK_METHOD(uint8_t, Major, (), (const, override));
     MOCK_METHOD(uint8_t, Minor, (), (const, override));
     MOCK_METHOD(uint8_t, Patch, (), (const, override));

--- a/Tests/tests/test_DeviceIdentification.cpp
+++ b/Tests/tests/test_DeviceIdentification.cpp
@@ -2,6 +2,7 @@
 
 #include "DeviceIdentification.h"
 
+#include "COMLinkMock.h"
 #include "ServiceMock.h"
 #include "source/SystemInfo.h"
 
@@ -62,6 +63,7 @@ class DeviceIdentificationInitializedTest : public DeviceIdentificationTest {
 protected:
     Core::Sink<SystemInfo> subSystem;
     ServiceMock service;
+    COMLinkMock comLinkMock;
 
     DeviceIdentificationInitializedTest()
         : DeviceIdentificationTest()
@@ -80,7 +82,7 @@ protected:
                     return result;
                 }));
         ON_CALL(service, COMLink())
-            .WillByDefault(::testing::Return(&service));
+            .WillByDefault(::testing::Return(&comLinkMock));
 
         EXPECT_EQ(string(""), plugin->Initialize(&service));
     }


### PR DESCRIPTION
Reason for change:
- Tests for getStoreDemoLink, deletePersistentPath, onSystemPowerStateChanged, onNetworkStandbyModeChanged, onRebootRequest.
- Fix segfault in ServiceMock. QueryInterfaceByCallsign uses reinterpret_cast. This won't work if the object has multiple inheritance. ServiceMock should not implement ICOMLink, whoever did that was in a rush.

Comments:
- "getPlatformConfiguration" returns too many unrelated or uncategorized properties, this is an example of an anti-pattern and a code smell. Should not test that.
- "uploadLogs" is hard to test. Also, not sure if it's used. Should not test that.

Test Procedure: Unit tests
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>