### PR TITLE
DELIA-58191 : Use interfaces instead of JSON-RPC

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -161,6 +161,23 @@ namespace WPEFramework {
 
     namespace Plugin {
 
+        namespace {
+            uint32_t activate(PluginHost::IShell* shell, const string& callsign)
+            {
+                uint32_t result;
+                auto interface = shell->QueryInterfaceByCallsign<PluginHost::IShell>(callsign);
+                if (interface == nullptr) {
+                    result = Core::ERROR_UNAVAILABLE;
+                    std::cout << "no IShell for " << callsign << std::endl;
+                } else {
+                    result = interface->Activate(PluginHost::IShell::reason::REQUESTED);
+                    std::cout << "IShell activate status " << result << " for " << callsign << std::endl;
+                    interface->Release();
+                }
+                return result;
+            }
+        }
+
         SERVICE_REGISTRATION(DisplaySettings, API_VERSION_NUMBER_MAJOR, API_VERSION_NUMBER_MINOR, API_VERSION_NUMBER_PATCH);
 
         DisplaySettings* DisplaySettings::_instance = nullptr;
@@ -4994,19 +5011,7 @@ namespace WPEFramework {
                 /*HDMICECSINK_CALLSIGN plugin activation moved to onTimer.
                  *To decouple from displyasettings init. Since its time taking*/
 
-                auto controller = m_service->QueryInterfaceByCallsign<PluginHost::IDispatcher>("Controller");
-                if (controller != nullptr) {
-                    auto message = (Core::ProxyType<Core::JSONRPC::Message>(PluginHost::IFactories::Instance().JSONRPC()));
-                    message->JSONRPC = Core::JSONRPC::Message::DefaultVersion;
-                    message->Id = 0;
-                    message->Designator = "Controller.1.activate";
-                    message->Parameters = "{\"callsign\":\"org.rdk.HdmiCecSink\"}";
-                    auto resp = controller->Invoke("", ~0, *message);
-                    if (resp->Error.IsSet()) {
-                        std::cout << "Call failed: " << message->Designator.Value() << " error: " << resp->Error.Text.Value() << "\n";
-                    }
-                    controller->Release();
-                }
+                activate(m_service, HDMICECSINK_CALLSIGN);
 
                 LOGWARN ("DisplaySettings::onTimer after activatePlugin HDMICECSINK_CALLSIGN line:%d", __LINE__);
                 sleep(HDMICECSINK_PLUGIN_ACTIVATION_TIME);

--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -32,6 +32,7 @@
 #include <interfaces/IFocus.h>
 #include <interfaces/IMemory.h>
 #include <interfaces/IBrowser.h>
+#include <interfaces/IStore.h>
 #include <rdkshell/logger.h>
 #include <plugins/System.h>
 #include <rdkshell/eastereggs.h>
@@ -247,6 +248,110 @@ namespace WPEFramework {
 
     namespace Plugin {
 
+        namespace {
+            // rdk Shell should use inter faces
+
+            uint32_t getValue(PluginHost::IShell* shell, const string& ns, const string& key, string& value)
+            {
+                uint32_t result;
+                auto interface = shell->QueryInterfaceByCallsign<Exchange::IStore>(PERSISTENT_STORE_CALLSIGN);
+                if (interface == nullptr) {
+                    result = Core::ERROR_UNAVAILABLE;
+                    std::cout << "no IStore" << std::endl;
+                } else {
+                    result = interface->GetValue(ns, key, value);
+                    std::cout << "IStore status " << result << " for get " << key << std::endl;
+                    interface->Release();
+                }
+                return result;
+            }
+            uint32_t setValue(PluginHost::IShell* shell, const string& ns, const string& key, const string& value)
+            {
+                uint32_t result;
+                auto interface = shell->QueryInterfaceByCallsign<Exchange::IStore>(PERSISTENT_STORE_CALLSIGN);
+                if (interface == nullptr) {
+                    result = Core::ERROR_UNAVAILABLE;
+                    std::cout << "no IStore" << std::endl;
+                } else {
+                    result = interface->SetValue(ns, key, value);
+                    std::cout << "IStore status " << result << " for set " << key << std::endl;
+                    interface->Release();
+                }
+                return result;
+            }
+            uint32_t getConfig(PluginHost::IShell* shell, const string& callsign, string& config)
+            {
+                uint32_t result;
+                auto interface = shell->QueryInterfaceByCallsign<PluginHost::IShell>(callsign);
+                if (interface == nullptr) {
+                    result = Core::ERROR_UNAVAILABLE;
+                    std::cout << "no IShell for " << callsign << std::endl;
+                } else {
+                    result = Core::ERROR_NONE;
+                    config = interface->ConfigLine();
+                    std::cout << "IShell config " << config << " for " << callsign << std::endl;
+                    interface->Release();
+                }
+                return result;
+            }
+            uint32_t setConfig(PluginHost::IShell* shell, const string& callsign, const string& config)
+            {
+                uint32_t result;
+                auto interface = shell->QueryInterfaceByCallsign<PluginHost::IShell>(callsign);
+                if (interface == nullptr) {
+                    result = Core::ERROR_UNAVAILABLE;
+                    std::cout << "no IShell for " << callsign << std::endl;
+                } else {
+                    result = interface->ConfigLine(config);
+                    std::cout << "IShell config status " << result << " for " << callsign << std::endl;
+                    interface->Release();
+                }
+                return result;
+            }
+            uint32_t getServiceState(PluginHost::IShell* shell, const string& callsign, PluginHost::IShell::state& state)
+            {
+                uint32_t result;
+                auto interface = shell->QueryInterfaceByCallsign<PluginHost::IShell>(callsign);
+                if (interface == nullptr) {
+                    result = Core::ERROR_UNAVAILABLE;
+                    std::cout << "no IShell for " << callsign << std::endl;
+                } else {
+                    result = Core::ERROR_NONE;
+                    state = interface->State();
+                    std::cout << "IShell state " << state << " for " << callsign << std::endl;
+                    interface->Release();
+                }
+                return result;
+            }
+            uint32_t activate(PluginHost::IShell* shell, const string& callsign)
+            {
+                uint32_t result;
+                auto interface = shell->QueryInterfaceByCallsign<PluginHost::IShell>(callsign);
+                if (interface == nullptr) {
+                    result = Core::ERROR_UNAVAILABLE;
+                    std::cout << "no IShell for " << callsign << std::endl;
+                } else {
+                    result = interface->Activate(PluginHost::IShell::reason::REQUESTED);
+                    std::cout << "IShell activate status " << result << " for " << callsign << std::endl;
+                    interface->Release();
+                }
+                return result;
+            }
+            uint32_t deactivate(PluginHost::IShell* shell, const string& callsign)
+            {
+                uint32_t result;
+                auto interface = shell->QueryInterfaceByCallsign<PluginHost::IShell>(callsign);
+                if (interface == nullptr) {
+                    result = Core::ERROR_UNAVAILABLE;
+                    std::cout << "no IShell for " << callsign << std::endl;
+                } else {
+                    result = interface->Deactivate(PluginHost::IShell::reason::REQUESTED);
+                    std::cout << "IShell deactivate status " << result << " for " << callsign << std::endl;
+                    interface->Release();
+                }
+                return result;
+            }
+        }
 
         struct JSONRPCDirectLink
         {
@@ -524,11 +629,7 @@ namespace WPEFramework {
                 }
 		else if (requestName.compare("deactivateresidentapp") == 0)
                 {
-                    auto thunderController = std::unique_ptr<JSONRPCDirectLink>(new JSONRPCDirectLink(mCurrentService));
-                    JsonObject deactivateParams;
-                    deactivateParams.Set("callsign", "ResidentApp");
-                    JsonObject deactivateResult;
-                    int32_t deactivateStatus = thunderController->Invoke(0, "deactivate", deactivateParams, deactivateResult);
+                    auto deactivateStatus = deactivate(mCurrentService, "ResidentApp");
                     std::cout << "deactivating resident app status " << deactivateStatus << std::endl;
                 }
                 else
@@ -592,11 +693,11 @@ namespace WPEFramework {
             return exist;
         }
        
-        static void updateSurfaceClientIdentifiers( void)
+        static void updateSurfaceClientIdentifiers(PluginHost::IShell* shell)
         {
           uint32_t status = 0;
           auto thunderController = RDKShell::getThunderControllerClient();
-          WPEFramework::Core::JSON::String configString;
+          string configString;
           Core::JSON::ArrayType<PluginHost::MetaData::Service> availablePluginResult;
           status = thunderController->Get<Core::JSON::ArrayType<PluginHost::MetaData::Service>>(RDKSHELL_THUNDER_TIMEOUT, "status", availablePluginResult);
           if(status > 0)
@@ -614,13 +715,13 @@ namespace WPEFramework {
 	    if (serviceConfig.HasLabel("clientidentifier"))
 	    { 
 	     JsonObject configSet;
-             std::string method = "configuration@";
              std::string pluginName = service.Callsign.Value();
-             method=method.append(pluginName);
-             status = thunderController->Get<WPEFramework::Core::JSON::String>(RDKSHELL_THUNDER_TIMEOUT, method.c_str(), configString);
-             configSet.FromString(configString.Value());
+             status = getConfig(shell, pluginName, configString);
+             configSet.FromString(configString);
              configSet["clientidentifier"] = RDKSHELL_SURFACECLIENT_DISPLAYNAME;
-             status = thunderController->Set<JsonObject>(RDKSHELL_THUNDER_TIMEOUT, method.c_str(), configSet);
+             string configSetAsString;
+             configSet.ToString(configSetAsString);
+             status = setConfig(shell, pluginName, configSetAsString);
              if(status > 0)
              {
                 std::cout<<"clientidentifier config set failed"<<std::endl;
@@ -1184,23 +1285,10 @@ namespace WPEFramework {
                   {
                       if (!sPersistentStoreFirstActivated)
                       {
-                          Core::JSON::ArrayType<PluginHost::MetaData::Service> joResult;
-                          auto thunderController = getThunderControllerClient();
-                          thunderController->Get<Core::JSON::ArrayType<PluginHost::MetaData::Service>>(RDKSHELL_THUNDER_TIMEOUT, "status", joResult);
-                          JsonArray stateArray;
-                          for (uint16_t i = 0; i < joResult.Length(); i++)
-                          {
-                              PluginHost::MetaData::Service service = joResult[i];
-                              std::string callsign;
-                              service.Callsign.ToString(callsign);
-                              if (callsign.find(PERSISTENT_STORE_CALLSIGN) != std::string::npos)
-                              {
-                                if (service.JSONState == PluginHost::MetaData::Service::state::ACTIVATED)
-                                {
-                                  sPersistentStoreFirstActivated = true;
-                                }
-                                break;
-                              } 
+                          PluginHost::IShell::state state;
+                          getServiceState(mCurrentService, PERSISTENT_STORE_CALLSIGN, state);
+                          if (state == PluginHost::IShell::state::ACTIVATED) {
+                              sPersistentStoreFirstActivated = true;
                           }
                       }
                       sPersistentStorePreLaunchChecked = true;
@@ -1305,7 +1393,7 @@ namespace WPEFramework {
             char* rdkshelltype = getenv("RDKSHELL_COMPOSITOR_TYPE");
             if((rdkshelltype != NULL) && (strcmp(rdkshelltype , "surface") == 0))
             {
-	      updateSurfaceClientIdentifiers();       
+	      updateSurfaceClientIdentifiers(mCurrentService);
 	    } 
             return "";
         }
@@ -1692,11 +1780,7 @@ namespace WPEFramework {
                     std::cout << "callsign will be " << callsign << std::endl;
                     if (callsign.compare("org.rdk.RDKShell.1") != 0)
                     {
-                        //get callsign
-                        JsonObject activateParams;
-                        activateParams.Set("callsign",callsign.c_str());
-                        JsonObject activateResult;
-                        thunderController->Invoke<JsonObject, JsonObject>(3500, "activate", activateParams, activateResult);
+                        activate(mShell.mCurrentService, callsign);
                     }
                     else
                     {
@@ -3416,23 +3500,21 @@ namespace WPEFramework {
                     }
                 }
 
-                WPEFramework::Core::JSON::String configString;
+                string configString;
 
                 uint32_t status = 0;
-                string method = "configuration@" + callsign;
-                Core::JSON::ArrayType<PluginHost::MetaData::Service> joResult;
-                status = thunderController->Get<WPEFramework::Core::JSON::String>(RDKSHELL_THUNDER_TIMEOUT, method.c_str(), configString);
+                status = getConfig(mCurrentService, callsign, configString);
 
                 std::cout << "config status: " << status << std::endl;
                 if (status > 0)
                 {
                     std::cout << "trying status one more time...\n";
-                    status = thunderController->Get<WPEFramework::Core::JSON::String>(RDKSHELL_THUNDER_TIMEOUT, method.c_str(), configString);
+                    status = getConfig(mCurrentService, callsign, configString);
                     std::cout << "config status: " << status << std::endl;
                 }
 
                 JsonObject configSet;
-                configSet.FromString(configString.Value());
+                configSet.FromString(configString);
 
                 if (!configuration.empty())
                 {
@@ -3581,50 +3663,46 @@ namespace WPEFramework {
 #endif
                 }
 
-                status = thunderController->Set<JsonObject>(RDKSHELL_THUNDER_TIMEOUT, method.c_str(), configSet);
+                string configSetAsString;
+                configSet.ToString(configSetAsString);
+                status = setConfig(mCurrentService, callsign, configSetAsString);
 
                 std::cout << "set status: " << status << std::endl;
                 if (status > 0)
                 {
                     std::cout << "trying status one more time...\n";
-                    status = thunderController->Set<JsonObject>(RDKSHELL_THUNDER_TIMEOUT, method.c_str(), configSet);
+                    status = setConfig(mCurrentService, callsign, configSetAsString);
                     std::cout << "set status: " << status << std::endl;
                 }
 
                 if (launchType == RDKShellLaunchType::UNKNOWN)
                 {
                     status = 0;
-                    string statusMethod = "status@"+callsign;
-                    Core::JSON::ArrayType<PluginHost::MetaData::Service> serviceResults;
-                    status = thunderController->Get<Core::JSON::ArrayType<PluginHost::MetaData::Service> >(RDKSHELL_THUNDER_TIMEOUT, statusMethod.c_str(),serviceResults);
+                    PluginHost::IShell::state state;
+                    status = getServiceState(mCurrentService, callsign, state);
 
                     std::cout << "get status: " << status << std::endl;
                     if (status > 0)
                     {
                         std::cout << "trying status one more time...\n";
-                        status = thunderController->Get<Core::JSON::ArrayType<PluginHost::MetaData::Service> >(RDKSHELL_THUNDER_TIMEOUT, statusMethod.c_str(),serviceResults);
+                        status = getServiceState(mCurrentService, callsign, state);
                         std::cout << "get status: " << status << std::endl;
                     }
 
-                    if (status == 0 && serviceResults.Length() > 0)
+                    if (status == 0)
                     {
-                        PluginHost::MetaData::Service service = serviceResults[0];
-                        if (service.JSONState == PluginHost::MetaData::Service::state::DEACTIVATED ||
-                            service.JSONState == PluginHost::MetaData::Service::state::DEACTIVATION ||
-                            service.JSONState == PluginHost::MetaData::Service::state::PRECONDITION)
+                        if (state == PluginHost::IShell::state::DEACTIVATED ||
+                            state == PluginHost::IShell::state::DEACTIVATION ||
+                            state == PluginHost::IShell::state::PRECONDITION)
                         {
                             launchType = RDKShellLaunchType::ACTIVATE;
-                            JsonObject activateParams;
-                            activateParams.Set("callsign",callsign.c_str());
-                            status = thunderController->Invoke(RDKSHELL_THUNDER_TIMEOUT, "activate", activateParams, joResult);
+                            status = activate(mCurrentService, callsign);
 
                             std::cout << "activate 1 status: " << status << std::endl;
                             if (status > 0)
                             {
                                 std::cout << "trying status one more time...\n";
-                                JsonObject activateParams2;
-                                activateParams2.Set("callsign",callsign.c_str());
-                                status = thunderController->Invoke(RDKSHELL_THUNDER_TIMEOUT, "activate", activateParams2, joResult);
+                                status = activate(mCurrentService, callsign);
                                 std::cout << "activate 1 status: " << status << std::endl;
                             }
                         }
@@ -3632,33 +3710,25 @@ namespace WPEFramework {
                     else
                     {
                         launchType = RDKShellLaunchType::ACTIVATE;
-                        JsonObject activateParams;
-                        activateParams.Set("callsign",callsign.c_str());
-                        status = thunderController->Invoke(RDKSHELL_THUNDER_TIMEOUT, "activate", activateParams, joResult);
+                        status = activate(mCurrentService, callsign);
                         std::cout << "activate 2 status: " << status << std::endl;
                         if (status > 0)
                         {
                             std::cout << "trying status one more time...\n";
-                            JsonObject activateParams2;
-                            activateParams2.Set("callsign",callsign.c_str());
-                            status = thunderController->Invoke(RDKSHELL_THUNDER_TIMEOUT, "activate", activateParams2, joResult);
+                            status = activate(mCurrentService, callsign);
                             std::cout << "activate 2 status: " << status << std::endl;
                         }
                     }
                 }
                 else
                 {
-                    JsonObject activateParams;
-                    activateParams.Set("callsign",callsign.c_str());
-                    status = thunderController->Invoke(RDKSHELL_THUNDER_TIMEOUT, "activate", activateParams, joResult);
+                    status = activate(mCurrentService, callsign);
 
                     std::cout << "activate 3 status: " << status << std::endl;
                     if (status > 0)
                     {
                         std::cout << "trying status one more time...\n";
-                        JsonObject activateParams2;
-                        activateParams2.Set("callsign",callsign.c_str());
-                        status = thunderController->Invoke(RDKSHELL_THUNDER_TIMEOUT, "activate", activateParams2, joResult);
+                        status = activate(mCurrentService, callsign);
                         std::cout << "activate 3 status: " << status << std::endl;
                     }
                 }
@@ -4022,12 +4092,8 @@ namespace WPEFramework {
                     returnResponse(false);
                 }
                 std::cout << "destroying " << callsign << std::endl;
-                JsonObject joParams;
-                joParams.Set("callsign",callsign.c_str());
-                JsonObject joResult;
-                auto thunderController = getThunderControllerClient();
                 gDestroyMutex.lock();
-                uint32_t status = thunderController->Invoke<JsonObject, JsonObject>(RDKSHELL_THUNDER_TIMEOUT, "deactivate", joParams, joResult);
+                uint32_t status = deactivate(mCurrentService, callsign);
                 gDestroyMutex.unlock();
                 if (status > 0)
                 {
@@ -4661,14 +4727,10 @@ namespace WPEFramework {
                 bool startup = parameters["startup"].Boolean();
                 if (startup)
                 {
-                    JsonObject joAgingParams;
-                    JsonObject joAgingResult;
-                    joAgingParams.Set("namespace","FactoryTest");
-                    joAgingParams.Set("key","AgingState");
-                    std::string agingGetInvoke = "org.rdk.PersistentStore.1.getValue";
+                    std::string valueString;
 
                     std::cout << "attempting to check aging flag \n";
-                    uint32_t status = getThunderControllerClient()->Invoke<JsonObject, JsonObject>(RDKSHELL_THUNDER_TIMEOUT, agingGetInvoke.c_str(), joAgingParams, joAgingResult);
+                    uint32_t status = getValue(mCurrentService, "FactoryTest", "AgingState", valueString);
                     std::cout << "get status: " << status << std::endl;
 
                     if (status > 0)
@@ -4678,14 +4740,6 @@ namespace WPEFramework {
                         returnResponse(false);
                     }
 
-                    if (!joAgingResult.HasLabel("value"))
-                    {
-                        response["message"] = " aging value not found";
-                        sFactoryAppLaunchStatus = NOTLAUNCHED;
-                        returnResponse(false);
-                    }
-
-                    const std::string valueString = joAgingResult["value"].String();
                     if (valueString != "true")
                     {
                         std::cout << "aging value is " << valueString << std::endl;
@@ -4701,15 +4755,8 @@ namespace WPEFramework {
             {
                 if (parameters.HasLabel("resetagingtime"))
                 {
-                    JsonObject joAgingSetValueParams;
-                    JsonObject joAgingSetValueResult;
-                    joAgingSetValueParams.Set("namespace","FactoryTest");
-                    joAgingSetValueParams.Set("key","AgingTotalTime");
-                    joAgingSetValueParams.Set("value","0");
-                    std::string agingSetInvoke = "org.rdk.PersistentStore.1.setValue";
-
                     std::cout << "attempting to set aging total time to 0 \n";
-                    uint32_t agingTotalTimeSetStatus = getThunderControllerClient()->Invoke<JsonObject, JsonObject>(RDKSHELL_THUNDER_TIMEOUT, agingSetInvoke.c_str(), joAgingSetValueParams, joAgingSetValueResult);
+                    uint32_t agingTotalTimeSetStatus = setValue(mCurrentService, "FactoryTest", "AgingTotalTime", "0");
                     std::cout << "aging total time set status: " <<  agingTotalTimeSetStatus << std::endl;
                 }
 
@@ -4740,26 +4787,13 @@ namespace WPEFramework {
                     returnResponse(false);
                 }
                 addFactoryModeEasterEggs();
-                JsonObject joFactoryModeParams;
-                JsonObject joFactoryModeResult;
-                joFactoryModeParams.Set("namespace","FactoryTest");
-                joFactoryModeParams.Set("key","FactoryMode");
-                joFactoryModeParams.Set("value","true");
-                std::string factoryModeSetInvoke = "org.rdk.PersistentStore.1.setValue";
 
                 std::cout << "attempting to set factory mode flag \n";
-                uint32_t setStatus = getThunderControllerClient()->Invoke<JsonObject, JsonObject>(RDKSHELL_THUNDER_TIMEOUT, factoryModeSetInvoke.c_str(), joFactoryModeParams, joFactoryModeResult);
+                uint32_t setStatus = setValue(mCurrentService, "FactoryTest", "FactoryMode", "true");
                 std::cout << "set status: " << setStatus << std::endl;
 
-                JsonObject joFactoryExitParams;
-                JsonObject joFactoryExitResult;
-                joFactoryExitParams.Set("namespace","FactoryTest");
-                joFactoryExitParams.Set("key","AllowExit");
-                joFactoryExitParams.Set("value","true");
-                std::string factoryExitSetInvoke = "org.rdk.PersistentStore.1.setValue";
-
                 std::cout << "attempting to set factory allow exit flag \n";
-                uint32_t setExitStatus = getThunderControllerClient()->Invoke<JsonObject, JsonObject>(RDKSHELL_THUNDER_TIMEOUT, factoryExitSetInvoke.c_str(), joFactoryExitParams, joFactoryExitResult);
+                uint32_t setExitStatus = setValue(mCurrentService, "FactoryTest", "AllowExit", "true");
                 std::cout << "set status: " << setExitStatus << std::endl;
 
                 sFactoryAppLaunchStatus = COMPLETED;
@@ -4792,15 +4826,10 @@ namespace WPEFramework {
                 returnResponse(true);
             }
 
-            JsonObject joToFacParams;
-            JsonObject joToFacResult;
-            joToFacParams.Set("namespace","FactoryTest");
-            joToFacParams.Set("key","ToFacFlag");
-            std::string toFacGetInvoke = "org.rdk.PersistentStore.1.getValue";
+            std::string valueString;
 
             std::cout << "attempting to check flag \n";
-            auto thunderController = getThunderControllerClient();
-            uint32_t status = thunderController->Invoke<JsonObject, JsonObject>(RDKSHELL_THUNDER_TIMEOUT, toFacGetInvoke.c_str(), joToFacParams, joToFacResult);
+            uint32_t status = getValue(mCurrentService, "FactoryTest", "ToFacFlag", valueString);
             std::cout << "get status: " << status << std::endl;
 
             if (status > 0)
@@ -4809,13 +4838,6 @@ namespace WPEFramework {
                 returnResponse(false);
             }
 
-            if (!joToFacResult.HasLabel("value"))
-            {
-                response["message"] = " toFac value not found";
-                returnResponse(false);
-            }
-
-            const std::string valueString = joToFacResult["value"].String();
             if (valueString != "M" && valueString != "m")
             {
                 std::cout << "toFac value is " << valueString << std::endl;
@@ -4846,19 +4868,14 @@ namespace WPEFramework {
             }
             else
             {
-                JsonObject joAgingParams;
-                JsonObject joAgingResult;
-                joAgingParams.Set("namespace","FactoryTest");
-                joAgingParams.Set("key","AgingState");
-                std::string agingGetInvoke = "org.rdk.PersistentStore.1.getValue";
+                std::string valueString;
 
                 std::cout << "attempting to check aging flag \n";
-                uint32_t agingStatus = getThunderControllerClient()->Invoke<JsonObject, JsonObject>(RDKSHELL_THUNDER_TIMEOUT, agingGetInvoke.c_str(), joAgingParams, joAgingResult);
+                uint32_t agingStatus = getValue(mCurrentService, "FactoryTest", "AgingState", valueString);
                 std::cout << "aging get status: " << agingStatus << std::endl;
 
-                if (agingStatus == 0 && joAgingResult.HasLabel("value"))
+                if (agingStatus == 0)
                 {
-                    const std::string valueString = joAgingResult["value"].String();
                     std::cout << "aging value is " << valueString << std::endl;
                     if (valueString == "true")
                     {
@@ -4872,19 +4889,12 @@ namespace WPEFramework {
                     std::cout << "aging value is not set\n";
                 }
 
-                JsonObject joExitParams;
-                JsonObject joExitResult;
-                joExitParams.Set("namespace","FactoryTest");
-                joExitParams.Set("key","AllowExit");
-                std::string factoryExitGetInvoke = "org.rdk.PersistentStore.1.getValue";
-
                 std::cout << "attempting to check factory exit flag\n";
-                uint32_t factoryExitStatus = getThunderControllerClient()->Invoke<JsonObject, JsonObject>(RDKSHELL_THUNDER_TIMEOUT, factoryExitGetInvoke.c_str(), joExitParams, joExitResult);
+                uint32_t factoryExitStatus = getValue(mCurrentService, "FactoryTest", "AllowExit", valueString);
                 std::cout << "factory exit get status: " << factoryExitStatus << std::endl;
 
-                if (factoryExitStatus == 0 && joExitResult.HasLabel("value"))
+                if (factoryExitStatus == 0)
                 {
-                    const std::string valueString = joExitResult["value"].String();
                     std::cout << "exit value is " << valueString << std::endl;
                     if (valueString == "false")
                     {
@@ -4927,26 +4937,23 @@ namespace WPEFramework {
             std::cout << "stopHdmiStatus status: " << stopHdmiStatus << std::endl;
 
             sForceResidentAppLaunch = true;
-            auto thunderController = getThunderControllerClient();
-            WPEFramework::Core::JSON::String configString;
+            string configString;
 
             int32_t status = 0;
-            string method = "configuration@ResidentApp";
-            Core::JSON::ArrayType<PluginHost::MetaData::Service> joResult;
-            status = thunderController->Get<WPEFramework::Core::JSON::String>(RDKSHELL_THUNDER_TIMEOUT, method.c_str(), configString);
+            status = getConfig(mCurrentService, "ResidentApp", configString);
 
             std::cout << "config resident app status: " << status << std::endl;
             std::string updatedUrl;
             if (status > 0)
             {
                 std::cout << "trying resident app config status one more time...\n";
-                status = thunderController->Get<WPEFramework::Core::JSON::String>(RDKSHELL_THUNDER_TIMEOUT, method.c_str(), configString);
+                status = getConfig(mCurrentService, "ResidentApp", configString);
                 std::cout << "trying resident app config status: " << status << std::endl;
             }
             else
             {
                 JsonObject configSet;
-                configSet.FromString(configString.Value());
+                configSet.FromString(configString);
                 updatedUrl = configSet["url"].String();
                 if (updatedUrl.find("?") != string::npos)
                 {
@@ -4960,16 +4967,13 @@ namespace WPEFramework {
 
             bool ret = true;
             std::string callsign("ResidentApp");
-            JsonObject activateParams;
-            activateParams.Set("callsign",callsign.c_str());
-            JsonObject activateResult;
-            status = thunderController->Invoke<JsonObject, JsonObject>(3500, "activate", activateParams, activateResult);
+            status = activate(mCurrentService, callsign);
 
             std::cout << "activate resident app status: " << status << std::endl;
             if (status > 0)
             {
                 std::cout << "trying status one more time...\n";
-                status = thunderController->Invoke<JsonObject, JsonObject>(3500, "activate", activateParams, activateResult);
+                status = activate(mCurrentService, callsign);
                 std::cout << "activate resident app status: " << status << std::endl;
                 if (status > 0)
                 {
@@ -4999,15 +5003,8 @@ namespace WPEFramework {
                 }
             }
 
-            JsonObject joFactoryModeParams;
-            JsonObject joFactoryModeResult;
-            joFactoryModeParams.Set("namespace","FactoryTest");
-            joFactoryModeParams.Set("key","FactoryMode");
-            joFactoryModeParams.Set("value","false");
-            std::string factoryModeSetInvoke = "org.rdk.PersistentStore.1.setValue";
-
             std::cout << "attempting to set factory mode flag \n";
-            uint32_t setStatus = thunderController->Invoke<JsonObject, JsonObject>(RDKSHELL_THUNDER_TIMEOUT, factoryModeSetInvoke.c_str(), joFactoryModeParams, joFactoryModeResult);
+            uint32_t setStatus = setValue(mCurrentService, "FactoryTest", "FactoryMode", "false");
             std::cout << "set status: " << setStatus << std::endl;
             sForceResidentAppLaunch = false;
             returnResponse(ret);
@@ -5074,14 +5071,10 @@ namespace WPEFramework {
         {
             LOGINFOMETHOD();
             bool ret = true;
-            JsonObject joAgingParams;
-            JsonObject joAgingResult;
-            joAgingParams.Set("namespace","FactoryTest");
-            joAgingParams.Set("key","AgingState");
-            std::string agingGetInvoke = "org.rdk.PersistentStore.1.getValue";
+            std::string valueString;
 
             std::cout << "attempting to check aging state flag \n";
-            uint32_t status = getThunderControllerClient()->Invoke<JsonObject, JsonObject>(RDKSHELL_THUNDER_TIMEOUT, agingGetInvoke.c_str(), joAgingParams, joAgingResult);
+            uint32_t status = getValue(mCurrentService, "FactoryTest", "AgingState", valueString);
             std::cout << "get status: " << status << std::endl;
 
             if (status > 0)
@@ -5090,13 +5083,6 @@ namespace WPEFramework {
                 returnResponse(false);
             }
 
-            if (!joAgingResult.HasLabel("value"))
-            {
-                response["message"] = " aging value not found";
-                returnResponse(false);
-            }
-
-            const std::string valueString = joAgingResult["value"].String();
             if (valueString != "true")
             {
                 std::cout << "aging value is " << valueString << std::endl;
@@ -5104,11 +5090,8 @@ namespace WPEFramework {
                 returnResponse(false);
             }
 
-
-            joAgingParams.Set("value","false");
-            std::string agingSetInvoke = "org.rdk.PersistentStore.1.setValue";
             std::cout << "attempting to set check aging state flag to false\n";
-            status = getThunderControllerClient()->Invoke<JsonObject, JsonObject>(RDKSHELL_THUNDER_TIMEOUT, agingSetInvoke.c_str(), joAgingParams, joAgingResult);
+            status = setValue(mCurrentService, "FactoryTest", "AgingState", "false");
             std::cout << "set status: " << status << std::endl;
 
             JsonObject request, res;
@@ -5660,18 +5643,14 @@ namespace WPEFramework {
 
             if (sPersistentStoreFirstActivated)
             {
-                JsonObject joAgingParams;
-                JsonObject joAgingResult;
-                joAgingParams.Set("namespace","FactoryTest");
-                joAgingParams.Set("key","AgingState");
+                std::string valueString;
 
                 std::cout << "attempting to check aging state \n";
-                uint32_t status = JSONRPCDirectLink(mCurrentService, PERSISTENT_STORE_CALLSIGN).Invoke<JsonObject, JsonObject>(RDKSHELL_THUNDER_TIMEOUT, "getValue", joAgingParams, joAgingResult);
+                uint32_t status = getValue(mCurrentService, "FactoryTest", "AgingState", valueString);
                 std::cout << "get status for aging state: " << status << std::endl;
 
-                if ((status == 0) && (joAgingResult.HasLabel("value")))
+                if ((status == 0))
                 {
-                  const std::string valueString = joAgingResult["value"].String();
                   std::cout << "aging result: " << valueString << std::endl;
                   if (valueString == "true")
                   {
@@ -5680,18 +5659,12 @@ namespace WPEFramework {
                   }
                 }
 
-                JsonObject joFactoryModeParams;
-                JsonObject joFactoryModeResult;
-                joFactoryModeParams.Set("namespace","FactoryTest");
-                joFactoryModeParams.Set("key","FactoryMode");
-
                 std::cout << "attempting to check factory mode \n";
-                status = JSONRPCDirectLink(mCurrentService, PERSISTENT_STORE_CALLSIGN).Invoke<JsonObject, JsonObject>(RDKSHELL_THUNDER_TIMEOUT, "getValue", joFactoryModeParams, joFactoryModeResult);
+                status = getValue(mCurrentService, "FactoryTest", "FactoryMode", valueString);
                 std::cout << "get status for factory mode: " << status << std::endl;
 
-                if ((status == 0) && (joFactoryModeResult.HasLabel("value")))
+                if ((status == 0))
                 {
-                  const std::string valueString = joFactoryModeResult["value"].String();
                   std::cout << "factory mode " << valueString << std::endl;
                   if (valueString == "true")
                   {


### PR DESCRIPTION
Reason for change: Fix design flaws.

Test Procedure: Check for logs:
"no IStore" or "IStore status",
"no IShell" or "IShell config" / "IShell state" /
/ "IShell activate status" / "IShell deactivate status.

Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>