### PR TITLE
RDK-38098:Provide link for Deprecated APIs

### DIFF
--- a/SystemServices/System.json
+++ b/SystemServices/System.json
@@ -285,6 +285,7 @@
     "methods": {
         "cacheContains": {
             "deprecated" : true,
+            "referenceUrl" : " https://rdkcentral.github.io/rdkservices/#/api/PersistentStorePlugin?id=getvalue",
             "summary": "Checks if a key is present in the cache.",
             "params": {
                 "type": "object",
@@ -403,6 +404,7 @@
         },
         "getCachedValue":{
             "deprecated" : true,
+            "referenceUrl" : "https://rdkcentral.github.io/rdkservices/#/api/PersistentStorePlugin?id=getvalue",
             "summary": "Gets the value of a key in the cache.",
             "params": {
                 "type": "object",
@@ -705,6 +707,7 @@
         },
         "getMilestones": {
 	        "deprecated" : true,
+            "referenceUrl" : "https://rdkcentral.github.io/rdkservices/#/api/DeviceDiagnosticsPlugin?id=getmilestones",
             "summary": "Returns the list of milestones.",
             "result": {
                 "type": "object",
@@ -1464,6 +1467,7 @@
         },
         "removeCacheKey":{
             "deprecated" : true,
+            "referenceUrl" : "https://rdkcentral.github.io/rdkservices/#/api/PersistentStorePlugin?id=deletekey",
             "summary": "Removes the cache key.",
             "params": {
                 "type":"object",
@@ -1519,6 +1523,7 @@
         },
         "setCachedValue": {
             "deprecated" : true,
+            "referenceUrl" : "https://rdkcentral.github.io/rdkservices/#/api/PersistentStorePlugin?id=setvalue",
             "summary": "Sets the value for a key in the cache.",
             "params": {
                 "type":"object",

--- a/Tools/json_generator/generator_json.py
+++ b/Tools/json_generator/generator_json.py
@@ -2099,7 +2099,11 @@ def CreateDocument(schema, path):
                     writeonly = True
                     MdParagraph("> This property is **write-only**.")
             if "deprecated" in props:
-                MdParagraph("> This API is **deprecated** and may be removed in the future. It is no longer recommended for use in new implementations.")
+                if "referenceUrl" in props:
+                    referenceUrl = props["referenceUrl"]
+                    MdParagraph("> This API is **deprecated** and may be removed in the future. It is no longer recommended for use in new implementations. [{}]({})".format("Refer this link for the new api",referenceUrl))
+                else:
+                    MdParagraph("> This API is **deprecated** and may be removed in the future. It is no longer recommended for use in new implementations.")
             elif "obsolete" in props:
                 MdParagraph("> This API is **obsolete**. It is no longer recommended for use in new implementations.")
             if "description" in props:

--- a/VoiceControl/VoiceControl.json
+++ b/VoiceControl/VoiceControl.json
@@ -226,7 +226,8 @@
             "result": {
                 "$ref": "#/common/result"
             },
-            "deprecated": true
+            "deprecated": true,
+            "referenceUrl": "https://rdkcentral.github.io/rdkservices/#/api/VoiceControlPlugin?id=voicesessionrequest"
         },
         "voiceSessionTypes": {
             "summary": "Retrieves the types of voice sessions which are supported by the platform.\n\n| Request Type | Description |\n| :-------- | :-------- |\n| ptt_transcription | A text-only session using the urlPtt routing url and the text transcription |\n| mic_transcription | A text-only session using the urlHf routing url and the text transcription |\n| mic_stream_default | An audio based session using the urlHf routing url and the platform's default audio output format |\n| mic_stream_single | An audio based session using the urlHf routing url and the platform's single channel audio input format |\n| mic_stream_multi | An audio based session using the urlHf routing url and the platform's multi-channel audio input format |\n| mic_tap_stream_single | An audio based session using the urlMicTap routing url and the platform's single channel audio input format |\n| mic_tap_stream_multi | An audio based session using the urlMicTap routing url and the platform's multi-channel audio input format |\n| mic_factory_test | An audio based session using the urlHf routing url and the platform's unprocessed multi-channel audio input format |",

--- a/docs/api/SystemPlugin.md
+++ b/docs/api/SystemPlugin.md
@@ -121,7 +121,7 @@ SystemServices interface methods:
 
 Checks if a key is present in the cache.
 
-> This API is **deprecated** and may be removed in the future. It is no longer recommended for use in new implementations.
+> This API is **deprecated** and may be removed in the future. It is no longer recommended for use in new implementations. [Refer this link for the new api]( https://rdkcentral.github.io/rdkservices/#/api/PersistentStorePlugin?id=getvalue)
 
 ### Events
 
@@ -463,7 +463,7 @@ This method takes no parameters.
 
 Gets the value of a key in the cache.
 
-> This API is **deprecated** and may be removed in the future. It is no longer recommended for use in new implementations.
+> This API is **deprecated** and may be removed in the future. It is no longer recommended for use in new implementations. [Refer this link for the new api](https://rdkcentral.github.io/rdkservices/#/api/PersistentStorePlugin?id=getvalue)
 
 ### Events
 
@@ -1059,7 +1059,7 @@ This method takes no parameters.
 
 Returns the list of milestones.
 
-> This API is **deprecated** and may be removed in the future. It is no longer recommended for use in new implementations.
+> This API is **deprecated** and may be removed in the future. It is no longer recommended for use in new implementations. [Refer this link for the new api](https://rdkcentral.github.io/rdkservices/#/api/DeviceDiagnosticsPlugin?id=getmilestones)
 
 ### Events
 
@@ -2495,7 +2495,7 @@ Requests that the system performs a reboot of the set-top box.
 
 Removes the cache key.
 
-> This API is **deprecated** and may be removed in the future. It is no longer recommended for use in new implementations.
+> This API is **deprecated** and may be removed in the future. It is no longer recommended for use in new implementations. [Refer this link for the new api](https://rdkcentral.github.io/rdkservices/#/api/PersistentStorePlugin?id=deletekey)
 
 ### Events
 
@@ -2643,7 +2643,7 @@ No Events
 
 Sets the value for a key in the cache.
 
-> This API is **deprecated** and may be removed in the future. It is no longer recommended for use in new implementations.
+> This API is **deprecated** and may be removed in the future. It is no longer recommended for use in new implementations. [Refer this link for the new api](https://rdkcentral.github.io/rdkservices/#/api/PersistentStorePlugin?id=setvalue)
 
 ### Events
 

--- a/docs/api/VoiceControlPlugin.md
+++ b/docs/api/VoiceControlPlugin.md
@@ -258,7 +258,7 @@ No Events
 
 Sends a voice session with a transcription string to simulate a real voice session for QA. Example use cases for this API call include rack and automation testing.
 
-> This API is **deprecated** and may be removed in the future. It is no longer recommended for use in new implementations.
+> This API is **deprecated** and may be removed in the future. It is no longer recommended for use in new implementations. [Refer this link for the new api](https://rdkcentral.github.io/rdkservices/#/api/VoiceControlPlugin?id=voicesessionrequest)
 
 ### Events
 


### PR DESCRIPTION
"RDK-38098: Provide link to Alternative API/s to use for Deprecated APIs"

Reason for change:
RDK-38098: APIs can be deprecated using the "deprecated" field in json schema. This would mark the API as deprecated in documentation. An alternate API to be used in place of this deprecated API. This alternate API is given as a link to the documentation for the new API. This new API is added in json file in thr method with key as "referenceUrl" that has deprecated value as "true"

Test Procedure: Executed and verified by generating api documentation in docsify
Risks: Create None
Signed-off-by: Rekha Jayaram "[Rekha_Jayaram3@comcast.com](mailto:Rekha_Jayaram3@comcast.com)"

Jira link :
https://ccp.sys.comcast.net/browse/RDK-38098