### PR TITLE
RDK-36673,38098:Generating event section automatically, link for Depr…

### DIFF
--- a/AVInput/AVInput.json
+++ b/AVInput/AVInput.json
@@ -39,7 +39,7 @@
             }
         },
         "currentVideoMode": {
-            "summary": "Returns a string encoding the video mode being supplied by the device currently attached to the HDMI input. The format of the string is the same format used for the `resolutionName` parameter of the XRE `setResolution` messages. HDMI input is presentable if its resolution is less than or equal to the current Parker display resolution. \n \n### Events\n \n No Events.",
+            "summary": "Returns a string encoding the video mode being supplied by the device currently attached to the HDMI input. The format of the string is the same format used for the `resolutionName` parameter of the XRE `setResolution` messages. HDMI input is presentable if its resolution is less than or equal to the current Parker display resolution.",
             "params": {
                 "summary": "An empty parameter object",
                 "type": "object",
@@ -70,7 +70,7 @@
             }
         },
         "numberOfInputs" : {
-            "summary": "Returns an integer that specifies the number of available inputs. For example, a value of `2` indicates that there are two available inputs that can be selected using `avin://input0` and `avin://input1`. \n \n### Events\n \n No Events.",
+            "summary": "Returns an integer that specifies the number of available inputs. For example, a value of `2` indicates that there are two available inputs that can be selected using `avin://input0` and `avin://input1`.",
             "params": {
                 "summary": "An empty parameter object",
                 "type": "object",

--- a/ActivityMonitor/ActivityMonitor.json
+++ b/ActivityMonitor/ActivityMonitor.json
@@ -34,11 +34,11 @@
     },
     "methods": {
         "enableMonitoring":{
-            "summary": "Enables monitoring for the given application PIDs using the given thresholds for memory and CPU usage at frequencies specified by the intervals.\n \n### Events \n| Event | Description | \n| :----------- | :----------- | \n| `onMemoryThresholdOccured` | Triggered when an application exceeds the given memory threshold | \n | `onCPUThresholdOccured` | Triggered when an application exceeds the `cpuThresholdPercent` value for a duration longer than the `cpuThresholdSeconds` value |",
-            "events": [
-                "onCPUThresholdOccurred",
-                "onMemoryThresholdOccurred"
-            ],
+            "summary": "Enables monitoring for the given application PIDs using the given thresholds for memory and CPU usage at frequencies specified by the intervals.",
+            "events": {
+                "onCPUThresholdOccurred" : "Triggered when an application exceeds the `cpuThresholdPercent` value for a duration longer than the `cpuThresholdSeconds` value",
+                "onMemoryThresholdOccurred" : "Triggered when an application exceeds the given memory threshold"
+            },
             "params": {
                 "type": "object",
                 "properties": {
@@ -97,7 +97,7 @@
             }
         },
         "disableMonitoring":{
-            "summary": "Disables monitoring for all applications. Monitoring stops immediately even if the full collection interval has not been reached.\n \n### Events \n \nNo events",
+            "summary": "Disables monitoring for all applications. Monitoring stops immediately even if the full collection interval has not been reached.",
             "params": {
                 "summary": "An empty parameter object",
                 "type": "object",
@@ -108,7 +108,7 @@
             }
         },
         "getApplicationMemoryUsage": {
-            "summary": "Returns memory usage for a specific monitor-enabled application.\n \n### Events \n \nNo events",
+            "summary": "Returns memory usage for a specific monitor-enabled application.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -154,7 +154,7 @@
             }
         },
         "getAllMemoryUsage": {
-            "summary": "Returns memory usage for all monitoring-enabled applications.\n \n### Events \n \nNo events",
+            "summary": "Returns memory usage for all monitoring-enabled applications.",
             "params": {
                 "summary": "An empty param object",
                 "type": "object",

--- a/Bluetooth/Bluetooth.json
+++ b/Bluetooth/Bluetooth.json
@@ -228,10 +228,10 @@
     },
     "methods": {
         "connect":{
-            "summary": "Initiates the connection with the given Bluetooth device. Triggers `onStatusChanged` event.\n \n### Events \n| Event | Description | \n| :----------- | :----------- | \n| `BluetoothState: CONNECTION_CHANGE` | Triggers `onStatusChanged` event once it is  connected to the given deviceID. |",
-            "events":[
-                "onStatuschanged"
-            ],
+            "summary": "Initiates the connection with the given Bluetooth device. Triggers `onStatusChanged` event.",
+            "events":{
+                "onStatusChanged" : "Triggers `onStatusChanged` event once it is  connected to the given deviceID."
+            },
             "params": {
                 "type":"object",
                 "properties": {
@@ -256,16 +256,16 @@
             }
         },
         "disable":{
-            "summary": "Disables the Bluetooth stack. \n \n### Events \n  \n No Events",
+            "summary": "Disables the Bluetooth stack.",
             "result": {
                 "$ref": "#/common/result"
             }
         },
         "disconnect":{
-            "summary": "Disconnects the given device from this device ID and triggers `onStatusChanged` Event. \n \n### Events  \n| Event | Description | \n| :----------- | :----------- | \n| `BluetoothState`: `CONNECTION_CHANGE` |Triggers `onStatusChanged` event once it is disconnected from given deviceID.| ",
-            "events": [
-                "onStatusChanged"
-            ],
+            "summary": "Disconnects the given device from this device ID and triggers `onStatusChanged` Event.",
+            "events": {
+                "onStatusChanged" : "Triggers `onStatusChanged` event once it is disconnected from given deviceID."
+            },
             "params": {
                 "type":"object",
                 "properties": {
@@ -286,13 +286,13 @@
             }
         },
         "enable":{
-            "summary": "Enables the Bluetooth stack. \n  \n### Events \n\n  No Events",
+            "summary": "Enables the Bluetooth stack.",
             "result": {
                 "$ref": "#/common/result"
             }
         },
         "getAudioInfo":{
-            "summary": "Provides information on the currently playing song/audio from an external source. The returned information from Bluetooth-In device provides information that could be displayed on a TV screen.  \n  \n### Events \n\n  No Events",
+            "summary": "Provides information on the currently playing song/audio from an external source. The returned information from Bluetooth-In device provides information that could be displayed on a TV screen.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -354,7 +354,7 @@
             }
         },
         "getConnectedDevices":{
-            "summary": "Returns a list of devices connected to this device.  \n  \n### Events \n\n  No Events ",
+            "summary": "Returns a list of devices connected to this device.",
             "result": {
                 "type":"object",
                 "properties": {
@@ -396,7 +396,7 @@
             }
         },
         "getDeviceInfo":{
-            "summary": "Returns information for the given device ID. \n  \n### Events \n\n  No Events ",
+            "summary": "Returns information for the given device ID.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -462,7 +462,7 @@
             }
         },
         "getDiscoveredDevices":{
-            "summary": "This method should be called after getting at least one event `onDiscoveredDevice` event and it returns an array of discovered devices. \n  \n### Events \n\n  No Events",
+            "summary": "This method should be called after getting at least one event `onDiscoveredDevice` event and it returns an array of discovered devices.",
             "result": {
                 "type":"object",
                 "properties": {
@@ -508,7 +508,7 @@
             }
         },
         "getName":{
-            "summary": "Returns the name of this device as seen by other Bluetooth devices. \n  \n### Events \n\n  No Events",
+            "summary": "Returns the name of this device as seen by other Bluetooth devices.",
             "result": {
                 "type":"object",
                 "properties": {
@@ -528,7 +528,7 @@
             }
         },
         "getPairedDevices":{
-            "summary": "Returns a list of devices that have paired with this device. \n  \n### Events \n\n  No Events",
+            "summary": "Returns a list of devices that have paired with this device.",
             "result": {
                 "type":"object",
                 "properties": {
@@ -572,7 +572,7 @@
             }
         },
         "isDiscoverable":{
-            "summary": "Returns `true`, if this device can be discovered by other Bluetooth devices.\n  \n### Events \n\n  No Events",
+            "summary": "Returns `true`, if this device can be discovered by other Bluetooth devices.",
             "result": {
                 "type":"object",
                 "properties": {
@@ -590,11 +590,11 @@
             }
         },
         "pair":{
-            "summary": "Pairs this device with device ID of Bluetooth. Triggers `onStatusChanged` and `onRequestFailed` events.\n \n### Events  \n| Event | Description | \n| :----------- | :----------- | \n| `BluetoothState`: `PAIRING_CHANGE` | Triggers `onStatusChanged` event when the device gets paired to given device ID. | \n| `BluetoothState`: `PAIRING_FAILED` | Triggers `onRequestFailed` event, when the device is unable to pair.|",
-            "events":[
-                "onStatusChanged",
-                "onRequestFailed"
-            ],
+            "summary": "Pairs this device with device ID of Bluetooth. Triggers `onStatusChanged` and `onRequestFailed` events.",
+            "events":{
+                "onStatusChanged" : "Triggers onStatusChanged event when the device gets paired to given device ID.",
+                "onRequestFailed" : "Triggers onRequestFailed event, when the device is unable to pair (BluetoothState: PAIRING_FAILED)"
+            },
             "params": {
                 "type":"object",
                 "properties": {
@@ -619,7 +619,7 @@
             }
         },
         "respondToEvent":{
-            "summary": "Provides the ability to respond the client Bluetooth event. For example, this device can respond to a pairing or connection event and indicate the proper response to the requested device, such as the connection request accepted. \n  \n### Events \n\n  No Events",
+            "summary": "Provides the ability to respond the client Bluetooth event. For example, this device can respond to a pairing or connection event and indicate the proper response to the requested device, such as the connection request accepted.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -644,7 +644,7 @@
             }
         },
         "sendAudioPlaybackCommand":{
-            "summary": "Provides control over the connected source. Requests can have one of the following values: PLAY, PAUSE, RESUME, STOP, SKIP_NEXT, SKIP_PREV, RESTART, MUTE, UNMUTE, VOLUME_UP, VOLUME_DOWN. \n \n### Events  \n \n No Events",
+            "summary": "Provides control over the connected source. Requests can have one of the following values: PLAY, PAUSE, RESUME, STOP, SKIP_NEXT, SKIP_PREV, RESTART, MUTE, UNMUTE, VOLUME_UP, VOLUME_DOWN.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -665,7 +665,7 @@
             }
         },
         "setAudioStream":{
-            "summary": "Sets the primary or secondary audio-out to the given Bluetooth device. \n  \n### Events \n\n  No Events",
+            "summary": "Sets the primary or secondary audio-out to the given Bluetooth device.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -686,7 +686,7 @@
             }
         },
         "setDiscoverable":{
-            "summary": "When true, this device can be discovered by other Bluetooth devices. When false, this device is not discoverable. \n  \n### Events \n\n  No Events",
+            "summary": "When true, this device can be discovered by other Bluetooth devices. When false, this device is not discoverable.",
             "params":{
                 "type":"object",
                 "properties":{
@@ -706,7 +706,7 @@
             }
         },
         "setName":{
-            "summary": "Sets the name of this device as seen by other Bluetooth devices.\n  \n### Events \n\n  No Events",
+            "summary": "Sets the name of this device as seen by other Bluetooth devices.",
             "params":{
                 "type":"object",
                 "properties":{
@@ -725,11 +725,11 @@
             }
         },
         "startScan":{
-            "summary": "Starts scanning for other Bluetooth devices that match the given profile. \n Supported profiles include:  \n* For Audio-Out: `LOUDSPEAKER`, `HEADPHONES`, `WEARABLE HEADSET`, `HIFI AUDIO DEVICE`  \n* For Audio-In: `SMARTPHONE`, `TABLET`  \n* For HID: `KEYBOARD`, `MOUSE`, `JOYSTICK`  \n* For HandsFree: `HandsFree`.  \n\n The method returns one of the following statuses:  \n* `AVAILABLE` - Bluetooth stack is initialized, not software disabled, and hardware is running  \n* `NO_BLUETOOTH_HARDWARE` - Bluetooth is supported in RDK software, but no Bluetooth hardware was found.\n* This method sends both `onStatusChanged` and `onDiscoveredDevice` events.\n \n### Events \n  \n| Event | Description | \n| :----------- | :----------- | \n| `BluetoothState:` `DISCOVERY_STARTED` |Triggered `onStatusChanged`event when device starts scanning the other available Bluetooth devices. | \n| `BluetoothState:` `DISCOVERY_COMPLETED` | Triggered `onStatusChanged`event when timeout (timeout param) is completed or the `StopScan` method called.| \n| `DiscoveryType:` `DISCOVERED` |Triggered `onDiscoveredDevice` event when device is in scanning mode and at least one device is discovered | \n|`DiscoveryType:` `LOST` | Triggered `onDiscoveredDevice` event when the scanned device is lost|",
-            "events": [
-                "onStatusChanged",
-                "onDiscoveredDevice"
-            ],
+            "summary": "Starts scanning for other Bluetooth devices that match the given profile. \n Supported profiles include:  \n* For Audio-Out: `LOUDSPEAKER`, `HEADPHONES`, `WEARABLE HEADSET`, `HIFI AUDIO DEVICE`  \n* For Audio-In: `SMARTPHONE`, `TABLET`  \n* For HID: `KEYBOARD`, `MOUSE`, `JOYSTICK`  \n* For HandsFree: `HandsFree`.  \n\n The method returns one of the following statuses:  \n* `AVAILABLE` - Bluetooth stack is initialized, not software disabled, and hardware is running  \n* `NO_BLUETOOTH_HARDWARE` - Bluetooth is supported in RDK software, but no Bluetooth hardware was found.\n* This method sends both `onStatusChanged` and `onDiscoveredDevice` events.",
+            "events": {
+                "onStatusChanged" : "Triggered onStatusChangedevent when device starts scanning the other available Bluetooth devices or when timeout (timeout param) is completed or the StopScan method called.",
+                "onDiscoveredDevice" : "Triggered onDiscoveredDevice event when device is in scanning mode and at least one device is discovered or when the scanned device is lost."
+            },
             "params":{
                 "type":"object",
                 "properties":{
@@ -761,19 +761,19 @@
             }
         },
         "stopScan":{
-            "summary": "Stops scanning for Bluetooth devices  if already scan is in-progress and triggers `onStatusChanged` event.  \n \n### Events  \n| Event | Description | \n| :----------- | :----------- | \n| `BluetoothState:` `DISCOVERY_COMPLETED` | Triggered `onStatusChanged` event when scan is stopped.| ",
-            "events":[
-                "onStatusChanged"
-            ],
+            "summary": "Stops scanning for Bluetooth devices  if already scan is in-progress and triggers `onStatusChanged` event.",
+            "events":{
+                "onStatusChanged" : "Triggered onStatusChanged event when scan is stopped."
+            },
             "result": {
                 "$ref": "#/common/result"
             }
         },
         "unpair":{
-            "summary": "Unpairs the given device ID from this device. Triggers `onStatusChanged` event.\n \n### Events  \n| Event | Description | \n| :----------- | :----------- | \n| `BluetoothState: PAIRING_CHANGE` | Triggers `onStatusChanged` event when device is unpaired |",
-            "events": [
-                "onStatusChanged"
-            ],
+            "summary": "Unpairs the given device ID from this device. Triggers `onStatusChanged` event.",
+            "events": {
+                "onStatusChanged" : "Triggers onStatusChanged event when device is unpaired."
+            },
             "params": {
                 "type":"object",
                 "properties": {
@@ -790,7 +790,7 @@
             }
         },
         "getDeviceVolumeMuteInfo":{
-            "summary": "Gets the volume information of the given Bluetooth device ID. \n \n### Events \n\n No Events",
+            "summary": "Gets the volume information of the given Bluetooth device ID.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -836,10 +836,10 @@
             }
         },
         "setDeviceVolumeMuteInfo": {
-            "summary": "Sets the volume of the connected Bluetooth device ID.  Triggers `onDeviceMediaStatus` event.\n \n### Events \n| Event | Description | \n| :----------- | :----------- | \n| `MediaAudioControlCommand`: `VOLUME_UP` | Triggers `onDeviceMediaStatus` event once volume of connected given deviceID is increased. | \n| `MediaAudioControlCommand`: `VOLUME_DOWN` | Triggers `onDeviceMediaStatus` event once volume of connected given deviceID is decreased. | \n| `MediaAudioControlCommand`: `MUTE` | Triggers `onDeviceMediaStatus` event when connected given deviceID is muted. | \n| `MediaAudioControlCommand`: `UNMUTE` | Triggers `onDeviceMediaStatus` event when connected given deviceID is unmuted. | \n| `MediaAudioControlCommand`: `CMD_UNKNOWN` | Triggers `onDeviceMediaStatus` event when unknown key is pressed on connected given deviceID. |",
-            "events": [
-                "onDeviceMediaStatus"
-            ],
+            "summary": "Sets the volume of the connected Bluetooth device ID.  Triggers `onDeviceMediaStatus` event.",
+            "events": {
+                "onDeviceMediaStatus" : "Triggers onDeviceMediaStatus event once volume of connected given deviceID is increased or decreased or when connected given deviceID is muted or unmuted or when unknown key is pressed on connected given deviceID."
+            },
             "params": {
                 "type":"object",
                 "properties": {
@@ -870,7 +870,7 @@
             }
         },
         "getApiVersionNumber": {
-            "summary": "Provides the current API version number. \n \n### Event \n\n No Events",
+            "summary": "Provides the current API version number.",
             "result": {
                 "type":"object",
                 "properties": {

--- a/CompositeInput/CompositeInput.json
+++ b/CompositeInput/CompositeInput.json
@@ -28,7 +28,7 @@
     },
     "methods": {
         "getCompositeInputDevices" :{
-            "summary": "returns a list of composite input devices.\n \n### Events\n \nNo Events.",
+            "summary": "returns a list of composite input devices.",
             "result": {
                 "type":"object",
                 "properties": {
@@ -66,7 +66,7 @@
             }
         },
         "setVideoRectangle":{
-            "summary": "Sets the composite input video window.\n \n### Events\n \nNo Events.",
+            "summary": "Sets the composite input video window.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -104,11 +104,11 @@
 
         },
         "startCompositeInput":{
-            "summary": "Activates the specified composite input as the primary video source.\n \n### Events \n| Event | Description | \n| :----------- | :----------- | \n| `onInputStatusChanged` | Triggers this event when activates composite input source and input status changes to `started` | \n| `onSignalChanged` | Triggers this event when composite input signal changes (must be one of the following:noSignal, unstableSignal, notSupportedSignal, stableSignal) |",
-            "events": [
-                "onInputStatusChanged",
-                "onSignalChanged"
-            ],
+            "summary": "Activates the specified composite input as the primary video source.",
+            "events": {
+                "onInputStatusChanged" : "Triggers this event when activates composite input source and input status changes to started",
+                "onSignalChanged" : "Triggers this event when composite input signal changes (must be one of the following:noSignal, unstableSignal, notSupportedSignal, stableSignal)"
+            },
             "params": {
                 "type":"object",
                 "properties": {
@@ -127,10 +127,10 @@
             }
         },
         "stopCompositeInput":{
-            "summary": "Deactivates the current composite input source that is the primary video source.\n \n### Events \n| Event | Description | \n| :----------- | :----------- | \n| `onInputStatusChanged` | Triggers this event when deactivates composite input source and input status changes to `stopped` |",
-            "events": [
-                "onInputStatusChanged"
-            ],
+            "summary": "Deactivates the current composite input source that is the primary video source.",
+            "events": {
+                "onInputStatusChanged" : "Triggers this event when deactivates composite input source and input status changes to stopped"
+            },
             "result": {
                 "$ref": "#/common/result"
             }

--- a/ControlService/ControlService.json
+++ b/ControlService/ControlService.json
@@ -98,7 +98,7 @@
     },
     "methods":{
         "canFindMyRemote":{
-            "summary": "Checks if the Control Manager can search for the remote. \n \n### Events\n \n No Events.",
+            "summary": "Checks if the Control Manager can search for the remote.",
             "params": {
                 "$ref": "#/definitions/params"
             },
@@ -121,7 +121,7 @@
             }
         },
         "checkRf4ceChipConnectivity":{
-            "summary": "Checks Rf4ce chip connectivity status. \n \n### Events\n \n No Events.",
+            "summary": "Checks Rf4ce chip connectivity status.",
             "params": {
                 "$ref": "#/definitions/params"
             },
@@ -144,7 +144,7 @@
             }
         },
         "endPairingMode":{
-            "summary": "Leaves pairing mode. \n \n### Events\n \n No Events.",
+            "summary": "Leaves pairing mode.",
             "params": {
                 "$ref": "#/definitions/params"
             },
@@ -172,8 +172,10 @@
 
         },
         "findLastUsedRemote":{
-            "summary": "Searches for the last used remote.\n \n### Events \n| Event | Description | \n| :----------- | :----------- |\n| `onControl`| Triggered when the last used remote is successfully found |",
-            "events": ["onControl"],
+            "summary": "Searches for the last used remote.",
+            "events": {
+            "onControl" : "Triggered when the last used remote is successfully found"
+            },
             "params": {
                 "type":"object",
                 "properties": {
@@ -204,7 +206,7 @@
             }
         },
         "getAllRemoteData":{
-            "summary": "Returns all remote data. \n \n### Events\n \n No Events.",
+            "summary": "Returns all remote data.",
             "params": {
                 "$ref": "#/definitions/params"
             },
@@ -708,7 +710,7 @@
             }
         },
         "getLastKeypressSource":{
-            "summary": "Returns last key press source data. The data, if any, is returned as part of the `result` object. \n \n### Events\n \n No Events.",
+            "summary": "Returns last key press source data. The data, if any, is returned as part of the `result` object.",
             "params": {
                 "$ref": "#/definitions/params"
             },
@@ -769,7 +771,7 @@
             }
         },
         "getLastPairedRemoteData":{
-            "summary": "Returns all remote data for the last paired remote. The data, if any, is returned as part of the `result` object. \n \n### Events\n \n No Events.",
+            "summary": "Returns all remote data for the last paired remote. The data, if any, is returned as part of the `result` object.",
             "params": {
                 "$ref": "#/definitions/params"
             },
@@ -1165,7 +1167,7 @@
             }
         },
         "getQuirks":{
-            "summary": "Gets quirks. \n \n### Events\n \n No Events.",
+            "summary": "Gets quirks.",
             "params": {
                 "$ref": "#/definitions/params"
             },
@@ -1191,7 +1193,7 @@
             }
         },
         "getSingleRemoteData":{
-            "summary": "Returns all remote data for the specified remote. The data, if any, is returned as part of the `result` object. \n \n### Events\n \n No Events.",
+            "summary": "Returns all remote data for the specified remote. The data, if any, is returned as part of the `result` object.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1595,7 +1597,7 @@
             }
         },
         "getValues":{
-            "summary": "Returns remote setting values. \n \n### Events\n \n No Events.",
+            "summary": "Returns remote setting values.",
             "params": {
                 "$ref": "#/definitions/params"
             },
@@ -1648,7 +1650,7 @@
             }
         },
         "setValues":{
-            "summary": "Sets remote setting values. \n \n### Events\n \n No Events.",
+            "summary": "Sets remote setting values.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1694,7 +1696,7 @@
             }
         },
         "startPairingMode":{
-            "summary": "Enters pairing mode. \n \n### Events\n \n No Events.",
+            "summary": "Enters pairing mode.",
             "params": {
                 "type":"object",
                 "properties": {

--- a/DTV/DTV.json
+++ b/DTV/DTV.json
@@ -1107,7 +1107,7 @@
     },
     "methods": {
         "addLnb": {
-            "summary": "Add a new LNB to the database.\n  \n### Events \n\n No Events",
+            "summary": "Add a new LNB to the database.",
             "params": {
                 "$ref": "#/definitions/lnbsettings"
             },
@@ -1118,7 +1118,7 @@
             }
         },
         "addSatellite": {
-            "summary": "Add a new satellite to the database.\n  \n### Events \n\n No Events",
+            "summary": "Add a new satellite to the database.",
             "params": {
                 "$ref": "#/definitions/satellitesettings"
             },
@@ -1129,7 +1129,7 @@
             }
         },
         "startServiceSearch": {
-            "summary": "Starts a service search.\n \n### Events  \n| Event | Description | \n| :----------- | :----------- | \n|`searchstatus`|Triggered during the course of a service search.|\n |`serviceupdated`|Triggered when a service is added|",
+            "summary": "Starts a service search.",
             "params": {
                 "type": "object",
                 "properties": {
@@ -1172,13 +1172,13 @@
                 "summary": "true if the search is started, false otherwise",
                 "example": true
             },
-            "events": [
-                "searchstatus",
-                "serviceupdated"
-            ]
+            "events": {
+                "searchstatus" : " Triggered during the course of a service search.",
+                "serviceupdated" : "Triggered when a service is added"
+            }
         },
         "finishServiceSearch": {
-            "summary": "Finishes a service search.\n  \n### Events \n\n No Events",
+            "summary": "Finishes a service search.",
             "params": {
                 "type": "object",
                 "properties": {
@@ -1204,7 +1204,7 @@
             }
         },
         "startPlaying": {
-            "summary": "Starts playing the specified service.\n  \n### Events\n| Event | Description |\n| :----------- | :----------- |\n|`serviceupdated`|Triggered when info for a service changes|\n|`eventchanged`|Triggered when the EIT 'now' event changes|\n|`videochanged`|Triggered when the video PID or codec are changed|\n|`audiochanged`|Triggered when the audio PID or codec are changed|\n|`subtitleschanged`|Triggered when the subtitle PID or details are changed| ",
+            "summary": "Starts playing the specified service.",
             "params": {
                 "type": "object",
                 "properties": {
@@ -1231,16 +1231,16 @@
                 "type": "number",
                 "example": 0
             },
-            "events": [
-                "serviceupdated",
-                "eventchanged",
-                "videochanged",
-                "audiochanged",
-                "subtitleschanged"
-            ]
+            "events": {
+                "serviceupdated" : "Triggered when info for a service changes",
+                "eventchanged" : "Triggered when the EIT ‘now’ event changes",
+                "videochanged" : "Triggered when the video PID or codec are changed",
+                "audiochanged" : "Triggered when the audio PID or codec are changed",
+                "subtitleschanged" : "Triggered when the subtitle PID or details are changed"
+            }
         },
         "stopPlaying": {
-            "summary": "Stops playing the specified service.\n  \n### Events \n\n No Events",
+            "summary": "Stops playing the specified service.",
             "params": {
                 "summary": "The play handle returned by startPlaying",
                 "type": "number",

--- a/DataCapture/DataCapture.json
+++ b/DataCapture/DataCapture.json
@@ -14,7 +14,7 @@
     },
     "methods": {
         "enableAudioCapture":{
-            "summary": "Enables audio capturing to buffer.  \nReturn Values:  \n* `0` - No error  \n* `1 - 254` - request exceeds the maximum allowed buffer size. The error number represents the maximum buffer length, in seconds, that the set-top device can support.  \n* `255` - set top device cannot accommodate any level of audio buffering. \n \n### Events \n\n No Events.",
+            "summary": "Enables audio capturing to buffer.  \nReturn Values:  \n* `0` - No error  \n* `1 - 254` - request exceeds the maximum allowed buffer size. The error number represents the maximum buffer length, in seconds, that the set-top device can support.  \n* `255` - set top device cannot accommodate any level of audio buffering.",
             "params": {
                 "type": "object",
                 "properties": {
@@ -47,10 +47,10 @@
             }     
         },
         "getAudioClip": {
-            "summary": "Requests the audio driver to capture an audio sample from the specified stream and then delivers the stream sample to a specified URL.  \nSupported streams:  \n* `primary` - The stream going to the analog output and the stream included in the HDMI output. This is the only stream that is valid when the request is made through a voice request.  \n* `secondary` - The stream is captured from a secondary decoder. A potential use case includes initiating a capture from a screen overlay where the user has a choice between primary or secondary audio (or the type of audio output to which the user listens – TV or Bluetooth).\n \nEvents\n \n| Event | Description | \n| :-------- | :-------- | \n| `onAudioClipReady` | Triggered if an audio clip uploaded successfully or not |",
-            "events": [
-                "onAudioClipReady"
-            ],
+            "summary": "Requests the audio driver to capture an audio sample from the specified stream and then delivers the stream sample to a specified URL.  \nSupported streams:  \n* `primary` - The stream going to the analog output and the stream included in the HDMI output. This is the only stream that is valid when the request is made through a voice request.  \n* `secondary` - The stream is captured from a secondary decoder. A potential use case includes initiating a capture from a screen overlay where the user has a choice between primary or secondary audio (or the type of audio output to which the user listens – TV or Bluetooth).",
+            "events": {
+                "onAudioClipReady" : "Triggered if an audio clip uploaded successfully or not"
+            },
             "params": {
                 "type": "object",
                 "properties": {

--- a/DeviceDiagnostics/DeviceDiagnostics.json
+++ b/DeviceDiagnostics/DeviceDiagnostics.json
@@ -33,7 +33,7 @@
     },
     "methods": {
         "getConfiguration": {
-            "summary": "Gets the values associated with the corresponding property names.\n \n### Events \n \nNo events",
+            "summary": "Gets the values associated with the corresponding property names.",
             "params": {
                 "type": "object",
                 "properties": {
@@ -88,7 +88,7 @@
             }
         },
 	"getMilestones": {
-            "summary": "Returns the list of milestones.\n \n### Events\n \n No Events.",
+            "summary": "Returns the list of milestones.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -111,7 +111,7 @@
             }
         },
         "logMilestone": {
-              "summary": "Log marker string to rdk milestones log.\n \n### Events\n \n No Events.",
+              "summary": "Log marker string to rdk milestones log.",
               "params": {
                   "type":"object",
                   "properties": {
@@ -129,7 +129,7 @@
               }
          },
         "getAVDecoderStatus":{
-            "summary": "Gets the most active status of audio/video decoder/pipeline. This API doesn't track individual pipelines. It will aggregate and report the pipeline status, and the pipeline states are prioritized from High to Low (`ACTIVE`, `PAUSED`, and `IDLE`). Therefore, if any of the pipelines is in active state, then `getAVDecoderStatus` will return `ACTIVE`. If none of the pipelines are active but one is in a paused state, then `getAVDecoderStatus` will return `PAUSED`, and if all the pipelines are idle only then, `IDLE` will be returned.\n \n### Events \n \nNo events.",
+            "summary": "Gets the most active status of audio/video decoder/pipeline. This API doesn't track individual pipelines. It will aggregate and report the pipeline status, and the pipeline states are prioritized from High to Low (`ACTIVE`, `PAUSED`, and `IDLE`). Therefore, if any of the pipelines is in active state, then `getAVDecoderStatus` will return `ACTIVE`. If none of the pipelines are active but one is in a paused state, then `getAVDecoderStatus` will return `PAUSED`, and if all the pipelines are idle only then, `IDLE` will be returned.",
             "result":{
                 "type":"object",
                 "properties": {

--- a/DisplaySettings/DisplaySettings.json
+++ b/DisplaySettings/DisplaySettings.json
@@ -193,7 +193,7 @@
     },
     "methods": {
         "enableSurroundDecoder":{
-            "summary": "Enables or disables Surround Decoder capability. The Surround Decoder is an upmixer that takes stereo music content, or surround-encoded two-channel movie content, and creates a high-quality multichannel upmix. If the Surround Decoder is enabled, two-channel signals and 5.1-channel signals are upmixed to 5.1.2.\n \n### Event \n\n No Events.",
+            "summary": "Enables or disables Surround Decoder capability. The Surround Decoder is an upmixer that takes stereo music content, or surround-encoded two-channel movie content, and creates a high-quality multichannel upmix. If the Surround Decoder is enabled, two-channel signals and 5.1-channel signals are upmixed to 5.1.2.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -213,7 +213,7 @@
             }
         },
         "getActiveInput":{
-            "summary": "Returns `true` if the STB HDMI output is currently connected to the active input of the sink device (determined by `RxSense`).\n \n### Event \n\n No Events.",
+            "summary": "Returns `true` if the STB HDMI output is currently connected to the active input of the sink device (determined by `RxSense`).",
             "params": {
                 "type":"object",
                 "properties": {
@@ -244,7 +244,7 @@
             }
         },
         "getAudioDelay":{
-            "summary": "Returns the audio delay (in ms) on the selected audio port. If the `audioPort` argument is not specified, it will browse all ports (checking HDMI0 first). If there is no display connected, then it defaults to `HDMI0`.\n \n### Event \n\n No Events.",
+            "summary": "Returns the audio delay (in ms) on the selected audio port. If the `audioPort` argument is not specified, it will browse all ports (checking HDMI0 first). If there is no display connected, then it defaults to `HDMI0`.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -273,7 +273,7 @@
             }
         },
         "getAudioDelayOffset":{
-            "summary": "Returns the audio delay offset (in ms) on the selected audio port. If the `audioPort` argument is not specified, it will browse all ports (checking HDMI0 first). If there is no display connected, then it defaults to `HDMI0`.\n \n### Event \n\n No Events.",
+            "summary": "Returns the audio delay offset (in ms) on the selected audio port. If the `audioPort` argument is not specified, it will browse all ports (checking HDMI0 first). If there is no display connected, then it defaults to `HDMI0`.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -302,7 +302,7 @@
             }
         },
         "getAudioFormat": {
-            "summary": "Returns the currently set audio format.\n \n### Event \n\n No Events.",
+            "summary": "Returns the currently set audio format.",
             "result": {
                 "type":"object",
                 "properties": {
@@ -324,7 +324,7 @@
             }
         },
         "getBassEnhancer":{
-            "summary": "Returns the current status of the Bass Enhancer settings.\n \n### Event \n\n No Events.",
+            "summary": "Returns the current status of the Bass Enhancer settings.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -357,7 +357,7 @@
             }
         },
         "getConnectedAudioPorts":{
-            "summary": "Returns connected audio output ports (a subset of the ports supported on the device). For SPDIF supported platforms, SPDIF port is always considered connected. HDMI port may or may not be connected.\n \n### Event \n\n No Events.",
+            "summary": "Returns connected audio output ports (a subset of the ports supported on the device). For SPDIF supported platforms, SPDIF port is always considered connected. HDMI port may or may not be connected.",
             "result": {
                 "type":"object",
                 "properties": {
@@ -380,7 +380,7 @@
             }
         },
         "getConnectedVideoDisplays":{
-            "summary": "Returns connected video displays.\n \n### Event \n\n No Events.",
+            "summary": "Returns connected video displays.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -398,7 +398,7 @@
             }
         },
         "getCurrentOutputSettings":{
-            "summary": "Returns current output settings.\n \n### Event \n\n No Events.",
+            "summary": "Returns current output settings.",
             "result": {
                 "type":"object",
                 "properties": {
@@ -441,7 +441,7 @@
             }
         },
         "getCurrentResolution":{
-            "summary": "Returns the current resolution on the selected video display port.\n \n### Event \n\n No Events.",
+            "summary": "Returns the current resolution on the selected video display port.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -469,7 +469,7 @@
             }
         },
         "getDefaultResolution":{
-            "summary": "Gets the default resolution supported by the HDMI0 video output port.\n \n### Event \n\n No Events.",
+            "summary": "Gets the default resolution supported by the HDMI0 video output port.",
             "result": {
                 "type":"object",
                 "properties": {
@@ -489,7 +489,7 @@
             }
         },
         "getDialogEnhancement":{
-            "summary": "Returns the current Dialog Enhancer level (port HDMI0).\n \n### Event \n\n No Events.",
+            "summary": "Returns the current Dialog Enhancer level (port HDMI0).",
             "params":{
                 "type":"object",
                 "properties": {
@@ -524,7 +524,7 @@
             }
         },
         "getDolbyVolumeMode":{
-            "summary": "Returns whether Dolby Volume mode is enabled or disabled (audio output port HDMI0).\n \n### Event \n\n No Events.",
+            "summary": "Returns whether Dolby Volume mode is enabled or disabled (audio output port HDMI0).",
             "result": {
                 "type":"object",
                 "properties": {
@@ -541,7 +541,7 @@
             }
         },
         "getDRCMode":{
-            "summary": "Returns the current Dynamic Range Control mode.\n \n### Event \n\n No Events.",
+            "summary": "Returns the current Dynamic Range Control mode.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -571,7 +571,7 @@
             }
         },
         "getEnableAudioPort": {
-            "summary": " Returns the current status of the specified input audio port.\n \n### Event \n\n No Events.",
+            "summary": " Returns the current status of the specified input audio port.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -602,7 +602,7 @@
             }
         },
         "getGain":{
-            "summary": "Returns the current gain value.\n \n### Event \n\n No Events.",
+            "summary": "Returns the current gain value.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -631,7 +631,7 @@
             }
         },
         "getGraphicEqualizerMode":{
-            "summary": "Returns the current Graphic Equalizer Mode setting (port HDMI0).\n \n### Event \n\n No Events.",
+            "summary": "Returns the current Graphic Equalizer Mode setting (port HDMI0).",
             "params": {
                 "type":"object",
                 "properties": {
@@ -668,7 +668,7 @@
             }
         },
         "getIntelligentEqualizerMode":{
-            "summary": "Returns the current Intelligent Equalizer Mode setting (port HDMI0).\n \n### Event \n\n No Events.",
+            "summary": "Returns the current Intelligent Equalizer Mode setting (port HDMI0).",
             "params":{
                 "type":"object",
                 "properties": {
@@ -705,7 +705,7 @@
             }
         },
         "getMISteering":{
-            "summary": "Returns the current status of Media Intelligence Steering settings.\n \n### Event \n\n No Events.",
+            "summary": "Returns the current status of Media Intelligence Steering settings.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -734,7 +734,7 @@
             }
         },
         "getMS12AudioCompression":{
-            "summary": "Returns the current audio compression settings.\n \n### Event \n\n No Events.",
+            "summary": "Returns the current audio compression settings.",
             "params":{
                 "type":"object",
                 "properties": {
@@ -769,7 +769,7 @@
             }
         },
         "getMS12AudioProfile":{
-            "summary": "Returns the current MS12 audio profile settings.\n \n### Event \n\n No Events.",
+            "summary": "Returns the current MS12 audio profile settings.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -798,7 +798,7 @@
             }
         },
         "getMuted":{
-            "summary": "Returns whether audio is muted on a given port.\n \n### Event \n\n No Events.",
+            "summary": "Returns whether audio is muted on a given port.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -827,7 +827,7 @@
             }
         },
         "getPreferredColorDepth":{
-            "summary": "Returns the current color depth on the selected video display port.\n \n### Event \n\n No Events.",
+            "summary": "Returns the current color depth on the selected video display port.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -859,7 +859,7 @@
             }
         },
         "getSettopAudioCapabilities":{
-            "summary": "Returns the set-top audio capabilities for the specified audio port.\n \n### Event \n\n No Events.",
+            "summary": "Returns the set-top audio capabilities for the specified audio port.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -894,7 +894,7 @@
             }
         },
         "getSettopHDRSupport":{
-            "summary": "Returns an HDR support object (list of standards that the STB supports).\n \n### Event \n\n No Events.",
+            "summary": "Returns an HDR support object (list of standards that the STB supports).",
             "result": {
                 "type":"object",
                 "properties": {
@@ -916,7 +916,7 @@
             }
         },
         "getSettopMS12Capabilities":{
-            "summary": "Returns the set-top MS12 audio capabilities for the specified audio port.\n \n### Event \n\n No Events.",
+            "summary": "Returns the set-top MS12 audio capabilities for the specified audio port.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -950,7 +950,7 @@
             }
         },
         "getSinkAtmosCapability":{
-            "summary": "Returns the ATMOS capability of the sink (HDMI0).\n \n### Event \n\n No Events.",
+            "summary": "Returns the ATMOS capability of the sink (HDMI0).",
             "result": {
                 "type":"object",
                 "properties": {
@@ -970,7 +970,7 @@
             }
         },
         "getSoundMode":{
-            "summary": "Returns the sound mode for the incoming video display. If the argument is `Null` or empty (although not recommended), this returns the output mode of all connected ports, whichever is connected, while giving priority to the HDMI port. If the video display is not connected, then it returns `Stereo` as a safe default.\n \n### Event \n\n No Events.",
+            "summary": "Returns the sound mode for the incoming video display. If the argument is `Null` or empty (although not recommended), this returns the output mode of all connected ports, whichever is connected, while giving priority to the HDMI port. If the video display is not connected, then it returns `Stereo` as a safe default.",
             "params": {
                 "type": "object",
                 "properties": {
@@ -999,7 +999,7 @@
             }
         },
         "getSupportedAudioModes": {
-            "summary": "Returns a list of strings containing the supported audio modes. If `Null` or empty, this returns the supported audio modes of the audio processor (regardless of the the output port).  \nIf a port name is specified, this returns the audio output modes supported by the connected sink device (EDID based). If the port is not connected, the return value is same as if `Null` is specified as the parameter.  \nFor **Auto** mode in DS5, this API has the following extra specification:  \n* For HDMI port, this API returns `Stereo` mode, `Dolby Digital 5.1` mode and `Auto` mode; \n* For SPDIF and HDMI ARC port, this API always returns `Surround` mode, `Stereo` mode, and `PASSTHRU` Mode;  \n* When `AUTO` mode is returned, it includes in parenthesis the best sound mode that the STB can output and the connected sink device can support, in the format of `AUTO` _(`Best Format`)_. For example, if the connected device supports surround, the auto mode string will be `AUTO (Dolby Digital 5.1)`.\n \n### Event \n\n No Events.",
+            "summary": "Returns a list of strings containing the supported audio modes. If `Null` or empty, this returns the supported audio modes of the audio processor (regardless of the the output port).  \nIf a port name is specified, this returns the audio output modes supported by the connected sink device (EDID based). If the port is not connected, the return value is same as if `Null` is specified as the parameter.  \nFor **Auto** mode in DS5, this API has the following extra specification:  \n* For HDMI port, this API returns `Stereo` mode, `Dolby Digital 5.1` mode and `Auto` mode; \n* For SPDIF and HDMI ARC port, this API always returns `Surround` mode, `Stereo` mode, and `PASSTHRU` Mode;  \n* When `AUTO` mode is returned, it includes in parenthesis the best sound mode that the STB can output and the connected sink device can support, in the format of `AUTO` _(`Best Format`)_. For example, if the connected device supports surround, the auto mode string will be `AUTO (Dolby Digital 5.1)`.",
             "params": {
                 "type":"object",
                 "properties":{
@@ -1033,7 +1033,7 @@
             }
         },
         "getSupportedAudioPorts": {
-            "summary": "Returns all audio ports supported on the device (all ports that are physically present).\n \n### Event \n\n No Events.",
+            "summary": "Returns all audio ports supported on the device (all ports that are physically present).",
             "result": {
                 "type":"object",
                 "properties": {
@@ -1056,7 +1056,7 @@
             }
         },
         "getSupportedMS12AudioProfiles":{
-            "summary": "Returns list of platform supported MS12 audio profiles for the specified audio port.\n \n### Event \n\n No Events.",
+            "summary": "Returns list of platform supported MS12 audio profiles for the specified audio port.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1090,7 +1090,7 @@
             }
         },
         "getSupportedResolutions":{
-            "summary": "Returns supported resolutions on the selected video display port (both TV and STB) by its name.\n \n### Event \n\n No Events.",
+            "summary": "Returns supported resolutions on the selected video display port (both TV and STB) by its name.",
             "params": {
                 "type": "object",
                 "properties": {
@@ -1124,7 +1124,7 @@
             }
         },
         "getSupportedSettopResolutions": {
-            "summary": "Returns supported STB resolutions.\n \n### Event \n\n No Events.",
+            "summary": "Returns supported STB resolutions.",
             "result": {
                 "type":"object",
                 "properties": {
@@ -1147,7 +1147,7 @@
             }
         },
         "getSupportedTvResolutions":{
-            "summary": "Returns supported TV resolutions on the selected video display port.\n \n### Event \n\n No Events.",
+            "summary": "Returns supported TV resolutions on the selected video display port.",
             "params":{
                 "type":"object",
                 "properties":{
@@ -1181,7 +1181,7 @@
             }
         },
         "getSupportedVideoDisplays":{
-            "summary": "Returns all video ports supported on the device (all ports that are physically present).\n \n### Event \n\n No Events.",
+            "summary": "Returns all video ports supported on the device (all ports that are physically present).",
             "result": {
                 "type":"object",
                 "properties": {
@@ -1204,7 +1204,7 @@
             }
         },
         "getSurroundVirtualizer":{
-            "summary": "(Version 1) Returns the current surround virtualizer boost settings.\n \n### Event \n\n No Events.",
+            "summary": "(Version 1) Returns the current surround virtualizer boost settings.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1239,7 +1239,7 @@
             }
         },
         "getSurroundVirtualizer":{
-            "summary": "(Version 2) Returns the current surround virtualizer boost settings.\n \n### Event \n\n No Events.",
+            "summary": "(Version 2) Returns the current surround virtualizer boost settings.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1272,7 +1272,7 @@
             }
         },
         "getTVHDRCapabilities":{
-            "summary": "Gets HDR capabilities supported by the TV. The following values (OR-ed value) are possible:  \n* 0 - HDRSTANDARD_NONE  \n* 1 - HDRSTANDARD_HDR10  \n* 2 - HDRSTANDARD_HLG  \n* 4 - HDRSTANDARD_DolbyVision  \n* 8 - HDRSTANDARD_TechnicolorPrime.\n \n### Event \n\n No Events.",
+            "summary": "Gets HDR capabilities supported by the TV. The following values (OR-ed value) are possible:  \n* 0 - HDRSTANDARD_NONE  \n* 1 - HDRSTANDARD_HDR10  \n* 2 - HDRSTANDARD_HLG  \n* 4 - HDRSTANDARD_DolbyVision  \n* 8 - HDRSTANDARD_TechnicolorPrime.",
             "result": {
                 "type":"object",
                 "properties": {
@@ -1292,7 +1292,7 @@
             }
         },
         "getTvHDRSupport":{
-            "summary": "Returns an HDR support object (list of standards that the TV supports).\n \n### Event \n\n No Events.",
+            "summary": "Returns an HDR support object (list of standards that the TV supports).",
             "result": {
                 "type":"object",
                 "properties": {
@@ -1314,7 +1314,7 @@
             }
         },
         "getVideoFormat": {
-            "summary": "Returns the current and supported video formats.\n \n### Event \n\n No Events.",
+            "summary": "Returns the current and supported video formats.",
             "result": {
                 "type":"object",
                 "properties": {
@@ -1336,7 +1336,7 @@
             }
         },
         "getVideoPortStatusInStandby":{
-            "summary": "Returns video port status in standby mode (failure if the port name is missing).\n \n### Event \n\n No Events.",
+            "summary": "Returns video port status in standby mode (failure if the port name is missing).",
             "params": {
                 "type": "object",
                 "properties": {
@@ -1371,7 +1371,7 @@
             }
         },
         "getVolumeLevel":{
-            "summary": "Returns the current volume level.\n \n### Event \n\n No Events.",
+            "summary": "Returns the current volume level.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1400,7 +1400,7 @@
             }
         },
         "getVolumeLeveller": {
-            "summary": "(Version 1)Returns the current Volume Leveller setting.\n \n### Event \n\n No Events.",
+            "summary": "(Version 1)Returns the current Volume Leveller setting.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1435,7 +1435,7 @@
             }
         },
         "getVolumeLeveller": {
-            "summary": "(Version 2) Returns the current Volume Leveller setting.\n \n### Event \n\n No Events.",
+            "summary": "(Version 2) Returns the current Volume Leveller setting.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1468,7 +1468,7 @@
             }
         },
         "getZoomSetting": {
-            "summary": "Returns the zoom setting value.\n \n### Event \n\n No Events.",
+            "summary": "Returns the zoom setting value.",
             "result": {
                 "type":"object",
                 "properties": {
@@ -1486,7 +1486,7 @@
             }
         },
         "isConnectedDeviceRepeater":{
-            "summary": "Indicates whether the device connected to the HDMI0 video output port is an HDCP repeater.\n \n### Event \n\n No Events.",
+            "summary": "Indicates whether the device connected to the HDMI0 video output port is an HDCP repeater.",
             "result": {
                 "type":"object",
                 "properties": {
@@ -1506,7 +1506,7 @@
             }
         },
         "isSurroundDecoderEnabled":{
-            "summary": "Returns the current status of Surround Decoder.\n \n### Event \n\n No Events.",
+            "summary": "Returns the current status of Surround Decoder.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1534,7 +1534,7 @@
             }
         },
         "readEDID":{
-            "summary": "Reads the EDID from the connected HDMI (output) device. Returns a key of `EDID` with a value of the base64 encoded byte array string representing the EDID.\n \n### Event \n\n No Events.",
+            "summary": "Reads the EDID from the connected HDMI (output) device. Returns a key of `EDID` with a value of the base64 encoded byte array string representing the EDID.",
             "result": {
                 "type":"object",
                 "properties": {
@@ -1551,7 +1551,7 @@
             }
         },
         "readHostEDID":{
-            "summary": "Reads the EDID of the host. Returns a key of `EDID` with a value of the base64 encoded raw byte array string representing the EDID.\n \n### Event \n\n No Events.",
+            "summary": "Reads the EDID of the host. Returns a key of `EDID` with a value of the base64 encoded raw byte array string representing the EDID.",
             "result": {
                 "type":"object",
                 "properties": {
@@ -1568,7 +1568,7 @@
             }
         },
         "resetBassEnhancer":{
-            "summary":"Resets the dialog enhancer level to its default bassboost value.\n \n### Event \n\n No Events.",
+            "summary":"Resets the dialog enhancer level to its default bassboost value.",
             "params":{
                 "type":"object",
                 "properties": {
@@ -1593,7 +1593,7 @@
             }   
         },
         "resetDialogEnhancement":{
-            "summary":"Resets the dialog enhancer level to its default enhancer level.\n \n### Event \n\n No Events.",
+            "summary":"Resets the dialog enhancer level to its default enhancer level.",
             "params":{
                 "type":"object",
                 "properties": {
@@ -1618,7 +1618,7 @@
             }   
         },
         "resetSurroundVirtualizer":{
-            "summary":"Resets the surround virtualizer to its default boost value.\n \n### Event \n\n No Events.",
+            "summary":"Resets the surround virtualizer to its default boost value.",
             "params":{
                 "type":"object",
                 "properties": {
@@ -1643,7 +1643,7 @@
             }
         },
         "resetVolumeLeveller":{
-            "summary":"Resets the Volume Leveller level to default volume value.\n \n### Event \n\n No Events.",
+            "summary":"Resets the Volume Leveller level to default volume value.",
             "params":{
                 "type":"object",
                 "properties": {
@@ -1668,7 +1668,7 @@
             } 
         },
         "setAudioAtmosOutputMode":{
-            "summary": "Sets ATMOS audio output mode (on HDMI0).\n \n### Event \n\n No Events.",
+            "summary": "Sets ATMOS audio output mode (on HDMI0).",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1687,7 +1687,7 @@
             }
         },        
         "setAudioDelay":{
-            "summary": "Sets the audio delay (in ms) on the selected audio port. If the `audioPort` argument is not specified, it will browse all ports (checking HDMI0 first). If there is no display connected, then it defaults to `HDMI0`.\n \n### Event \n\n No Events.",
+            "summary": "Sets the audio delay (in ms) on the selected audio port. If the `audioPort` argument is not specified, it will browse all ports (checking HDMI0 first). If there is no display connected, then it defaults to `HDMI0`.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1708,7 +1708,7 @@
             }
         },
         "setAudioDelayOffset":{
-            "summary": "Sets the audio delay offset (in ms) on the selected audio port. If the `audioPort` argument is not specified, it will browse all ports (checking HDMI0 first). If there is no display connected, then it defaults to `HDMI0`.\n \n### Event \n\n No Events.",
+            "summary": "Sets the audio delay offset (in ms) on the selected audio port. If the `audioPort` argument is not specified, it will browse all ports (checking HDMI0 first). If there is no display connected, then it defaults to `HDMI0`.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1729,7 +1729,7 @@
             }
         },
         "setBassEnhancer":{
-            "summary": "Sets the Bass Enhancer. Bass Enhancer provides the consumer a single control to apply a fixed bass boost to correct for a lack of bass reproduction in the playback system.\n \n### Event \n\n No Events.",
+            "summary": "Sets the Bass Enhancer. Bass Enhancer provides the consumer a single control to apply a fixed bass boost to correct for a lack of bass reproduction in the playback system.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1749,11 +1749,11 @@
             }
         },
         "setCurrentResolution":{
-            "summary": "Sets the current resolution.\n \n### Events \n| Event | Description | \n| :----------- | :----------- |\n| `resolutionPreChange`| Triggered when the resolution of the video display is about to change.|\n| `resolutionChanged`| Triggered when the resolution is changed by the user and returns the current resolution.|",
-            "events":[
-                "resolutionPreChange",
-                "resolutionChanged"
-            ],
+            "summary": "Sets the current resolution.",
+            "events":{
+                "resolutionPreChange" : "Triggered when the resolution of the video display is about to change.",
+                "resolutionChanged" : "Triggered when the resolution is changed by the user and returns the current resolution."
+            },
             "params": {
                 "type": "object",
                 "properties": {
@@ -1785,7 +1785,7 @@
             }
         },
         "setDialogEnhancement":{
-            "summary": "Sets the Dialog Enhancer level.A dialog enhancer boosts the speech audio separately from other background content, without increasing the loudness.The method fails if no value is set.\n \n### Event \n\n No Events.",
+            "summary": "Sets the Dialog Enhancer level.A dialog enhancer boosts the speech audio separately from other background content, without increasing the loudness.The method fails if no value is set.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1805,7 +1805,7 @@
             }
         },
         "setDolbyVolumeMode":{
-            "summary": "Enables or disables Dolby Volume mode on audio track (audio output port HDMI0).\n \n### Event \n\n No Events.",
+            "summary": "Enables or disables Dolby Volume mode on audio track (audio output port HDMI0).",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1822,7 +1822,7 @@
             }
         },
         "setDRCMode":{
-            "summary": "Sets the Dynamic Range Control (DRC) setting. DRC is a compression control applied to audio to limit the dynamic range to suit a specific listening situation. For default settings, RF mode is preferred for two-channel outputs (television speaker or headphone) and Line mode for multichannel outputs.\n \n### Event \n\n No Events.",
+            "summary": "Sets the Dynamic Range Control (DRC) setting. DRC is a compression control applied to audio to limit the dynamic range to suit a specific listening situation. For default settings, RF mode is preferred for two-channel outputs (television speaker or headphone) and Line mode for multichannel outputs.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1844,7 +1844,7 @@
             }
         },
         "setEnableAudioPort": {
-            "summary": "Enable or disable the specified audio port based on the input audio port name. This feature provides the consumer with a single user control to enable or disable the specified audio port.\n \n### Event \n\n No Events.",
+            "summary": "Enable or disable the specified audio port based on the input audio port name. This feature provides the consumer with a single user control to enable or disable the specified audio port.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1867,7 +1867,7 @@
             }
         },
         "setForceHDRMode": {
-            "summary": "Enables or disables the force HDR mode. If enabled, the HDR format that is currently configured on the device is used.\n \n### Event \n\n No Events.",
+            "summary": "Enables or disables the force HDR mode. If enabled, the HDR format that is currently configured on the device is used.",
             "params": {
                 "type": "object",
                 "properties": {
@@ -1884,7 +1884,7 @@
             }
         },
         "setGain":{
-            "summary": "Adjusts the gain on a specific port.\n \n### Event \n\n No Events.",
+            "summary": "Adjusts the gain on a specific port.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1904,7 +1904,7 @@
             }
         },
         "setGraphicEqualizerMode":{
-            "summary": "Sets the Graphic Equalizer Mode. The Graphic Equalizer is a multi-band equalizer that allows the end user to customize the sonic qualities of the system.\n \n### Event \n\n No Events.",
+            "summary": "Sets the Graphic Equalizer Mode. The Graphic Equalizer is a multi-band equalizer that allows the end user to customize the sonic qualities of the system.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1926,7 +1926,7 @@
             }
         },
         "setIntelligentEqualizerMode":{
-            "summary": "Sets the Intelligent Equalizer Mode (port HDMI0). An Intelligent Equalizer continuously monitors the audio spectrum and adjusts its equalization filter to transform the original audio tone into desired tone.\n \n### Event \n\n No Events.",
+            "summary": "Sets the Intelligent Equalizer Mode (port HDMI0). An Intelligent Equalizer continuously monitors the audio spectrum and adjusts its equalization filter to transform the original audio tone into desired tone.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1948,7 +1948,7 @@
             }
         },
         "setMISteering":{
-            "summary": "Enables or Disables Media Intelligent Steering. Media Intelligence analyzes audio content and steers the Volume Leveler, the Dialogue Enhancer, the Intelligent Equalizer, and the Speaker Virtualizer, based on the type of audio content.\n \n### Event \n\n No Events.",
+            "summary": "Enables or Disables Media Intelligent Steering. Media Intelligence analyzes audio content and steers the Volume Leveler, the Dialogue Enhancer, the Intelligent Equalizer, and the Speaker Virtualizer, based on the type of audio content.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1968,7 +1968,7 @@
             }
         },
         "setMS12AudioCompression":{
-            "summary": "Sets the audio dynamic range compression level (port HDMI0).\n \n### Event \n\n No Events.",
+            "summary": "Sets the audio dynamic range compression level (port HDMI0).",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1988,7 +1988,7 @@
             }
         },
         "setMS12AudioProfile":{
-            "summary": "Sets the selected MS12 audio profile.\n \n### Event \n\n No Events.",
+            "summary": "Sets the selected MS12 audio profile.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -2049,7 +2049,7 @@
             }
         },
         "setMuted":{
-            "summary": "Mutes or unmutes audio on a specific port.\n \n### Event \n\n No Events.",
+            "summary": "Mutes or unmutes audio on a specific port.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -2095,7 +2095,7 @@
             }
         },
         "setScartParameter":{
-            "summary": "Sets SCART parameters.  \n   \nPossible values:  \n| **Parameter** | **ParameterData** |  \n| `aspect_ratio` | `4x3` or `16x9` |  \n| `tv_startup` | `on` or `off` |  \n| `rgb` | `on` (disables cvbs) |  \n| `cvbs` | `on` (disables rgb) |  \n| `macrovision` | not implemented |  \n| `cgms` |  `disabled`, `copyNever`, `copyOnce`, `copyFreely`, or `copyNoMore` |  \n| `port` | `on` or `off` | \n \n### Event \n\n No Events.",
+            "summary": "Sets SCART parameters.  \n   \nPossible values:  \n| **Parameter** | **ParameterData** |  \n| `aspect_ratio` | `4x3` or `16x9` |  \n| `tv_startup` | `on` or `off` |  \n| `rgb` | `on` (disables cvbs) |  \n| `cvbs` | `on` (disables rgb) |  \n| `macrovision` | not implemented |  \n| `cgms` |  `disabled`, `copyNever`, `copyOnce`, `copyFreely`, or `copyNoMore` |  \n| `port` | `on` or `off` |",
             "params": {
                 "type":"object",
                 "properties": {
@@ -2120,7 +2120,7 @@
             }
         },
         "setSoundMode":{
-            "summary": "Sets the current sound mode for the corresponding video display. If the `audioPort` argument value is missing or empty all ports are set.\n \n### Event \n\n No Events.",
+            "summary": "Sets the current sound mode for the corresponding video display. If the `audioPort` argument value is missing or empty all ports are set.",
             "params": {
                 "type": "object",
                 "properties": {
@@ -2146,7 +2146,7 @@
             }
         },
         "setSurroundVirtualizer":{
-            "summary": "(Version 1)Sets the Surround Virtualizer boost. The Speaker/Surround Virtualizer enables a surround sound signal (including one generated by the Surround Decoder) to be rendered over a device with built-in speakers or headphones.\n \n### Event \n\n No Events.",
+            "summary": "(Version 1)Sets the Surround Virtualizer boost. The Speaker/Surround Virtualizer enables a surround sound signal (including one generated by the Surround Decoder) to be rendered over a device with built-in speakers or headphones.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -2166,7 +2166,7 @@
             }
         },
         "setSurroundVirtualizer":{
-            "summary": "(Version 2) Sets the Surround Virtualizer boost. The Speaker/Surround Virtualizer enables a surround sound signal (including one generated by the Surround Decoder) to be rendered over a device with built-in speakers or headphones.\n \n### Event \n\n No Events.",
+            "summary": "(Version 2) Sets the Surround Virtualizer boost. The Speaker/Surround Virtualizer enables a surround sound signal (including one generated by the Surround Decoder) to be rendered over a device with built-in speakers or headphones.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -2190,7 +2190,7 @@
             }
         },
         "setVideoPortStatusInStandby":{
-            "summary": "Sets the specified video port status to be used in standby mode (failure if the port name is missing).\n \n### Event \n\n No Events.",
+            "summary": "Sets the specified video port status to be used in standby mode (failure if the port name is missing).",
             "params": {
                 "type": "object",
                 "properties": {
@@ -2226,7 +2226,7 @@
             }
         },
         "setVolumeLevel":{
-            "summary": "Adjusts the Volume Level on a specific port.\n \n### Event \n\n No Events.",
+            "summary": "Adjusts the Volume Level on a specific port.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -2246,7 +2246,7 @@
             }
         },
         "setVolumeLeveller":{
-            "summary": "(Version 1)Sets the Volume Leveller level. Volume Leveller is an advanced volume-control solution that maintains consistent playback levels for content from different sources.\n \n### Event \n\n No Events.",
+            "summary": "(Version 1)Sets the Volume Leveller level. Volume Leveller is an advanced volume-control solution that maintains consistent playback levels for content from different sources.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -2266,7 +2266,7 @@
             }
         },
         "setVolumeLeveller":{
-            "summary": "(Version 2) Sets the Volume Leveller level. Volume Leveller is an advanced volume-control solution that maintains consistent playback levels for content from different sources.\n \n### Event \n\n No Events.",
+            "summary": "(Version 2) Sets the Volume Leveller level. Volume Leveller is an advanced volume-control solution that maintains consistent playback levels for content from different sources.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -2290,7 +2290,10 @@
             }
         },
         "setZoomSetting": {
-            "summary": "Sets the current zoom value.\n \n### Events \n| Event | Description | \n| :----------- | :----------- |\n| `zoomSettingsUpdated`| Triggered when the zoom setting changes and returns the zoom setting values for all video display types.|",
+            "summary": "Sets the current zoom value.",
+            "events":{
+                "zoomSettingUpdated" : "Triggered when the zoom setting changes and returns the zoom setting values for all video display types."
+            },
             "params": {
                 "type":"object",
                 "properties":{
@@ -2307,7 +2310,7 @@
             }
         },
         "getColorDepthCapabilities": {
-            "summary": "Returns supported color depth capabilities.\n \n### Event \n\n No Events.",
+            "summary": "Returns supported color depth capabilities.",
             "result": {
                 "type":"object",
                 "properties": {

--- a/FrameRate/FrameRate.json
+++ b/FrameRate/FrameRate.json
@@ -35,7 +35,7 @@
     },
     "methods": {
         "getDisplayFrameRate": {
-            "summary": "(Version 2) Returns the current display frame rate values.\n  \n### Events \n\n No events",
+            "summary": "(Version 2) Returns the current display frame rate values.",
             "result": {
                 "type":"object",
                 "properties": {
@@ -53,7 +53,7 @@
             }
         },
         "getFrmMode": {
-            "summary": "(Version 2) Returns the current auto framerate mode.\n  \n### Events \n\n No events",
+            "summary": "(Version 2) Returns the current auto framerate mode.",
             "result": {
                 "type":"object",
                 "properties": {
@@ -71,7 +71,7 @@
             }
         },
         "setCollectionFrequency": {
-            "summary": "Sets the FPS data collection interval.\n  \n### Events \n\n No events",
+            "summary": "Sets the FPS data collection interval.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -88,11 +88,11 @@
             }
         },
         "setDisplayFrameRate": {
-            "summary": "(Version 2) Sets the display framerate values. \n \n### Events \n| Event | Description | \n| :----------- | :----------- |\n| `onDisplayFrameRateChanging`|Triggered when the framerate changes started.| \n| `onDisplayFrameRateChanged`|Triggered when the framerate changed.|",
-            "events": [
-                "onDisplayFrameRateChanging",
-                "onDisplayFrameRateChanged"
-            ],
+            "summary": "(Version 2) Sets the display framerate values.",
+            "events": {
+                "onDisplayFrameRateChanging" : "Triggered when the framerate changes started.",
+                "onDisplayFrameRateChanged" : "Triggered when the framerate changed"
+            },
             "params": {
                 "type":"object",
                 "properties": {
@@ -109,7 +109,7 @@
             }
         },
         "setFrmMode":{
-            "summary": "(Version 2) Sets the auto framerate mode.\n  \n### Events \n\n No events",
+            "summary": "(Version 2) Sets the auto framerate mode.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -126,25 +126,25 @@
             }
         },
         "startFpsCollection":{
-            "summary": "Starts the FPS data collection.\n \n### Events \n| Event | Description | \n| :----------- | :----------- |\n| `onFpsEvent`|Triggered at the end of each interval as defined by the `setCollectionFrequency` method.|",
-            "events": [
-                "onFpsEvent"
-            ],
+            "summary": "Starts the FPS data collection.",
+            "events": {
+                "onFpsEvent" : "Triggered at the end of each interval as defined by the setCollectionFrequency"
+            },
             "result": {
                 "$ref": "#/common/result"
             }
         },
         "stopFpsCollection":{
-            "summary": "Stops the FPS data collection.\n \n### Events \n| Event | Description | \n| :----------- | :----------- |\n| `onFpsEvent`|Triggered once after the `stopFpsCollection` method is invoked.|",
-            "events": [
-                "onFpsEvent"
-            ],
+            "summary": "Stops the FPS data collection.",
+            "events": {
+                "onFpsEvent" : "Triggered once after the stopFpsCollection method is invoked."
+            },
             "result": {
                 "$ref": "#/common/result"
             }
         },
         "updateFps": {
-            "summary": "Updates Fps values.\n  \n### Events \n\n No events",
+            "summary": "Updates Fps values.",
             "params": {
                 "type":"object",
                 "properties": {

--- a/HdcpProfile/HdcpProfile.json
+++ b/HdcpProfile/HdcpProfile.json
@@ -66,7 +66,7 @@
     },
     "methods": {
         "getHDCPStatus": {
-            "summary": "Returns HDCP-related data.  \n**hdcpReason Argument Values**  \n* `0`: HDMI cable is not connected or rx sense status is `off`  \n* `1`: Rx device is connected with power ON state, and HDCP authentication is not initiated  \n* `2`: HDCP success  \n* `3`:  HDCP authentication failed after multiple retries  \n* `4`:  HDCP authentication in progress   \n* `5`: HDMI video port is disabled. \n \n### Events\n \nNo Events",
+            "summary": "Returns HDCP-related data.  \n**hdcpReason Argument Values**  \n* `0`: HDMI cable is not connected or rx sense status is `off`  \n* `1`: Rx device is connected with power ON state, and HDCP authentication is not initiated  \n* `2`: HDCP success  \n* `3`:  HDCP authentication failed after multiple retries  \n* `4`:  HDCP authentication in progress   \n* `5`: HDMI video port is disabled.",
             "result": {
                 "type":"object",
                 "properties": {
@@ -84,7 +84,7 @@
             }
         },
         "getSettopHDCPSupport": {
-            "summary": "Returns which version of HDCP is supported by the STB. \n \n### Events\n \nNo Events",
+            "summary": "Returns which version of HDCP is supported by the STB.",
             "result":{
                 "type":"object",
                 "properties": {

--- a/HdmiCec/HdmiCec.json
+++ b/HdmiCec/HdmiCec.json
@@ -51,7 +51,7 @@
     },
     "methods": {
         "getActiveSourceStatus":{
-            "summary": "Gets the active source status of the device.\n  \n### Event \n\n No Events",
+            "summary": "Gets the active source status of the device.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -68,7 +68,7 @@
             }
         },
         "getCECAddresses":{
-            "summary": "Returns the HDMI-CEC addresses that are assigned to the local device.\n  \n### Event \n\n No Events",
+            "summary": "Returns the HDMI-CEC addresses that are assigned to the local device.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -107,7 +107,7 @@
             }
         },
         "getDeviceList":{
-            "summary": "Gets the list of number of CEC enabled devices connected and system information for each device. The information includes logicalAddress,OSD name and vendor ID.\n  \n### Event \n\n No Events",
+            "summary": "Gets the list of number of CEC enabled devices connected and system information for each device. The information includes logicalAddress,OSD name and vendor ID.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -151,7 +151,7 @@
             }
         },
         "getEnabled": {
-            "summary": "Returns whether HDMI-CEC is enabled.\n  \n### Event \n\n No Events",
+            "summary": "Returns whether HDMI-CEC is enabled.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -169,10 +169,10 @@
             }
         },
         "sendMessage":{
-            "summary": "Writes HDMI-CEC frame to the driver.\n \n### Events \n| Event | Description | \n| :----------- | :----------- |\n| `onMessage`|Triggered when a message is sent from an HDMI device|",
-             "events": [
-                    "onMessage"
-            ],
+            "summary": "Writes HDMI-CEC frame to the driver.",
+             "events": {
+                    "onMessage" : "Triggered when a message is sent from an HDMI device"
+             },
             "params": {
                 "type":"object",
                 "properties": {
@@ -189,7 +189,7 @@
             }
         },
         "setEnabled":{
-            "summary": "Enables or disables HDMI-CEC driver.\n  \n### Event \n\n No Events",
+            "summary": "Enables or disables HDMI-CEC driver.",
             "params": {
                 "type":"object",
                 "properties": {

--- a/HdmiCecSink/HdmiCecSink.json
+++ b/HdmiCecSink/HdmiCecSink.json
@@ -88,7 +88,7 @@
     },
     "methods": {
         "getActiveRoute": {
-            "summary": "Gets details for the current route from the source to sink devices. This API is used for debugging the route.\n  \n### Event \n\n No Events",
+            "summary": "Gets details for the current route from the source to sink devices. This API is used for debugging the route.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -150,7 +150,7 @@
             }
         },
         "getActiveSource": {
-            "summary": "Gets details for the current active source.\n  \n### Event \n\n No Events",
+            "summary": "Gets details for the current active source.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -200,7 +200,7 @@
             }
         },
         "getAudioDeviceConnectedStatus": {
-            "summary": "Get status of audio device connection.\n  \n### Event \n\n No Events",
+            "summary": "Get status of audio device connection.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -218,7 +218,7 @@
             }
         },
         "getDeviceList":{
-            "summary": "Gets the number of connected source devices and system information for each device. The information includes device type, physical address, CEC version, vendor ID, power status and OSD name.\n  \n### Event \n\n No Events",
+            "summary": "Gets the number of connected source devices and system information for each device. The information includes device type, physical address, CEC version, vendor ID, power status and OSD name.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -284,7 +284,7 @@
             }
         },
         "getEnabled":{
-            "summary": "Returns whether HDMI-CEC is enabled on platform or not.\n  \n### Event \n\n No Events",
+            "summary": "Returns whether HDMI-CEC is enabled on platform or not.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -302,7 +302,7 @@
             }
         },
         "getOSDName":{
-            "summary": "Returns the OSD name used by host device.\n  \n### Event \n\n No Events",
+            "summary": "Returns the OSD name used by host device.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -320,7 +320,7 @@
             }
         },
         "getVendorId":{
-            "summary": "Gets the current vendor ID used by host device.\n  \n### Event \n\n No Events",
+            "summary": "Gets the current vendor ID used by host device.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -338,7 +338,7 @@
             }
         },
         "printDeviceList": {
-            "summary": "This is a helper debug command for developers. It prints the list of connected devices and properties of connected devices like deviceType, VendorID, CEC version, PowerStatus, OSDName, PhysicalAddress etc.\n  \n### Event \n\n No Events",
+            "summary": "This is a helper debug command for developers. It prints the list of connected devices and properties of connected devices like deviceType, VendorID, CEC version, PowerStatus, OSDName, PhysicalAddress etc.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -356,45 +356,45 @@
             }
         },
         "requestActiveSource": {
-            "summary": "Requests the active source in the network.\n \n### Events \n| Event | Description | \n| :----------- | :----------- |\n| `onActiveSourceChange`|Triggered with the active source device changes.|\n| `onDeviceAdded`|Triggered when an HDMI cable is physically connected to the HDMI port on a TV, or the power cable is connected to the source device.| \n| `onDeviceInfoUpdated`|Triggered when device information changes (physicalAddress, deviceType, vendorID, osdName, cecVersion, powerStatus).|",
-            "events": [
-                "onActiveSourceChange",
-                "onDeviceAdded",
-                "onDeviceInfoUpdated"
-            ],
+            "summary": "Requests the active source in the network.",
+            "events": {
+                "onActiveSourceChange" : "Triggered with the active source device changes.",
+                "onDeviceAdded" : "Triggered when an HDMI cable is physically connected to the HDMI port on a TV, or the power cable is connected to the source device.",
+                "onDeviceInfoUpdated" : "Triggered when device information changes (physicalAddress, deviceType, vendorID, osdName, cecVersion, powerStatus)."
+            },
             "result": {
                 "$ref": "#/common/result"
             }
         },
         "requestShortAudioDescriptor": {
-            "summary": "Sends the CEC Request Short Audio Descriptor (SAD) message as an event.\n \n### Events \n| Event | Description | \n| :----------- | :----------- |\n| `shortAudiodesciptorEvent`|Triggered when SAD is received from the connected audio device.|",
-            "events": [
-                "shortAudiodesciptorEvent"
-            ],
+            "summary": "Sends the CEC Request Short Audio Descriptor (SAD) message as an event.",
+            "events": {
+                "shortAudiodesciptorEvent" : "Triggered when SAD is received from the connected audio device."
+            },
             "result": {
                 "$ref": "#/common/result"
             }
         },
         "sendAudioDevicePowerOnMessage": {
-            "summary": "This message is used to power on the connected audio device. Usually sent by the TV when it comes out of standby and detects audio device connected in the network.\n \n### Events \n| Event | Description | \n| :----------- | :----------- |\n| `setSystemAudioModeEvent`|Triggered when CEC \\<Set System Audio Mode\\> message of device is received.|",
-            "events": [
-                "setSystemAudioModeEvent"
-            ],
+            "summary": "This message is used to power on the connected audio device. Usually sent by the TV when it comes out of standby and detects audio device connected in the network.",
+            "events": {
+                "setSystemAudioModeEvent" : "Triggered when CEC <Set System Audio Mode> message of device is received."
+            },
             "result": {
                 "$ref": "#/common/result"
             }
         },
         "sendGetAudioStatusMessage": {
-            "summary": "Sends the CEC \\<Give Audio Status\\> message to request the audio status.\n \n### Events \n| Event | Description | \n| :----------- | :----------- |\n| `reportAudioStatusEvent`|Triggered when CEC \\<Report Audio Status\\> message of device is received.|",
-            "events": [
-                "reportAudioStatusEvent"
-            ],
+            "summary": "Sends the CEC \\<Give Audio Status\\> message to request the audio status.",
+            "events": {
+                "reportAudioStatusEvent" : "Triggered when CEC <Report Audio Status> message of device is received."
+            },
             "result": {
                 "$ref": "#/common/result"
             }
         },
         "sendKeyPressEvent": {
-            "summary": "Sends the CEC \\<User Control Pressed\\> message when TV remote key is pressed.\n  \n### Event \n\n No Events",
+            "summary": "Sends the CEC \\<User Control Pressed\\> message when TV remote key is pressed.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -417,13 +417,13 @@
             }
         },
         "sendStandbyMessage": {
-            "summary": "Sends a CEC \\<Standby\\> message to the logical address of the device.\n  \n### Event \n\n No Events",
+            "summary": "Sends a CEC \\<Standby\\> message to the logical address of the device.",
             "result": {
                 "$ref": "#/common/result"
             }
         },
         "setActivePath": {
-            "summary": "Sets the source device to active (`setStreamPath`). The source wakes from standby if it's in the standby state.\n  \n### Event \n\n No Events",
+            "summary": "Sets the source device to active (`setStreamPath`). The source wakes from standby if it's in the standby state.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -442,16 +442,16 @@
             }
         },
         "setActiveSource": {
-            "summary": "Sets the current active source as TV (physical address 0.0.0.0). This call needs to be made when the TV switches to internal tuner or any apps.\n  \n### Event \n\n No Events",
+            "summary": "Sets the current active source as TV (physical address 0.0.0.0). This call needs to be made when the TV switches to internal tuner or any apps.",
             "result": {
                 "$ref": "#/common/result"
             }
         },
         "setEnabled": {
-            "summary": "Enables or disables HDMI-CEC support in the platform.\n \n### Events \n| Event | Description | \n| :----------- | :----------- |\n| `reportCecEnabledEvent`|Triggered when the HDMI-CEC is enabled.|",
-            "events": [
-                "reportCecEnabledEvent"
-            ],
+            "summary": "Enables or disables HDMI-CEC support in the platform.",
+            "events": {
+                "reportCecEnabledEvent" : "Triggered when the HDMI-CEC is enabled."
+            },
             "params": {
                 "type":"object",
                 "properties": {
@@ -468,7 +468,7 @@
             }
         },
         "setMenuLanguage": {
-            "summary": "Updates the internal data structure with the new menu Language and also broadcasts the \\<Set Menu Language\\> CEC message.\n  \n### Event \n\n No Events",
+            "summary": "Updates the internal data structure with the new menu Language and also broadcasts the \\<Set Menu Language\\> CEC message.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -487,7 +487,7 @@
             }
         },
         "setOSDName": {
-            "summary": "Sets the OSD Name used by host device.\n  \n### Event \n\n No Events",
+            "summary": "Sets the OSD Name used by host device.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -504,7 +504,7 @@
             }
         },
         "setRoutingChange":{
-            "summary": "Changes routing while switching between HDMI inputs and TV.\n  \n### Event \n\n No Events",
+            "summary": "Changes routing while switching between HDMI inputs and TV.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -529,11 +529,11 @@
             }
         },
         "setupARCRouting":{
-            "summary": "Enable (or disable) HDMI-CEC Audio Return Channel (ARC) routing. Upon enabling, triggers arcInitiationEvent and upon disabling, triggers arcTerminationEvent.\n| Event | Description | \n| :----------- | :----------- |\n| `arcInitiationEvent` |Triggered when routing though the HDMI ARC port is successfully established. | \n|`arcTerminationEvent` |Triggered when routing though the HDMI ARC port terminates.|",
-            "events": [
-                "arcInitiationEvent",
-                "arcTerminationEvent"
-            ],
+            "summary": "Enable (or disable) HDMI-CEC Audio Return Channel (ARC) routing. Upon enabling, triggers arcInitiationEvent and upon disabling, triggers arcTerminationEvent.",
+            "events": {
+                "arcInitiationEvent" : "Triggered when routing though the HDMI ARC port is successfully established.",
+                "arcTerminationEvent" : "Triggered when routing though the HDMI ARC port terminates."
+            },
             "params": {
                 "type":"object",
                 "properties": {
@@ -552,7 +552,7 @@
             }
         },
         "setVendorId":{
-            "summary": "Sets a vendor ID used by host device.\n  \n### Event \n\n No Events",
+            "summary": "Sets a vendor ID used by host device.",
             "params": {
                 "type":"object",
                 "properties": {

--- a/HdmiCec_2/HDMICec_2.json
+++ b/HdmiCec_2/HDMICec_2.json
@@ -53,7 +53,7 @@
     },
     "methods": {
         "getActiveSourceStatus":{
-            "summary": "Gets the active source status of the device.\n  \n### Event \n\n No Events",
+            "summary": "Gets the active source status of the device.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -70,7 +70,7 @@
             }
         },
         "getDeviceList":{
-            "summary": "Gets the list of CEC enabled devices connected and system information for each device. The information includes logicalAddress,OSD name and vendor ID.\n  \n### Events \n\n No Events",
+            "summary": "Gets the list of CEC enabled devices connected and system information for each device. The information includes logicalAddress,OSD name and vendor ID.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -114,7 +114,7 @@
             }
         },
         "getEnabled": {
-            "summary": "Returns HDMI-CEC driver enabled status.\n  \n### Events \n\n No Events",
+            "summary": "Returns HDMI-CEC driver enabled status.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -132,7 +132,7 @@
             }
         },
         "getOSDName":{
-            "summary": "Returns the OSD name set by the application.\n  \n### Events \n\n No Events",
+            "summary": "Returns the OSD name set by the application.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -150,7 +150,7 @@
             }
         },
         "getOTPEnabled":{
-            "summary": "Returns HDMI-CEC OTP option enabled status.\n  \n### Events \n\n No Events",
+            "summary": "Returns HDMI-CEC OTP option enabled status.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -168,7 +168,7 @@
             }
         },
         "getVendorId":{
-            "summary": "Returns the vendor ID set by the application.\n  \n### Events \n\n No Events",
+            "summary": "Returns the vendor ID set by the application.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -186,19 +186,19 @@
             }
         },
         "performOTPAction":{
-            "summary": "Turns on the TV and takes back the input to the device.\n  \n### Events \n\n No Events",
+            "summary": "Turns on the TV and takes back the input to the device.",
             "result": {
                 "$ref": "#/common/result"
             }
         },
         "sendStandbyMessage": {
-            "summary": "Sends a CEC \\<Standby\\> message to the logical address of the device.\n  \n### Events \n\n No Events",
+            "summary": "Sends a CEC \\<Standby\\> message to the logical address of the device.",
             "result": {
                 "$ref": "#/common/result"
             }
         },
         "setEnabled":{
-            "summary": "Enables or disables HDMI-CEC driver.\n  \n### Events \n\n No Events",
+            "summary": "Enables or disables HDMI-CEC driver.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -215,7 +215,7 @@
             }
         },
         "setOSDName":{
-            "summary": "Sets the OSD name of the application.\n  \n### Events \n\n No Events",
+            "summary": "Sets the OSD name of the application.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -232,7 +232,7 @@
             }
         },
         "setOTPEnabled":{
-            "summary": "Enables or disables HDMI-CEC OTP option.\n  \n### Events \n\n No Events",
+            "summary": "Enables or disables HDMI-CEC OTP option.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -249,7 +249,7 @@
             }
         },
         "setVendorId":{
-            "summary": "Sets the vendor ID of the application.\n  \n### Events \n\n No Events",
+            "summary": "Sets the vendor ID of the application.",
             "params": {
                 "type":"object",
                 "properties": {

--- a/HdmiInput/HdmiInput.json
+++ b/HdmiInput/HdmiInput.json
@@ -56,7 +56,7 @@
     },
     "methods": {
         "getHDMIInputDevices": {
-            "summary": "Returns an array of available HDMI Input ports.\n \n### Events\n \nNo Events.",
+            "summary": "Returns an array of available HDMI Input ports.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -74,7 +74,7 @@
             }
         },
         "getEdidVersion":{
-            "summary": "(Version 2) Returns the EDID version.\n \n### Events\n \nNo Events.",
+            "summary": "(Version 2) Returns the EDID version.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -105,7 +105,7 @@
             }
         },
         "getHDMISPD": {
-            "summary": "(Version 2) Returns the Source Data Product Descriptor (SPD) infoFrame packet information for the specified HDMI Input device. The SPD infoFrame packet includes vendor name, product description, and source information.\n \n### Events\n \nNo Events.",
+            "summary": "(Version 2) Returns the Source Data Product Descriptor (SPD) infoFrame packet information for the specified HDMI Input device. The SPD infoFrame packet includes vendor name, product description, and source information.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -136,7 +136,7 @@
             }
         },
         "getRawHDMISPD":{
-            "summary": "(Version 2) Returns the Source Data Product Descriptor (SPD) infoFrame packet information for the specified HDMI Input device as raw bits.\n \n### Events\n \nNo Events.",
+            "summary": "(Version 2) Returns the Source Data Product Descriptor (SPD) infoFrame packet information for the specified HDMI Input device as raw bits.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -167,7 +167,7 @@
             }
         },
         "readEDID":{
-            "summary": "Returns the current EDID value.\n \n### Events\n \nNo Events.",
+            "summary": "Returns the current EDID value.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -198,11 +198,11 @@
             }
         },
         "startHdmiInput": {
-            "summary": "Activates the specified HDMI Input port as the primary video source.\n \n### Events \n| Event | Description | \n| :----------- | :----------- | \n| `onInputStatusChanged` | Triggers the event when HDMI Input source is activated and Input status changes to `started` | \n| `onSignalChanged` | Triggers the event when HDMI Input signal changes (must be one of the following:noSignal, unstableSignal, notSupportedSignal, stableSignal)",
-            "events": [
-                "onInputStatusChanged",
-                "onSignalChanged"
-            ],
+            "summary": "Activates the specified HDMI Input port as the primary video source.",
+            "events": {
+                "onInputStatusChanged" : "Triggers the event when HDMI Input source is activated and Input status changes to started",
+                "onSignalChanged" : "Triggers the event when HDMI Input signal changes (must be one of the following:noSignal, unstableSignal, notSupportedSignal, stableSignal)."
+            },
             "params": {
                 "type":"object",
                 "properties": {
@@ -219,10 +219,10 @@
             }
         },
         "stopHdmiInput": {
-            "summary": "Deactivates the HDMI Input port currently selected as the primary video source.\n \n### Events \n| Event | Description | \n| :----------- | :----------- | \n| `onInputStatusChanged` | Triggers the event when HDMI Input source is deactivated and Input status changes to `stopped`",
-            "events": [
-                "onInputStatusChanged"
-            ],
+            "summary": "Deactivates the HDMI Input port currently selected as the primary video source.",
+            "events": {
+                "onInputStatusChanged" : "Triggers the event when HDMI Input source is deactivated and Input status changes to `stopped`"
+            },
             "result": {
                 "type": "object",
                 "properties": {
@@ -236,7 +236,7 @@
             }            
         },
         "setEdidVersion": {
-            "summary": "(Version 2) Sets an HDMI EDID version.\n \n### Events\n \nNo Events.",
+            "summary": "(Version 2) Sets an HDMI EDID version.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -259,7 +259,7 @@
             }
         },
         "setVideoRectangle": {
-            "summary": "Sets an HDMI Input video window.\n \n### Events\n \nNo Events.",
+            "summary": "Sets an HDMI Input video window.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -295,7 +295,7 @@
             }
         },
         "writeEDID": {
-            "summary": "Changes a current EDID value.\n \n### Events\n \nNo Events.",
+            "summary": "Changes a current EDID value.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -320,7 +320,7 @@
             }
         },
         "getSupportedGameFeatures":{
-            "summary": "Returns the list of supported game features.\n \n### Events\n \nNo Events.",
+            "summary": "Returns the list of supported game features.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -340,7 +340,7 @@
             }
         },
        "getHdmiGameFeatureStatus":{
-            "summary": "Returns the Game Feature Status. For example: ALLM\n \n### Events\n \nNo Events.",
+            "summary": "Returns the Game Feature Status. For example: ALLM",
             "params": {
                 "type":"object",
                 "properties": {

--- a/LocationSync/LocationSync.json
+++ b/LocationSync/LocationSync.json
@@ -14,7 +14,10 @@
     },
     "methods": {
         "sync": {
-            "summary": "Synchronizes the location. \n \n### Events \n| Event | Description | \n| :----------- | :----------- |\n| `locationchange` | Signals the change of location |",
+            "summary": "Synchronizes the location.",
+            "events": {
+                "locationchange" : "Signals the change of location"
+            },
             "result": {
                 "$ref": "#/common/results/void"
             },

--- a/LoggingPreferences/LoggingPreferences.json
+++ b/LoggingPreferences/LoggingPreferences.json
@@ -18,7 +18,7 @@
     },
     "methods": {
         "isKeystrokeMaskEnabled": {
-            "summary": "Gets logging keystroke mask status (enabled or disabled). \n \n### Events \n\n No Events.",
+            "summary": "Gets logging keystroke mask status (enabled or disabled).",
             "result": {
                 "type": "object",
                 "properties": {
@@ -36,10 +36,10 @@
             }
         },
         "setKeystrokeMaskEnabled": {
-            "summary": "Sets the keystroke logging mask property. If a keystroke mask is successfully changed, then this method triggers an `onKeystrokeMaskEnabledChange` event.\n \n### Events \n| Event | Description | \n| :----------- | :----------- |\n| `onKeystrokeMaskEnabledChange`| Triggered if the keystroke mask is changed successfully |",
-            "events": [
-                "onKeystrokeMaskEnabledChange"
-            ],
+            "summary": "Sets the keystroke logging mask property. If a keystroke mask is successfully changed, then this method triggers an `onKeystrokeMaskEnabledChange` event.",
+            "events": {
+                "onKeystrokeMaskEnabledChange" : "Triggered if the keystroke mask is changed successfully"
+            },
             "params": {
                 "type":"object",
                 "properties": {

--- a/MaintenanceManager/MaintenanceManager.json
+++ b/MaintenanceManager/MaintenanceManager.json
@@ -30,7 +30,7 @@
     },
     "methods": {
         "getMaintenanceActivityStatus" :{
-            "summary": "Gets the maintenance activity status details.  \n**Maintenance Status**  \n* `MAINTENANCE_IDLE` - Maintenance service is not executing any activities before the start of first maintenance task  \n* `MAINTENANCE_STARTED` - Maintenance has started either by schedule or on boot  \n* `MAINTENANCE_ERROR` - One or more tasks of the maintenance service has failed  \n* `MAINTENANCE_COMPLETE` - All critical maintenance tasks are completed successfully  \n* `MAINTENANCE_INCOMPLETE` - Maintenance service didn't execute one or more of the tasks. \n \n### Events\n \n No Events.",
+            "summary": "Gets the maintenance activity status details.  \n**Maintenance Status**  \n* `MAINTENANCE_IDLE` - Maintenance service is not executing any activities before the start of first maintenance task  \n* `MAINTENANCE_STARTED` - Maintenance has started either by schedule or on boot  \n* `MAINTENANCE_ERROR` - One or more tasks of the maintenance service has failed  \n* `MAINTENANCE_COMPLETE` - All critical maintenance tasks are completed successfully  \n* `MAINTENANCE_INCOMPLETE` - Maintenance service didn't execute one or more of the tasks.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -66,7 +66,7 @@
             }
         },
         "getMaintenanceStartTime":{
-            "summary": "Gets the scheduled maintenance start time. \n \n### Events\n \n No Events.",
+            "summary": "Gets the scheduled maintenance start time.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -86,7 +86,7 @@
             }
         },
         "setMaintenanceMode":{
-            "summary": "Sets the maintenance mode and software upgrade opt-out mode.  \n*Opt-Out Modes*  \n* `NONE` - The software upgrade process is unaffected and proceeds with the download and update.  \n* `ENFORCE_OPTPOUT` - The software upgrade process pauses after discovering an update is available and sends a `System` service `onFirmwareUpdateStateChange` event with the `On Hold for opt-out` state. An application must give the user the option of whether or not to accept the update. If the user accepts the update, then the opt-out mode must be set to `BYPASS-OPTOUT`.  \n* `BYPASS_OPTOUT` The software upgrade process proceeds with a download and update, as directed by the application, for this occurrence of the maintenance window (used when the user accepts the software update).  \n* `IGNORE-UPDATE` -  The software upgrade process ignores any non-mandatory firmware updates, and will NOT send any notification. Note that in this mode, the software upgrade process still sets `ENFORCE-OPTOUT` if the update is mandatory. Use the `getFirmwareUpdateInfo` method from the `System` service to determine what software version is available for download and to determine if the update is consider mandatory (using the `rebootImmediately` parameter). \n \n### Events\n \n No Events.",
+            "summary": "Sets the maintenance mode and software upgrade opt-out mode.  \n*Opt-Out Modes*  \n* `NONE` - The software upgrade process is unaffected and proceeds with the download and update.  \n* `ENFORCE_OPTPOUT` - The software upgrade process pauses after discovering an update is available and sends a `System` service `onFirmwareUpdateStateChange` event with the `On Hold for opt-out` state. An application must give the user the option of whether or not to accept the update. If the user accepts the update, then the opt-out mode must be set to `BYPASS-OPTOUT`.  \n* `BYPASS_OPTOUT` The software upgrade process proceeds with a download and update, as directed by the application, for this occurrence of the maintenance window (used when the user accepts the software update).  \n* `IGNORE-UPDATE` -  The software upgrade process ignores any non-mandatory firmware updates, and will NOT send any notification. Note that in this mode, the software upgrade process still sets `ENFORCE-OPTOUT` if the update is mandatory. Use the `getFirmwareUpdateInfo` method from the `System` service to determine what software version is available for download and to determine if the update is consider mandatory (using the `rebootImmediately` parameter).",
             "params": {
                 "type":"object",
                 "properties": {
@@ -122,21 +122,25 @@
             }
         },
         "startMaintenance":{
-            "summary": "Starts maintenance activities. \n \n### Events \n| Event | Description | \n| :----------- | :----------- |\n| `onMaintenanceStatusChange` | Triggers whenever the maintenance status changes |.",
-            "events": ["onMaintenanceStatusChange"],
+            "summary": "Starts maintenance activities.",
+            "events": {
+                "onMaintenanceStatusChange" : "Triggers whenever the maintenance status changes"
+            },
             "result": {
                 "$ref": "#/common/result"
             }          
         },
         "stopMaintenance":{
-            "summary": "Stops maintenance activities. \n \n### Events \n| Event | Description | \n| :----------- | :----------- |\n| `onMaintenanceStatusChange` | Triggers whenever the maintenance status changes |.",
-            "events": ["onMaintenanceStatusChange"],
+            "summary": "Stops maintenance activities.",
+            "events": {
+                "onMaintenanceStatusChange" : "Triggers whenever the maintenance status changes"
+            },
             "result": {
                 "$ref": "#/common/result"
             }          
         },
         "getMaintenanceMode":{
-            "summary": "Gets the current maintenance mode and software upgrade opt-out mode which are stored in the persistent location. \n \n### Events\n \n No Events.",
+            "summary": "Gets the current maintenance mode and software upgrade opt-out mode which are stored in the persistent location.",
             "result": {
                 "type": "object",
                 "properties": {

--- a/Messenger/Messenger.json
+++ b/Messenger/Messenger.json
@@ -31,9 +31,9 @@
     "join": {
       "summary": "Joins a messaging room",
       "description": "Use this method to join a room. If the specified room does not exist, then it will be created.",
-      "events": [
-        "userupdate"
-      ],
+      "events": {
+        "userupdate" : "Notifies about user status updates."
+      },
       "params": {
         "type": "object",
         "properties": {
@@ -89,9 +89,9 @@
     "leave": {
       "summary": "Leaves a messaging room",
       "description": "Use this method to leave a room. The room ID becomes invalid after this call. If there are no more users, the room will be destroyed and related resources freed.",
-      "events": [
-        "userupdate"
-      ],
+      "events": {
+        "userupdate" : "Notifies about user status updates."
+      },
       "params": {
         "type": "object",
         "properties": {
@@ -115,9 +115,9 @@
     "send": {
       "summary": "Sends a message to a room",
       "description": "Use this method to send a message to a room.",
-      "events": [
-        "message"
-      ],
+      "events": {
+        "message" : "Notifies about new messages in a room."
+      },
       "params": {
         "type": "object",
         "properties": {

--- a/Monitor/Monitor.json
+++ b/Monitor/Monitor.json
@@ -133,7 +133,7 @@
     },
     "methods": {
         "restartlimits": {
-            "summary": "Sets new restart limits for a service.\n ### Events \nNo Events.",
+            "summary": "Sets new restart limits for a service.",
             "params": {
                 "type": "object",
                 "properties": {
@@ -156,7 +156,7 @@
             }
         },
         "resetstats": {
-            "summary": "Resets memory and process statistics for a single service watched by the Monitor.\n ### Events \nNo Events.",
+            "summary": "Resets memory and process statistics for a single service watched by the Monitor.",
             "params": {
                 "type": "object",
                 "properties": {

--- a/MotionDetection/MotionDetection.json
+++ b/MotionDetection/MotionDetection.json
@@ -85,7 +85,7 @@
     },
     "methods": {
         "arm":{
-            "summary": "Enables a motion detector in the mode requested. This enables a single shot event. Once an event is sent, the device is in the disarmed state. If the application wishes to receive another event, then the application must re-arm.\n \n### Events \n\n No Events.",
+            "summary": "Enables a motion detector in the mode requested. This enables a single shot event. Once an event is sent, the device is in the disarmed state. If the application wishes to receive another event, then the application must re-arm.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -106,7 +106,7 @@
             }
         },
         "disarm": {
-            "summary": "Disables the specified motion detector.\n \n### Events \n\n No Events.",
+            "summary": "Disables the specified motion detector.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -123,7 +123,7 @@
             }
         },
         "getLastMotionEventElapsedTime": {
-            "summary": "Returns the elapsed time since the last motion event occurred for the specified motion detector.\n \n### Events \n\n No Events.",
+            "summary": "Returns the elapsed time since the last motion event occurred for the specified motion detector.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -154,7 +154,7 @@
             }
         },
         "getMotionDetectors":{
-            "summary": "Returns the available motion detectors and then lists information for each detector including their supported sensitivity mode.  \n  \n**Note:** The `sensitivityMode` property that is returned by this method indicates whether a number or a name controls the sensitivity of a motion detector. If `sensitivityMode` is `1`, then a set of properties (`min`, `max`, and `step`) are returned that define a valid number range to use. If `sensitivityMode` is `2`, then a `sensitivities` property is returned that contains valid names to use.\n \n### Events \n\n No Events.",
+            "summary": "Returns the available motion detectors and then lists information for each detector including their supported sensitivity mode.  \n  \n**Note:** The `sensitivityMode` property that is returned by this method indicates whether a number or a name controls the sensitivity of a motion detector. If `sensitivityMode` is `1`, then a set of properties (`min`, `max`, and `step`) are returned that define a valid number range to use. If `sensitivityMode` is `2`, then a `sensitivities` property is returned that contains valid names to use.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -254,7 +254,7 @@
             }
         },
         "getMotionEventsActivePeriod": {
-            "summary": "Returns the configured times during the day when the motion sensor is active and detecting motion.\n \n### Events \n\n No Events.",
+            "summary": "Returns the configured times during the day when the motion sensor is active and detecting motion.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -285,7 +285,7 @@
             }
         },
         "getNoMotionPeriod":{
-            "summary": "Returns the no-motion period for the specified motion detector.\n \n### Events \n\n No Events.",
+            "summary": "Returns the no-motion period for the specified motion detector.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -314,7 +314,7 @@
             }
         },
         "getSensitivity":{
-            "summary": "Returns the current sensitivity configuration for the specified motion detector. The result is either a `name` property with the sensitivity name or a `value` property with the sensitivity number. See `getMotionDetectors`.\n \n### Events \n\n No Events.",
+            "summary": "Returns the current sensitivity configuration for the specified motion detector. The result is either a `name` property with the sensitivity name or a `value` property with the sensitivity number. See `getMotionDetectors`.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -361,7 +361,7 @@
             }
         },
         "isarmed":{
-            "summary": "Returns whether the specified motion detector is enabled.\n \n### Events \n\n No Events.",
+            "summary": "Returns whether the specified motion detector is enabled.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -392,7 +392,7 @@
             }
         },
         "setMotionEventsActivePeriod": {
-            "summary": "Sets the period of time during the day when the motion sensor is active and detecting motion. Any motion notifications outside of this period should be deferred until the start of the active period or cancelled if the notification is no longer valid. If this method is not called, then the active period is considered disabled and the sensor is armed 24 hours per day.  \n**Note:** The start time may be a higher value than the end time (for example, when a configured activation period spans across midnight from 09:00 pm to 01:00 am). Also, Daylight savings time (DST) may apply to the time zone where this feature is being used and the caller should be aware of the 23 hour and 25 hour days which occur during the shift days. For this reason it is advised that the caller reprograms the active period the day before and the day after the shift days to ensure reliable operation. If the caller is reprogramming this value every 24 hours then this should not be an issue.\n \n### Events \n\n No Events.",
+            "summary": "Sets the period of time during the day when the motion sensor is active and detecting motion. Any motion notifications outside of this period should be deferred until the start of the active period or cancelled if the notification is no longer valid. If this method is not called, then the active period is considered disabled and the sensor is armed 24 hours per day.  \n**Note:** The start time may be a higher value than the end time (for example, when a configured activation period spans across midnight from 09:00 pm to 01:00 am). Also, Daylight savings time (DST) may apply to the time zone where this feature is being used and the caller should be aware of the 23 hour and 25 hour days which occur during the shift days. For this reason it is advised that the caller reprograms the active period the day before and the day after the shift days to ensure reliable operation. If the caller is reprogramming this value every 24 hours then this should not be an issue.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -419,7 +419,7 @@
             }
         },
         "setNoMotionPeriod":{
-            "summary": "Sets the no-motion period, in seconds, for the specified motion detector. When a motion detector is set to detect motion, this is the period of time, in seconds, that MUST elapse with no motion before a motion event is generated. If motion is detected within this period of time, then the time is reset and the countdown begins again. When a motion detector is set to detect no motion, then this is the period of time with no motion detected that MUST elapse before a no-motion event is generated.\n \n### Events \n\n No Events.",
+            "summary": "Sets the no-motion period, in seconds, for the specified motion detector. When a motion detector is set to detect motion, this is the period of time, in seconds, that MUST elapse with no motion before a motion event is generated. If motion is detected within this period of time, then the time is reset and the countdown begins again. When a motion detector is set to detect no motion, then this is the period of time with no motion detected that MUST elapse before a no-motion event is generated.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -440,7 +440,7 @@
             }
         },
         "setSensitivity":{
-            "summary": "Sets the sensitivity of the sensor for the specified motion detector. The argument required depends on the supported sensitivity mode and can be one of:  \n* `name`: Used when `sensitivityMode` is set to `2` requiring a sensitivity name.  \n* `value`: Used when the `sensitivityMode` is set to `1` requiring a sensitivity number within a valid range.  \n  \nSee `getMotionDetectors` to get the supported sensitivity mode.\n \n### Events \n\n No Events.",
+            "summary": "Sets the sensitivity of the sensor for the specified motion detector. The argument required depends on the supported sensitivity mode and can be one of:  \n* `name`: Used when `sensitivityMode` is set to `2` requiring a sensitivity name.  \n* `value`: Used when the `sensitivityMode` is set to `1` requiring a sensitivity number within a valid range.  \n  \nSee `getMotionDetectors` to get the supported sensitivity mode.",
             "params": {
                 "type":"object",
                 "properties": {

--- a/Network/Network.json
+++ b/Network/Network.json
@@ -169,7 +169,7 @@
     },
     "methods": {
         "getDefaultInterface":{
-            "summary": "Gets the default network interface. The active network interface is defined as the one that can make requests to the external network. Returns one of the supported interfaces as per `getInterfaces`, or an empty value which indicates that there is no default network interface. \n  \n### Events \n\n  No Events",
+            "summary": "Gets the default network interface. The active network interface is defined as the one that can make requests to the external network. Returns one of the supported interfaces as per `getInterfaces`, or an empty value which indicates that there is no default network interface.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -187,7 +187,7 @@
             }
         },
         "getInterfaces":{
-            "summary": "Returns a list of interfaces supported by this device including their state. \n  \n### Events \n\n  No Events",
+            "summary": "Returns a list of interfaces supported by this device including their state.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -235,7 +235,7 @@
             }
         },
         "getIPSettings":{
-            "summary": "Gets the IP setting for the given interface. \n  \n### Events \n\n  No Events",
+            "summary": "Gets the IP setting for the given interface.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -298,7 +298,7 @@
             }
         },
         "getNamedEndpoints":{
-            "summary": "Returns a list of endpoint names. Currently supported endpoint names are: `CMTS`. \n  \n### Events \n\n  No Events",
+            "summary": "Returns a list of endpoint names. Currently supported endpoint names are: `CMTS`.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -321,7 +321,7 @@
             }
         },
         "getQuirks":{
-            "summary": "Get standard string `RDK-20093`. \n  \n### Events \n\n  No Events",
+            "summary": "Get standard string `RDK-20093`.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -339,7 +339,7 @@
             }
         },
         "getStbIp":{
-            "summary": "Gets the IP address of the default interface. \n  \n### Events \n\n  No Events",
+            "summary": "Gets the IP address of the default interface.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -359,7 +359,7 @@
             }
         },
         "getSTBIPFamily":{
-            "summary": "Gets the IP address of the default interface by address family. \n  \n### Events \n\n  No Events",
+            "summary": "Gets the IP address of the default interface by address family.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -392,7 +392,7 @@
             }
         },
         "isConnectedToInternet":{
-            "summary": "Whether the device has internet connectivity. This API might take up to 2s to validate internet connectivity. \n  \n### Events \n\n  No Events",
+            "summary": "Whether the device has internet connectivity. This API might take up to 2s to validate internet connectivity.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -412,7 +412,7 @@
             }
         },
         "isInterfaceEnabled":{
-            "summary": "Whether the specified interface is enabled. \n  \n### Events \n\n  No Events",
+            "summary": "Whether the specified interface is enabled.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -443,7 +443,7 @@
             }
         },
         "ping":{
-            "summary": "Pings the specified endpoint with the specified number of packets. \n  \n### Events \n\n  No Events",
+            "summary": "Pings the specified endpoint with the specified number of packets.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -515,7 +515,7 @@
             }
         },
         "pingNamedEndpoint":{
-            "summary": "Pings the specified named endpoint with the specified number of packets. Only names returned by `getNamedEndpoints` can be used. The named endpoint is resolved to a specific host or IP address on the device side based on the `endpointName`. \n  \n### Events \n\n  No Events",
+            "summary": "Pings the specified named endpoint with the specified number of packets. Only names returned by `getNamedEndpoints` can be used. The named endpoint is resolved to a specific host or IP address on the device side based on the `endpointName`.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -587,7 +587,7 @@
             }
         },
         "setConnectivityTestEndpoints":{
-            "summary": "Sets the default list of endpoints used for a connectivity test. Maximum number of endpoints is 5. \n  \n### Events \n\n  No Events",
+            "summary": "Sets the default list of endpoints used for a connectivity test. Maximum number of endpoints is 5.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -609,13 +609,13 @@
             }
         },
         "setDefaultInterface":{
-            "summary": "Sets the default interface. The call fails if the interface is not enabled.\n \n### Events \n| Event | Description | \n| :----------- | :----------- | \n| `onDefaultInterfaceChanged` | Triggered when device's default interface changed.| \n| `onInterfaceStatusChanged` | Triggered when interface's status changes to enabled/disabled. | \n| `onConnectionStatusChanged` | Triggered when the device connects to router. | \n| `onIPAddressStatusChanged` | Triggered when each IP address is lost or acquired.|",
-            "events":[
-                "onInterfaceStatusChanged",
-                "onConnectionStatusChanged",
-                "onIPAddressStatusChanged",
-                "onDefaultInterfaceChanged"
-            ],
+            "summary": "Sets the default interface. The call fails if the interface is not enabled.",
+            "events":{
+                "onInterfaceStatusChanged" : "Triggered when device’s default interface changed.",
+                "onConnectionStatusChanged" : "Triggered when interface’s status changes to enabled/disabled.",
+                "onIPAddressStatusChanged" : "Triggered when the device connects to router.",
+                "onDefaultInterfaceChanged" : "Triggered when each IP address is lost or acquired."
+            },
             "params": {
                 "type":"object",
                 "properties": {
@@ -638,10 +638,10 @@
             }
         },
         "setInterfaceEnabled":{
-            "summary": "Enables the specified interface.\n \n### Events \n| Event | Description | \n| :----------- | :----------- | \n| `onInterfaceStatusChanged` | Triggered when interface's status changes to enabled/disabled.|",
-            "events": [
-                "onInterfaceStatusChanged"
-            ],
+            "summary": "Enables the specified interface.",
+            "events": {
+                "onInterfaceStatusChanged" : "Triggered when interface’s status changes to enabled/disabled."
+            },
             "params": {
                 "type": "object",
                 "properties": {
@@ -670,10 +670,10 @@
             }
         },
         "setIPSettings":{
-            "summary": "Sets the IP settings.All the inputs are mandatory for v1. But for v2, the interface and autconfig params are mandatory input to autoconfig IP settings & other parameters not required. For manual IP, all the input parameters are mandatory except secondaryDNS \n \n### Events \n| Event | Description | \n| :----------- | :----------- | \n| `onIPAddressStatusChanged` | Triggered when each IP address is lost or acquired.|",
-            "events":[
-                "onIPAddressStatusChanged"
-            ],
+            "summary": "Sets the IP settings.All the inputs are mandatory for v1. But for v2, the interface and autconfig params are mandatory input to autoconfig IP settings & other parameters not required. For manual IP, all the input parameters are mandatory except secondaryDNS.",
+            "events":{
+                "onIPAddressStatusChanged" : "Triggered when each IP address is lost or acquired."
+            },
             "params": {
                 "type":"object",
                 "properties": {
@@ -732,7 +732,7 @@
             }
         },
          "getPublicIP":{
-            "summary": "It allows either zero parameter or with only interface and ipv6 parameter to determine WAN ip address. \n  \n### Events \n\n  No Events",
+            "summary": "It allows either zero parameter or with only interface and ipv6 parameter to determine WAN ip address.",
             "params": {
                 "type":"object",
                 "summary":"it allows empty parameter too",
@@ -768,7 +768,7 @@
             }
         },
         "setStunEndPoint":{
-            "summary": "Set the Stun Endpoint used for getPublicIP. \n  \n### Events \n\n  No Events",
+            "summary": "Set the Stun Endpoint used for getPublicIP.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -810,7 +810,7 @@
             }
         },
         "trace":{
-            "summary": "Traces the specified endpoint with the specified number of packets using `traceroute`. \n  \n### Events \n\n  No Events",
+            "summary": "Traces the specified endpoint with the specified number of packets using `traceroute`.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -851,7 +851,7 @@
             }
         },
         "traceNamedEndpoint":{
-            "summary": "Traces the specified named endpoint with the specified number of packets using `traceroute`. \n  \n### Events \n\n  No Events",
+            "summary": "Traces the specified named endpoint with the specified number of packets using `traceroute`.",
             "params": {
                 "type":"object",
                 "properties": {

--- a/OCIContainer/OCIContainer.json
+++ b/OCIContainer/OCIContainer.json
@@ -45,7 +45,7 @@
     },
     "methods": {
         "executeCommand":{
-            "summary": "Executes a command inside a running container. The path to the executable must resolve within the container's namespace.\n \n### Events \n\n No Events.",
+            "summary": "Executes a command inside a running container. The path to the executable must resolve within the container's namespace.",
             "params": {
                 "type": "object",
                 "properties": {
@@ -71,7 +71,7 @@
             }
         },
         "getContainerInfo":{
-            "summary": "Gets information about a running container such as CPU, memory, and GPU usage (GPU not supported on Xi6).\n \n### Events \n\n No Events.",
+            "summary": "Gets information about a running container such as CPU, memory, and GPU usage (GPU not supported on Xi6).",
             "params": {
                 "type": "object",
                 "properties": {
@@ -203,7 +203,7 @@
             }
         },
         "getContainerState":{
-            "summary": "Gets the state of a currently running container.\n \n### Events \n\n No Events.",
+            "summary": "Gets the state of a currently running container.",
             "params": {
                 "type": "object",
                 "properties": {
@@ -245,7 +245,7 @@
             }
         },
         "listContainers":{
-            "summary": "Lists all running OCI containers Dobby knows about.\n \n### Events \n\n No Events.",
+            "summary": "Lists all running OCI containers Dobby knows about.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -281,7 +281,7 @@
             } 
         },
         "pauseContainer":{
-            "summary": "Pauses a currently running container.\n \n### Events \n\n No Events.",
+            "summary": "Pauses a currently running container.",
             "params": {
                 "type": "object",
                 "properties": {
@@ -298,7 +298,7 @@
             }
         },
         "resumeContainer":{
-            "summary": "Resumes a previously paused container.\n \n### Events \n\n No Events.",
+            "summary": "Resumes a previously paused container.",
             "params": {
                 "type": "object",
                 "properties": {
@@ -315,10 +315,10 @@
             }
         },
         "startContainer":{
-            "summary": "Starts a new container from an existing OCI bundle. \n \n### Events \n| Event | Description | \n| :----------- | :----------- | \n| `onContainerStarted` |  Triggers when a new container starts running.|",
-            "events": [
-               "onContainerStarted" 
-            ],
+            "summary": "Starts a new container from an existing OCI bundle.",
+            "events": {
+               "onContainerStarted" : "Triggers when a new container starts running."
+            },
             "params": {
                 "type": "object",
                 "properties": {
@@ -369,10 +369,10 @@
             }
         },
         "startContainerFromDobbySpec":{
-            "summary": "Starts a new container from a legacy Dobby JSON specification.\n \n### Events \n| Event | Description | \n| :----------- | :----------- | \n| `onContainerStarted` |  Triggers when a new container starts running.|",
-            "events": [
-               "onContainerStarted" 
-            ],
+            "summary": "Starts a new container from a legacy Dobby JSON specification.",
+            "events": {
+               "onContainerStarted"  : "Triggers when a new container starts running."
+            },
             "params": {
                 "type": "object",
                 "properties": {
@@ -416,10 +416,10 @@
 
         },
         "stopContainer":{
-            "summary": "Stops a currently running container. \n \n### Events \n| Event | Description | \n| :----------- | :----------- | \n| `onContainerStopped` | Triggers when the container stops running.|",
-            "events": [
-               "onContainerStopped" 
-            ],
+            "summary": "Stops a currently running container.",
+            "events": {
+               "onContainerStopped" : "Triggers when the container stops running."
+            },
             "params": {
                 "type": "object",
                 "properties": {

--- a/PersistentStore/PersistentStore.json
+++ b/PersistentStore/PersistentStore.json
@@ -28,7 +28,7 @@
     },
     "methods": {
         "deleteKey":{
-            "summary": "Deletes a key from the specified namespace.\n \n### Events \n\n No Events.",
+            "summary": "Deletes a key from the specified namespace.",
             "params": {
                 "type": "object",
                 "properties": {
@@ -49,7 +49,7 @@
             }
         },
         "deleteNamespace":{
-            "summary": "Deletes the specified namespace.\n \n### Events \n\n No Events.",
+            "summary": "Deletes the specified namespace.",
             "params": {
                 "type": "object",
                 "properties": {
@@ -66,13 +66,13 @@
             }    
         },
         "flushCache":{
-            "summary": "Flushes the database cache by invoking `flush` in SQLite.\n \n### Events \n\n No Events.",
+            "summary": "Flushes the database cache by invoking `flush` in SQLite.",
             "result": {
                 "$ref": "#/common/result"
             }
         },
         "getKeys":{
-            "summary": "Returns the keys that are stored in the specified namespace.\n \n### Events \n\n No Events.",
+            "summary": "Returns the keys that are stored in the specified namespace.",
             "params": {
                 "type": "object",
                 "properties": {
@@ -106,7 +106,7 @@
             }
         },
         "getNamespaces":{
-            "summary": "Returns the namespaces in the datastore.\n \n### Events \n\n No Events.",
+            "summary": "Returns the namespaces in the datastore.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -129,7 +129,7 @@
             }
         },
         "getStorageSize":{
-            "summary": "Returns the size occupied by each namespace. This is a processing-intense operation. The total size of the datastore should not exceed more than 1MB in size. If the storage size is exceeded then, new values are not stored and the `onStorageExceeded` event is sent.\n \n### Events \n\n No Events.",
+            "summary": "Returns the size occupied by each namespace. This is a processing-intense operation. The total size of the datastore should not exceed more than 1MB in size. If the storage size is exceeded then, new values are not stored and the `onStorageExceeded` event is sent.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -159,7 +159,7 @@
             }
         },
         "getValue":{
-            "summary": "Returns the value of a key from the specified namespace.\n \n### Events \n\n No Events.",
+            "summary": "Returns the value of a key from the specified namespace.",
             "params": {
                 "type": "object",
                 "properties": {
@@ -192,11 +192,11 @@
             }
         },
         "setValue": {
-            "summary": "Sets the value of a key in the the specified namespace.\n \n### Events \n| Event | Description | \n| :----------- | :----------- |\n| `onStorageExceeded`| Triggered if the storage size has surpassed 1 MB storage size|\n| `onValueChanged` | Triggered whenever any of the values stored are changed using setValue |",
-            "events": [
-                "onStorageExceeded",
-                "onValueChanged"
-            ],
+            "summary": "Sets the value of a key in the the specified namespace.",
+            "events": {
+                "onStorageExceeded" : "Triggered if the storage size has surpassed 1 MB storage size",
+                "onValueChanged" : "Triggered whenever any of the values stored are changed using setValue"
+            },
             "params": {
                 "type": "object",
                 "properties": {

--- a/PlayerInfo/PlayerInfo.json
+++ b/PlayerInfo/PlayerInfo.json
@@ -95,7 +95,7 @@
     },
     "methods": {
         "audiocodecs": {
-            "summary": "Returns the audio codec supported by the platform. \n \n### Events \n \nNo Events.",
+            "summary": "Returns the audio codec supported by the platform.",
             "result": {
                 "type":"array",
                 "items": {
@@ -119,7 +119,7 @@
             }
         },
         "videocodecs": {
-            "summary": "Returns the video codec supported by the platform.\n \n### Events \n \nNo Events.",
+            "summary": "Returns the video codec supported by the platform.",
             "result": {
                 "type":"array",
                 "items": {

--- a/RDKShell/RDKShell.json
+++ b/RDKShell/RDKShell.json
@@ -132,7 +132,7 @@
     },
     "methods": {
         "addAnimation":{
-            "summary": "Performs the set of animations. \n \n### Events\n \n No Events.",
+            "summary": "Performs the set of animations.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -212,7 +212,7 @@
             }
         },
         "addKeyIntercept":{
-            "summary": "Adds a key intercept to the client application specified. The keys are specified by a key code and a set of modifiers. Regardless of the application that has focus, key presses that match the key code and modifiers will be sent to the client application. \n \n### Events\n \n No Events.",
+            "summary": "Adds a key intercept to the client application specified. The keys are specified by a key code and a set of modifiers. Regardless of the application that has focus, key presses that match the key code and modifiers will be sent to the client application.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -242,7 +242,7 @@
             }
         },
         "addKeyIntercepts": {
-            "summary": "Adds the list of key intercepts. \n \n### Events\n \n No Events.",
+            "summary": "Adds the list of key intercepts.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -291,7 +291,7 @@
             }
         },
         "addKeyListener":{
-            "summary": "Adds a key listener to an application. The keys are bubbled up based on their z-order. \n \n### Events\n \n No Events.",
+            "summary": "Adds a key listener to an application. The keys are bubbled up based on their z-order.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -350,7 +350,7 @@
             }
         },
         "addKeyMetadataListener": {
-            "summary": "Adds the key metadata listeners. \n \n### Events\n \n No Events.",
+            "summary": "Adds the key metadata listeners.",
             "params": {
                 "type": "object",
                 "properties":{
@@ -374,7 +374,7 @@
             }
         },
         "createDisplay": {
-            "summary": " Creates a display for the specified client using the configuration parameters. \n \n### Events\n \n No Events.",
+            "summary": " Creates a display for the specified client using the configuration parameters.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -440,8 +440,10 @@
             }
         },
         "destroy":{
-            "summary": "Destroys an application. \n \n### Events \n| Event | Description | \n| :----------- | :----------- |\n| `OnDestroyed` | Triggers when a runtime is successfully destroyed |",
-            "events": ["onDestroyed"],
+            "summary": "Destroys an application.",
+            "events": {
+                "onDestroyed" : "Triggers when a runtime is successfully destroyed"
+            },
             "params": {
                 "type": "object",
                 "properties": {
@@ -458,7 +460,7 @@
             }
         },
         "enableInactivityReporting":{
-            "summary": "Enables or disables inactivity reporting and events. \n \n### Events\n \n No Events.",
+            "summary": "Enables or disables inactivity reporting and events.",
             "params": {
                 "type": "object",
                 "properties": {
@@ -477,7 +479,7 @@
             }
         },
         "enableKeyRepeats": {
-            "summary": "Enables or disables key repeats. \n \n### Events\n \n No Events.",
+            "summary": "Enables or disables key repeats.",
             "params": {
                 "type": "object",
                 "properties": {
@@ -496,7 +498,7 @@
             }            
         },
         "enableLogsFlushing": {
-            "summary": "Enables or disables flushing all logs. \n \n### Events\n \n No Events.",
+            "summary": "Enables or disables flushing all logs.",
             "params": {
                 "type": "object",
                 "properties": {
@@ -515,7 +517,7 @@
             }            
         },
         "enableVirtualDisplay":{
-            "summary": "Enables or disables a virtual display for the specified client. \n \n### Events\n \n No Events.",
+            "summary": "Enables or disables a virtual display for the specified client.",
             "params": {
                 "type": "object",
                 "properties": {
@@ -543,7 +545,7 @@
             }
         },
         "generateKey": {
-            "summary": "Triggers the key events (key press and release). \n \n### Events\n \n No Events.",
+            "summary": "Triggers the key events (key press and release).",
             "params": {
                 "type":"object",
                 "properties": {
@@ -590,7 +592,7 @@
             }
         },
         "getAvailableTypes": {
-            "summary": "Returns the list of application types available on the firmware. \n \n### Events\n \n No Events.",
+            "summary": "Returns the list of application types available on the firmware.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -613,7 +615,7 @@
             }
         },
         "getBounds": {
-            "summary": "Gets the bounds of the specified client. \n \n### Events\n \n No Events.",
+            "summary": "Gets the bounds of the specified client.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -667,7 +669,7 @@
             }    
         },
         "getClients": {
-            "summary": "Gets a list of clients. \n \n### Events\n \n No Events.",
+            "summary": "Gets a list of clients.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -685,7 +687,7 @@
             }
         },
         "getCursorSize": {
-            "summary": "Returns the currently set cursor size. \n \n### Events\n \n No Events.",
+            "summary": "Returns the currently set cursor size.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -707,7 +709,7 @@
             }
         },
         "getHolePunch": {
-            "summary": "Returns whether video hole punching is enabled or disabled for the specified client. \n \n### Events\n \n No Events.",
+            "summary": "Returns whether video hole punching is enabled or disabled for the specified client.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -741,7 +743,7 @@
             }
         },
         "getKeyRepeatsEnabled": {
-            "summary": "Returns whether key repeating is enabled or disabled. \n \n### Events\n \n No Events.",
+            "summary": "Returns whether key repeating is enabled or disabled.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -761,7 +763,7 @@
             }
         },
         "getLastWakeupKey": {
-            "summary": "Returns the last key press prior to a device wakeup. \n \n### Events\n \n No Events.",
+            "summary": "Returns the last key press prior to a device wakeup.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -789,7 +791,7 @@
             }   
         },
         "getLogLevel": {
-            "summary": "Returns the currently set logging level. \n \n### Events\n \n No Events.",
+            "summary": "Returns the currently set logging level.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -807,7 +809,7 @@
             }
         },
         "getLogsFlushingEnabled": {
-            "summary": "Returns whether log flushing is enabled or disabled. \n \n### Events\n \n No Events.",
+            "summary": "Returns whether log flushing is enabled or disabled.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -827,7 +829,7 @@
             }
         },
         "getOpacity":{
-            "summary": "Gets the opacity of the specified client. \n \n### Events\n \n No Events.",
+            "summary": "Gets the opacity of the specified client.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -856,7 +858,7 @@
             }
         },
         "getScale":{
-            "summary": "Returns the scale of an application. \n \n### Events\n \n No Events.",
+            "summary": "Returns the scale of an application.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -893,7 +895,7 @@
             }
         },
         "getScreenResolution":{
-            "summary": "Gets the screen resolution. \n \n### Events\n \n No Events.",
+            "summary": "Gets the screen resolution.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -915,14 +917,16 @@
             }
         },
         "getScreenshot": {
-            "summary": "Captures a screenshot. \n \n### Events \n| Event | Description | \n| :----------- | :----------- |\n| `onScreenshotComplete` | Triggers when a screenshot is captured successfully |",
-            "events": ["onScreenshotComplete"],
+            "summary": "Captures a screenshot.",
+            "events": {
+                "onScreenshotComplete" : "Triggers when a screenshot is captured successfully"
+            },
             "result":{
                 "$ref": "#/common/result"
             }
         },
         "getState":{
-            "summary": "Returns the state of all applications.\n \n### Events\n \n No Events.",
+            "summary": "Returns the state of all applications.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -962,7 +966,7 @@
             }
         },
         "getSystemMemory": {
-            "summary": "Gets the information of System Memory. \n \n### Events\n \n No Events.",
+            "summary": "Gets the information of System Memory.",
             "result": {
                 "type":"object",
                 "properties": {
@@ -994,7 +998,7 @@
             }
         },
         "getSystemResourceInfo":{
-            "summary": "Returns system resource information about each application. \n \n### Events\n \n No Events.",
+            "summary": "Returns system resource information about each application.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -1036,7 +1040,7 @@
             }
         },
         "getVirtualDisplayEnabled":{
-            "summary": "Returns whether virtual display is enabled or disabled for the specified client. \n \n### Events\n \n No Events.",
+            "summary": "Returns whether virtual display is enabled or disabled for the specified client.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1072,7 +1076,7 @@
             }
         },
         "getVirtualResolution": {
-            "summary": "Returns the virtual display resolution for the specified client.\n \n### Events\n \n No Events.",
+            "summary": "Returns the virtual display resolution for the specified client.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1110,7 +1114,7 @@
             }
         },
         "getVisibility":{
-            "summary": "Gets the visibility of the specified client. \n \n### Events\n \n No Events.",
+            "summary": "Gets the visibility of the specified client.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1146,7 +1150,7 @@
             }
         },
         "getZOrder":{
-            "summary": "Returns an array of clients in Z order, starting with the top most application client first. \n \n### Events\n \n No Events.",
+            "summary": "Returns an array of clients in Z order, starting with the top most application client first.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -1182,7 +1186,7 @@
             }
         },
         "hideAllClients": {
-            "summary": "Hides/Unhides all the clients. \n \n### Events\n \n No Events.",
+            "summary": "Hides/Unhides all the clients.",
             "params": {
                 "type": "object",
                 "properties":{
@@ -1198,19 +1202,19 @@
             }
         },
         "hideCursor": {
-            "summary": "Hides the cursor from showing on the display. The cursor is hidden by default. \n \n### Events\n \n No Events.",
+            "summary": "Hides the cursor from showing on the display. The cursor is hidden by default.",
             "result": {
                 "$ref": "#/common/result"
             }
         },
         "hideFullScreenImage":{
-            "summary": "Hides the Full Screen Image. \n \n### Events\n \n No Events.",
+            "summary": "Hides the Full Screen Image.",
             "result": {
                 "$ref": "#/common/result"
             }
         },
         "hideSplashLogo": {
-            "summary": "Removes the splash screen. \n \n### Events\n \n No Events.",
+            "summary": "Removes the splash screen.",
             "result": {
                 "$ref": "#/common/result"
             }
@@ -1235,7 +1239,7 @@
             }
         },
         "injectKey": {
-            "summary": "Injects the keys. \n \n### Events\n \n No Events.",
+            "summary": "Injects the keys.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1256,7 +1260,7 @@
             }
         },
         "kill": {
-            "summary": "Kills the specified client. \n \n### Events\n \n No Events.",
+            "summary": "Kills the specified client.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1278,8 +1282,10 @@
             }
         },
         "launch":{
-            "summary": "Launches an application. \n \n### Events \n| Event | Description | \n| :----------- | :----------- |\n| `onLaunched` | Triggers when the runtime of an application is launched successfully |",
-            "events": ["onLaunched"],
+            "summary": "Launches an application.",
+            "events": {
+                "onLaunched" : "Triggers when the runtime of an application is launched successfull"
+            },
             "params": {
                 "type": "object",
                 "properties": {
@@ -1390,8 +1396,10 @@
             }
         },
         "launchApplication": {
-            "summary": "Launches an application. \n \n### Events \n| Event | Description | \n| :----------- | :----------- |\n| `onApplicationLaunched` | Triggers when an application is launched successfully |.",
-            "events": ["onApplicationLaunched"],
+            "summary": "Launches an application.",
+            "events": {
+                "onApplicationLaunched" : "Triggers when an application is launched successfully"
+            },
             "params": {
                 "type": "object",
                 "properties":{
@@ -1432,13 +1440,13 @@
             }
         },
         "launchResidentApp": {
-            "summary": "Launches the Resident application. \n \n### Events\n \n No Events.",
+            "summary": "Launches the Resident application.",
             "result": {
                 "$ref": "#/common/result"
             }
         },
         "moveBehind":{
-            "summary": "Moves the specified client behind the specified target client. \n \n### Events\n \n No Events.",
+            "summary": "Moves the specified client behind the specified target client.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1461,7 +1469,7 @@
             }
         },
         "moveToBack":{
-            "summary": "Moves the specified client to the back or bottom of the Z order. \n \n### Events\n \n No Events.",
+            "summary": "Moves the specified client to the back or bottom of the Z order.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1483,7 +1491,7 @@
             }
         },
         "moveToFront": {
-            "summary": "Moves the specified client to the front or top of the Z order. \n \n### Events\n \n No Events.",
+            "summary": "Moves the specified client to the front or top of the Z order.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1505,19 +1513,19 @@
             }
         },
         "removeAllKeyIntercepts": {
-            "summary": "Removes all key intercepts. \n \n### Events\n \n No Events.",
+            "summary": "Removes all key intercepts.",
             "result": {
                 "$ref": "#/common/result"
             }            
         },
         "removeAllKeyListeners": {
-            "summary": "Removes all key listeners. \n \n### Events\n \n No Events.",
+            "summary": "Removes all key listeners.",
             "result": {
                 "$ref": "#/common/result"
             }            
         },
         "removeAnimation":{
-            "summary": "Removes the current animation for the specified client. \n \n### Events\n \n No Events.",
+            "summary": "Removes the current animation for the specified client.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1539,7 +1547,7 @@
             }
         },
         "removeKeyIntercept": {
-            "summary": "Removes a key intercept. \n \n### Events\n \n No Events.",
+            "summary": "Removes a key intercept.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1564,7 +1572,7 @@
             }
         },
         "removeKeyListener": {
-            "summary": "Removes a key listener for an application. \n \n### Events\n \n No Events.",
+            "summary": "Removes a key listener for an application.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1606,7 +1614,7 @@
             }
         },
         "removeKeyMetadataListener":{
-            "summary": "Removes the key metadata listeners. \n \n### Events\n \n No Events.",
+            "summary": "Removes the key metadata listeners.",
             "params": {
                 "type": "object",
                 "properties":{
@@ -1630,14 +1638,16 @@
             }
         },
         "resetInactivityTime":{
-            "summary": "Resets the inactivity notification interval. \n \n### Events\n \n No Events.",
+            "summary": "Resets the inactivity notification interval.",
             "result": {
                 "$ref": "#/common/result"
             }
         },
         "resumeApplication": {
-            "summary": "Resumes an application. \n \n### Events \n| Event | Description | \n| :----------- | :----------- |\n| `onApplicationResumed` | Triggers when an application resumes from a suspended state |.",
-            "events": ["onApplicationResumed"],
+            "summary": "Resumes an application.",
+            "events": {
+                "onApplicationResumed" : "Triggers when an application resumes from a suspended state"
+            },
             "params": {
                 "type": "object",
                 "properties":{
@@ -1653,7 +1663,7 @@
             }
         },
         "scaleToFit": {
-            "summary": "Scales the specified client to fit the current bounds. \n \n### Events\n \n No Events.",
+            "summary": "Scales the specified client to fit the current bounds.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1691,7 +1701,7 @@
             }
         },
         "setBounds": {
-            "summary": "Sets the bounds of the specified client. \n \n### Events\n \n No Events.",
+            "summary": "Sets the bounds of the specified client.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1729,7 +1739,7 @@
             }
         },
         "setCursorSize": {
-            "summary": "Sets the cursor size. \n \n### Events\n \n No Events.",
+            "summary": "Sets the cursor size.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1750,7 +1760,7 @@
             }
         },
         "setFocus": {
-            "summary": "Sets focus to the specified client. \n \n### Events\n \n No Events.",
+            "summary": "Sets focus to the specified client.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1772,7 +1782,7 @@
             }
         },
         "setHolePunch": {
-            "summary": "Enables or disables video hole punching for the specified client. \n \n### Events\n \n No Events.",
+            "summary": "Enables or disables video hole punching for the specified client.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1798,8 +1808,10 @@
             }
         },
         "setInactivityInterval": {
-            "summary": "Sets the inactivity notification interval. \n \n### Events \n| Event | Description | \n| :----------- | :----------- |\n| `onUserInactivity` | Triggers only if the device is inactive for the specified time interval |.",
-            "events": ["onUserInactivity"],
+            "summary": "Sets the inactivity notification interval.",
+            "events": {
+                "onUserInactivity" : "Triggers only if the device is inactive for the specified time interval"
+            },
             "params": {
                 "type":"object",
                 "properties": {
@@ -1818,7 +1830,7 @@
             }
         },
         "setLogLevel":{
-            "summary": "Sets the logging level. \n \n### Events\n \n No Events.",
+            "summary": "Sets the logging level.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1835,7 +1847,7 @@
             }
         },
         "setMemoryMonitor":{
-            "summary": "Enables or disables RAM memory monitoring on the device. Upon enabling, triggers possible events are onDeviceLowRamWarning, onDeviceCriticallyLowRamWarning, onDeviceLowRamWarningCleared, and onDeviceCriticallyLowRamWarningCleared. \n \n### Events\n \n No Events.",
+            "summary": "Enables or disables RAM memory monitoring on the device. Upon enabling, triggers possible events are onDeviceLowRamWarning, onDeviceCriticallyLowRamWarning, onDeviceLowRamWarningCleared, and onDeviceCriticallyLowRamWarningCleared.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1872,7 +1884,7 @@
             }
         },
         "setOpacity":{
-            "summary": "Sets the opacity of the specified client. \n \n### Events\n \n No Events.",
+            "summary": "Sets the opacity of the specified client.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1893,7 +1905,7 @@
             }
         },
         "setScale": {
-            "summary": "Scales an application. \n \n### Events\n \n No Events.",
+            "summary": "Scales an application.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1923,7 +1935,7 @@
             }
         },
         "setScreenResolution": {
-            "summary": "Sets the screen resolution. \n \n### Events\n \n No Events.",
+            "summary": "Sets the screen resolution.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1944,7 +1956,7 @@
             }
         },
         "setTopmost":{
-            "summary": "Sets whether the specified client appears above all other clients on the display. \n \n### Events\n \n No Events.",
+            "summary": "Sets whether the specified client appears above all other clients on the display.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1972,7 +1984,7 @@
             }
         },
         "setVirtualResolution": {
-            "summary": "Sets the virtual resolution for the specified client. \n \n### Events\n \n No Events.",
+            "summary": "Sets the virtual resolution for the specified client.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1999,7 +2011,7 @@
             }
         },
         "setVisibility":{
-            "summary": "Sets whether the specified client should be visible. \n \n### Events\n \n No Events.",
+            "summary": "Sets whether the specified client should be visible.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -2025,7 +2037,7 @@
             }
         },
         "setGraphicsFrameRate":{
-            "summary": "Set Graphics Frame Rate.. \n \n### Events\n \n No Events.",
+            "summary": "Set Graphics Frame Rate.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -2044,13 +2056,13 @@
             }
         },
         "showCursor": {
-            "summary": "Shows the cursor on the display using the current cursor size. See `setCursorSize`. The cursor automatically disappears after 5 seconds of inactivity. \n \n### Events\n \n No Events.",
+            "summary": "Shows the cursor on the display using the current cursor size. See `setCursorSize`. The cursor automatically disappears after 5 seconds of inactivity.",
             "result": {
                 "$ref": "#/common/result"
             }
         },
         "showFullScreenImage": {
-            "summary": "Shows the Full Screen Image. \n \n### Events\n \n No Events.",
+            "summary": "Shows the Full Screen Image.",
             "params": {
                 "type": "object",
                 "properties":{
@@ -2066,7 +2078,7 @@
             }
         },
         "showSplashLogo": {
-            "summary": "Displays the splash screen. \n \n### Events\n \n No Events.",
+            "summary": "Displays the splash screen.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -2085,7 +2097,7 @@
             }
         },
         "showWatermark": {
-            "summary": "Sets whether a watermark shows on the display. \n \n### Events\n \n No Events.",
+            "summary": "Sets whether a watermark shows on the display.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -2104,8 +2116,10 @@
             }
         },
         "suspend": {
-            "summary": "Suspends an application. \n \n### Events \n| Event | Description | \n| :----------- | :----------- |\n| `onSuspended` | Triggers when the runtime of an application is suspended |",
-            "events": ["onSuspended"],
+            "summary": "Suspends an application.",
+            "events": {
+                "onSuspended" : "Triggers when the runtime of an application is suspended"
+            },
             "params": {
                 "type":"object",
                 "properties": {
@@ -2122,8 +2136,10 @@
             }
         },
         "suspendApplication": {
-            "summary": "Suspends an application. \n \n### Events \n| Event | Description | \n| :----------- | :----------- |\n| `onApplicationSuspended` | Triggers when an application is suspended |.",
-            "events": ["onApplicationSuspended"],
+            "summary": "Suspends an application.",
+            "events": {
+                "onApplicationSuspended" : "Triggers when an application is suspended"
+            },
             "params": {
                 "type": "object",
                 "properties":{
@@ -2139,7 +2155,7 @@
             }
         },
         "keyRepeatConfig": {
-            "summary": "Customizes key repeats. \n \n### Events\n \n No Events.",
+            "summary": "Customizes key repeats.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -2171,11 +2187,11 @@
                 ]
             },
             "result": {
-                "$ref": "#/definitions/result"
+                "$ref": "#/common/result"
             }
         },
         "setAVBlocked": {
-            "summary": "adds/removes the list of applications with the given callsigns to/from the blacklist.\n \n### Events\n \n No Events.",
+            "summary": "adds/removes the list of applications with the given callsigns to/from the blacklist.",
             "params": {
                 "type": "object",
                 "properties":{
@@ -2200,7 +2216,7 @@
             }
         },
         "getBlockedAVApplications": {
-            "summary": "Gets a list of blacklisted clients. \n \n### Events\n \n No Events.",
+            "summary": "Gets a list of blacklisted clients.",
             "result": {
                 "type": "object",
                 "properties": {

--- a/RemoteActionMapping/RemoteActionMapping.json
+++ b/RemoteActionMapping/RemoteActionMapping.json
@@ -63,7 +63,7 @@
     },
     "methods":{
         "cancelCodeDownload": {
-            "summary": "Cancels downloading IR and five digit codes from the IRRF database.\n \n### Events \n\n No Events.",
+            "summary": "Cancels downloading IR and five digit codes from the IRRF database.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -92,7 +92,7 @@
             }
         },
         "clearKeyActionMapping":{
-            "summary": "Clears an action mapping for the specified keys.\n \n### Events \n\n No Events.",
+            "summary": "Clears an action mapping for the specified keys.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -133,7 +133,7 @@
             }
         },
        "getApiVersionNumber":{
-            "summary": "Returns the API version number.\n \n### Events \n\n No Events.",
+            "summary": "Returns the API version number.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -153,7 +153,7 @@
             }
        },
         "getFullKeyActionMapping": {
-            "summary": "Returns the mapping of all action keys.\n \n### Events \n\n No Events.",
+            "summary": "Returns the mapping of all action keys.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -214,7 +214,7 @@
             }
         },
         "getKeymap": {
-            "summary": "Returns a hard-coded list of key names.\n \n### Events \n\n No Events.",
+            "summary": "Returns a hard-coded list of key names.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -251,7 +251,7 @@
             }
         },
         "getLastUsedDeviceID":{
-            "summary": "Returns the last used remote information.\n \n### Events \n\n No Events.",
+            "summary": "Returns the last used remote information.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -291,7 +291,7 @@
             }
         },
         "getSingleKeyActionMapping":{
-            "summary": "Returns the mapping for a single action key.\n \n### Events \n\n No Events.",
+            "summary": "Returns the mapping for a single action key.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -353,10 +353,10 @@
             }
         },
         "setFiveDigitCode":{
-            "summary": "Sets the TV and AVR five digit code.\n \nEvents\n \n| Event | Description | \n| :-------- | :-------- | \n| `onFiveDigitCodeLoad` | Triggered if new five digit codes are loaded successfully |",
-            "events": [
-                "onFiveDigitCodeLoad"
-            ],
+            "summary": "Sets the TV and AVR five digit code.",
+            "events": {
+                "onFiveDigitCodeLoad" : "Triggered if new five digit codes are loaded successfully"
+            },
             "params": {
                 "type":"object",
                 "properties": {
@@ -397,10 +397,10 @@
             }
         },
         "setKeyActionMapping": {
-            "summary": "Sets the mapping of a single action key. This method is unavailable (returns error) if the remote supports 5 digit codes.\n \nEvents\n \n| Event | Description | \n| :-------- | :-------- | \n| `onIRCodeLoad` | Triggered if new IR codes are loaded successfully |",
-            "events": [
-                "onIRCodeLoad"
-            ],
+            "summary": "Sets the mapping of a single action key. This method is unavailable (returns error) if the remote supports 5 digit codes.",
+            "events": {
+                "onIRCodeLoad" : "Triggered if new IR codes are loaded successfully"
+            },
             "params": {
                 "type":"object",
                 "properties": {

--- a/ScreenCapture/ScreenCapture.json
+++ b/ScreenCapture/ScreenCapture.json
@@ -14,8 +14,10 @@
     },
     "methods":{
         "uploadScreenCapture":{
-            "summary": "Takes a screenshot and uploads it to the specified URL. A screenshot is uploaded using raw HTTP POST request as binary image/png data. It's the same as running the following command:  \n`wget -d -q -O - --header='Content-Type: application/octet-stream' --post-file=/path/to/screenshot.png http://server/cgi-bin/upload.cgi`  \nor,  \n`curl -F image=@/path/to/screenshot.png http://server/cgi-bin/upload.cgi`  \nFor implementation details, see `bool ScreenCapture::uploadDataToUrl(std::vector<unsigned char> &data, const char *url, std::string &error_str)`.\n \nEvents\n \n| Event | Description | \n| :-------- | :-------- | \n| `uploadComplete` | Triggered after uploading a screen capture with status and message |",
-            "events": ["uploadComplete"],
+            "summary": "Takes a screenshot and uploads it to the specified URL. A screenshot is uploaded using raw HTTP POST request as binary image/png data. It's the same as running the following command:  \n`wget -d -q -O - --header='Content-Type: application/octet-stream' --post-file=/path/to/screenshot.png http://server/cgi-bin/upload.cgi`  \nor,  \n`curl -F image=@/path/to/screenshot.png http://server/cgi-bin/upload.cgi`  \nFor implementation details, see `bool ScreenCapture::uploadDataToUrl(std::vector<unsigned char> &data, const char *url, std::string &error_str)`.",
+            "events": {
+                "uploadComplete" : "Triggered after uploading a screen capture with status and message"
+            },
             "params": {
                 "type":"object",
                 "properties": {

--- a/StateObserver/StateObserver.json
+++ b/StateObserver/StateObserver.json
@@ -46,7 +46,7 @@
     },
     "methods": {
         "getApiVersionNumber":{
-            "summary": "Returns the API version number.\n \n### Events \n\n No Events.",
+            "summary": "Returns the API version number.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -64,7 +64,7 @@
             }
         },
         "getName": {
-            "summary": "Returns the plugin name.\n \n### Events \n\n No Events.",
+            "summary": "Returns the plugin name.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -84,7 +84,7 @@
             }
         },
         "getRegisteredPropertyNames": {
-            "summary": "Returns all properties which have active listeners.\n \n### Events \n\n No Events.",
+            "summary": "Returns all properties which have active listeners.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -107,7 +107,7 @@
             }
         },
         "getValues": {
-            "summary": "Returns the values and errors for the specified properties.  \n**Error Code of Properties**  \n* `com.comcast.channel_map` - RDK-03005  \n* `com.comcast.card.disconnected` - RDK-03007  \n* `com.comcast.cmac` - RDK-03002  \n* `com.comcast.time_source` - RDK-03006  \n* `com.comcast.estb_ip` - RDK-03009  \n* `com.comcast.ecm_ip` - RDK-03004  \n* `com.comcast.dsg_ca_tunnel` - RDK-03003  \n* `com.comcast.cable_card` - RDK-03001.\n \n### Events \n\n No Events.",
+            "summary": "Returns the values and errors for the specified properties.  \n**Error Code of Properties**  \n* `com.comcast.channel_map` - RDK-03005  \n* `com.comcast.card.disconnected` - RDK-03007  \n* `com.comcast.cmac` - RDK-03002  \n* `com.comcast.time_source` - RDK-03006  \n* `com.comcast.estb_ip` - RDK-03009  \n* `com.comcast.ecm_ip` - RDK-03004  \n* `com.comcast.dsg_ca_tunnel` - RDK-03003  \n* `com.comcast.cable_card` - RDK-03001.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -156,7 +156,7 @@
             }
         },
         "registerListeners":{
-            "summary": "Register a listener on the specified properties for value change notifications. These properties are added to a registered properties list. Internally, this method calls the `getValues` method and hence it returns the current value of those properties.\n \n### Events \n\n No Events.",
+            "summary": "Register a listener on the specified properties for value change notifications. These properties are added to a registered properties list. Internally, this method calls the `getValues` method and hence it returns the current value of those properties.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -205,7 +205,7 @@
             }    
         },         
         "setApiVersionNumber": {
-            "summary": "Sets the API version number.\n \n### Events \n\n No Events.",
+            "summary": "Sets the API version number.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -222,7 +222,7 @@
             }
         },
         "unregisterListeners": {
-            "summary": "Removes the listeners on the specified properties. The properties are removed from the registered properties list.\n \n### Events \n\n No Events.",
+            "summary": "Removes the listeners on the specified properties. The properties are removed from the registered properties list.",
             "params": {
                 "type":"object",
                 "properties": {

--- a/SystemAudioPlayer/SystemAudioPlayer.json
+++ b/SystemAudioPlayer/SystemAudioPlayer.json
@@ -18,7 +18,7 @@
     },
     "methods": {
         "close": {
-            "summary": "Closes the system audio player with the specified ID. The `SystemAudioPlayer` plugin destroys the player object. That is, if the player is playing, then it is stopped and closed. All volume mixer level settings are restored. \n\n Also See: [open](#method.open).\n \n### Events \n\n No Events.",
+            "summary": "Closes the system audio player with the specified ID. The `SystemAudioPlayer` plugin destroys the player object. That is, if the player is playing, then it is stopped and closed. All volume mixer level settings are restored. \n\n Also See: [open](#method.open).",
             "params": {
                 "type": "object",
                 "properties": {
@@ -35,7 +35,7 @@
             }
         },
         "config": {
-            "summary": "Configures playback for a PCM audio source (audio/x-raw) on the specified player. This method must be called before the [play](#method.play) method. There may be more optional configuration parameters added in the future for PCM as well as for other audio types. Supported audio/x-raw configuration parameters can be found at https://gstreamer.freedesktop.org/documentation/rawparse/rawaudioparse.html#src.\n \n### Events \n\n No Events.",
+            "summary": "Configures playback for a PCM audio source (audio/x-raw) on the specified player. This method must be called before the [play](#method.play) method. There may be more optional configuration parameters added in the future for PCM as well as for other audio types. Supported audio/x-raw configuration parameters can be found at https://gstreamer.freedesktop.org/documentation/rawparse/rawaudioparse.html#src.",
             "params": {
                 "type": "object",
                 "properties": {
@@ -106,7 +106,7 @@
             }
         },
         "getPlayerSessionId": {
-            "summary": "Gets the session ID from the provided the URL. The session is the ID returned in open cal. \n \n### Events \n\n No Events ",
+            "summary": "Gets the session ID from the provided the URL. The session is the ID returned in open cal.",
             "params": {
                 "type": "object",
                 "properties": {
@@ -137,7 +137,7 @@
             }
         },
         "isspeaking": {
-            "summary": "Checks if playback is in progress.\n \n### Events \n\n No Events.",
+            "summary": "Checks if playback is in progress.",
             "params": {
                 "type": "object",
                 "properties": {
@@ -154,7 +154,7 @@
             }
         },
         "open": {
-            "summary": "Opens a player instance and assigns it a unique ID. The player ID is used to reference the player when calling other methods.  \n\n**Note**: The `SystemAudioPlayer` plugin can have a maximum of 1 system and 1 application play mode player at a time.  \n\nAlso See: [close](#method.close).\n \n### Events \n\n No Events.",
+            "summary": "Opens a player instance and assigns it a unique ID. The player ID is used to reference the player when calling other methods.  \n\n**Note**: The `SystemAudioPlayer` plugin can have a maximum of 1 system and 1 application play mode player at a time.  \n\nAlso See: [close](#method.close).",
             "params": {
                 "type": "object",
                 "properties": {
@@ -212,10 +212,10 @@
             }
         },
         "pause": {
-            "summary": "Pauses playback on the specified player. Pause is only supported for HTTP and file source types.\n \n### Events \n| Event | Description | \n| :----------- | :----------- |\n| `onsapevents:PLAYBACK_PAUSED`| Triggered if the playback paused on the specified player.|",
-            "events": [
-                "onsapevents"
-            ],
+            "summary": "Pauses playback on the specified player. Pause is only supported for HTTP and file source types.",
+            "events": {
+                "onsapevents" : "Triggered if the playback paused on the specified player."
+            },
             "params": {
                 "type": "object",
                 "properties": {
@@ -232,10 +232,10 @@
             }
         },
         "play": {
-            "summary": "Plays audio on the specified player.  \n\n**Note**: If a player is using one play mode and another player tries to play audio using the same play mode, then an error returns indicating that the hardware resource has already been acquired by the session and includes the player ID.\n \n### Events \n| Event | Description | \n| :----------- | :----------- |\n| `onsapevents:PLAYBACK_STARTED`| Triggered if the playback is started to play on the specified player.|\n| `onsapevents:PLAYBACK_FINISHED`| Triggered if the playback is finished  normally on the specified player.|",
-            "events": [
-                "onsapevents"
-            ],
+            "summary": "Plays audio on the specified player.  \n\n**Note**: If a player is using one play mode and another player tries to play audio using the same play mode, then an error returns indicating that the hardware resource has already been acquired by the session and includes the player ID.",
+            "events": {
+                "onsapevents" : "Triggered if the playback is started to play or finished normally on the specified player."
+            },
             "params": {
                 "type": "object",
                 "properties": {
@@ -258,10 +258,10 @@
             }
         },
         "playbuffer": {
-            "summary": "Buffers the audio playback on the specified player.\n \n### Events \n| Event | Description | \n| :----------- | :----------- |\n| `onsapevents:NEED_DATA`| Triggered if  the buffer needs more data to play|",
-            "events": [
-                "onsapevents"
-            ],
+            "summary": "Buffers the audio playback on the specified player.",
+            "events": {
+                "onsapevents" : "Triggered if the buffer needs more data to play."
+            },
             "params": {
                 "type": "object",
                 "properties": {
@@ -284,10 +284,10 @@
             }
         },
         "resume": {
-            "summary": "Resumes playback on the specified player. Resume is only supported for HTTP and file source types.\n \n### Events \n| Event | Description | \n| :----------- | :----------- |\n| `onsapevents:PLAYBACK_RESUMED`| Triggered if the playback resumed on the specified player.|",
-            "events": [
-                "onsapevents"
-            ],
+            "summary": "Resumes playback on the specified player. Resume is only supported for HTTP and file source types.",
+            "events": {
+                "onsapevents" : "Triggered if the playback resumed on the specified player."
+            },
             "params": {
                 "type": "object",
                 "properties": {
@@ -304,7 +304,7 @@
             }
         },
         "setMixerLevels": {
-            "summary": "Sets the audio level on the specified player. The `SystemAudioPlayer` plugin can control the volume of the content being played back as well as the primary program audio; thus, an application can duck down the volume on the primary program audio when system audio is played and then restore it back when the system audio playback is complete.\n \n### Events \n\n No Events.",
+            "summary": "Sets the audio level on the specified player. The `SystemAudioPlayer` plugin can control the volume of the content being played back as well as the primary program audio; thus, an application can duck down the volume on the primary program audio when system audio is played and then restore it back when the system audio playback is complete.",
             "params": {
                 "type": "object",
                 "properties": {
@@ -333,7 +333,7 @@
             }
         },
         "setSmartVolControl": {
-            "summary": "Sets the smart volume audio control on the specified player. The plugin can control the smart volume of the content being played back as well as the primary program audio; thus, an application can duck down the volume on the primary program audio when system audio is played and then restore it back when the system audio playback is complete.\n \n### Events \n\n No Events.",
+            "summary": "Sets the smart volume audio control on the specified player. The plugin can control the smart volume of the content being played back as well as the primary program audio; thus, an application can duck down the volume on the primary program audio when system audio is played and then restore it back when the system audio playback is complete.",
             "params": {
                 "type": "object",
                 "properties": {
@@ -380,7 +380,7 @@
             }
         },
         "stop": {
-            "summary": "Stops playback on the specified player.\n \n### Events \n\n No Events.",
+            "summary": "Stops playback on the specified player.",
             "params": {
                 "type": "object",
                 "properties": {

--- a/SystemServices/System.json
+++ b/SystemServices/System.json
@@ -285,7 +285,8 @@
     "methods": {
         "cacheContains": {
             "deprecated" : true,
-            "summary": "Checks if a key is present in the cache.\n \n### Events\n \n No Events.",
+            "referenceUrl" : " https://rdkcentral.github.io/rdkservices/#/api/PersistentStorePlugin?id=getvalue",
+            "summary": "Checks if a key is present in the cache.",
             "params": {
                 "type": "object",
                 "properties": {
@@ -302,13 +303,13 @@
             }
         },
         "clearLastDeepSleepReason":{
-            "summary": "Clears the last deep sleep reason.\n \n### Events\n \n No Events.",
+            "summary": "Clears the last deep sleep reason.",
             "result": {
                 "$ref": "#/common/result"
             }
         },
         "deletePersistentPath": {
-            "summary": "(Version 2) Deletes persistent path associated with a callsign.\n \n### Events\n \n No Events.",
+            "summary": "(Version 2) Deletes persistent path associated with a callsign.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -332,7 +333,7 @@
             }
         },
         "enableMoca":{
-            "summary": "Enables (or disables) Moca support for the platform.\n \n### Events\n \n No Events.",
+            "summary": "Enables (or disables) Moca support for the platform.",
             "params": {
                 "type": "object",
                 "properties": {
@@ -351,7 +352,7 @@
             }
         },
         "enableXREConnectionRetention":{
-            "summary": "Enables (or disables) XRE Connection Retention option.\n \n### Events\n \n No Events.",
+            "summary": "Enables (or disables) XRE Connection Retention option.",
             "params": {
                 "type": "object",
                 "properties": {
@@ -370,16 +371,16 @@
             }
         },
         "fireFirmwarePendingReboot":{
-            "summary": "(Version 2) Notifies the device about a pending reboot.\n \n### Events \n| Event | Description | \n| :----------- | :----------- |\n| `onFirmwarePendingReboot` | Triggers when the firmware has a pending reboot |",
-            "events": [
-                "onFirmwarePendingReboot"
-            ],
+            "summary": "(Version 2) Notifies the device about a pending reboot.",
+            "events": {
+                "onFirmwarePendingReboot" : "Triggers when the firmware has a pending reboot"
+            },
             "result": {
                 "$ref": "#/common/result"
             }
         },
         "getAvailableStandbyModes": {
-            "summary": "Queries the available standby modes.\n \n### Events\n \n No Events.",
+            "summary": "Queries the available standby modes.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -403,7 +404,8 @@
         },
         "getCachedValue":{
             "deprecated" : true,
-            "summary": "Gets the value of a key in the cache.\n \n### Events\n \n No Events.",
+            "referenceUrl" : "https://rdkcentral.github.io/rdkservices/#/api/PersistentStorePlugin?id=getvalue",
+            "summary": "Gets the value of a key in the cache.",
             "params": {
                 "type": "object",
                 "properties": {
@@ -434,7 +436,7 @@
             }
         },
         "getCoreTemperature":{
-            "summary": "Returns the core temperature of the device. Not supported on all devices.\n \n### Events\n \n No Events.",
+            "summary": "Returns the core temperature of the device. Not supported on all devices.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -452,7 +454,7 @@
             }
         },
         "getDeviceInfo":{
-            "summary": "Collects device details. Sample keys include:  \n* bluetooth_mac  \n* boxIP  \n* build_type  \n* estb_mac  \n* imageVersion  \n* rf4ce_mac  \n* wifi_mac.\n \n### Events\n \n No Events.",
+            "summary": "Collects device details. Sample keys include:  \n* bluetooth_mac  \n* boxIP  \n* build_type  \n* estb_mac  \n* imageVersion  \n* rf4ce_mac  \n* wifi_mac.",
             "params": {
                 "type": "object",
                 "properties": {
@@ -488,7 +490,7 @@
             }
         },
         "getDownloadedFirmwareInfo":{
-            "summary": "Returns information about firmware downloads.\n \n### Events\n \n No Events.",
+            "summary": "Returns information about firmware downloads.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -526,7 +528,7 @@
             }
         },
         "getFirmwareDownloadPercent": {
-            "summary": "Gets the current download percentage.\n \n### Events\n \n No Events.",
+            "summary": "Gets the current download percentage.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -546,10 +548,10 @@
             }
         },
         "getFirmwareUpdateInfo":{
-            "summary": "Checks the firmware update information.\n \n### Events \n| Event | Description | \n| :----------- | :----------- |\n| `onFirmwareUpdateInfoReceived` | Triggers when the firmware update information is requested |",
-            "events": [
-                "onFirmwareUpdateInfoReceived"
-            ],
+            "summary": "Checks the firmware update information.",
+            "events": {
+                "onFirmwareUpdateInfoReceived" : "Triggers when the firmware update information is requested"
+            },
             "params": {
                 "type": "object",
                 "properties": {
@@ -576,7 +578,7 @@
             }
         },
         "getFirmwareUpdateState":{
-            "summary": "Checks the state of the firmware update.\n \n### Events\n \n No Events.",
+            "summary": "Checks the state of the firmware update.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -594,7 +596,7 @@
             }
         },
         "getLastDeepSleepReason":{
-            "summary": "Retrieves the last deep sleep reason.\n \n### Events\n \n No Events.",
+            "summary": "Retrieves the last deep sleep reason.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -614,7 +616,7 @@
             }
         },
         "getLastFirmwareFailureReason": {
-            "summary": "(Version 2) Retrieves the last firmware failure reason.\n \n### Events\n \n No Events.",
+            "summary": "(Version 2) Retrieves the last firmware failure reason.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -634,7 +636,7 @@
             }
         },
         "getLastWakeupKeyCode":{
-            "summary": "(Version 2) Returns the last wakeup keycode.\n \n### Events\n \n No Events.",
+            "summary": "(Version 2) Returns the last wakeup keycode.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -654,10 +656,10 @@
             }
         },
         "getMacAddresses":{
-            "summary": "Gets the MAC address of the device.\n \n### Events \n| Event | Description | \n| :----------- | :----------- |\n| `onMacAddressesRetreived` | Triggers when the MAC addresses are requested |",
-            "events": [
-                "onMacAddressesRetreived"
-            ],
+            "summary": "Gets the MAC address of the device.",
+            "events": {
+                "onMacAddressesRetreived" : "Triggers when the MAC addresses are requested"
+            },
             "params": {
                 "type": "object",
                 "properties": {
@@ -684,7 +686,7 @@
             }
         },
         "getMfgSerialNumber": {
-            "summary": "Gets the Manufacturing Serial Number.\n \n### Events\n \n No Events.",
+            "summary": "Gets the Manufacturing Serial Number.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -705,7 +707,8 @@
         },
         "getMilestones": {
 	        "deprecated" : true,
-            "summary": "Returns the list of milestones.\n \n### Events\n \n No Events.",
+            "referenceUrl" : "https://rdkcentral.github.io/rdkservices/#/api/DeviceDiagnosticsPlugin?id=getmilestones",
+            "summary": "Returns the list of milestones.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -728,7 +731,7 @@
             }
         },
         "getMode":{
-            "summary": "Returns the currently set mode information.\n \n### Events\n \n No Events.",
+            "summary": "Returns the currently set mode information.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -746,7 +749,7 @@
             }
         },
         "getNetworkStandbyMode": {
-            "summary": "Returns the network standby mode of the device. If network standby is `true`, the device supports `WakeOnLAN` and `WakeOnWLAN` actions in STR (S3) mode.\n \n### Events\n \n No Events.",
+            "summary": "Returns the network standby mode of the device. If network standby is `true`, the device supports `WakeOnLAN` and `WakeOnWLAN` actions in STR (S3) mode.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -764,7 +767,7 @@
             }
         },
         "getOvertempGraceInterval": {
-            "summary": "Returns the over-temperature grace interval value. Not supported on all devices.\n \n### Events\n \n No Events.",
+            "summary": "Returns the over-temperature grace interval value. Not supported on all devices.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -782,7 +785,7 @@
             }
         },
         "getPlatformConfiguration": {
-            "summary": "(Version 2) Returns the supported features and device/account info.\n \n### Events\n \n No Events.",
+            "summary": "(Version 2) Returns the supported features and device/account info.",
             "params": {
                 "type": "object",
                 "properties": {
@@ -811,7 +814,7 @@
             }
         },
         "getPowerState":{
-            "summary": "Returns the power state of the device.\n \n### Events\n \n No Events.",
+            "summary": "Returns the power state of the device.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -829,7 +832,7 @@
             }
         },
         "getPowerStateBeforeReboot":{
-            "summary": "Returns the power state before reboot.\n \n### Events\n \n No Events.",
+            "summary": "Returns the power state before reboot.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -849,7 +852,7 @@
             }
         },
         "getPowerStateIsManagedByDevice": {
-            "summary": "Checks whether the power state is managed by the device.\n \n### Events\n \n No Events.",
+            "summary": "Checks whether the power state is managed by the device.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -869,7 +872,7 @@
             }
         },
         "getPreferredStandbyMode":{
-            "summary": "Returns the preferred standby mode. This method returns an empty string if the preferred mode has not been set.\n \n### Events\n \n No Events.",
+            "summary": "Returns the preferred standby mode. This method returns an empty string if the preferred mode has not been set.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -887,7 +890,7 @@
             }
         },
         "getPreviousRebootInfo":{
-            "summary": "Returns basic information about a reboot.\n \n### Events\n \n No Events.",
+            "summary": "Returns basic information about a reboot.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -929,7 +932,7 @@
             }
         },
         "getPreviousRebootInfo2":{
-            "summary": "Returns detailed information about a reboot.\n \n### Events\n \n No Events.",
+            "summary": "Returns detailed information about a reboot.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -975,7 +978,7 @@
             }
         },
         "getPreviousRebootReason":{
-            "summary": "Returns the last reboot reason.\n \n### Events\n \n No Events.",
+            "summary": "Returns the last reboot reason.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -993,7 +996,7 @@
             }
         },
         "getRFCConfig":{
-            "summary": "Returns information that is related to RDK Feature Control (RFC) configurations.\n \n### Events\n \n No Events.",
+            "summary": "Returns information that is related to RDK Feature Control (RFC) configurations.",
             "params": {
                 "type": "object",
                 "properties": {
@@ -1037,7 +1040,7 @@
             }
         },
         "getSerialNumber":{
-            "summary": "Returns the device serial number.\n \n### Events\n \n No Events.",
+            "summary": "Returns the device serial number.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -1057,7 +1060,7 @@
             }
         },
         "getStateInfo":{
-            "summary": "Queries device state information of various properties.\n \n### Events\n \n No Events.",
+            "summary": "Queries device state information of various properties.",
             "params": {
                 "type": "object",
                 "properties": {
@@ -1089,7 +1092,7 @@
             }
         },
         "getStoreDemoLink":{
-            "summary": "(Version 2) Returns the store demo video link.\n \n### Events\n \n No Events.",
+            "summary": "(Version 2) Returns the store demo video link.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -1108,7 +1111,7 @@
             }
         },
         "getSystemVersions":{
-            "summary": "Returns system version details.\n \n### Events\n \n No Events.",
+            "summary": "Returns system version details.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -1140,7 +1143,7 @@
             }
         },
         "getTemperatureThresholds":{
-            "summary": "Returns temperature threshold values. Not supported on all devices.\n \n### Events\n \n No Events.",
+            "summary": "Returns temperature threshold values. Not supported on all devices.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -1174,7 +1177,7 @@
             }
         },
         "getTerritory":{
-            "summary": "Gets the configured system territory and region. Territory is a ISO-3166-1 alpha-3 standard (see https://en.wikipedia.org/wiki/ISO_3166-1). Region is a ISO-3166-2 alpha-2 standard (see https://en.wikipedia.org/wiki/ISO_3166-2).\n \n### Events\n \n No Events.",
+            "summary": "Gets the configured system territory and region. Territory is a ISO-3166-1 alpha-3 standard (see https://en.wikipedia.org/wiki/ISO_3166-1). Region is a ISO-3166-2 alpha-2 standard (see https://en.wikipedia.org/wiki/ISO_3166-2).",
             "result":{
                 "type" : "object",
                 "properties": {
@@ -1196,7 +1199,7 @@
             }		
         },
         "getTimeZones":{
-            "summary": "(Version2) Gets the available timezones from the system's time zone database. This method is useful for determining time offsets per zone.\n \n### Events\n \n No Events.",
+            "summary": "(Version2) Gets the available timezones from the system's time zone database. This method is useful for determining time offsets per zone.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -1246,7 +1249,7 @@
             }
         },
         "getTimeZoneDST":{
-            "summary": "Get the configured time zone from the file referenced by `TZ_FILE`. If the time zone is not set, then `null` is returned.\n \n### Events\n \n No Events.",
+            "summary": "Get the configured time zone from the file referenced by `TZ_FILE`. If the time zone is not set, then `null` is returned.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -1264,7 +1267,7 @@
             }
         },
         "getWakeupReason":{
-            "summary": "(Version 2) Returns the reason for the device coming out of deep sleep.\n \n### Events\n \n No Events.",
+            "summary": "(Version 2) Returns the reason for the device coming out of deep sleep.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -1304,7 +1307,7 @@
             }
         },
         "getXconfParams":{
-            "summary": "Returns XCONF configuration parameters for the device.\n \n### Events\n \n No Events.",
+            "summary": "Returns XCONF configuration parameters for the device.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -1351,7 +1354,7 @@
             }
         },
         "hasRebootBeenRequested":{
-            "summary": "Checks whether a reboot has been requested.\n \n### Events\n \n No Events.",
+            "summary": "Checks whether a reboot has been requested.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -1372,7 +1375,7 @@
         },
         "isGzEnabled":{
 	    "deprecated" : true,
-            "summary": "Checks whether GZ is enabled.\n \n### Events\n \n No Events.",
+            "summary": "Checks whether GZ is enabled.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -1390,7 +1393,7 @@
             }
         },
         "isOptOutTelemetry": {
-            "summary": "Checks the telemetry opt-out status.\n \n### Events\n \n No Events.",
+            "summary": "Checks the telemetry opt-out status.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -1409,7 +1412,7 @@
 
         },
         "queryMocaStatus":{
-            "summary": "Checks whether MOCA is enabled.\n \n### Events\n \n No Events.",
+            "summary": "Checks whether MOCA is enabled.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -1429,10 +1432,10 @@
             }
         },
         "reboot":{
-            "summary": "Requests that the system performs a reboot of the set-top box.\n \n### Events \n| Event | Description | \n| :----------- | :----------- |\n| `onRebootRequest` | Triggers when a device reboot request is made |",
-            "events": [
-                "onRebootRequest"
-            ],
+            "summary": "Requests that the system performs a reboot of the set-top box.",
+            "events": {
+                "onRebootRequest" : "Triggers when a device reboot request is made"
+            },
             "params": {
                 "type":"object",
                 "properties": {
@@ -1464,7 +1467,8 @@
         },
         "removeCacheKey":{
             "deprecated" : true,
-            "summary": "Removes the cache key.\n \n### Events\n \n No Events.",
+            "referenceUrl" : "https://rdkcentral.github.io/rdkservices/#/api/PersistentStorePlugin?id=deletekey",
+            "summary": "Removes the cache key.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1481,7 +1485,7 @@
             }
         },
         "requestSystemUptime":{
-            "summary": "Returns the device uptime.\n \n### Events\n \n No Events.",
+            "summary": "Returns the device uptime.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -1501,7 +1505,7 @@
             }
         },
         "setBootLoaderPattern":{
-            "summary": "Sets the boot loader pattern mode in MFR. \n### Events\n \n No Events.",
+            "summary": "Sets the boot loader pattern mode in MFR.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1519,7 +1523,8 @@
         },
         "setCachedValue": {
             "deprecated" : true,
-            "summary": "Sets the value for a key in the cache.\n \n### Events\n \n No Events.",
+            "referenceUrl" : "https://rdkcentral.github.io/rdkservices/#/api/PersistentStorePlugin?id=setvalue",
+            "summary": "Sets the value for a key in the cache.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1542,7 +1547,7 @@
             }
         },
         "setDeepSleepTimer": {
-            "summary": "Sets the deep sleep timeout period.\n \n### Events\n \n No Events.",
+            "summary": "Sets the deep sleep timeout period.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1559,7 +1564,7 @@
             }
         },
         "setFirmwareAutoReboot": {
-            "summary": "(Version 2) Enables or disables the AutoReboot Feature. This method internally sets the tr181 `AutoReboot.Enable` parameter to `true` or `false`.\n \n### Events\n \n No Events.",
+            "summary": "(Version 2) Enables or disables the AutoReboot Feature. This method internally sets the tr181 `AutoReboot.Enable` parameter to `true` or `false`.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1578,7 +1583,7 @@
             }
         },
         "setFirmwareRebootDelay": {
-            "summary": "(Version 2) Delays the firmware reboot.\n \n### Events\n \n No Events.",
+            "summary": "(Version 2) Delays the firmware reboot.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1598,7 +1603,7 @@
         },
         "setGzEnabled": {
             "deprecated" : true,
-            "summary": "Enables or disables GZ.\n \n### Events\n \n No Events.",
+            "summary": "Enables or disables GZ.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1615,10 +1620,10 @@
             }
         },
         "setMode":{
-            "summary": "Sets the mode of the set-top box for a specific duration before returning to normal mode. Valid modes are:  \n* `NORMAL` - The set-top box is operating in normal mode.  \n* `EAS` - The set-top box is operating in Emergency Alert System (EAS) mode. This mode is set when the device needs to perform certain tasks when entering EAS mode, such as setting the clock display or preventing the user from using the diagnostics menu.  \n* `WAREHOUSE` - The set-top box is operating in warehouse mode.\n \n### Events \n| Event | Description | \n| :----------- | :----------- |\n| `onSystemModeChanged` | Triggers when the system mode is changed successfully |",
-            "events": [
-                "onSystemModeChanged"
-            ],
+            "summary": "Sets the mode of the set-top box for a specific duration before returning to normal mode. Valid modes are:  \n* `NORMAL` - The set-top box is operating in normal mode.  \n* `EAS` - The set-top box is operating in Emergency Alert System (EAS) mode. This mode is set when the device needs to perform certain tasks when entering EAS mode, such as setting the clock display or preventing the user from using the diagnostics menu.  \n* `WAREHOUSE` - The set-top box is operating in warehouse mode.",
+            "events": {
+                "onSystemModeChanged" : "Triggers when the system mode is changed successfully"
+            },
             "params": {
                 "type":"object",
                 "properties": {
@@ -1635,7 +1640,7 @@
             }            
         },
         "setNetworkStandbyMode":{
-            "summary": "Enables or disables the network standby mode of the device. If network standby is enabled, the device supports `WakeOnLAN` and `WakeOnWLAN` actions in STR (S3) mode.\n \n### Events\n \n No Events.",
+            "summary": "Enables or disables the network standby mode of the device. If network standby is enabled, the device supports `WakeOnLAN` and `WakeOnWLAN` actions in STR (S3) mode.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1652,7 +1657,7 @@
             }
         },
         "setOptOutTelemetry": {
-            "summary": "Sets the telemetry opt-out status.\n \n### Events\n \n No Events.",
+            "summary": "Sets the telemetry opt-out status.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1669,7 +1674,7 @@
             }
         },
         "setOvertempGraceInterval":{
-            "summary": "Sets the over-temperature grace interval value. Not supported on all devices.\n \n### Events\n \n No Events.",
+            "summary": "Sets the over-temperature grace interval value. Not supported on all devices.",
             "params": {
                 "type": "object",
                 "properties": {
@@ -1686,10 +1691,10 @@
             }
         },
         "setPowerState":{
-            "summary": "Sets the power state of the device.\n \n### Events \n| Event | Description | \n| :----------- | :----------- |\n| `onSystemPowerStateChanged` | Triggers when the system power state changes |",
-            "events": [
-                "onSystemPowerStateChanged" 
-            ],
+            "summary": "Sets the power state of the device.",
+            "events": {
+                "onSystemPowerStateChanged" : "Triggers when the system power state changes"
+            },
             "params": {
                 "type":"object",
                 "properties": {
@@ -1712,7 +1717,7 @@
             }
         },
         "setPreferredStandbyMode":{
-            "summary": "Sets and persists the preferred standby mode. See [getAvailableStandbyModes](#getAvailableStandbyModes) for valid modes. Invoking this function does not change the power state of the device. It only sets the user preference for the preferred action when the [setPowerState](#setPowerState) method is invoked with a value of `STANDBY`.\n \n### Events\n \n No Events.",
+            "summary": "Sets and persists the preferred standby mode. See [getAvailableStandbyModes](#getAvailableStandbyModes) for valid modes. Invoking this function does not change the power state of the device. It only sets the user preference for the preferred action when the [setPowerState](#setPowerState) method is invoked with a value of `STANDBY`.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1729,7 +1734,7 @@
             }
         },
         "setTemperatureThresholds":{
-            "summary": "Sets the temperature threshold values. Not supported on all devices.\n \n### Events\n \n No Events.",
+            "summary": "Sets the temperature threshold values. Not supported on all devices.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1758,7 +1763,7 @@
             }
         },
         "setTerritory":{
-            "summary": "Sets the system territory and region.Territory is a ISO-3166-1 alpha-3 standard (see https://en.wikipedia.org/wiki/ISO_3166-1). Region is a ISO-3166-2 alpha-2 standard (see https://en.wikipedia.org/wiki/ISO_3166-2).\n \n### Events\n \n No Events.",
+            "summary": "Sets the system territory and region.Territory is a ISO-3166-1 alpha-3 standard (see https://en.wikipedia.org/wiki/ISO_3166-1). Region is a ISO-3166-2 alpha-2 standard (see https://en.wikipedia.org/wiki/ISO_3166-2).",
             "params": {
                 "type" :"object",
                 "properties": {
@@ -1778,7 +1783,7 @@
             }
         },
         "setTimeZoneDST":{
-            "summary": "Sets the system time zone. See `getTimeZones` to get a list of available timezones on the system.\n \n### Events\n \n No Events.",
+            "summary": "Sets the system time zone. See `getTimeZones` to get a list of available timezones on the system.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1795,7 +1800,7 @@
             }
         },
         "setWakeupSrcConfiguration": {
-            "summary": "Sets the wakeup source configuration.\n \n### Events\n \n No Events.",
+            "summary": "Sets the wakeup source configuration.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1820,13 +1825,13 @@
             }
         },
         "updateFirmware":{
-            "summary": "Initiates a firmware update. This method has no affect if an update is not available.\n \n### Events\n \n No Events.",
+            "summary": "Initiates a firmware update. This method has no affect if an update is not available.",
             "result": {
                 "$ref": "#/common/result"
             }
         },
         "uploadLogs": {
-            "summary": "(Version 2) Uploads logs to a URL returned by SSR.\n \n### Events\n \n No Events.",
+            "summary": "(Version 2) Uploads logs to a URL returned by SSR.",
             "params": {
                 "type": "object",
                 "properties": {

--- a/TextToSpeech/TextToSpeech.json
+++ b/TextToSpeech/TextToSpeech.json
@@ -89,10 +89,10 @@
     },
     "methods": {
         "cancel": {
-            "summary": "Cancels the speech. Triggers the `onspeechinterrupted` event.  \n \n### Events  \n| Event | Description | \n| :----------- | :-----------| \n|`onspeechinterrupted` | Triggered when ongoing speech is cancelled. Event is not triggered: if TTS is not enabled; if ongoing Speech is completed |",
-            "events": [
-                "onspeechinterrupted"
-            ],
+            "summary": "Cancels the speech. Triggers the `onspeechinterrupted` event.",
+            "events": {
+                "onspeechinterrupted" : "Triggered when ongoing speech is cancelled. Event is not triggered: if TTS is not enabled; if ongoing Speech is completed"
+            },
             "params": {
                 "type": "object",
                 "properties": {
@@ -121,11 +121,11 @@
             }
         },
         "enabletts": {
-            "summary": "(For Resident App) Enables or disables the TTS conversion processing. Triggered `onttsstatechanged` event when state changes and `onspeechinterrupted` event when disabling TTS while speech is in-progress. \n \n### Events  \n| Event | Description | \n| :----------- | :----------- | \n| `onttsstatechanged` | `state` : `true` Triggered when TTS is enabled; `state` : `false` Triggered when TTS is disabled; otherwise `No event` When TTS enable or disable is in-progress | \n| `onspeechinterrupted` | Triggered when disabling TTS while speech is in-progress",
-            "events": [
-               "onttsstatechanged",
-               "onspeechinterrupted"
-            ],
+            "summary": "(For Resident App) Enables or disables the TTS conversion processing. Triggered `onttsstatechanged` event when state changes and `onspeechinterrupted` event when disabling TTS while speech is in-progress.",
+            "events": {
+               "onttsstatechanged" : "state : true Triggered when TTS is enabled; state : false Triggered when TTS is disabled; otherwise No event When TTS enable or disable is in-progress",
+               "onspeechinterrupted" : "Triggered when disabling TTS while speech is in-progress."
+            },
             "params": {
                 "type": "object",
                 "properties": {
@@ -156,7 +156,7 @@
             }
         },
         "getapiversion":{
-            "summary": "Gets the API Version.\n \n### Events \n\nNo Events.",
+            "summary": "Gets the API Version.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -176,7 +176,7 @@
             }
         },
         "getspeechstate":{
-            "summary": "Returns the current state of the speech request.\n  \n### Events \n\nNo Events.",
+            "summary": "Returns the current state of the speech request.",
             "params": {
                 "type": "object",
                 "properties": {
@@ -217,7 +217,7 @@
             }
         },
         "getttsconfiguration": {
-            "summary": "Gets the current TTS configuration.\n  \n### Events \n \nNo Events.",
+            "summary": "Gets the current TTS configuration.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -259,7 +259,7 @@
             }
         },
         "isspeaking": {
-            "summary": "Checks if speech is in progress.\n  \n### Event \n\nNo Events.",
+            "summary": "Checks if speech is in progress.",
             "params": {
                 "type": "object",
                 "properties": {
@@ -294,7 +294,7 @@
             }
         },
         "isttsenabled": {
-            "summary": "Returns whether the TTS engine is enabled or disabled. By default the TTS engine is disabled.\n  \n### Events \n\n No Events.",
+            "summary": "Returns whether the TTS engine is enabled or disabled. By default the TTS engine is disabled.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -318,7 +318,7 @@
             }
         },
         "listvoices": {
-            "summary": "Lists the available voices for the specified language. For every language there is a set of pre-defined voices.  \n  \n### Events \n\nNo Events.",
+            "summary": "Lists the available voices for the specified language. For every language there is a set of pre-defined voices.",
             "params": {
                 "type": "object",
                 "properties": {
@@ -353,10 +353,10 @@
             }
         },
         "pause": {
-            "summary": "Pauses the speech. Triggers the `onspeechpause` event.  \n \n### Events  \n| Event | Description | \n| :----------- | :----------- | \n|  `onspeechpause` | Triggered when ongoing speech is paused. Event not triggered on following conditions: TTS is not enabled; Speech is already in pause; or Speech is completed | ",
-            "events": [
-                "onspeechpause"
-            ],
+            "summary": "Pauses the speech. Triggers the `onspeechpause` event.",
+            "events": {
+                "onspeechpause" : "Triggered when ongoing speech is paused. Event not triggered on following conditions: TTS is not enabled; Speech is already in pause; or Speech is completed"
+            },
             "params": {
                 "type": "object",
                 "properties": {
@@ -385,10 +385,10 @@
             }
         },
         "resume": {
-            "summary": "Resumes the speech. Triggers the `onspeechresume` event. \n \n### Events  \n| Event | Description | \n| :----------- | :----------- | \n| `onspeechresume` | Triggered when speech is resumed and speech output is available. Event not triggered under following conditions: TTS is not enabled; Speech is resumed already; or Speech is completed |",
-            "events": [
-                "onspeechresume"
-            ],
+            "summary": "Resumes the speech. Triggers the `onspeechresume` event.",
+            "events": {
+                "onspeechresume" : "Triggered when speech is resumed and speech output is available. Event not triggered under following conditions: TTS is not enabled; Speech is resumed already; or Speech is completed"
+            },
             "params": {
                 "type": "object",
                 "properties": {
@@ -417,10 +417,10 @@
             }
         },
         "setttsconfiguration": {
-            "summary": "Sets the TTS configuration. Triggers the `onvoicechanged` event.\n \n### Events  \n| Event | Description | \n| :----------- | :----------- | \n|`onvoicechanged`|Triggered only when the voice configuration is changed| ",
-            "events":[
-                "onvoicechanged"
-            ],
+            "summary": "Sets the TTS configuration. Triggers the `onvoicechanged` event.",
+            "events":{
+                "onvoicechanged" : "Triggered only when the voice configuration is changed"
+            },
             "params": {
                 "type": "object",
                 "properties": {
@@ -495,15 +495,15 @@
             }
         },
         "speak": {
-            "summary": "Converts the input text to speech when TTS is enabled. Any ongoing speech is interrupted and the newly requested speech is processed. The clients of the previous speech is sent an `onspeechinterrupted` event. Upon success, this API returns an ID, which is used as input to other API methods for controlling the speech (for example, `pause`, `resume`, and `cancel`)\n \n### Events \n| Event | Description | \n| :----------- | :----------- |\n| `onwillspeak` | Triggered when speech conversion is about to start | \n| `onspeechstart` | Triggered when conversion of text to speech is started | \n| `onspeechcomplete `| Triggered when conversion from text to speech is completed | \n| `onspeechinterrupted`| Current speech is interrupted either by a next speech request; by calling the `cancel` method; or by disabling TTS, when speech is in-progress | \n| `onnetworkerror` | Triggered when failed to fetch audio from the endpoint |  \n| `onplaybackerror` | Triggered when an error occurs during playback including pipeline failures; Triggered when `speak` is called during TTS disabled |",
-            "events": [
-                "onwillspeak",
-                "onspeechstart",
-                "onspeechinterrupted",
-                "onspeechcomplete",
-                "onnetworkerror",
-                "onplaybackerror"
-            ],
+            "summary": "Converts the input text to speech when TTS is enabled. Any ongoing speech is interrupted and the newly requested speech is processed. The clients of the previous speech is sent an `onspeechinterrupted` event. Upon success, this API returns an ID, which is used as input to other API methods for controlling the speech (for example, `pause`, `resume`, and `cancel`)",
+            "events": {
+                "onwillspeak" : "Triggered when speech conversion is about to start",
+                "onspeechstart" : "Triggered when conversion of text to speech is started",
+                "onspeechinterrupted" : "Current speech is interrupted either by a next speech request; by calling the cancel method; or by disabling TTS, when speech is in-progress",
+                "onspeechcomplete" : "Triggered when conversion from text to speech is completed",
+                "onnetworkerror" : "Triggered when failed to fetch audio from the endpoint",
+                "onplaybackerror" : "Triggered when an error occurs during playback including pipeline failures; Triggered when speak is called during TTS disabled"
+            },
             "params": {
                 "type": "object",
                 "properties": {
@@ -539,7 +539,7 @@
             }
         },
         "setACL": {
-            "summary":"Configures app to speak. Allows the ResidentAPP to configure the particular app and provides access to `speak` method. If not configured any then gives access to all apps to speak. Configuration does not retained after reboot.\n  \n### Events \n\nNo Events.",
+            "summary":"Configures app to speak. Allows the ResidentAPP to configure the particular app and provides access to `speak` method. If not configured any then gives access to all apps to speak. Configuration does not retained after reboot.",
             "params":{
                 "type": "object",
                 "properties": {

--- a/Timer/Timer.json
+++ b/Timer/Timer.json
@@ -68,7 +68,7 @@
     },
     "methods": {
         "cancel":{
-            "summary": "Stops the specified timer.\n \n### Events\n \nNo Events.",
+            "summary": "Stops the specified timer.",
             "params": {
                 "type": "object",
                 "properties": {
@@ -82,7 +82,7 @@
             }
         },
         "getTimers":{
-            "summary": "Gets the status of all timers.\n \n### Events\n \nNo Events.",
+            "summary": "Gets the status of all timers.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -132,7 +132,7 @@
             }
         },
         "getTimerStatus": {
-            "summary": "Gets the status of the specified timer.\n \n### Events\n \nNo Events.",
+            "summary": "Gets the status of the specified timer.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -177,7 +177,7 @@
             }           
         },
         "resume":{
-            "summary": "Resumes the specified timer.\n \n### Events\n \nNo Events.",
+            "summary": "Resumes the specified timer.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -191,11 +191,11 @@
             }
         },
         "startTimer": {
-            "summary": "Starts a timer with the specified interval. After the timer expires, a `timerExpired `notification is sent. The timer can execute once (one-shot mode) or repeatedly.\n \n### Events\n \n| Event | Description | \n| :-------- | :-------- | \n| `timerExpired` | Triggered when a timer expires | \n| `timerExpiryReminder` | Triggered to remind that, the timer will expire in remindBefore value in seconds |",
-            "events": [
-                "timerExpired",
-                "timerExpiryReminder"
-            ],
+            "summary": "Starts a timer with the specified interval. After the timer expires, a `timerExpired `notification is sent. The timer can execute once (one-shot mode) or repeatedly.",
+            "events": {
+                "timerExpired" : "Triggered when a timer expires",
+                "timerExpiryReminder" : "Triggered to remind that, the timer will expire in remindBefore value in seconds"
+            },
             "params": {
                 "type":"object",
                 "properties": {
@@ -235,7 +235,7 @@
             }
         },
         "suspend":{
-            "summary": "Suspends the specified timer.\n \n### Events\n \nNo Events.",
+            "summary": "Suspends the specified timer.",
             "params": {
                 "type":"object",
                 "properties": {

--- a/Tools/json_generator/generator_json.py
+++ b/Tools/json_generator/generator_json.py
@@ -2099,7 +2099,11 @@ def CreateDocument(schema, path):
                     writeonly = True
                     MdParagraph("> This property is **write-only**.")
             if "deprecated" in props:
-                MdParagraph("> This API is **deprecated** and may be removed in the future. It is no longer recommended for use in new implementations.")
+                if "referenceUrl" in props:
+                    referenceUrl = props["referenceUrl"]
+                    MdParagraph("> This API is **deprecated** and may be removed in the future. It is no longer recommended for use in new implementations. [{}]({})".format("Refer this link for the new api",referenceUrl))
+                else:
+                    MdParagraph("> This API is **deprecated** and may be removed in the future. It is no longer recommended for use in new implementations.")
             elif "obsolete" in props:
                 MdParagraph("> This API is **obsolete**. It is no longer recommended for use in new implementations.")
             if "description" in props:

--- a/Tools/json_generator/generator_json.py
+++ b/Tools/json_generator/generator_json.py
@@ -2105,9 +2105,15 @@ def CreateDocument(schema, path):
             if "description" in props:
                 MdHeader("Description", 3)
                 MdParagraph(props["description"])
-            if "events" in props:
-                events = [props["events"]] if isinstance(props["events"], str) else props["events"]
-                MdParagraph("Also see: " + (", ".join(map(lambda x: link("event." + x), events))))
+            if type == "method" or is_property:
+                MdHeader("Events", 3)
+                if "events" in props:
+                    MdTableHeader(["Event", "Description"])
+                    event_dict = props["events"]
+                    for k,v in event_dict.items():
+                        MdRow([link("event." + k), v])
+                else:
+                    MdParagraph("No Events")
             if is_property:
                 MdHeader("Value", 3)
                 if not "description" in props["params"]:

--- a/TraceControl/TraceControl.json
+++ b/TraceControl/TraceControl.json
@@ -53,7 +53,7 @@
     },
     "methods": {
         "set": {
-            "summary": "Sets traces. Enables or disables all or select category traces for the specified module. \n  \n### Events \n\n No events",
+            "summary": "Sets traces. Enables or disables all or select category traces for the specified module.",
             "params": {
                 "$ref": "#/definitions/trace"
             },
@@ -62,7 +62,7 @@
             }
         },
         "status":{
-            "summary": "Retrieves the actual trace status information for the specified module and category. If the category or module is not specified then, all the information is returned. If both module and category are not specified then, the result is empty. It retrieves the details about the console status and remote address (port and binding), if these are configured. \n \n### Events\n \n No Events",
+            "summary": "Retrieves the actual trace status information for the specified module and category. If the category or module is not specified then, all the information is returned. If both module and category are not specified then, the result is empty. It retrieves the details about the console status and remote address (port and binding), if these are configured.",
             "params": {
                 "type": "object",
                 "properties": {

--- a/UsbAccess/UsbAccess.json
+++ b/UsbAccess/UsbAccess.json
@@ -14,7 +14,7 @@
     },
     "methods": {
         "clearLink": {
-            "summary": "Clears or removes the symbolic link created by the `createLink` method.\n \n### Events \n\n No Events.",
+            "summary": "Clears or removes the symbolic link created by the `createLink` method.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -33,7 +33,7 @@
             }
         },
         "createLink": {
-            "summary": "Creates a symbolic link to the root folder of the USB drive. If called, and a link already exists, then it errors out. Symbolic link has read-only access. Use the name `usbdrive`. \n \n### Events \n\n No Events.",
+            "summary": "Creates a symbolic link to the root folder of the USB drive. If called, and a link already exists, then it errors out. Symbolic link has read-only access. Use the name `usbdrive`.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -58,7 +58,7 @@
             }
         },
         "getAvailableFirmwareFiles": {
-            "summary": "(Version 2) Gets a list of firmware files on the device. These files should start with the PMI or model number for that device and end with `.bin`. For example `HSTP11MWR_4.11p5s1_VBN_sdy.bin`.  \nFirmware files are scanned in the root directories. If multiple USB devices are found, then the available firmware files are checked and listed from each device.\n \n### Events \n\n No Events.",
+            "summary": "(Version 2) Gets a list of firmware files on the device. These files should start with the PMI or model number for that device and end with `.bin`. For example `HSTP11MWR_4.11p5s1_VBN_sdy.bin`.  \nFirmware files are scanned in the root directories. If multiple USB devices are found, then the available firmware files are checked and listed from each device.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -82,7 +82,7 @@
             }
         },
         "getFileList": {
-            "summary": "Gets a list of files and folders from the specified directory or path.\n \n### Events \n\n No Events.",
+            "summary": "Gets a list of files and folders from the specified directory or path.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -136,7 +136,7 @@
             }
         },
         "getMounted": {
-            "summary": "(Version 2) Returns a list of mounted USB devices.\n \n### Events \n\n No Events.",
+            "summary": "(Version 2) Returns a list of mounted USB devices.",
                 "result": {
                 "type": "object",
                 "properties": {
@@ -159,7 +159,7 @@
             }
         },
         "updateFirmware": {
-            "summary": "(Version 2) Updates the firmware using the specified file retrieved from the `getAvailableFirmwareFiles` method.\n \n### Events \n\n No Events.",
+            "summary": "(Version 2) Updates the firmware using the specified file retrieved from the `getAvailableFirmwareFiles` method.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -191,10 +191,10 @@
             }
         },
         "ArchiveLogs":{
-            "summary":"(Version 2) Compresses and uploads device logs into attached USB drive from /opt/logs with a name comprises of Mac of the device , date and time in a `tgz` format. For example `18310C696834_Logs_10-13-21-04-42PM.tgz` `(<MAC address>_Logs_<unix epoch time>.tgz)`.\n \n### Events \n| Event | Description | \n| :----------- | :----------- |\n| `onArchiveLogs`| Triggered to archive the device logs and returns the status of the archive |",
-            "events":[
-                "onArchiveLogs"
-            ],
+            "summary":"(Version 2) Compresses and uploads device logs into attached USB drive from /opt/logs with a name comprises of Mac of the device , date and time in a `tgz` format. For example `18310C696834_Logs_10-13-21-04-42PM.tgz` `(<MAC address>_Logs_<unix epoch time>.tgz)`.Notifies about new messages in a room.",
+            "events":{
+                "onArchiveLogs" : "Triggered to archive the device logs and returns the status of the archive"
+            },
             "result":{
                 "type":"object",
                 "properties": {

--- a/VoiceControl/VoiceControl.json
+++ b/VoiceControl/VoiceControl.json
@@ -74,7 +74,7 @@
     },
     "methods": {
         "configureVoice": {
-            "summary": "Configures the RDK's voice stack. NOTE: The URL Scheme determines which API protocol is used. Supported URL schemes include:\n\n| Scheme | Description |\n| :-------- | :-------- |\n| http/https | VREX Legacy HTTP API |\n| ws/wss | VREX XR18 WS API |\n| vrng/vrngs | VREX NextGen WS API |\n| aows/aowss | Audio only over websockets with no protocol layer |\n| sdt | Simple data transfer for direct handling of audio in the protocol layer |\n\n### Events\n\n No Events.",
+            "summary": "Configures the RDK's voice stack. NOTE: The URL Scheme determines which API protocol is used. Supported URL schemes include:\n\n| Scheme | Description |\n| :-------- | :-------- |\n| http/https | VREX Legacy HTTP API |\n| ws/wss | VREX XR18 WS API |\n| vrng/vrngs | VREX NextGen WS API |\n| aows/aowss | Audio only over websockets with no protocol layer |\n| sdt | Simple data transfer for direct handling of audio in the protocol layer |",
             "params": {
                 "type": "object",
                 "properties": {
@@ -138,7 +138,7 @@
             }
         },
         "sendVoiceMessage": {
-            "summary": "Sends a message to the Voice Server. The specification of this message is not in the scope of this document. Example use cases for this API call include sending context or sending ASR blobs to the server.\n\n### Events\n\n No Events",
+            "summary": "Sends a message to the Voice Server. The specification of this message is not in the scope of this document. Example use cases for this API call include sending context or sending ASR blobs to the server.",
             "params":{
                 "type": "object",
                 "properties": {
@@ -172,7 +172,7 @@
             }
         },
         "setVoiceInit": {
-            "summary": "Sets the application metadata in the INIT message that gets sent to the Voice Server. The specification of this blob is not in the scope of this document, but it MUST be a JSON blob.\n\n### Events\n\n No Events.",
+            "summary": "Sets the application metadata in the INIT message that gets sent to the Voice Server. The specification of this blob is not in the scope of this document, but it MUST be a JSON blob.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -192,15 +192,14 @@
             }
         },
         "voiceSessionByText": {
-            "summary": "Sends a voice session with a transcription string to simulate a real voice session for QA. Example use cases for this API call include rack and automation testing.\n\n### Events\n\n| Event | Description |\n| :-------- | :-------- |\n| `onSessionBegin` |Triggers if the voice session begins |\n| `onStreamBegin` |Triggers if a device starts streaming voice data to the RDK|\n| `onServerMessage` |Triggers if a message is received from the Voice Server |\n| `onStreamEnd` |Triggers if streaming audio is stopped from the device |\n| `onSessionEnd` |Triggers if interaction with the server is end|",
-            "events":[
-                "onSessionBegin",
-                "onStreamBegin",
-                "onServerMessage",
-                "onStreamEnd",
-                "onSessionEnd"
-
-            ],
+            "summary": "Sends a voice session with a transcription string to simulate a real voice session for QA. Example use cases for this API call include rack and automation testing.",
+            "events":{
+                "onSessionBegin" : "Triggers if the voice session begins",
+                "onStreamBegin" : "Triggers if a device starts streaming voice data to the RDK",
+                "onServerMessage" : "Triggers if a message is received from the Voice Server",
+                "onStreamEnd" : "Triggers if streaming audio is stopped from the device",
+                "onSessionEnd" : "Triggers if interaction with the server is end"
+            },
             "params":{
                 "type": "object",
                 "properties": {
@@ -222,10 +221,11 @@
             "result": {
                 "$ref": "#/common/result"
             },
-            "deprecated": true
+            "deprecated": true,
+            "referenceUrl": "https://rdkcentral.github.io/rdkservices/#/api/VoiceControlPlugin?id=voicesessionrequest"
         },
         "voiceSessionTypes": {
-            "summary": "Retrieves the types of voice sessions which are supported by the platform.\n\n| Request Type | Description |\n| :-------- | :-------- |\n| ptt_transcription | A text-only session using the urlPtt routing url and the text transcription |\n| mic_transcription | A text-only session using the urlHf routing url and the text transcription |\n| mic_stream_default | An audio based session using the urlHf routing url and the platform's default audio output format |\n| mic_stream_single | An audio based session using the urlHf routing url and the platform's single channel audio input format |\n| mic_stream_multi | An audio based session using the urlHf routing url and the platform's multi-channel audio input format |\n| mic_tap_stream_single | An audio based session using the urlMicTap routing url and the platform's single channel audio input format |\n| mic_tap_stream_multi | An audio based session using the urlMicTap routing url and the platform's multi-channel audio input format |\n| mic_factory_test | An audio based session using the urlHf routing url and the platform's unprocessed multi-channel audio input format |\n\n### Events\n\n No Events.",
+            "summary": "Retrieves the types of voice sessions which are supported by the platform.\n\n| Request Type | Description |\n| :-------- | :-------- |\n| ptt_transcription | A text-only session using the urlPtt routing url and the text transcription |\n| mic_transcription | A text-only session using the urlHf routing url and the text transcription |\n| mic_stream_default | An audio based session using the urlHf routing url and the platform's default audio output format |\n| mic_stream_single | An audio based session using the urlHf routing url and the platform's single channel audio input format |\n| mic_stream_multi | An audio based session using the urlHf routing url and the platform's multi-channel audio input format |\n| mic_tap_stream_single | An audio based session using the urlMicTap routing url and the platform's single channel audio input format |\n| mic_tap_stream_multi | An audio based session using the urlMicTap routing url and the platform's multi-channel audio input format |\n| mic_factory_test | An audio based session using the urlHf routing url and the platform's unprocessed multi-channel audio input format |",
             "result": {
                 "type": "object",
                 "properties": {
@@ -242,15 +242,14 @@
             }
         },
         "voiceSessionRequest": {
-            "summary": "Requests a voice session using the specified request type and optional parameters.\n\n### Events\n\n| Event | Description |\n| :-------- | :-------- |\n| `onSessionBegin` |Triggers if the voice session begins |\n| `onStreamBegin` |Triggers if a device starts streaming voice data to the RDK|\n| `onServerMessage` |Triggers if a message is received from the Voice Server |\n| `onStreamEnd` |Triggers if streaming audio is stopped from the device |\n| `onSessionEnd` |Triggers if interaction with the server is end|",
-            "events":[
-                "onSessionBegin",
-                "onStreamBegin",
-                "onServerMessage",
-                "onStreamEnd",
-                "onSessionEnd"
-
-            ],
+            "summary": "Requests a voice session using the specified request type and optional parameters.",
+            "events":{
+                "onSessionBegin" : "Triggers if the voice session begins",
+                "onStreamBegin" : "Triggers if a device starts streaming voice data to the RDK",
+                "onServerMessage" : "Triggers if a message is received from the Voice Server",
+                "onStreamEnd" : "Triggers if streaming audio is stopped from the device",
+                "onSessionEnd" : "Triggers if interaction with the server is end"
+            },
             "params":{
                 "type": "object",
                 "properties": {
@@ -274,7 +273,7 @@
             }
         },
         "voiceSessionTerminate": {
-            "summary": "Terminates a voice session using the specified session identifier.\n\n### Events\n\n No Events.",
+            "summary": "Terminates a voice session using the specified session identifier.",
             "params":{
                 "type": "object",
                 "properties": {
@@ -293,7 +292,7 @@
             }
         },
         "voiceStatus": {
-            "summary": "Returns the current status of the RDK voice stack. This includes which URLs the stack is currently configured for along with the status for each device type.\n\n### Events\n\n No Events.",
+            "summary": "Returns the current status of the RDK voice stack. This includes which URLs the stack is currently configured for along with the status for each device type.",
             "result": {
                 "type": "object",
                 "properties": {

--- a/Warehouse/Warehouse.json
+++ b/Warehouse/Warehouse.json
@@ -18,13 +18,13 @@
     },
     "methods":{
         "executeHardwareTest": {
-            "summary": "(Version 2) Starts a hardware test on the device. See `getHardwareTestResults`. \n \n### Events\n \n No Events.",
+            "summary": "(Version 2) Starts a hardware test on the device. See `getHardwareTestResults`.",
             "result": {
                 "$ref": "#/common/result"
             }
         },
         "getDeviceInfo":{
-            "summary": "Returns STB device information gathered from `/lib/rdk/getDeviceDetails.sh`.(DEPRECATED - Use `getDeviceInfo` from `org.rdk.System` instead.) \n \n### Events\n \n No Events.",
+            "summary": "Returns STB device information gathered from `/lib/rdk/getDeviceDetails.sh`.(DEPRECATED - Use `getDeviceInfo` from `org.rdk.System` instead.)",
             "result": {
                 "type": "object",
                 "properties": {
@@ -107,7 +107,7 @@
             }
         },
         "getHardwareTestResults": {
-            "summary": "(Version 2) Returns the results of the last hardware test. \n \n### Events\n \n No Events.",
+            "summary": "(Version 2) Returns the results of the last hardware test.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -127,7 +127,7 @@
 
         },
         "internalReset":{
-            "summary": "Invokes the internal reset script, which reboots the Warehouse service (`/rebootNow.sh -s WarehouseService &`). Note that this method checks the `/version.txt` file for the image name and fails to run if the STB image version is marked as production (`PROD`). \n \n### Events\n \n No Events.",
+            "summary": "Invokes the internal reset script, which reboots the Warehouse service (`/rebootNow.sh -s WarehouseService &`). Note that this method checks the `/version.txt` file for the image name and fails to run if the STB image version is marked as production (`PROD`).",
             "params": {
                 "type":"object",
                 "properties": {
@@ -157,7 +157,7 @@
             }
         },
         "isClean":{
-            "summary": "Checks the locations on the device where customer data may be stored. If there are contents contained in those folders, then the device is not clean. \n \n### Events\n \n No Events.",
+            "summary": "Checks the locations on the device where customer data may be stored. If there are contents contained in those folders, then the device is not clean.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -186,7 +186,7 @@
             }
         },
         "lightReset":{
-            "summary": "Resets the application data. \n \n### Events\n \n No Events.",
+            "summary": "Resets the application data.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -203,10 +203,10 @@
             }
         },
         "resetDevice":{
-            "summary": "Resets the STB to the warehouse state. \n \n### Events \n| Event | Description | \n| :----------- | :----------- |\n| `resetDone` | Triggers when the device reset is finished indicating a successful reset or failure|.",
-            "events": [
-                "resetDone"
-            ],
+            "summary": "Resets the STB to the warehouse state.",
+            "events": {
+                "resetDone" : "Triggers when the device reset is finished indicating a successful reset or failure"
+            },
             "params": {
                 "type":"object",
                 "properties": {
@@ -249,7 +249,7 @@
             } 
         },
         "setFrontPanelState":{
-            "summary": "Sets the state of the front panel LEDs to indicate the download state of the STB software image. \n \n### Events\n \n No Events.",
+            "summary": "Sets the state of the front panel LEDs to indicate the download state of the STB software image.",
             "params": {
                 "type":"object",
                 "properties": {

--- a/WebKitBrowser/WebKitBrowser.json
+++ b/WebKitBrowser/WebKitBrowser.json
@@ -27,7 +27,7 @@
         },
         "headers": {
             "summary": "Headers to send on all requests that the browser makes",
-            "description": "Use this property to send on all requests that the browser makes.\n \n### Events \n\n No Events.",
+            "description": "Use this property to send on all requests that the browser makes.",
             "params": {
                 "type": "array",
                 "items": {
@@ -50,7 +50,7 @@
         },
         "httpcookieacceptpolicy": {
             "summary": "HTTP cookies accept policy",
-            "description": "Use this property to accept HTTP cookie policy.\n \n### Events \n\n No Events.",
+            "description": "Use this property to accept HTTP cookie policy.",
             "params": {
                 "type": "string",
                 "enum": [
@@ -70,7 +70,7 @@
         },
         "languages": {
             "summary": "User preferred languages",
-            "description": "Use this property to return User preferred languages.\n \n### Events \n\n No Events.",
+            "description": "Use this property to return User preferred languages.",
             "params": {
                 "type": "array",
                 "items": {
@@ -81,7 +81,7 @@
         },
         "localstorageenabled":{
             "summary": "Local storage availability",
-            "description": "Use this property to return Local storage availability.\n \n### Events \n\n No Events.",
+            "description": "Use this property to return Local storage availability.",
             "params": {
                 "type": "boolean",
                 "example": false
@@ -89,10 +89,10 @@
         },
         "state": {
             "summary": "Running state of the service",
-            "description": "Use this property to return the running state of the service.\n \n### Events \n| Event | Description | \n| :----------- | :----------- |\n| `statechange`| Triggered if the state of the service changes.|",
-            "events": [
-                "statechange"
-            ],
+            "description": "Use this property to return the running state of the service.",
+            "events": {
+                "statechange" : "Triggered if the state of the service changes."
+            },
             "params": {
                 "type": "string",
                 "enum": [
@@ -104,10 +104,12 @@
         },
         "url": {
             "summary": "URL loaded in the browser",
-            "description": "Use this property to load URL in the browser.\n \n### Events \n| Event | Description | \n| :----------- | :----------- |\n| `urlchange`| Triggered if the URL changes in the browser | \n |`loadfinished`| Triggered if the `urlchange` event returns `true` as URL loaded successfully |\n |`loadfailed`| Triggered if the `urlchange` event returns `false` as URL failed to load |",
-            "events": [
-                "urlchange"
-            ],
+            "description": "Use this property to load URL in the browser.",
+            "events": {
+                "urlchange" : "Triggered if the URL changes in the browser",
+                "loadfinished" : "Triggered if the urlchange event returns true as URL loaded successfully",
+                "loadfailed" : "Triggered if the urlchange event returns false as URL failed to load"
+            },
             "params": {
                 "type": "string",
                 "example": "https://www.google.com"
@@ -121,7 +123,7 @@
         },
         "useragent": {
             "summary": "`UserAgent` string used by the browser",
-            "description": "Use this property to return `UserAgent` string used by the browser.\n \n### Events \n\n No Events. ",
+            "description": "Use this property to return `UserAgent` string used by the browser.",
             "params": {
                 "type": "string",
                 "example": "Mozilla/5.0 (Linux; x86_64 GNU/Linux) AppleWebKit/601.1 (KHTML, like Gecko) Version/8.0 Safari/601.1 WP"
@@ -129,10 +131,10 @@
         },
         "visibility": {
             "summary": "Current browser visibility",
-            "description": "Use this property to return visibilty status of current browser.\n \n### Events \n| Event | Description | \n| :----------- | :----------- |\n| `visibilitychange`| Triggered if the browser visibility changes.|",
-            "events": [
-                "visibilitychange"
-            ],
+            "description": "Use this property to return visibilty status of current browser.",
+            "events": {
+                "visibilitychange" : "Triggered if the urlchange event returns false as URL failed to load"
+            },
             "params": {
                 "type": "string",
                 "example": "visible"
@@ -147,7 +149,7 @@
     },
     "methods": {
         "bridgeevent": {
-            "summary": "Sends a legacy `$badger` event.\n \n### Events \n\n No Events.",
+            "summary": "Sends a legacy `$badger` event.",
             "params": {
                 "summary": "A base64 encoded JSON string response to be delivered to the `window.$badger.event(handlerId, json)` method",
                 "type": "string",
@@ -158,7 +160,7 @@
             }
         },
         "bridgereply":{
-            "summary": "A response for legacy `$badger`.\n \n### Events \n\n No Events.",
+            "summary": "A response for legacy `$badger`.",
             "params": {
                 "summary": "A base64 encoded JSON string response to be delivered to the `$badger.callback(pid, success, json)` method",
                 "type": "string",
@@ -169,7 +171,7 @@
             }
         },
         "delete": {
-            "summary": "Removes the contents of a directory recursively from the persistent storage.\n \n### Events \n\n No Events.",
+            "summary": "Removes the contents of a directory recursively from the persistent storage.",
             "params": {
                 "type": "object",
                 "properties": {

--- a/WifiManager/Wifi.json
+++ b/WifiManager/Wifi.json
@@ -67,11 +67,11 @@
     },
     "methods": {
         "cancelWPSPairing":{
-            "summary": "Cancels the in-progress WPS pairing operation. The operation forcefully stops the in-progress pairing attempt and aborts the current scan. WPS pairing must be in-progress for the operation to succeed. \n \n### Events \n| Event | Description | \n| :----------- | :----------- | \n| `onWIFIStateChanged` | Triggered when Wifi state changes to DISCONNECTED. | \n| `onError` | Triggered when device fails to cancel the in-progress WPS pairing.|",
-            "events":[
-                "onWIFIStateChanged",
-                "onError"
-            ],
+            "summary": "Cancels the in-progress WPS pairing operation. The operation forcefully stops the in-progress pairing attempt and aborts the current scan. WPS pairing must be in-progress for the operation to succeed.",
+            "events":{
+                "onWIFIStateChanged" : "Triggered when Wifi state changes to DISCONNECTED.",
+                "onError" : "Triggered when device fails to cancel the in-progress WPS pairing."
+            },
             "result": {
                 "type": "object",
                 "properties": {
@@ -89,10 +89,10 @@
             }
         },
         "clearSSID":{
-            "summary": "Clears the saved SSID. A `result` value of `0` indicates that the SSID was cleared. A nonzero value indicates that the SSID was not cleared.\n \n### Events \n| Event | Description | \n| :----------- | :----------- | \n| `onWIFIStateChanged` | Triggered when Wifi state changes to DISCONNECTED (only if currently connected).|",
-            "events":[
-                "onWIFIStateChanged"
-            ],
+            "summary": "Clears the saved SSID. A `result` value of `0` indicates that the SSID was cleared. A nonzero value indicates that the SSID was not cleared.",
+            "events":{
+                "onWIFIStateChanged" : "Triggered when Wifi state changes to DISCONNECTED (only if currently connected)."
+            },
             "result": {
                 "type": "object",
                 "properties": {
@@ -110,11 +110,11 @@
             }
         },
         "connect":{
-            "summary": "Attempts to connect to the specified SSID with the given passphrase. Passphrase can be `null` when the network security is `NONE`. When called with no arguments, this method attempts to connect to the saved SSID and password. See `saveSSID`. \n \n### Events \n| Event | Description | \n| :----------- | :----------- | \n| `onWIFIStateChanged` | Triggered when Wifi state changes to CONNECTING, CONNECTED . | \n| `onError` | Triggered when requested SSID connection fails.|",
-            "events":[
-                "onWIFIStateChanged",
-                "onError"
-            ],
+            "summary": "Attempts to connect to the specified SSID with the given passphrase. Passphrase can be `null` when the network security is `NONE`. When called with no arguments, this method attempts to connect to the saved SSID and password. See `saveSSID`.",
+            "events":{
+                "onWIFIStateChanged" : "Triggered when Wifi state changes to CONNECTING, CONNECTED .",
+                "onError" : "Triggered when requested SSID connection fails."
+            },
             "params": {
                 "type": "object",
                 "properties": {
@@ -139,10 +139,10 @@
             }
         },
         "disconnect":{
-            "summary": "Disconnects from the SSID. A `result` value of `0` indicates that the SSID was disconnected. A nonzero value indicates that the SSID did not disconnect. \n \n### Events \n| Event | Description | \n| :----------- | :----------- | \n| `onWIFIStateChanged` | Triggered when Wifi state changes to DISCONNECTED (only if currently connected).|",
-            "events":[
-                "onWIFIStateChanged"
-            ],
+            "summary": "Disconnects from the SSID. A `result` value of `0` indicates that the SSID was disconnected. A nonzero value indicates that the SSID did not disconnect.",
+            "events":{
+                "onWIFIStateChanged" : "Triggered when Wifi state changes to DISCONNECTED (only if currently connected)."
+        },
             "result": {
                 "type": "object",
                 "properties": {
@@ -160,7 +160,7 @@
             }
         },
         "getConnectedSSID":{
-            "summary": "Returns the connected SSID information. \n  \n### Events \n\n  No Events",
+            "summary": "Returns the connected SSID information.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -208,7 +208,7 @@
             }
         },
         "getCurrentState": {
-            "summary": "Returns the current Wifi State. The possible Wifi states are as follows.  \n**Wifi States**  \n* `0`: UNINSTALLED - The device was in an installed state and was uninstalled; or, the device does not have a Wifi radio installed   \n* `1`: DISABLED - The device is installed but not yet enabled  \n* `2`: DISCONNECTED - The device is installed and enabled, but not yet connected to a network  \n* `3`: PAIRING - The device is in the process of pairing, but not yet connected to a network  \n* `4`: CONNECTING - The device is attempting to connect to a network  \n* `5`: CONNECTED - The device is successfully connected to a network  \n* `6`: FAILED - The device has encountered an unrecoverable error with the Wifi adapter. \n  \n### Events \n\n  No Events",
+            "summary": "Returns the current Wifi State. The possible Wifi states are as follows.  \n**Wifi States**  \n* `0`: UNINSTALLED - The device was in an installed state and was uninstalled; or, the device does not have a Wifi radio installed   \n* `1`: DISABLED - The device is installed but not yet enabled  \n* `2`: DISCONNECTED - The device is installed and enabled, but not yet connected to a network  \n* `3`: PAIRING - The device is in the process of pairing, but not yet connected to a network  \n* `4`: CONNECTING - The device is attempting to connect to a network  \n* `5`: CONNECTED - The device is successfully connected to a network  \n* `6`: FAILED - The device has encountered an unrecoverable error with the Wifi adapter.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -227,7 +227,7 @@
             
         },
         "getPairedSSID":{
-            "summary": "Returns the SSID to which the device is currently paired. \n  \n### Events \n\n  No Events",
+            "summary": "Returns the SSID to which the device is currently paired.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -245,7 +245,7 @@
             }
         },
         "getPairedSSIDInfo":{
-            "summary": "Returns the SSID and BSSID to which the device is currently paired. \n  \n### Events \n\n  No Events",
+            "summary": "Returns the SSID and BSSID to which the device is currently paired.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -267,7 +267,7 @@
             }
         },
         "getSupportedSecurityModes":{
-            "summary": "(Version 2) Returns the Wifi security modes that the device supports. \n  \n### Events \n\n  No Events",
+            "summary": "(Version 2) Returns the Wifi security modes that the device supports.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -349,11 +349,11 @@
             }
         },
         "initiateWPSPairing":{
-            "summary": "Initiates a connection using Wifi Protected Setup (WPS). An existing connection will be disconnected before attempting to initiate a new connection. Failure in WPS pairing will trigger an error event.\n \n### Events \n| Event | Description | \n| :----------- | :----------- | \n| `onWIFIStateChanged` | Triggered when Wifi state changes to DISCONNECTED (only if currently connected), CONNECTING, CONNECTED. | \n| `onError` | Triggered when WPS pairing fails.|",
-            "events":[
-                "onWIFIStateChanged",
-                "onError"
-            ],
+            "summary": "Initiates a connection using Wifi Protected Setup (WPS). An existing connection will be disconnected before attempting to initiate a new connection. Failure in WPS pairing will trigger an error event.",
+            "events":{
+                "onWIFIStateChanged" : "Triggered when Wifi state changes to DISCONNECTED (only if currently connected), CONNECTING, CONNECTED.",
+                "onError" : "Triggered when WPS pairing fails."
+            },
             "result": {
                 "type": "object",
                 "properties": {
@@ -371,11 +371,11 @@
             }
         },
         "initiateWPSPairing":{
-            "summary": "(Version 2) Initiates a connection using Wifi Protected Setup (WPS). An existing connection will be disconnected before attempting to initiate a new connection. Failure in WPS pairing will trigger an error event.\n\nIf the `method` parameter is set to `SERIALIZED_PIN`, then RDK retrieves the serialized pin using the Manufacturer (MFR) API. If the `method` parameter is set to `PIN`, then RDK use the pin supplied as part of the request. If the `method` parameter is set to `PBC`, then RDK uses Push Button Configuration (PBC) to obtain the pin.\n \n### Events \n| Event | Description | \n| :----------- | :----------- | \n| `onWIFIStateChanged` | Triggered when Wifi state changes to DISCONNECTED (only if currently connected), CONNECTING, CONNECTED. | \n| `onError` | Triggered when WPS pairing fails.|",
-            "events":[
-                "onWIFIStateChanged",
-                "onError"
-            ],
+            "summary": "(Version 2) Initiates a connection using Wifi Protected Setup (WPS). An existing connection will be disconnected before attempting to initiate a new connection. Failure in WPS pairing will trigger an error event.\n\nIf the `method` parameter is set to `SERIALIZED_PIN`, then RDK retrieves the serialized pin using the Manufacturer (MFR) API. If the `method` parameter is set to `PIN`, then RDK use the pin supplied as part of the request. If the `method` parameter is set to `PBC`, then RDK uses Push Button Configuration (PBC) to obtain the pin.",
+            "events":{
+                "onWIFIStateChanged" : "Triggered when Wifi state changes to DISCONNECTED (only if currently connected), CONNECTING, CONNECTED.",
+                "onError" : "Triggered when WPS pairing fails."
+            },
             "params": {
                 "type": "object",
                 "properties": {
@@ -421,7 +421,7 @@
             }
         },
         "isPaired":{
-            "summary": "Determines if the device is paired to an SSID. A `result` value of `0` indicates that this device has been previously paired (calling `saveSSID` marks this device as paired). A nonzero value indicates that the device is not paired. \n  \n### Events \n\n  No Events",
+            "summary": "Determines if the device is paired to an SSID. A `result` value of `0` indicates that this device has been previously paired (calling `saveSSID` marks this device as paired). A nonzero value indicates that the device is not paired.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -439,7 +439,7 @@
             }
         },
         "isSignalThresholdChangeEnabled":{
-            "summary": "Returns whether `onWifiSignalThresholdChanged` event is enabled or not. \n  \n### Events \n\n  No Events",
+            "summary": "Returns whether `onWifiSignalThresholdChanged` event is enabled or not.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -457,7 +457,7 @@
             }
         },
         "saveSSID":{
-            "summary": "Saves the SSID, passphrase, and security mode for future sessions. If an SSID was previously saved, the new SSID and passphrase overwrite the existing values. A `result` value of `0` indicates that the SSID was successfully saved. \n  \n### Events \n\n  No Events",
+            "summary": "Saves the SSID, passphrase, and security mode for future sessions. If an SSID was previously saved, the new SSID and passphrase overwrite the existing values. A `result` value of `0` indicates that the SSID was successfully saved.",
             "params": {
                 "type": "object",
                 "properties": {
@@ -494,7 +494,7 @@
             }
         },
         "setEnabled":{
-            "summary": "Enables or disables the Wifi adapter for this device. \n  \n### Events \n\n  No Events",
+            "summary": "Enables or disables the Wifi adapter for this device.",
             "params": {
                 "type": "object",
                 "properties": {
@@ -513,10 +513,10 @@
             }
         },
         "setSignalThresholdChangeEnabled":{
-            "summary": "Enables `signalThresholdChange` events to be triggered.\n \n### Events \n| Event | Description | \n| :----------- | :----------- | \n| `onWifiSignalThresholdChanged` | Triggered when Wifi signal strength switches between Excellent, Good, Fair, Weak.|",
-            "events":[
-                "onWifiSignalThresholdChanged"
-            ],
+            "summary": "Enables `signalThresholdChange` events to be triggered.",
+            "events":{
+                "onWifiSignalThresholdChanged" : "Triggered when Wifi signal strength switches between Excellent, Good, Fair, Weak."
+            },
             "params": {
                 "type": "object",
                 "properties": {
@@ -541,10 +541,10 @@
             }
         },
         "startScan":{
-            "summary": "Scans for available SSIDs. Available SSIDs are returned in an `onAvailableSSIDs` event.\n \n### Events \n| Event | Description | \n| :----------- | :----------- | \n| `onAvailableSSIDs` | Triggered when list of SSIDs is available after the scan completes.|",
-            "events": [
-                "onAvailableSSIDs"
-            ],
+            "summary": "Scans for available SSIDs. Available SSIDs are returned in an `onAvailableSSIDs` event.",
+            "events": {
+                "onAvailableSSIDs" : "Triggered when list of SSIDs is available after the scan completes."
+            },
             "params": {
                 "type": "object",
                 "properties": {
@@ -587,7 +587,7 @@
             }
         },
         "stopScan":{
-            "summary": "Stops scanning for SSIDs. Any discovered SSIDs from the call to the `startScan` method up to the point where this method is called are still returned.\n  \n### Events \n\n  No Events",
+            "summary": "Stops scanning for SSIDs. Any discovered SSIDs from the call to the `startScan` method up to the point where this method is called are still returned.",
             "result": {
                 "$ref": "#/common/result"
             }

--- a/XCast/XCast.json
+++ b/XCast/XCast.json
@@ -48,7 +48,7 @@
     },
     "methods": {
         "getApiVersionNumber":{
-            "summary": "Gets the API version.\n  \n### Events \n\n No Events",
+            "summary": "Gets the API version.",
             "result": {
                 "type":"object",
                 "properties": {
@@ -68,7 +68,7 @@
             }
         },
         "getEnabled":{
-            "summary": "Reports whether xcast is enabled or disabled.\n  \n### Events \n\n No Events",
+            "summary": "Reports whether xcast is enabled or disabled.",
             "result": {
                 "type":"object",
                 "properties": {
@@ -86,7 +86,7 @@
             }
         },
         "getFriendlyName":{
-            "summary": "Returns the friendly name set by setFriendlyName API.\n  \n### Events \n\n No Events",
+            "summary": "Returns the friendly name set by setFriendlyName API.",
             "result": {
                 "type":"object",
                 "properties": {
@@ -104,7 +104,7 @@
             }
         },
         "getProtocolVersion":{
-            "summary": "Returns the DIAL protocol version supported by the server.\n  \n### Events \n\n No Events",
+            "summary": "Returns the DIAL protocol version supported by the server.",
             "result": {
                 "type":"object",
                 "properties": {
@@ -122,7 +122,7 @@
             }
         },
         "getStandbyBehavior":{
-            "summary": "Gets the expected xcast behavior in standby mode.\n  \n### Events \n\n No Events",
+            "summary": "Gets the expected xcast behavior in standby mode.",
             "result": {
                 "type":"object",
                 "properties": {
@@ -140,7 +140,7 @@
             }
         },  
         "onApplicationStateChanged":{
-            "summary": "Provides notification whenever an application changes state due to user activity, an internal error, or other reasons. For singleton applications, the `applicationId` parameter is optional. If an application request is denied, fails to fulfill, or the state change is triggered by an internal error, then a predefined error string should be included. This error may be translated to an XCast client.  \n\nThe following table provides a client error mapping example: \n\n| Error | Description | HTTP Status Codes |  \n| :-------- | :-------- | :-------- |   \n| `none` | The request (start/stop) is fulfilled successfully | HTTP 200 OK |  \n| `forbidden` | The user is not allowed to change the state of the application. This is not related to user account authentication of the native application | HTTP 403 Forbidden |  \n| `unavailable` | The target native application is not available on the device | HTTP 404 Not Found |  \n| `invalid` | The request is invalid (bad parameter for example) | HTTP 400 Bad Request |  \n| `internal` | The server failed to fulfill the request (server error) | HTTP 500 Internal |\n  \n### Events \n\n No Events",
+            "summary": "Provides notification whenever an application changes state due to user activity, an internal error, or other reasons. For singleton applications, the `applicationId` parameter is optional. If an application request is denied, fails to fulfill, or the state change is triggered by an internal error, then a predefined error string should be included. This error may be translated to an XCast client.  \n\nThe following table provides a client error mapping example: \n\n| Error | Description | HTTP Status Codes |  \n| :-------- | :-------- | :-------- |   \n| `none` | The request (start/stop) is fulfilled successfully | HTTP 200 OK |  \n| `forbidden` | The user is not allowed to change the state of the application. This is not related to user account authentication of the native application | HTTP 403 Forbidden |  \n| `unavailable` | The target native application is not available on the device | HTTP 404 Not Found |  \n| `invalid` | The request is invalid (bad parameter for example) | HTTP 400 Bad Request |  \n| `internal` | The server failed to fulfill the request (server error) | HTTP 500 Internal |",
             "params": {
                 "type":"object",
                 "properties": {
@@ -171,7 +171,7 @@
             }
         },
         "registerApplications": {
-            "summary": "Registers an application. This allows to whitelist the apps which support dial service. To dynamically update the app list, same API should be called with the updated list.\n  \n### Events \n\n No Events",
+            "summary": "Registers an application. This allows to whitelist the apps which support dial service. To dynamically update the app list, same API should be called with the updated list.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -190,7 +190,7 @@
             }
         },
         "setEnabled":{
-            "summary": "Enables or disables xcast.\n  \n### Events \n\n No Events",
+            "summary": "Enables or disables xcast.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -207,7 +207,7 @@
             }
         },
         "setFriendlyName":{
-            "summary": "Sets the friendly name of device. It allows an application to override the default friendly name value with the friendly name passed as an argument.\n  \n### Events \n\n No Events",
+            "summary": "Sets the friendly name of device. It allows an application to override the default friendly name value with the friendly name passed as an argument.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -224,7 +224,7 @@
             }
         },
         "setStandbyBehavior":{
-            "summary": "Sets the expected xcast behavior in standby mode. It allows an application to override controls on xcast behavior in standby mode. The default behavior in STANDBY mode is inactive, so client device can not discover the server. When STANDBY behavior is active, client device can discover the server.\n  \n### Events \n\n No Events",
+            "summary": "Sets the expected xcast behavior in standby mode. It allows an application to override controls on xcast behavior in standby mode. The default behavior in STANDBY mode is inactive, so client device can not discover the server. When STANDBY behavior is active, client device can discover the server.",
             "params": {
                 "type":"object",
                 "properties": {

--- a/docs/api/AVInputPlugin.md
+++ b/docs/api/AVInputPlugin.md
@@ -57,6 +57,10 @@ AVInput interface methods:
 
 Returns `true` if the content coming in the HDMI input is protected; otherwise, it returns `false`. If the content is protected, then it is only presented if the component and composite outputs of the box are disabled.
 
+### Events
+
+No Events
+
 ### Parameters
 
 | Name | Type | Description |
@@ -100,11 +104,11 @@ Returns `true` if the content coming in the HDMI input is protected; otherwise, 
 <a name="currentVideoMode"></a>
 ## *currentVideoMode*
 
-Returns a string encoding the video mode being supplied by the device currently attached to the HDMI input. The format of the string is the same format used for the `resolutionName` parameter of the XRE `setResolution` messages. HDMI input is presentable if its resolution is less than or equal to the current Parker display resolution. 
- 
+Returns a string encoding the video mode being supplied by the device currently attached to the HDMI input. The format of the string is the same format used for the `resolutionName` parameter of the XRE `setResolution` messages. HDMI input is presentable if its resolution is less than or equal to the current Parker display resolution.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -151,11 +155,11 @@ Returns a string encoding the video mode being supplied by the device currently 
 <a name="numberOfInputs"></a>
 ## *numberOfInputs*
 
-Returns an integer that specifies the number of available inputs. For example, a value of `2` indicates that there are two available inputs that can be selected using `avin://input0` and `avin://input1`. 
- 
+Returns an integer that specifies the number of available inputs. For example, a value of `2` indicates that there are two available inputs that can be selected using `avin://input0` and `avin://input1`.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 

--- a/docs/api/ActivityMonitorPlugin.md
+++ b/docs/api/ActivityMonitorPlugin.md
@@ -57,15 +57,13 @@ ActivityMonitor interface methods:
 ## *enableMonitoring*
 
 Enables monitoring for the given application PIDs using the given thresholds for memory and CPU usage at frequencies specified by the intervals.
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- | 
-| `onMemoryThresholdOccured` | Triggered when an application exceeds the given memory threshold | 
- | `onCPUThresholdOccured` | Triggered when an application exceeds the `cpuThresholdPercent` value for a duration longer than the `cpuThresholdSeconds` value |.
 
-Also see: [onCPUThresholdOccurred](#onCPUThresholdOccurred), [onMemoryThresholdOccurred](#onMemoryThresholdOccurred)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onCPUThresholdOccurred](#onCPUThresholdOccurred) | Triggered when an application exceeds the `cpuThresholdPercent` value for a duration longer than the `cpuThresholdSeconds` value |
+| [onMemoryThresholdOccurred](#onMemoryThresholdOccurred) | Triggered when an application exceeds the given memory threshold |
 ### Parameters
 
 | Name | Type | Description |
@@ -127,10 +125,10 @@ Also see: [onCPUThresholdOccurred](#onCPUThresholdOccurred), [onMemoryThresholdO
 ## *disableMonitoring*
 
 Disables monitoring for all applications. Monitoring stops immediately even if the full collection interval has not been reached.
- 
-### Events 
- 
-No events.
+
+### Events
+
+No Events
 
 ### Parameters
 
@@ -174,10 +172,10 @@ No events.
 ## *getApplicationMemoryUsage*
 
 Returns memory usage for a specific monitor-enabled application.
- 
-### Events 
- 
-No events.
+
+### Events
+
+No Events
 
 ### Parameters
 
@@ -233,10 +231,10 @@ No events.
 ## *getAllMemoryUsage*
 
 Returns memory usage for all monitoring-enabled applications.
- 
-### Events 
- 
-No events.
+
+### Events
+
+No Events
 
 ### Parameters
 

--- a/docs/api/BluetoothPlugin.md
+++ b/docs/api/BluetoothPlugin.md
@@ -76,14 +76,12 @@ Bluetooth interface methods:
 ## *connect*
 
 Initiates the connection with the given Bluetooth device. Triggers `onStatusChanged` 
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- | 
-| `BluetoothState: CONNECTION_CHANGE` | Triggers `onStatusChanged` event once it is  connected to the given deviceID. |.
 
-Also see: [onStatuschanged](#onStatuschanged)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onStatusChanged](#onStatusChanged) | Triggers `onStatusChanged` event once it is  connected to the given deviceID. |
 ### Parameters
 
 | Name | Type | Description |
@@ -132,11 +130,11 @@ Also see: [onStatuschanged](#onStatuschanged)
 <a name="disable"></a>
 ## *disable*
 
-Disables the Bluetooth stack. 
- 
-### Events 
-  
- No Events.
+Disables the Bluetooth stack.
+
+### Events
+
+No Events
 
 ### Parameters
 
@@ -176,15 +174,13 @@ This method takes no parameters.
 <a name="disconnect"></a>
 ## *disconnect*
 
-Disconnects the given device from this device ID and triggers `onStatusChanged` Event. 
- 
-### Events  
-| Event | Description | 
-| :----------- | :----------- | 
-| `BluetoothState`: `CONNECTION_CHANGE` |Triggers `onStatusChanged` event once it is disconnected from given deviceID.| .
+Disconnects the given device from this device ID and triggers `onStatusChanged` Event.
 
-Also see: [onStatusChanged](#onStatusChanged)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onStatusChanged](#onStatusChanged) | Triggers `onStatusChanged` event once it is disconnected from given deviceID. |
 ### Parameters
 
 | Name | Type | Description |
@@ -231,11 +227,11 @@ Also see: [onStatusChanged](#onStatusChanged)
 <a name="enable"></a>
 ## *enable*
 
-Enables the Bluetooth stack. 
-  
-### Events 
+Enables the Bluetooth stack.
 
-  No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -275,11 +271,11 @@ This method takes no parameters.
 <a name="getAudioInfo"></a>
 ## *getAudioInfo*
 
-Provides information on the currently playing song/audio from an external source. The returned information from Bluetooth-In device provides information that could be displayed on a TV screen.  
-  
-### Events 
+Provides information on the currently playing song/audio from an external source. The returned information from Bluetooth-In device provides information that could be displayed on a TV screen.
 
-  No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -342,11 +338,11 @@ Provides information on the currently playing song/audio from an external source
 <a name="getConnectedDevices"></a>
 ## *getConnectedDevices*
 
-Returns a list of devices connected to this device.  
-  
-### Events 
+Returns a list of devices connected to this device.
 
-  No Events .
+### Events
+
+No Events
 
 ### Parameters
 
@@ -400,11 +396,11 @@ This method takes no parameters.
 <a name="getDeviceInfo"></a>
 ## *getDeviceInfo*
 
-Returns information for the given device ID. 
-  
-### Events 
+Returns information for the given device ID.
 
-  No Events .
+### Events
+
+No Events
 
 ### Parameters
 
@@ -469,11 +465,11 @@ Returns information for the given device ID.
 <a name="getDiscoveredDevices"></a>
 ## *getDiscoveredDevices*
 
-This method should be called after getting at least one event `onDiscoveredDevice` event and it returns an array of discovered devices. 
-  
-### Events 
+This method should be called after getting at least one event `onDiscoveredDevice` event and it returns an array of discovered devices.
 
-  No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -529,11 +525,11 @@ This method takes no parameters.
 <a name="getName"></a>
 ## *getName*
 
-Returns the name of this device as seen by other Bluetooth devices. 
-  
-### Events 
+Returns the name of this device as seen by other Bluetooth devices.
 
-  No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -575,11 +571,11 @@ This method takes no parameters.
 <a name="getPairedDevices"></a>
 ## *getPairedDevices*
 
-Returns a list of devices that have paired with this device. 
-  
-### Events 
+Returns a list of devices that have paired with this device.
 
-  No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -634,10 +630,10 @@ This method takes no parameters.
 ## *isDiscoverable*
 
 Returns `true`, if this device can be discovered by other Bluetooth devices.
-  
-### Events 
 
-  No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -680,15 +676,13 @@ This method takes no parameters.
 ## *pair*
 
 Pairs this device with device ID of Bluetooth. Triggers `onStatusChanged` and `onRequestFailed` events.
- 
-### Events  
-| Event | Description | 
-| :----------- | :----------- | 
-| `BluetoothState`: `PAIRING_CHANGE` | Triggers `onStatusChanged` event when the device gets paired to given device ID. | 
-| `BluetoothState`: `PAIRING_FAILED` | Triggers `onRequestFailed` event, when the device is unable to pair.|.
 
-Also see: [onStatusChanged](#onStatusChanged), [onRequestFailed](#onRequestFailed)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onStatusChanged](#onStatusChanged) | Triggers onStatusChanged event when the device gets paired to given device ID. |
+| [onRequestFailed](#onRequestFailed) | Triggers onRequestFailed event, when the device is unable to pair (BluetoothState: PAIRING_FAILED) |
 ### Parameters
 
 | Name | Type | Description |
@@ -733,11 +727,11 @@ Also see: [onStatusChanged](#onStatusChanged), [onRequestFailed](#onRequestFaile
 <a name="respondToEvent"></a>
 ## *respondToEvent*
 
-Provides the ability to respond the client Bluetooth  For example, this device can respond to a pairing or connection event and indicate the proper response to the requested device, such as the connection request accepted. 
-  
-### Events 
+Provides the ability to respond the client Bluetooth  For example, this device can respond to a pairing or connection event and indicate the proper response to the requested device, such as the connection request accepted.
 
-  No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -787,11 +781,11 @@ Provides the ability to respond the client Bluetooth  For example, this device c
 <a name="sendAudioPlaybackCommand"></a>
 ## *sendAudioPlaybackCommand*
 
-Provides control over the connected source. Requests can have one of the following values: PLAY, PAUSE, RESUME, STOP, SKIP_NEXT, SKIP_PREV, RESTART, MUTE, UNMUTE, VOLUME_UP, VOLUME_DOWN. 
- 
-### Events  
- 
- No Events.
+Provides control over the connected source. Requests can have one of the following values: PLAY, PAUSE, RESUME, STOP, SKIP_NEXT, SKIP_PREV, RESTART, MUTE, UNMUTE, VOLUME_UP, VOLUME_DOWN.
+
+### Events
+
+No Events
 
 ### Parameters
 
@@ -839,11 +833,11 @@ Provides control over the connected source. Requests can have one of the followi
 <a name="setAudioStream"></a>
 ## *setAudioStream*
 
-Sets the primary or secondary audio-out to the given Bluetooth device. 
-  
-### Events 
+Sets the primary or secondary audio-out to the given Bluetooth device.
 
-  No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -891,11 +885,11 @@ Sets the primary or secondary audio-out to the given Bluetooth device.
 <a name="setDiscoverable"></a>
 ## *setDiscoverable*
 
-When true, this device can be discovered by other Bluetooth devices. When false, this device is not discoverable. 
-  
-### Events 
+When true, this device can be discovered by other Bluetooth devices. When false, this device is not discoverable.
 
-  No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -944,10 +938,10 @@ When true, this device can be discovered by other Bluetooth devices. When false,
 ## *setName*
 
 Sets the name of this device as seen by other Bluetooth devices.
-  
-### Events 
 
-  No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -1004,18 +998,13 @@ Starts scanning for other Bluetooth devices that match the given profile.
 * `AVAILABLE` - Bluetooth stack is initialized, not software disabled, and hardware is running  
 * `NO_BLUETOOTH_HARDWARE` - Bluetooth is supported in RDK software, but no Bluetooth hardware was found.
 * This method sends both `onStatusChanged` and `onDiscoveredDevice` events.
- 
-### Events 
-  
-| Event | Description | 
-| :----------- | :----------- | 
-| `BluetoothState:` `DISCOVERY_STARTED` |Triggered `onStatusChanged`event when device starts scanning the other available Bluetooth devices. | 
-| `BluetoothState:` `DISCOVERY_COMPLETED` | Triggered `onStatusChanged`event when timeout (timeout param) is completed or the `StopScan` method called.| 
-| `DiscoveryType:` `DISCOVERED` |Triggered `onDiscoveredDevice` event when device is in scanning mode and at least one device is discovered | 
-|`DiscoveryType:` `LOST` | Triggered `onDiscoveredDevice` event when the scanned device is lost|.
 
-Also see: [onStatusChanged](#onStatusChanged), [onDiscoveredDevice](#onDiscoveredDevice)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onStatusChanged](#onStatusChanged) | Triggered onStatusChangedevent when device starts scanning the other available Bluetooth devices or when timeout (timeout param) is completed or the StopScan method called. |
+| [onDiscoveredDevice](#onDiscoveredDevice) | Triggered onDiscoveredDevice event when device is in scanning mode and at least one device is discovered or when the scanned device is lost. |
 ### Parameters
 
 | Name | Type | Description |
@@ -1064,15 +1053,13 @@ Also see: [onStatusChanged](#onStatusChanged), [onDiscoveredDevice](#onDiscovere
 <a name="stopScan"></a>
 ## *stopScan*
 
-Stops scanning for Bluetooth devices  if already scan is in-progress and triggers `onStatusChanged`   
- 
-### Events  
-| Event | Description | 
-| :----------- | :----------- | 
-| `BluetoothState:` `DISCOVERY_COMPLETED` | Triggered `onStatusChanged` event when scan is stopped.| .
+Stops scanning for Bluetooth devices  if already scan is in-progress and triggers `onStatusChanged` 
 
-Also see: [onStatusChanged](#onStatusChanged)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onStatusChanged](#onStatusChanged) | Triggered onStatusChanged event when scan is stopped. |
 ### Parameters
 
 This method takes no parameters.
@@ -1112,14 +1099,12 @@ This method takes no parameters.
 ## *unpair*
 
 Unpairs the given device ID from this device. Triggers `onStatusChanged` 
- 
-### Events  
-| Event | Description | 
-| :----------- | :----------- | 
-| `BluetoothState: PAIRING_CHANGE` | Triggers `onStatusChanged` event when device is unpaired |.
 
-Also see: [onStatusChanged](#onStatusChanged)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onStatusChanged](#onStatusChanged) | Triggers onStatusChanged event when device is unpaired. |
 ### Parameters
 
 | Name | Type | Description |
@@ -1164,11 +1149,11 @@ Also see: [onStatusChanged](#onStatusChanged)
 <a name="getDeviceVolumeMuteInfo"></a>
 ## *getDeviceVolumeMuteInfo*
 
-Gets the volume information of the given Bluetooth device ID. 
- 
-### Events 
+Gets the volume information of the given Bluetooth device ID.
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -1224,18 +1209,12 @@ Gets the volume information of the given Bluetooth device ID.
 ## *setDeviceVolumeMuteInfo*
 
 Sets the volume of the connected Bluetooth device ID.  Triggers `onDeviceMediaStatus` 
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- | 
-| `MediaAudioControlCommand`: `VOLUME_UP` | Triggers `onDeviceMediaStatus` event once volume of connected given deviceID is increased. | 
-| `MediaAudioControlCommand`: `VOLUME_DOWN` | Triggers `onDeviceMediaStatus` event once volume of connected given deviceID is decreased. | 
-| `MediaAudioControlCommand`: `MUTE` | Triggers `onDeviceMediaStatus` event when connected given deviceID is muted. | 
-| `MediaAudioControlCommand`: `UNMUTE` | Triggers `onDeviceMediaStatus` event when connected given deviceID is unmuted. | 
-| `MediaAudioControlCommand`: `CMD_UNKNOWN` | Triggers `onDeviceMediaStatus` event when unknown key is pressed on connected given deviceID. |.
 
-Also see: [onDeviceMediaStatus](#onDeviceMediaStatus)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onDeviceMediaStatus](#onDeviceMediaStatus) | Triggers onDeviceMediaStatus event once volume of connected given deviceID is increased or decreased or when connected given deviceID is muted or unmuted or when unknown key is pressed on connected given deviceID. |
 ### Parameters
 
 | Name | Type | Description |
@@ -1286,11 +1265,11 @@ Also see: [onDeviceMediaStatus](#onDeviceMediaStatus)
 <a name="getApiVersionNumber"></a>
 ## *getApiVersionNumber*
 
-Provides the current API version number. 
- 
-### Event 
+Provides the current API version number.
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 

--- a/docs/api/CompositeInputPlugin.md
+++ b/docs/api/CompositeInputPlugin.md
@@ -57,10 +57,10 @@ CompositeInput interface methods:
 ## *getCompositeInputDevices*
 
 returns a list of composite input devices.
- 
+
 ### Events
- 
-No Events.
+
+No Events
 
 ### Parameters
 
@@ -113,10 +113,10 @@ This method takes no parameters.
 ## *setVideoRectangle*
 
 Sets the composite input video window.
- 
+
 ### Events
- 
-No Events.
+
+No Events
 
 ### Parameters
 
@@ -169,15 +169,13 @@ No Events.
 ## *startCompositeInput*
 
 Activates the specified composite input as the primary video source.
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- | 
-| `onInputStatusChanged` | Triggers this event when activates composite input source and input status changes to `started` | 
-| `onSignalChanged` | Triggers this event when composite input signal changes (must be one of the following:noSignal, unstableSignal, notSupportedSignal, stableSignal) |.
 
-Also see: [onInputStatusChanged](#onInputStatusChanged), [onSignalChanged](#onSignalChanged)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onInputStatusChanged](#onInputStatusChanged) | Triggers this event when activates composite input source and input status changes to started |
+| [onSignalChanged](#onSignalChanged) | Triggers this event when composite input signal changes (must be one of the following:noSignal, unstableSignal, notSupportedSignal, stableSignal) |
 ### Parameters
 
 | Name | Type | Description |
@@ -223,14 +221,12 @@ Also see: [onInputStatusChanged](#onInputStatusChanged), [onSignalChanged](#onSi
 ## *stopCompositeInput*
 
 Deactivates the current composite input source that is the primary video source.
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- | 
-| `onInputStatusChanged` | Triggers this event when deactivates composite input source and input status changes to `stopped` |.
 
-Also see: [onInputStatusChanged](#onInputStatusChanged)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onInputStatusChanged](#onInputStatusChanged) | Triggers this event when deactivates composite input source and input status changes to stopped |
 ### Parameters
 
 This method takes no parameters.

--- a/docs/api/ContinueWatchingPlugin.md
+++ b/docs/api/ContinueWatchingPlugin.md
@@ -56,6 +56,10 @@ ContinueWatching interface methods:
 
 Deletes the stored tokens for a particular application.
 
+### Events
+
+No Events
+
 ### Parameters
 
 | Name | Type | Description |
@@ -101,6 +105,10 @@ Deletes the stored tokens for a particular application.
 ## *getApplicationToken*
 
 Retrieves the tokens for a particular application.
+
+### Events
+
+No Events
 
 ### Parameters
 
@@ -157,6 +165,10 @@ Retrieves the tokens for a particular application.
 ## *setApplicationToken*
 
 Sets the given tokens for an application.
+
+### Events
+
+No Events
 
 ### Parameters
 

--- a/docs/api/ControlServicePlugin.md
+++ b/docs/api/ControlServicePlugin.md
@@ -64,11 +64,11 @@ ControlService interface methods:
 <a name="canFindMyRemote"></a>
 ## *canFindMyRemote*
 
-Checks if the Control Manager can search for the remote. 
- 
+Checks if the Control Manager can search for the remote.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -113,11 +113,11 @@ Checks if the Control Manager can search for the remote.
 <a name="checkRf4ceChipConnectivity"></a>
 ## *checkRf4ceChipConnectivity*
 
-Checks Rf4ce chip connectivity status. 
- 
+Checks Rf4ce chip connectivity status.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -162,11 +162,11 @@ Checks Rf4ce chip connectivity status.
 <a name="endPairingMode"></a>
 ## *endPairingMode*
 
-Leaves pairing mode. 
- 
+Leaves pairing mode.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -214,14 +214,12 @@ Leaves pairing mode.
 ## *findLastUsedRemote*
 
 Searches for the last used remote.
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- |
-| `onControl`| Triggered when the last used remote is successfully found |.
 
-Also see: [onControl](#onControl)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onControl](#onControl) | Triggered when the last used remote is successfully found |
 ### Parameters
 
 | Name | Type | Description |
@@ -268,11 +266,11 @@ Also see: [onControl](#onControl)
 <a name="getAllRemoteData"></a>
 ## *getAllRemoteData*
 
-Returns all remote data. 
- 
+Returns all remote data.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -504,11 +502,11 @@ Returns all remote data.
 <a name="getLastKeypressSource"></a>
 ## *getLastKeypressSource*
 
-Returns last key press source data. The data, if any, is returned as part of the `result` object. 
- 
+Returns last key press source data. The data, if any, is returned as part of the `result` object.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -567,11 +565,11 @@ Returns last key press source data. The data, if any, is returned as part of the
 <a name="getLastPairedRemoteData"></a>
 ## *getLastPairedRemoteData*
 
-Returns all remote data for the last paired remote. The data, if any, is returned as part of the `result` object. 
- 
+Returns all remote data for the last paired remote. The data, if any, is returned as part of the `result` object.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -767,11 +765,11 @@ Returns all remote data for the last paired remote. The data, if any, is returne
 <a name="getQuirks"></a>
 ## *getQuirks*
 
-Gets quirks. 
- 
+Gets quirks.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -819,11 +817,11 @@ Gets quirks.
 <a name="getSingleRemoteData"></a>
 ## *getSingleRemoteData*
 
-Returns all remote data for the specified remote. The data, if any, is returned as part of the `result` object. 
- 
+Returns all remote data for the specified remote. The data, if any, is returned as part of the `result` object.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -1022,11 +1020,11 @@ Returns all remote data for the specified remote. The data, if any, is returned 
 <a name="getValues"></a>
 ## *getValues*
 
-Returns remote setting values. 
- 
+Returns remote setting values.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -1087,11 +1085,11 @@ Returns remote setting values.
 <a name="setValues"></a>
 ## *setValues*
 
-Sets remote setting values. 
- 
+Sets remote setting values.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -1151,11 +1149,11 @@ Sets remote setting values.
 <a name="startPairingMode"></a>
 ## *startPairingMode*
 
-Enters pairing mode. 
- 
+Enters pairing mode.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 

--- a/docs/api/DTVPlugin.md
+++ b/docs/api/DTVPlugin.md
@@ -60,10 +60,10 @@ DTV interface methods:
 ## *addLnb*
 
 Add a new LNB to the database.
-  
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -133,10 +133,10 @@ Add a new LNB to the database.
 ## *addSatellite*
 
 Add a new satellite to the database.
-  
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -184,15 +184,13 @@ Add a new satellite to the database.
 ## *startServiceSearch*
 
 Starts a service search.
- 
-### Events  
-| Event | Description | 
-| :----------- | :----------- | 
-|`searchstatus`|Triggered during the course of a service search.|
- |`serviceupdated`|Triggered when a service is added|.
 
-Also see: [searchstatus](#searchstatus), [serviceupdated](#serviceupdated)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [searchstatus](#searchstatus) |  Triggered during the course of a service search. |
+| [serviceupdated](#serviceupdated) | Triggered when a service is added |
 ### Parameters
 
 | Name | Type | Description |
@@ -280,10 +278,10 @@ Also see: [searchstatus](#searchstatus), [serviceupdated](#serviceupdated)
 ## *finishServiceSearch*
 
 Finishes a service search.
-  
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -329,18 +327,16 @@ Finishes a service search.
 ## *startPlaying*
 
 Starts playing the specified service.
-  
+
 ### Events
+
 | Event | Description |
-| :----------- | :----------- |
-|`serviceupdated`|Triggered when info for a service changes|
-|`eventchanged`|Triggered when the EIT 'now' event changes|
-|`videochanged`|Triggered when the video PID or codec are changed|
-|`audiochanged`|Triggered when the audio PID or codec are changed|
-|`subtitleschanged`|Triggered when the subtitle PID or details are changed| .
-
-Also see: [serviceupdated](#serviceupdated), [eventchanged](#eventchanged), [videochanged](#videochanged), [audiochanged](#audiochanged), [subtitleschanged](#subtitleschanged)
-
+| :-------- | :-------- |
+| [serviceupdated](#serviceupdated) | Triggered when info for a service changes |
+| [eventchanged](#eventchanged) | Triggered when the EIT ‘now’ event changes |
+| [videochanged](#videochanged) | Triggered when the video PID or codec are changed |
+| [audiochanged](#audiochanged) | Triggered when the audio PID or codec are changed |
+| [subtitleschanged](#subtitleschanged) | Triggered when the subtitle PID or details are changed |
 ### Parameters
 
 | Name | Type | Description |
@@ -387,10 +383,10 @@ Also see: [serviceupdated](#serviceupdated), [eventchanged](#eventchanged), [vid
 ## *stopPlaying*
 
 Stops playing the specified service.
-  
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -460,6 +456,10 @@ Provides access to the number of country configurations available.
 
 > This property is **read-only**.
 
+### Events
+
+No Events
+
 ### Value
 
 | Name | Type | Description |
@@ -494,6 +494,10 @@ Provides access to the number of country configurations available.
 Provides access to the array containing the name and 3 character ISO country code for all the available country configurations.
 
 > This property is **read-only**.
+
+### Events
+
+No Events
 
 ### Value
 
@@ -535,6 +539,10 @@ Provides access to the array containing the name and 3 character ISO country cod
 ## *country*
 
 Provides access to the country configuration using the ISO 3-character country code.
+
+### Events
+
+No Events
 
 ### Value
 
@@ -591,6 +599,10 @@ Provides access to the country configuration using the ISO 3-character country c
 Provides access to the array of LNBs defined in the database.
 
 > This property is **read-only**.
+
+### Events
+
+No Events
 
 ### Value
 
@@ -659,6 +671,10 @@ Provides access to the array of satellites defined in the database.
 
 > This property is **read-only**.
 
+### Events
+
+No Events
+
 ### Value
 
 | Name | Type | Description |
@@ -704,6 +720,10 @@ Provides access to the total number of services in the service database.
 
 > This property is **read-only**.
 
+### Events
+
+No Events
+
 ### Value
 
 | Name | Type | Description |
@@ -738,6 +758,10 @@ Provides access to the total number of services in the service database.
 Provides access to the list of services for the given type of tuner, transport (version 2), or all services if neither is given.
 
 > This property is **read-only**.
+
+### Events
+
+No Events
 
 ### Value
 
@@ -800,6 +824,10 @@ Provides access to the information for the given service as defined by its DVB t
 
 > This property is **read-only**.
 
+### Events
+
+No Events
+
 ### Value
 
 | Name | Type | Description |
@@ -857,6 +885,10 @@ Provides access to the information for the given service as defined by its DVB t
 Provides access to the (Version 2) array of components for the given service defined by its URI.
 
 > This property is **read-only**.
+
+### Events
+
+No Events
 
 ### Value
 
@@ -946,6 +978,10 @@ Provides access to the information for the given transport as defined by its DVB
 
 > This property is **read-only**.
 
+### Events
+
+No Events
+
 ### Value
 
 | Name | Type | Description |
@@ -1032,6 +1068,10 @@ Provides access to the information for the given transport as defined by its DVB
 Provides access to the now and next events (EITp/f) for the given service.
 
 > This property is **read-only**.
+
+### Events
+
+No Events
 
 ### Value
 
@@ -1123,6 +1163,10 @@ Provides access to the events which are scheduled (EITsched) for the given servi
 
 > This property is **read-only**.
 
+### Events
+
+No Events
+
 ### Value
 
 | Name | Type | Description |
@@ -1187,6 +1231,10 @@ Provides access to the extended event info for the given service and event ID (v
 
 > This property is **read-only**.
 
+### Events
+
+No Events
+
 ### Value
 
 | Name | Type | Description |
@@ -1237,6 +1285,10 @@ Provides access to the information related to the play handle defined by the ind
 
 > This property is **read-only**.
 
+### Events
+
+No Events
+
 ### Value
 
 | Name | Type | Description |
@@ -1284,6 +1336,10 @@ Provides access to the information related to the play handle defined by the ind
 Provides access to the strength and quality of the currently tuned signal for the given play handle (version 2).
 
 > This property is **read-only**.
+
+### Events
+
+No Events
 
 ### Value
 

--- a/docs/api/DataCapturePlugin.md
+++ b/docs/api/DataCapturePlugin.md
@@ -58,11 +58,11 @@ Enables audio capturing to buffer.
 Return Values:  
 * `0` - No error  
 * `1 - 254` - request exceeds the maximum allowed buffer size. The error number represents the maximum buffer length, in seconds, that the set-top device can support.  
-* `255` - set top device cannot accommodate any level of audio buffering. 
- 
-### Events 
+* `255` - set top device cannot accommodate any level of audio buffering.
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -114,15 +114,12 @@ Requests the audio driver to capture an audio sample from the specified stream a
 Supported streams:  
 * `primary` - The stream going to the analog output and the stream included in the HDMI output. This is the only stream that is valid when the request is made through a voice request.  
 * `secondary` - The stream is captured from a secondary decoder. A potential use case includes initiating a capture from a screen overlay where the user has a choice between primary or secondary audio (or the type of audio output to which the user listens – TV or Bluetooth).
- 
-Events
- 
-| Event | Description | 
-| :-------- | :-------- | 
-| `onAudioClipReady` | Triggered if an audio clip uploaded successfully or not |.
 
-Also see: [onAudioClipReady](#onAudioClipReady)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onAudioClipReady](#onAudioClipReady) | Triggered if an audio clip uploaded successfully or not |
 ### Parameters
 
 | Name | Type | Description |

--- a/docs/api/DeviceDiagnosticsPlugin.md
+++ b/docs/api/DeviceDiagnosticsPlugin.md
@@ -57,10 +57,10 @@ DeviceDiagnostics interface methods:
 ## *getConfiguration*
 
 Gets the values associated with the corresponding property names.
- 
-### Events 
- 
-No events.
+
+### Events
+
+No Events
 
 ### Parameters
 
@@ -120,10 +120,10 @@ No events.
 ## *getMilestones*
 
 Returns the list of milestones.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -169,10 +169,10 @@ This method takes no parameters.
 ## *logMilestone*
 
 Log marker string to rdk milestones log.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -219,10 +219,10 @@ Log marker string to rdk milestones log.
 ## *getAVDecoderStatus*
 
 Gets the most active status of audio/video decoder/pipeline. This API doesn't track individual pipelines. It will aggregate and report the pipeline status, and the pipeline states are prioritized from High to Low (`ACTIVE`, `PAUSED`, and `IDLE`). Therefore, if any of the pipelines is in active state, then `getAVDecoderStatus` will return `ACTIVE`. If none of the pipelines are active but one is in a paused state, then `getAVDecoderStatus` will return `PAUSED`, and if all the pipelines are idle only then, `IDLE` will be returned.
- 
-### Events 
- 
-No events.
+
+### Events
+
+No Events
 
 ### Parameters
 

--- a/docs/api/DeviceIdentificationPlugin.md
+++ b/docs/api/DeviceIdentificationPlugin.md
@@ -56,6 +56,10 @@ Provides access to the device platform specific information.
 
 > This property is **read-only**.
 
+### Events
+
+No Events
+
 ### Value
 
 | Name | Type | Description |

--- a/docs/api/DeviceInfoPlugin.md
+++ b/docs/api/DeviceInfoPlugin.md
@@ -60,6 +60,10 @@ DeviceInfo interface methods:
 
 Supported resolutions on the selected video display port.
 
+### Events
+
+No Events
+
 ### Parameters
 
 | Name | Type | Description |
@@ -115,6 +119,10 @@ Supported resolutions on the selected video display port.
 
 Default resolution on the selected video display port.
 
+### Events
+
+No Events
+
 ### Parameters
 
 | Name | Type | Description |
@@ -167,6 +175,10 @@ Default resolution on the selected video display port.
 
 Supported HDCP version on the selected video display port.
 
+### Events
+
+No Events
+
 ### Parameters
 
 | Name | Type | Description |
@@ -218,6 +230,10 @@ Supported HDCP version on the selected video display port.
 ## *audiocapabilities*
 
 Audio capabilities for the specified audio port.
+
+### Events
+
+No Events
 
 ### Parameters
 
@@ -274,6 +290,10 @@ Audio capabilities for the specified audio port.
 
 MS12 audio capabilities for the specified audio port.
 
+### Events
+
+No Events
+
 ### Parameters
 
 | Name | Type | Description |
@@ -328,6 +348,10 @@ MS12 audio capabilities for the specified audio port.
 ## *supportedms12audioprofiles*
 
 Supported MS12 audio profiles for the specified audio port.
+
+### Events
+
+No Events
 
 ### Parameters
 
@@ -410,6 +434,10 @@ Provides access to the system general information.
 
 > This property is **read-only**.
 
+### Events
+
+No Events
+
 ### Value
 
 | Name | Type | Description |
@@ -475,6 +503,10 @@ Provides access to the network interface addresses.
 
 > This property is **read-only**.
 
+### Events
+
+No Events
+
 ### Value
 
 | Name | Type | Description |
@@ -523,6 +555,10 @@ Provides access to the socket information.
 
 > This property is **read-only**.
 
+### Events
+
+No Events
+
 ### Value
 
 | Name | Type | Description |
@@ -560,6 +596,10 @@ Provides access to the socket information.
 Provides access to the versions maintained in version.txt.
 
 > This property is **read-only**.
+
+### Events
+
+No Events
 
 ### Value
 
@@ -611,6 +651,10 @@ Provides access to the serial number set by manufacturer.
 
 > This property is **read-only**.
 
+### Events
+
+No Events
+
 ### Value
 
 | Name | Type | Description |
@@ -654,6 +698,10 @@ Provides access to the serial number set by manufacturer.
 Provides access to the device model number or SKU.
 
 > This property is **read-only**.
+
+### Events
+
+No Events
 
 ### Value
 
@@ -699,6 +747,10 @@ Provides access to the device manufacturer.
 
 > This property is **read-only**.
 
+### Events
+
+No Events
+
 ### Value
 
 | Name | Type | Description |
@@ -742,6 +794,10 @@ Provides access to the device manufacturer.
 Provides access to the friendly device model name.
 
 > This property is **read-only**.
+
+### Events
+
+No Events
 
 ### Value
 
@@ -787,6 +843,10 @@ Provides access to the device type.
 
 > This property is **read-only**.
 
+### Events
+
+No Events
+
 ### Value
 
 | Name | Type | Description |
@@ -831,6 +891,10 @@ Provides access to the partner ID or distributor ID for device.
 
 > This property is **read-only**.
 
+### Events
+
+No Events
+
 ### Value
 
 | Name | Type | Description |
@@ -874,6 +938,10 @@ Provides access to the partner ID or distributor ID for device.
 Provides access to the audio ports supported on the device (all ports that are physically present).
 
 > This property is **read-only**.
+
+### Events
+
+No Events
 
 ### Value
 
@@ -922,6 +990,10 @@ Provides access to the video ports supported on the device (all ports that are p
 
 > This property is **read-only**.
 
+### Events
+
+No Events
+
 ### Value
 
 | Name | Type | Description |
@@ -968,6 +1040,10 @@ Provides access to the video ports supported on the device (all ports that are p
 Provides access to the EDID of the host.
 
 > This property is **read-only**.
+
+### Events
+
+No Events
 
 ### Value
 

--- a/docs/api/DisplayInfoPlugin.md
+++ b/docs/api/DisplayInfoPlugin.md
@@ -58,6 +58,10 @@ DisplayInfo interface methods:
 
 Returns the TV's Extended Display Identification Data (EDID).
 
+### Events
+
+No Events
+
 ### Parameters
 
 | Name | Type | Description |
@@ -106,6 +110,10 @@ Returns the TV's Extended Display Identification Data (EDID).
 
 Horizontal size in centimeters.
 
+### Events
+
+No Events
+
 ### Parameters
 
 This method takes no parameters.
@@ -142,6 +150,10 @@ This method takes no parameters.
 ## *heightincentimeters*
 
 Vertical size in centimeters.
+
+### Events
+
+No Events
 
 ### Parameters
 
@@ -211,6 +223,10 @@ Provides access to the total GPU DRAM memory (in bytes).
 
 > This property is **read-only**.
 
+### Events
+
+No Events
+
 ### Value
 
 | Name | Type | Description |
@@ -245,6 +261,10 @@ Provides access to the total GPU DRAM memory (in bytes).
 Provides access to the free GPU DRAM memory (in bytes).
 
 > This property is **read-only**.
+
+### Events
+
+No Events
 
 ### Value
 
@@ -281,6 +301,10 @@ Provides access to the current audio passthrough status on HDMI.
 
 > This property is **read-only**.
 
+### Events
+
+No Events
+
 ### Value
 
 | Name | Type | Description |
@@ -315,6 +339,10 @@ Provides access to the current audio passthrough status on HDMI.
 Provides access to the current HDMI connection status.
 
 > This property is **read-only**.
+
+### Events
+
+No Events
 
 ### Value
 
@@ -351,6 +379,10 @@ Provides access to the horizontal resolution of the TV.
 
 > This property is **read-only**.
 
+### Events
+
+No Events
+
 ### Value
 
 | Name | Type | Description |
@@ -385,6 +417,10 @@ Provides access to the horizontal resolution of the TV.
 Provides access to the vertical resolution of the TV.
 
 > This property is **read-only**.
+
+### Events
+
+No Events
 
 ### Value
 
@@ -421,6 +457,10 @@ Provides access to the vertical Frequency.
 
 > This property is **read-only**.
 
+### Events
+
+No Events
+
 ### Value
 
 | Name | Type | Description |
@@ -455,6 +495,10 @@ Provides access to the vertical Frequency.
 Provides access to the HDCP protocol used for transmission.
 
 > This property is **read-only**.
+
+### Events
+
+No Events
 
 ### Value
 
@@ -491,6 +535,10 @@ Provides access to the video output port on the STB used for connecting to the T
 
 > This property is **read-only**.
 
+### Events
+
+No Events
+
 ### Value
 
 | Name | Type | Description |
@@ -525,6 +573,10 @@ Provides access to the video output port on the STB used for connecting to the T
 Provides access to the HDR formats supported by the TV.
 
 > This property is **read-only**.
+
+### Events
+
+No Events
 
 ### Value
 
@@ -561,6 +613,10 @@ Provides access to the HDR formats supported by the STB.
 
 > This property is **read-only**.
 
+### Events
+
+No Events
+
 ### Value
 
 | Name | Type | Description |
@@ -595,6 +651,10 @@ Provides access to the HDR formats supported by the STB.
 Provides access to the HDR format in use.
 
 > This property is **read-only**.
+
+### Events
+
+No Events
 
 ### Value
 
@@ -631,6 +691,10 @@ Provides access to the display color space (chroma subsampling format).
 
 > This property is **read-only**.
 
+### Events
+
+No Events
+
 ### Value
 
 | Name | Type | Description |
@@ -665,6 +729,10 @@ Provides access to the display color space (chroma subsampling format).
 Provides access to the display frame rate.
 
 > This property is **read-only**.
+
+### Events
+
+No Events
 
 ### Value
 
@@ -701,6 +769,10 @@ Provides access to the display colour depth.
 
 > This property is **read-only**.
 
+### Events
+
+No Events
+
 ### Value
 
 | Name | Type | Description |
@@ -735,6 +807,10 @@ Provides access to the display colour depth.
 Provides access to the display quantization range.
 
 > This property is **read-only**.
+
+### Events
+
+No Events
 
 ### Value
 
@@ -771,6 +847,10 @@ Provides access to the display colorimetry.
 
 > This property is **read-only**.
 
+### Events
+
+No Events
+
 ### Value
 
 | Name | Type | Description |
@@ -805,6 +885,10 @@ Provides access to the display colorimetry.
 Provides access to the display Electro Optical Transfer Function (EOTF).
 
 > This property is **read-only**.
+
+### Events
+
+No Events
 
 ### Value
 

--- a/docs/api/DisplaySettingsPlugin.md
+++ b/docs/api/DisplaySettingsPlugin.md
@@ -131,10 +131,10 @@ DisplaySettings interface methods:
 ## *enableSurroundDecoder*
 
 Enables or disables Surround Decoder capability. The Surround Decoder is an upmixer that takes stereo music content, or surround-encoded two-channel movie content, and creates a high-quality multichannel upmix. If the Surround Decoder is enabled, two-channel signals and 5.1-channel signals are upmixed to 5.1.2.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -183,10 +183,10 @@ Enables or disables Surround Decoder capability. The Surround Decoder is an upmi
 ## *getActiveInput*
 
 Returns `true` if the STB HDMI output is currently connected to the active input of the sink device (determined by `RxSense`).
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -235,10 +235,10 @@ Returns `true` if the STB HDMI output is currently connected to the active input
 ## *getAudioDelay*
 
 Returns the audio delay (in ms) on the selected audio port. If the `audioPort` argument is not specified, it will browse all ports (checking HDMI0 first). If there is no display connected, then it defaults to `HDMI0`.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -287,10 +287,10 @@ Returns the audio delay (in ms) on the selected audio port. If the `audioPort` a
 ## *getAudioDelayOffset*
 
 Returns the audio delay offset (in ms) on the selected audio port. If the `audioPort` argument is not specified, it will browse all ports (checking HDMI0 first). If there is no display connected, then it defaults to `HDMI0`.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -339,10 +339,10 @@ Returns the audio delay offset (in ms) on the selected audio port. If the `audio
 ## *getAudioFormat*
 
 Returns the currently set audio format.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -390,10 +390,10 @@ This method takes no parameters.
 ## *getBassEnhancer*
 
 Returns the current status of the Bass Enhancer settings.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -444,10 +444,10 @@ Returns the current status of the Bass Enhancer settings.
 ## *getConnectedAudioPorts*
 
 Returns connected audio output ports (a subset of the ports supported on the device). For SPDIF supported platforms, SPDIF port is always considered connected. HDMI port may or may not be connected.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -493,10 +493,10 @@ This method takes no parameters.
 ## *getConnectedVideoDisplays*
 
 Returns connected video displays.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -542,10 +542,10 @@ This method takes no parameters.
 ## *getCurrentOutputSettings*
 
 Returns current output settings.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -596,10 +596,10 @@ This method takes no parameters.
 ## *getCurrentResolution*
 
 Returns the current resolution on the selected video display port.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -648,10 +648,10 @@ Returns the current resolution on the selected video display port.
 ## *getDefaultResolution*
 
 Gets the default resolution supported by the HDMI0 video output port.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -694,10 +694,10 @@ This method takes no parameters.
 ## *getDialogEnhancement*
 
 Returns the current Dialog Enhancer level (port HDMI0).
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -748,10 +748,10 @@ Returns the current Dialog Enhancer level (port HDMI0).
 ## *getDolbyVolumeMode*
 
 Returns whether Dolby Volume mode is enabled or disabled (audio output port HDMI0).
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -794,10 +794,10 @@ This method takes no parameters.
 ## *getDRCMode*
 
 Returns the current Dynamic Range Control mode.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -846,10 +846,10 @@ Returns the current Dynamic Range Control mode.
 ## *getEnableAudioPort*
 
  Returns the current status of the specified input audio port.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -898,10 +898,10 @@ Returns the current Dynamic Range Control mode.
 ## *getGain*
 
 Returns the current gain value.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -950,10 +950,10 @@ Returns the current gain value.
 ## *getGraphicEqualizerMode*
 
 Returns the current Graphic Equalizer Mode setting (port HDMI0).
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -1004,10 +1004,10 @@ Returns the current Graphic Equalizer Mode setting (port HDMI0).
 ## *getIntelligentEqualizerMode*
 
 Returns the current Intelligent Equalizer Mode setting (port HDMI0).
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -1058,10 +1058,10 @@ Returns the current Intelligent Equalizer Mode setting (port HDMI0).
 ## *getMISteering*
 
 Returns the current status of Media Intelligence Steering settings.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -1110,10 +1110,10 @@ Returns the current status of Media Intelligence Steering settings.
 ## *getMS12AudioCompression*
 
 Returns the current audio compression settings.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -1164,10 +1164,10 @@ Returns the current audio compression settings.
 ## *getMS12AudioProfile*
 
 Returns the current MS12 audio profile settings.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -1216,10 +1216,10 @@ Returns the current MS12 audio profile settings.
 ## *getMuted*
 
 Returns whether audio is muted on a given port.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -1268,10 +1268,10 @@ Returns whether audio is muted on a given port.
 ## *getPreferredColorDepth*
 
 Returns the current color depth on the selected video display port.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -1322,10 +1322,10 @@ Returns the current color depth on the selected video display port.
 ## *getSettopAudioCapabilities*
 
 Returns the set-top audio capabilities for the specified audio port.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -1377,10 +1377,10 @@ Returns the set-top audio capabilities for the specified audio port.
 ## *getSettopHDRSupport*
 
 Returns an HDR support object (list of standards that the STB supports).
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -1428,10 +1428,10 @@ This method takes no parameters.
 ## *getSettopMS12Capabilities*
 
 Returns the set-top MS12 audio capabilities for the specified audio port.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -1483,10 +1483,10 @@ Returns the set-top MS12 audio capabilities for the specified audio port.
 ## *getSinkAtmosCapability*
 
 Returns the ATMOS capability of the sink (HDMI0).
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -1529,10 +1529,10 @@ This method takes no parameters.
 ## *getSoundMode*
 
 Returns the sound mode for the incoming video display. If the argument is `Null` or empty (although not recommended), this returns the output mode of all connected ports, whichever is connected, while giving priority to the HDMI port. If the video display is not connected, then it returns `Stereo` as a safe default.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -1586,10 +1586,10 @@ For **Auto** mode in DS5, this API has the following extra specification:
 * For HDMI port, this API returns `Stereo` mode, `Dolby Digital 5.1` mode and `Auto` mode; 
 * For SPDIF and HDMI ARC port, this API always returns `Surround` mode, `Stereo` mode, and `PASSTHRU` Mode;  
 * When `AUTO` mode is returned, it includes in parenthesis the best sound mode that the STB can output and the connected sink device can support, in the format of `AUTO` _(`Best Format`)_. For example, if the connected device supports surround, the auto mode string will be `AUTO (Dolby Digital 5.1)`.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -1641,10 +1641,10 @@ For **Auto** mode in DS5, this API has the following extra specification:
 ## *getSupportedAudioPorts*
 
 Returns all audio ports supported on the device (all ports that are physically present).
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -1690,10 +1690,10 @@ This method takes no parameters.
 ## *getSupportedMS12AudioProfiles*
 
 Returns list of platform supported MS12 audio profiles for the specified audio port.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -1745,10 +1745,10 @@ Returns list of platform supported MS12 audio profiles for the specified audio p
 ## *getSupportedResolutions*
 
 Returns supported resolutions on the selected video display port (both TV and STB) by its name.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -1800,10 +1800,10 @@ Returns supported resolutions on the selected video display port (both TV and ST
 ## *getSupportedSettopResolutions*
 
 Returns supported STB resolutions.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -1849,10 +1849,10 @@ This method takes no parameters.
 ## *getSupportedTvResolutions*
 
 Returns supported TV resolutions on the selected video display port.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -1904,10 +1904,10 @@ Returns supported TV resolutions on the selected video display port.
 ## *getSupportedVideoDisplays*
 
 Returns all video ports supported on the device (all ports that are physically present).
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -1953,10 +1953,10 @@ This method takes no parameters.
 ## *getSurroundVirtualizer*
 
 (Version 2) Returns the current surround virtualizer boost settings.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -2012,10 +2012,10 @@ Gets HDR capabilities supported by the TV. The following values (OR-ed value) ar
 * 2 - HDRSTANDARD_HLG  
 * 4 - HDRSTANDARD_DolbyVision  
 * 8 - HDRSTANDARD_TechnicolorPrime.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -2058,10 +2058,10 @@ This method takes no parameters.
 ## *getTvHDRSupport*
 
 Returns an HDR support object (list of standards that the TV supports).
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -2109,10 +2109,10 @@ This method takes no parameters.
 ## *getVideoFormat*
 
 Returns the current and supported video formats.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -2160,10 +2160,10 @@ This method takes no parameters.
 ## *getVideoPortStatusInStandby*
 
 Returns video port status in standby mode (failure if the port name is missing).
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -2214,10 +2214,10 @@ Returns video port status in standby mode (failure if the port name is missing).
 ## *getVolumeLevel*
 
 Returns the current volume level.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -2266,10 +2266,10 @@ Returns the current volume level.
 ## *getVolumeLeveller*
 
 (Version 2) Returns the current Volume Leveller setting.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -2320,10 +2320,10 @@ Returns the current volume level.
 ## *getZoomSetting*
 
 Returns the zoom setting value.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -2366,10 +2366,10 @@ This method takes no parameters.
 ## *isConnectedDeviceRepeater*
 
 Indicates whether the device connected to the HDMI0 video output port is an HDCP repeater.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -2412,10 +2412,10 @@ This method takes no parameters.
 ## *isSurroundDecoderEnabled*
 
 Returns the current status of Surround Decoder.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -2464,10 +2464,10 @@ Returns the current status of Surround Decoder.
 ## *readEDID*
 
 Reads the EDID from the connected HDMI (output) device. Returns a key of `EDID` with a value of the base64 encoded byte array string representing the EDID.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -2510,10 +2510,10 @@ This method takes no parameters.
 ## *readHostEDID*
 
 Reads the EDID of the host. Returns a key of `EDID` with a value of the base64 encoded raw byte array string representing the EDID.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -2556,10 +2556,10 @@ This method takes no parameters.
 ## *resetBassEnhancer*
 
 Resets the dialog enhancer level to its default bassboost value.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -2606,10 +2606,10 @@ Resets the dialog enhancer level to its default bassboost value.
 ## *resetDialogEnhancement*
 
 Resets the dialog enhancer level to its default enhancer level.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -2656,10 +2656,10 @@ Resets the dialog enhancer level to its default enhancer level.
 ## *resetSurroundVirtualizer*
 
 Resets the surround virtualizer to its default boost value.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -2706,10 +2706,10 @@ Resets the surround virtualizer to its default boost value.
 ## *resetVolumeLeveller*
 
 Resets the Volume Leveller level to default volume value.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -2756,10 +2756,10 @@ Resets the Volume Leveller level to default volume value.
 ## *setAudioAtmosOutputMode*
 
 Sets ATMOS audio output mode (on HDMI0).
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -2806,10 +2806,10 @@ Sets ATMOS audio output mode (on HDMI0).
 ## *setAudioDelay*
 
 Sets the audio delay (in ms) on the selected audio port. If the `audioPort` argument is not specified, it will browse all ports (checking HDMI0 first). If there is no display connected, then it defaults to `HDMI0`.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -2858,10 +2858,10 @@ Sets the audio delay (in ms) on the selected audio port. If the `audioPort` argu
 ## *setAudioDelayOffset*
 
 Sets the audio delay offset (in ms) on the selected audio port. If the `audioPort` argument is not specified, it will browse all ports (checking HDMI0 first). If there is no display connected, then it defaults to `HDMI0`.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -2910,10 +2910,10 @@ Sets the audio delay offset (in ms) on the selected audio port. If the `audioPor
 ## *setBassEnhancer*
 
 Sets the Bass Enhancer. Bass Enhancer provides the consumer a single control to apply a fixed bass boost to correct for a lack of bass reproduction in the playback system.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -2962,15 +2962,13 @@ Sets the Bass Enhancer. Bass Enhancer provides the consumer a single control to 
 ## *setCurrentResolution*
 
 Sets the current resolution.
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- |
-| `resolutionPreChange`| Triggered when the resolution of the video display is about to change.|
-| `resolutionChanged`| Triggered when the resolution is changed by the user and returns the current resolution.|.
 
-Also see: [resolutionPreChange](#resolutionPreChange), [resolutionChanged](#resolutionChanged)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [resolutionPreChange](#resolutionPreChange) | Triggered when the resolution of the video display is about to change. |
+| [resolutionChanged](#resolutionChanged) | Triggered when the resolution is changed by the user and returns the current resolution. |
 ### Parameters
 
 | Name | Type | Description |
@@ -3022,10 +3020,10 @@ Also see: [resolutionPreChange](#resolutionPreChange), [resolutionChanged](#reso
 ## *setDialogEnhancement*
 
 Sets the Dialog Enhancer level.A dialog enhancer boosts the speech audio separately from other background content, without increasing the loudness.The method fails if no value is set.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -3074,10 +3072,10 @@ Sets the Dialog Enhancer level.A dialog enhancer boosts the speech audio separat
 ## *setDolbyVolumeMode*
 
 Enables or disables Dolby Volume mode on audio track (audio output port HDMI0).
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -3124,10 +3122,10 @@ Enables or disables Dolby Volume mode on audio track (audio output port HDMI0).
 ## *setDRCMode*
 
 Sets the Dynamic Range Control (DRC) setting. DRC is a compression control applied to audio to limit the dynamic range to suit a specific listening situation. For default settings, RF mode is preferred for two-channel outputs (television speaker or headphone) and Line mode for multichannel outputs.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -3176,10 +3174,10 @@ Sets the Dynamic Range Control (DRC) setting. DRC is a compression control appli
 ## *setEnableAudioPort*
 
 Enable or disable the specified audio port based on the input audio port name. This feature provides the consumer with a single user control to enable or disable the specified audio port.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -3228,10 +3226,10 @@ Enable or disable the specified audio port based on the input audio port name. T
 ## *setForceHDRMode*
 
 Enables or disables the force HDR mode. If enabled, the HDR format that is currently configured on the device is used.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -3278,10 +3276,10 @@ Enables or disables the force HDR mode. If enabled, the HDR format that is curre
 ## *setGain*
 
 Adjusts the gain on a specific port.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -3330,10 +3328,10 @@ Adjusts the gain on a specific port.
 ## *setGraphicEqualizerMode*
 
 Sets the Graphic Equalizer Mode. The Graphic Equalizer is a multi-band equalizer that allows the end user to customize the sonic qualities of the system.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -3382,10 +3380,10 @@ Sets the Graphic Equalizer Mode. The Graphic Equalizer is a multi-band equalizer
 ## *setIntelligentEqualizerMode*
 
 Sets the Intelligent Equalizer Mode (port HDMI0). An Intelligent Equalizer continuously monitors the audio spectrum and adjusts its equalization filter to transform the original audio tone into desired tone.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -3434,10 +3432,10 @@ Sets the Intelligent Equalizer Mode (port HDMI0). An Intelligent Equalizer conti
 ## *setMISteering*
 
 Enables or Disables Media Intelligent Steering. Media Intelligence analyzes audio content and steers the Volume Leveler, the Dialogue Enhancer, the Intelligent Equalizer, and the Speaker Virtualizer, based on the type of audio content.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -3486,10 +3484,10 @@ Enables or Disables Media Intelligent Steering. Media Intelligence analyzes audi
 ## *setMS12AudioCompression*
 
 Sets the audio dynamic range compression level (port HDMI0).
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -3538,10 +3536,10 @@ Sets the audio dynamic range compression level (port HDMI0).
 ## *setMS12AudioProfile*
 
 Sets the selected MS12 audio profile.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -3590,6 +3588,10 @@ Sets the selected MS12 audio profile.
 ## *setMS12ProfileSettingsOverride*
 
 Overrides individual MS12 audio settings in order to optimize the customer experience (for example, enabling dialog enhancement in sports mode).
+
+### Events
+
+No Events
 
 ### Parameters
 
@@ -3644,10 +3646,10 @@ Overrides individual MS12 audio settings in order to optimize the customer exper
 ## *setMuted*
 
 Mutes or unmutes audio on a specific port.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -3697,6 +3699,10 @@ Mutes or unmutes audio on a specific port.
 
 Sets the current color depth for the videoDisplay.
 .
+
+### Events
+
+No Events
 
 ### Parameters
 
@@ -3756,11 +3762,11 @@ Possible values:
 | `cvbs` | `on` (disables rgb) |  
 | `macrovision` | not implemented |  
 | `cgms` |  `disabled`, `copyNever`, `copyOnce`, `copyFreely`, or `copyNoMore` |  
-| `port` | `on` or `off` | 
- 
-### Event 
+| `port` | `on` or `off` |.
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -3809,10 +3815,10 @@ Possible values:
 ## *setSoundMode*
 
 Sets the current sound mode for the corresponding video display. If the `audioPort` argument value is missing or empty all ports are set.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -3863,10 +3869,10 @@ Sets the current sound mode for the corresponding video display. If the `audioPo
 ## *setSurroundVirtualizer*
 
 (Version 2) Sets the Surround Virtualizer boost. The Speaker/Surround Virtualizer enables a surround sound signal (including one generated by the Surround Decoder) to be rendered over a device with built-in speakers or headphones.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -3917,10 +3923,10 @@ Sets the current sound mode for the corresponding video display. If the `audioPo
 ## *setVideoPortStatusInStandby*
 
 Sets the specified video port status to be used in standby mode (failure if the port name is missing).
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -3971,10 +3977,10 @@ Sets the specified video port status to be used in standby mode (failure if the 
 ## *setVolumeLevel*
 
 Adjusts the Volume Level on a specific port.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -4023,10 +4029,10 @@ Adjusts the Volume Level on a specific port.
 ## *setVolumeLeveller*
 
 (Version 2) Sets the Volume Leveller level. Volume Leveller is an advanced volume-control solution that maintains consistent playback levels for content from different sources.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -4077,12 +4083,12 @@ Adjusts the Volume Level on a specific port.
 ## *setZoomSetting*
 
 Sets the current zoom value.
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- |
-| `zoomSettingsUpdated`| Triggered when the zoom setting changes and returns the zoom setting values for all video display types.|.
 
+### Events
+
+| Event | Description |
+| :-------- | :-------- |
+| [zoomSettingUpdated](#zoomSettingUpdated) | Triggered when the zoom setting changes and returns the zoom setting values for all video display types. |
 ### Parameters
 
 | Name | Type | Description |
@@ -4128,10 +4134,10 @@ Sets the current zoom value.
 ## *getColorDepthCapabilities*
 
 Returns supported color depth capabilities.
- 
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 

--- a/docs/api/FireboltMediaPlayerPlugin.md
+++ b/docs/api/FireboltMediaPlayerPlugin.md
@@ -67,6 +67,10 @@ FireboltMediaPlayer interface methods:
 
 Initiates a new AAMP player instance suitable for playback of IP feeds. If a player that is identified by the specified ID already exists, then it will be ref-counted.
 
+### Events
+
+No Events
+
 ### Parameters
 
 | Name | Type | Description |
@@ -115,6 +119,10 @@ Modifies the default AAMP configuration.
 
 For complete list of configuration properties, see:https://wiki.rdkcentral.com/display/RDK/AAMP+UVE+-+API#AAMPUVEAPI-Configuration.
 
+### Events
+
+No Events
+
 ### Parameters
 
 | Name | Type | Description |
@@ -160,6 +168,10 @@ For complete list of configuration properties, see:https://wiki.rdkcentral.com/d
 ## *load*
 
 Associates a specified URL with a player instance.
+
+### Events
+
+No Events
 
 ### Parameters
 
@@ -211,6 +223,10 @@ Associates a specified URL with a player instance.
 
 Pauses streaming content that is associated with the specified player instance. The play speed is set to 0.
 
+### Events
+
+No Events
+
 ### Parameters
 
 | Name | Type | Description |
@@ -256,6 +272,10 @@ Pauses streaming content that is associated with the specified player instance. 
 ## *play*
 
 Begins or resumes streaming content that is associated with the specified player instance. The play speed is set to 1.
+
+### Events
+
+No Events
 
 ### Parameters
 
@@ -303,6 +323,10 @@ Begins or resumes streaming content that is associated with the specified player
 
 Decreases the ref-count of the player. The player gets destroyed when the ref-count reaches 0.
 
+### Events
+
+No Events
+
 ### Parameters
 
 | Name | Type | Description |
@@ -348,6 +372,10 @@ Decreases the ref-count of the player. The player gets destroyed when the ref-co
 ## *seek*
 
 Moves the media to a specific position.
+
+### Events
+
+No Events
 
 ### Parameters
 
@@ -396,6 +424,10 @@ Moves the media to a specific position.
 ## *setDRMConfig*
 
 Modifies the default configuration of the DRM used by AAMP.
+
+### Events
+
+No Events
 
 ### Parameters
 
@@ -448,6 +480,10 @@ Modifies the default configuration of the DRM used by AAMP.
 ## *stop*
 
 Stops streaming content.
+
+### Events
+
+No Events
 
 ### Parameters
 

--- a/docs/api/FrameRatePlugin.md
+++ b/docs/api/FrameRatePlugin.md
@@ -61,10 +61,10 @@ FrameRate interface methods:
 ## *getDisplayFrameRate*
 
 (Version 2) Returns the current display frame rate values.
-  
-### Events 
 
- No events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -107,10 +107,10 @@ This method takes no parameters.
 ## *getFrmMode*
 
 (Version 2) Returns the current auto framerate mode.
-  
-### Events 
 
- No events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -153,10 +153,10 @@ This method takes no parameters.
 ## *setCollectionFrequency*
 
 Sets the FPS data collection interval.
-  
-### Events 
 
- No events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -202,16 +202,14 @@ Sets the FPS data collection interval.
 <a name="setDisplayFrameRate"></a>
 ## *setDisplayFrameRate*
 
-(Version 2) Sets the display framerate values. 
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- |
-| `onDisplayFrameRateChanging`|Triggered when the framerate changes started.| 
-| `onDisplayFrameRateChanged`|Triggered when the framerate changed.|.
+(Version 2) Sets the display framerate values.
 
-Also see: [onDisplayFrameRateChanging](#onDisplayFrameRateChanging), [onDisplayFrameRateChanged](#onDisplayFrameRateChanged)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onDisplayFrameRateChanging](#onDisplayFrameRateChanging) | Triggered when the framerate changes started. |
+| [onDisplayFrameRateChanged](#onDisplayFrameRateChanged) | Triggered when the framerate changed |
 ### Parameters
 
 | Name | Type | Description |
@@ -257,10 +255,10 @@ Also see: [onDisplayFrameRateChanging](#onDisplayFrameRateChanging), [onDisplayF
 ## *setFrmMode*
 
 (Version 2) Sets the auto framerate mode.
-  
-### Events 
 
- No events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -307,14 +305,12 @@ Also see: [onDisplayFrameRateChanging](#onDisplayFrameRateChanging), [onDisplayF
 ## *startFpsCollection*
 
 Starts the FPS data collection.
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- |
-| `onFpsEvent`|Triggered at the end of each interval as defined by the `setCollectionFrequency` |.
 
-Also see: [onFpsEvent](#onFpsEvent)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onFpsEvent](#onFpsEvent) | Triggered at the end of each interval as defined by the setCollectionFrequency |
 ### Parameters
 
 This method takes no parameters.
@@ -354,14 +350,12 @@ This method takes no parameters.
 ## *stopFpsCollection*
 
 Stops the FPS data collection.
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- |
-| `onFpsEvent`|Triggered once after the `stopFpsCollection` method is invoked.|.
 
-Also see: [onFpsEvent](#onFpsEvent)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onFpsEvent](#onFpsEvent) | Triggered once after the stopFpsCollection method is invoked. |
 ### Parameters
 
 This method takes no parameters.
@@ -401,10 +395,10 @@ This method takes no parameters.
 ## *updateFps*
 
 Updates Fps values.
-  
-### Events 
 
- No events.
+### Events
+
+No Events
 
 ### Parameters
 

--- a/docs/api/FrontPanelPlugin.md
+++ b/docs/api/FrontPanelPlugin.md
@@ -67,6 +67,10 @@ FrontPanel interface methods:
 
 Get the brightness of the specified LED or FrontPanel.
 
+### Events
+
+No Events
+
 ### Parameters
 
 | Name | Type | Description |
@@ -115,6 +119,10 @@ Get the brightness of the specified LED or FrontPanel.
 
 Returns the current clock brightness value.
 
+### Events
+
+No Events
+
 ### Parameters
 
 This method takes no parameters.
@@ -156,6 +164,10 @@ This method takes no parameters.
 ## *getFrontPanelLights*
 
 Returns a list of supported Front Panel LEDs and their properties.
+
+### Events
+
+No Events
 
 ### Parameters
 
@@ -223,6 +235,10 @@ This method takes no parameters.
 
 Returns the preferences that are saved in the `/opt/fp_service_preferences.json` file.
 
+### Events
+
+No Events
+
 ### Parameters
 
 This method takes no parameters.
@@ -266,6 +282,10 @@ This method takes no parameters.
 Gets the currently set clock mode (12 or 24 hour).  
 **Note:** On Xi6, this method always returns `false` despite having successfully set the clock to 24 hour mode.
 
+### Events
+
+No Events
+
 ### Parameters
 
 This method takes no parameters.
@@ -307,6 +327,10 @@ This method takes no parameters.
 ## *powerLedOff*
 
 Switches the specified LED off.
+
+### Events
+
+No Events
 
 ### Parameters
 
@@ -354,6 +378,10 @@ Switches the specified LED off.
 
 Switches the specified LED indicator on. The LED must be powered on prior to setting its brightness.
 
+### Events
+
+No Events
+
 ### Parameters
 
 | Name | Type | Description |
@@ -399,6 +427,10 @@ Switches the specified LED indicator on. The LED must be powered on prior to set
 ## *set24HourClock*
 
 Sets the clock mode to either 12 or 24 hour.
+
+### Events
+
+No Events
 
 ### Parameters
 
@@ -446,6 +478,10 @@ Sets the clock mode to either 12 or 24 hour.
 
 Sets a blinking pattern for a particular LED indicator.  
 **Note:** This API does not currently work nor does it provide a meaningful error status.
+
+### Events
+
+No Events
 
 ### Parameters
 
@@ -516,6 +552,10 @@ Sets a blinking pattern for a particular LED indicator.
 
 Sets the brightness of the specified LED indicator. If no indicator is specified, then FrontPanel all indicators are set.
 
+### Events
+
+No Events
+
 ### Parameters
 
 | Name | Type | Description |
@@ -564,6 +604,10 @@ Sets the brightness of the specified LED indicator. If no indicator is specified
 
 Sets the clock brightness.
 
+### Events
+
+No Events
+
 ### Parameters
 
 | Name | Type | Description |
@@ -609,6 +653,10 @@ Sets the clock brightness.
 ## *setClockTestPattern*
 
 Allows you to set a test pattern on the STB clock (`88 88`).
+
+### Events
+
+No Events
 
 ### Parameters
 
@@ -657,6 +705,10 @@ Allows you to set a test pattern on the STB clock (`88 88`).
 ## *setLED*
 
 Set preferences for the specified Front Panel LED indicator. Data are not validated in this call.
+
+### Events
+
+No Events
 
 ### Parameters
 
@@ -713,6 +765,10 @@ Set preferences for the specified Front Panel LED indicator. Data are not valida
 ## *setPreferences*
 
 Sets preferences for Front Panel LED indicators which are saved to `/opt/fp_service_preferences.json`. This function neither validates an input nor changes LED states (color, brightness). It's the users responsibility to provide valid and updated data.
+
+### Events
+
+No Events
 
 ### Parameters
 

--- a/docs/api/HdcpProfilePlugin.md
+++ b/docs/api/HdcpProfilePlugin.md
@@ -2,7 +2,7 @@
 <a name="HdcpProfile_Plugin"></a>
 # HdcpProfile Plugin
 
-**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/HdcpProfile/CHANGELOG.md)**
+**Version: [1.0.1](https://github.com/rdkcentral/rdkservices/blob/main/HdcpProfile/CHANGELOG.md)**
 
 A org.rdk.HdcpProfile plugin for Thunder framework.
 
@@ -61,11 +61,11 @@ Returns HDCP-related data.
 * `2`: HDCP success  
 * `3`:  HDCP authentication failed after multiple retries  
 * `4`:  HDCP authentication in progress   
-* `5`: HDMI video port is disabled. 
- 
+* `5`: HDMI video port is disabled.
+
 ### Events
- 
-No Events.
+
+No Events
 
 ### Parameters
 
@@ -122,11 +122,11 @@ This method takes no parameters.
 <a name="getSettopHDCPSupport"></a>
 ## *getSettopHDCPSupport*
 
-Returns which version of HDCP is supported by the STB. 
- 
+Returns which version of HDCP is supported by the STB.
+
 ### Events
- 
-No Events.
+
+No Events
 
 ### Parameters
 

--- a/docs/api/HdmiCecPlugin.md
+++ b/docs/api/HdmiCecPlugin.md
@@ -59,10 +59,10 @@ HdmiCec interface methods:
 ## *getActiveSourceStatus*
 
 Gets the active source status of the device.
-  
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -109,10 +109,10 @@ Gets the active source status of the device.
 ## *getCECAddresses*
 
 Returns the HDMI-CEC addresses that are assigned to the local device.
-  
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -165,10 +165,10 @@ This method takes no parameters.
 ## *getDeviceList*
 
 Gets the list of number of CEC enabled devices connected and system information for each device. The information includes logicalAddress,OSD name and vendor ID.
-  
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -223,10 +223,10 @@ This method takes no parameters.
 ## *getEnabled*
 
 Returns whether HDMI-CEC is enabled.
-  
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -269,14 +269,12 @@ This method takes no parameters.
 ## *sendMessage*
 
 Writes HDMI-CEC frame to the driver.
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- |
-| `onMessage`|Triggered when a message is sent from an HDMI device|.
 
-Also see: [onMessage](#onMessage)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onMessage](#onMessage) | Triggered when a message is sent from an HDMI device |
 ### Parameters
 
 | Name | Type | Description |
@@ -322,10 +320,10 @@ Also see: [onMessage](#onMessage)
 ## *setEnabled*
 
 Enables or disables HDMI-CEC driver.
-  
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 

--- a/docs/api/HdmiCecSinkPlugin.md
+++ b/docs/api/HdmiCecSinkPlugin.md
@@ -75,10 +75,10 @@ HdmiCecSink interface methods:
 ## *getActiveRoute*
 
 Gets details for the current route from the source to sink devices. This API is used for debugging the route.
-  
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -141,10 +141,10 @@ This method takes no parameters.
 ## *getActiveSource*
 
 Gets details for the current active source.
-  
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -203,10 +203,10 @@ This method takes no parameters.
 ## *getAudioDeviceConnectedStatus*
 
 Get status of audio device connection.
-  
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -249,10 +249,10 @@ This method takes no parameters.
 ## *getDeviceList*
 
 Gets the number of connected source devices and system information for each device. The information includes device type, physical address, CEC version, vendor ID, power status and OSD name.
-  
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -317,10 +317,10 @@ This method takes no parameters.
 ## *getEnabled*
 
 Returns whether HDMI-CEC is enabled on platform or not.
-  
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -363,10 +363,10 @@ This method takes no parameters.
 ## *getOSDName*
 
 Returns the OSD name used by host device.
-  
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -409,10 +409,10 @@ This method takes no parameters.
 ## *getVendorId*
 
 Gets the current vendor ID used by host device.
-  
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -455,10 +455,10 @@ This method takes no parameters.
 ## *printDeviceList*
 
 This is a helper debug command for developers. It prints the list of connected devices and properties of connected devices like deviceType, VendorID, CEC version, PowerStatus, OSDName, PhysicalAddress etc.
-  
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -501,16 +501,14 @@ This method takes no parameters.
 ## *requestActiveSource*
 
 Requests the active source in the network.
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- |
-| `onActiveSourceChange`|Triggered with the active source device changes.|
-| `onDeviceAdded`|Triggered when an HDMI cable is physically connected to the HDMI port on a TV, or the power cable is connected to the source device.| 
-| `onDeviceInfoUpdated`|Triggered when device information changes (physicalAddress, deviceType, vendorID, osdName, cecVersion, powerStatus).|.
 
-Also see: [onActiveSourceChange](#onActiveSourceChange), [onDeviceAdded](#onDeviceAdded), [onDeviceInfoUpdated](#onDeviceInfoUpdated)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onActiveSourceChange](#onActiveSourceChange) | Triggered with the active source device changes. |
+| [onDeviceAdded](#onDeviceAdded) | Triggered when an HDMI cable is physically connected to the HDMI port on a TV, or the power cable is connected to the source device. |
+| [onDeviceInfoUpdated](#onDeviceInfoUpdated) | Triggered when device information changes (physicalAddress, deviceType, vendorID, osdName, cecVersion, powerStatus). |
 ### Parameters
 
 This method takes no parameters.
@@ -550,14 +548,12 @@ This method takes no parameters.
 ## *requestShortAudioDescriptor*
 
 Sends the CEC Request Short Audio Descriptor (SAD) message as an 
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- |
-| `shortAudiodesciptorEvent`|Triggered when SAD is received from the connected audio device.|.
 
-Also see: [shortAudiodesciptorEvent](#shortAudiodesciptorEvent)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [shortAudiodesciptorEvent](#shortAudiodesciptorEvent) | Triggered when SAD is received from the connected audio device. |
 ### Parameters
 
 This method takes no parameters.
@@ -597,14 +593,12 @@ This method takes no parameters.
 ## *sendAudioDevicePowerOnMessage*
 
 This message is used to power on the connected audio device. Usually sent by the TV when it comes out of standby and detects audio device connected in the network.
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- |
-| `setSystemAudioModeEvent`|Triggered when CEC \<Set System Audio Mode\> message of device is received.|.
 
-Also see: [setSystemAudioModeEvent](#setSystemAudioModeEvent)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [setSystemAudioModeEvent](#setSystemAudioModeEvent) | Triggered when CEC <Set System Audio Mode> message of device is received. |
 ### Parameters
 
 This method takes no parameters.
@@ -644,14 +638,12 @@ This method takes no parameters.
 ## *sendGetAudioStatusMessage*
 
 Sends the CEC \<Give Audio Status\> message to request the audio status.
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- |
-| `reportAudioStatusEvent`|Triggered when CEC \<Report Audio Status\> message of device is received.|.
 
-Also see: [reportAudioStatusEvent](#reportAudioStatusEvent)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [reportAudioStatusEvent](#reportAudioStatusEvent) | Triggered when CEC <Report Audio Status> message of device is received. |
 ### Parameters
 
 This method takes no parameters.
@@ -691,10 +683,10 @@ This method takes no parameters.
 ## *sendKeyPressEvent*
 
 Sends the CEC \<User Control Pressed\> message when TV remote key is pressed.
-  
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -743,10 +735,10 @@ Sends the CEC \<User Control Pressed\> message when TV remote key is pressed.
 ## *sendStandbyMessage*
 
 Sends a CEC \<Standby\> message to the logical address of the device.
-  
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -787,10 +779,10 @@ This method takes no parameters.
 ## *setActivePath*
 
 Sets the source device to active (`setStreamPath`). The source wakes from standby if it's in the standby state.
-  
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -837,10 +829,10 @@ Sets the source device to active (`setStreamPath`). The source wakes from standb
 ## *setActiveSource*
 
 Sets the current active source as TV (physical address 0.0.0.0). This call needs to be made when the TV switches to internal tuner or any apps.
-  
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -881,14 +873,12 @@ This method takes no parameters.
 ## *setEnabled*
 
 Enables or disables HDMI-CEC support in the platform.
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- |
-| `reportCecEnabledEvent`|Triggered when the HDMI-CEC is enabled.|.
 
-Also see: [reportCecEnabledEvent](#reportCecEnabledEvent)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [reportCecEnabledEvent](#reportCecEnabledEvent) | Triggered when the HDMI-CEC is enabled. |
 ### Parameters
 
 | Name | Type | Description |
@@ -934,10 +924,10 @@ Also see: [reportCecEnabledEvent](#reportCecEnabledEvent)
 ## *setMenuLanguage*
 
 Updates the internal data structure with the new menu Language and also broadcasts the \<Set Menu Language\> CEC message.
-  
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -984,10 +974,10 @@ Updates the internal data structure with the new menu Language and also broadcas
 ## *setOSDName*
 
 Sets the OSD Name used by host device.
-  
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -1034,10 +1024,10 @@ Sets the OSD Name used by host device.
 ## *setRoutingChange*
 
 Changes routing while switching between HDMI inputs and TV.
-  
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -1086,13 +1076,13 @@ Changes routing while switching between HDMI inputs and TV.
 ## *setupARCRouting*
 
 Enable (or disable) HDMI-CEC Audio Return Channel (ARC) routing. Upon enabling, triggers arcInitiationEvent and upon disabling, triggers arcTerminationEvent.
-| Event | Description | 
-| :----------- | :----------- |
-| `arcInitiationEvent` |Triggered when routing though the HDMI ARC port is successfully established. | 
-|`arcTerminationEvent` |Triggered when routing though the HDMI ARC port terminates.|.
 
-Also see: [arcInitiationEvent](#arcInitiationEvent), [arcTerminationEvent](#arcTerminationEvent)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [arcInitiationEvent](#arcInitiationEvent) | Triggered when routing though the HDMI ARC port is successfully established. |
+| [arcTerminationEvent](#arcTerminationEvent) | Triggered when routing though the HDMI ARC port terminates. |
 ### Parameters
 
 | Name | Type | Description |
@@ -1138,10 +1128,10 @@ Also see: [arcInitiationEvent](#arcInitiationEvent), [arcTerminationEvent](#arcT
 ## *setVendorId*
 
 Sets a vendor ID used by host device.
-  
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 

--- a/docs/api/HdmiCec_2Plugin.md
+++ b/docs/api/HdmiCec_2Plugin.md
@@ -65,10 +65,10 @@ HdmiCec_2 interface methods:
 ## *getActiveSourceStatus*
 
 Gets the active source status of the device.
-  
-### Event 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -115,10 +115,10 @@ Gets the active source status of the device.
 ## *getDeviceList*
 
 Gets the list of CEC enabled devices connected and system information for each device. The information includes logicalAddress,OSD name and vendor ID.
-  
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -173,10 +173,10 @@ This method takes no parameters.
 ## *getEnabled*
 
 Returns HDMI-CEC driver enabled status.
-  
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -219,10 +219,10 @@ This method takes no parameters.
 ## *getOSDName*
 
 Returns the OSD name set by the application.
-  
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -265,10 +265,10 @@ This method takes no parameters.
 ## *getOTPEnabled*
 
 Returns HDMI-CEC OTP option enabled status.
-  
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -311,10 +311,10 @@ This method takes no parameters.
 ## *getVendorId*
 
 Returns the vendor ID set by the application.
-  
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -357,10 +357,10 @@ This method takes no parameters.
 ## *performOTPAction*
 
 Turns on the TV and takes back the input to the device.
-  
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -401,10 +401,10 @@ This method takes no parameters.
 ## *sendStandbyMessage*
 
 Sends a CEC \<Standby\> message to the logical address of the device.
-  
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -445,10 +445,10 @@ This method takes no parameters.
 ## *setEnabled*
 
 Enables or disables HDMI-CEC driver.
-  
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -495,10 +495,10 @@ Enables or disables HDMI-CEC driver.
 ## *setOSDName*
 
 Sets the OSD name of the application.
-  
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -545,10 +545,10 @@ Sets the OSD name of the application.
 ## *setOTPEnabled*
 
 Enables or disables HDMI-CEC OTP option.
-  
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -595,10 +595,10 @@ Enables or disables HDMI-CEC OTP option.
 ## *setVendorId*
 
 Sets the vendor ID of the application.
-  
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 

--- a/docs/api/HdmiInputPlugin.md
+++ b/docs/api/HdmiInputPlugin.md
@@ -65,10 +65,10 @@ HdmiInput interface methods:
 ## *getHDMIInputDevices*
 
 Returns an array of available HDMI Input ports.
- 
+
 ### Events
- 
-No Events.
+
+No Events
 
 ### Parameters
 
@@ -121,10 +121,10 @@ This method takes no parameters.
 ## *getEdidVersion*
 
 (Version 2) Returns the EDID version.
- 
+
 ### Events
- 
-No Events.
+
+No Events
 
 ### Parameters
 
@@ -173,10 +173,10 @@ No Events.
 ## *getHDMISPD*
 
 (Version 2) Returns the Source Data Product Descriptor (SPD) infoFrame packet information for the specified HDMI Input device. The SPD infoFrame packet includes vendor name, product description, and source information.
- 
+
 ### Events
- 
-No Events.
+
+No Events
 
 ### Parameters
 
@@ -225,10 +225,10 @@ No Events.
 ## *getRawHDMISPD*
 
 (Version 2) Returns the Source Data Product Descriptor (SPD) infoFrame packet information for the specified HDMI Input device as raw bits.
- 
+
 ### Events
- 
-No Events.
+
+No Events
 
 ### Parameters
 
@@ -277,10 +277,10 @@ No Events.
 ## *readEDID*
 
 Returns the current EDID value.
- 
+
 ### Events
- 
-No Events.
+
+No Events
 
 ### Parameters
 
@@ -329,15 +329,13 @@ No Events.
 ## *startHdmiInput*
 
 Activates the specified HDMI Input port as the primary video source.
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- | 
-| `onInputStatusChanged` | Triggers the event when HDMI Input source is activated and Input status changes to `started` | 
-| `onSignalChanged` | Triggers the event when HDMI Input signal changes (must be one of the following:noSignal, unstableSignal, notSupportedSignal, stableSignal).
 
-Also see: [onInputStatusChanged](#onInputStatusChanged), [onSignalChanged](#onSignalChanged)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onInputStatusChanged](#onInputStatusChanged) | Triggers the event when HDMI Input source is activated and Input status changes to started |
+| [onSignalChanged](#onSignalChanged) | Triggers the event when HDMI Input signal changes (must be one of the following:noSignal, unstableSignal, notSupportedSignal, stableSignal). |
 ### Parameters
 
 | Name | Type | Description |
@@ -383,14 +381,12 @@ Also see: [onInputStatusChanged](#onInputStatusChanged), [onSignalChanged](#onSi
 ## *stopHdmiInput*
 
 Deactivates the HDMI Input port currently selected as the primary video source.
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- | 
-| `onInputStatusChanged` | Triggers the event when HDMI Input source is deactivated and Input status changes to `stopped`.
 
-Also see: [onInputStatusChanged](#onInputStatusChanged)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onInputStatusChanged](#onInputStatusChanged) | Triggers the event when HDMI Input source is deactivated and Input status changes to `stopped` |
 ### Parameters
 
 This method takes no parameters.
@@ -430,10 +426,10 @@ This method takes no parameters.
 ## *setEdidVersion*
 
 (Version 2) Sets an HDMI EDID version.
- 
+
 ### Events
- 
-No Events.
+
+No Events
 
 ### Parameters
 
@@ -482,10 +478,10 @@ No Events.
 ## *setVideoRectangle*
 
 Sets an HDMI Input video window.
- 
+
 ### Events
- 
-No Events.
+
+No Events
 
 ### Parameters
 
@@ -538,10 +534,10 @@ No Events.
 ## *writeEDID*
 
 Changes a current EDID value.
- 
+
 ### Events
- 
-No Events.
+
+No Events
 
 ### Parameters
 
@@ -590,10 +586,10 @@ No Events.
 ## *getSupportedGameFeatures*
 
 Returns the list of supported game features.
- 
+
 ### Events
- 
-No Events.
+
+No Events
 
 ### Parameters
 
@@ -635,11 +631,11 @@ This method takes no parameters.
 <a name="getHdmiGameFeatureStatus"></a>
 ## *getHdmiGameFeatureStatus*
 
-Returns the Game Feature Status. For example: ALLM
- 
+Returns the Game Feature Status. For example: ALLM.
+
 ### Events
- 
-No Events.
+
+No Events
 
 ### Parameters
 

--- a/docs/api/LinearPlaybackControlPlugin.md
+++ b/docs/api/LinearPlaybackControlPlugin.md
@@ -51,6 +51,10 @@ LinearPlaybackControl interface properties:
 
 Provides access to the current channel.
 
+### Events
+
+No Events
+
 ### Value
 
 | Name | Type | Description |
@@ -120,6 +124,10 @@ Provides access to the current channel.
 
 Provides access to the TSB seek position offset, from live position, in seconds.
 
+### Events
+
+No Events
+
 ### Value
 
 | Name | Type | Description |
@@ -188,6 +196,10 @@ Provides access to the TSB seek position offset, from live position, in seconds.
 ## *trickPlay*
 
 Provides access to the trick play speed and direction.
+
+### Events
+
+No Events
 
 ### Value
 
@@ -260,6 +272,10 @@ Provides access to the current TSB status information containing buffer size, se
 
 > This property is **read-only**.
 
+### Events
+
+No Events
+
 ### Value
 
 | Name | Type | Description |
@@ -317,6 +333,10 @@ Provides access to the current TSB status information containing buffer size, se
 ## *tracing*
 
 Provides access to the tracing enable/disable flag.
+
+### Events
+
+No Events
 
 ### Value
 

--- a/docs/api/LocationSyncPlugin.md
+++ b/docs/api/LocationSyncPlugin.md
@@ -58,13 +58,13 @@ LocationSync interface methods:
 <a name="sync"></a>
 ## *sync*
 
-Synchronizes the location. 
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- |
-| `locationchange` | Signals the change of location |.
+Synchronizes the location.
 
+### Events
+
+| Event | Description |
+| :-------- | :-------- |
+| [locationchange](#locationchange) | Signals the change of location |
 ### Parameters
 
 This method takes no parameters.
@@ -124,6 +124,10 @@ LocationSync interface properties:
 Provides access to the location information.
 
 > This property is **read-only**.
+
+### Events
+
+No Events
 
 ### Value
 

--- a/docs/api/LoggingPreferencesPlugin.md
+++ b/docs/api/LoggingPreferencesPlugin.md
@@ -54,11 +54,11 @@ LoggingPreferences interface methods:
 <a name="isKeystrokeMaskEnabled"></a>
 ## *isKeystrokeMaskEnabled*
 
-Gets logging keystroke mask status (enabled or disabled). 
- 
-### Events 
+Gets logging keystroke mask status (enabled or disabled).
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -101,14 +101,12 @@ This method takes no parameters.
 ## *setKeystrokeMaskEnabled*
 
 Sets the keystroke logging mask  If a keystroke mask is successfully changed, then this method triggers an `onKeystrokeMaskEnabledChange` 
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- |
-| `onKeystrokeMaskEnabledChange`| Triggered if the keystroke mask is changed successfully |.
 
-Also see: [onKeystrokeMaskEnabledChange](#onKeystrokeMaskEnabledChange)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onKeystrokeMaskEnabledChange](#onKeystrokeMaskEnabledChange) | Triggered if the keystroke mask is changed successfully |
 ### Parameters
 
 | Name | Type | Description |

--- a/docs/api/MaintenanceManagerPlugin.md
+++ b/docs/api/MaintenanceManagerPlugin.md
@@ -64,11 +64,11 @@ Gets the maintenance activity status details.
 * `MAINTENANCE_STARTED` - Maintenance has started either by schedule or on boot  
 * `MAINTENANCE_ERROR` - One or more tasks of the maintenance service has failed  
 * `MAINTENANCE_COMPLETE` - All critical maintenance tasks are completed successfully  
-* `MAINTENANCE_INCOMPLETE` - Maintenance service didn't execute one or more of the tasks. 
- 
+* `MAINTENANCE_INCOMPLETE` - Maintenance service didn't execute one or more of the tasks.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -116,11 +116,11 @@ This method takes no parameters.
 <a name="getMaintenanceStartTime"></a>
 ## *getMaintenanceStartTime*
 
-Gets the scheduled maintenance start time. 
- 
+Gets the scheduled maintenance start time.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -167,11 +167,11 @@ Sets the maintenance mode and software upgrade opt-out mode.
 * `NONE` - The software upgrade process is unaffected and proceeds with the download and update.  
 * `ENFORCE_OPTPOUT` - The software upgrade process pauses after discovering an update is available and sends a `System` service `onFirmwareUpdateStateChange` event with the `On Hold for opt-out` state. An application must give the user the option of whether or not to accept the update. If the user accepts the update, then the opt-out mode must be set to `BYPASS-OPTOUT`.  
 * `BYPASS_OPTOUT` The software upgrade process proceeds with a download and update, as directed by the application, for this occurrence of the maintenance window (used when the user accepts the software update).  
-* `IGNORE-UPDATE` -  The software upgrade process ignores any non-mandatory firmware updates, and will NOT send any notification. Note that in this mode, the software upgrade process still sets `ENFORCE-OPTOUT` if the update is mandatory. Use the `getFirmwareUpdateInfo` method from the `System` service to determine what software version is available for download and to determine if the update is consider mandatory (using the `rebootImmediately` parameter). 
- 
+* `IGNORE-UPDATE` -  The software upgrade process ignores any non-mandatory firmware updates, and will NOT send any notification. Note that in this mode, the software upgrade process still sets `ENFORCE-OPTOUT` if the update is mandatory. Use the `getFirmwareUpdateInfo` method from the `System` service to determine what software version is available for download and to determine if the update is consider mandatory (using the `rebootImmediately` parameter).
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -219,15 +219,13 @@ Sets the maintenance mode and software upgrade opt-out mode.
 <a name="startMaintenance"></a>
 ## *startMaintenance*
 
-Starts maintenance activities. 
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- |
-| `onMaintenanceStatusChange` | Triggers whenever the maintenance status changes |.
+Starts maintenance activities.
 
-Also see: [onMaintenanceStatusChange](#onMaintenanceStatusChange)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onMaintenanceStatusChange](#onMaintenanceStatusChange) | Triggers whenever the maintenance status changes |
 ### Parameters
 
 This method takes no parameters.
@@ -266,15 +264,13 @@ This method takes no parameters.
 <a name="stopMaintenance"></a>
 ## *stopMaintenance*
 
-Stops maintenance activities. 
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- |
-| `onMaintenanceStatusChange` | Triggers whenever the maintenance status changes |.
+Stops maintenance activities.
 
-Also see: [onMaintenanceStatusChange](#onMaintenanceStatusChange)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onMaintenanceStatusChange](#onMaintenanceStatusChange) | Triggers whenever the maintenance status changes |
 ### Parameters
 
 This method takes no parameters.
@@ -313,11 +309,11 @@ This method takes no parameters.
 <a name="getMaintenanceMode"></a>
 ## *getMaintenanceMode*
 
-Gets the current maintenance mode and software upgrade opt-out mode which are stored in the persistent location. 
- 
+Gets the current maintenance mode and software upgrade opt-out mode which are stored in the persistent location.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 

--- a/docs/api/MessengerPlugin.md
+++ b/docs/api/MessengerPlugin.md
@@ -61,8 +61,11 @@ Joins a messaging room.
 
 Use this method to join a room. If the specified room does not exist, then it will be created.
 
-Also see: [userupdate](#userupdate)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [userupdate](#userupdate) | Notifies about user status updates. |
 ### Parameters
 
 | Name | Type | Description |
@@ -130,8 +133,11 @@ Leaves a messaging room.
 
 Use this method to leave a room. The room ID becomes invalid after this call. If there are no more users, the room will be destroyed and related resources freed.
 
-Also see: [userupdate](#userupdate)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [userupdate](#userupdate) | Notifies about user status updates. |
 ### Parameters
 
 | Name | Type | Description |
@@ -185,8 +191,11 @@ Sends a message to a room.
 
 Use this method to send a message to a room.
 
-Also see: [message](#message)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [message](#message) | Notifies about new messages in a room. |
 ### Parameters
 
 | Name | Type | Description |

--- a/docs/api/MonitorPlugin.md
+++ b/docs/api/MonitorPlugin.md
@@ -56,8 +56,10 @@ Monitor interface methods:
 ## *restartlimits*
 
 Sets new restart limits for a service.
- ### Events 
-No Events.
+
+### Events
+
+No Events
 
 ### Parameters
 
@@ -108,8 +110,10 @@ No Events.
 ## *resetstats*
 
 Resets memory and process statistics for a single service watched by the Monitor.
- ### Events 
-No Events.
+
+### Events
+
+No Events
 
 ### Parameters
 
@@ -228,6 +232,10 @@ Monitor interface properties:
 Provides access to the service statistics.
 
 > This property is **read-only**.
+
+### Events
+
+No Events
 
 ### Value
 

--- a/docs/api/MotionDetectionPlugin.md
+++ b/docs/api/MotionDetectionPlugin.md
@@ -64,10 +64,10 @@ MotionDetection interface methods:
 ## *arm*
 
 Enables a motion detector in the mode requested. This enables a single shot  Once an event is sent, the device is in the disarmed state. If the application wishes to receive another event, then the application must re-arm.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -116,10 +116,10 @@ Enables a motion detector in the mode requested. This enables a single shot  Onc
 ## *disarm*
 
 Disables the specified motion detector.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -166,10 +166,10 @@ Disables the specified motion detector.
 ## *getLastMotionEventElapsedTime*
 
 Returns the elapsed time since the last motion event occurred for the specified motion detector.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -220,10 +220,10 @@ Returns the elapsed time since the last motion event occurred for the specified 
 Returns the available motion detectors and then lists information for each detector including their supported sensitivity mode.  
   
 **Note:** The `sensitivityMode` property that is returned by this method indicates whether a number or a name controls the sensitivity of a motion detector. If `sensitivityMode` is `1`, then a set of properties (`min`, `max`, and `step`) are returned that define a valid number range to use. If `sensitivityMode` is `2`, then a `sensitivities` property is returned that contains valid names to use.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -290,10 +290,10 @@ This method takes no parameters.
 ## *getMotionEventsActivePeriod*
 
 Returns the configured times during the day when the motion sensor is active and detecting motion.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -344,10 +344,10 @@ This method takes no parameters.
 ## *getNoMotionPeriod*
 
 Returns the no-motion period for the specified motion detector.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -396,10 +396,10 @@ Returns the no-motion period for the specified motion detector.
 ## *getSensitivity*
 
 Returns the current sensitivity configuration for the specified motion detector. The result is either a `name` property with the sensitivity name or a `value` property with the sensitivity number. See `getMotionDetectors`.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -448,10 +448,10 @@ Returns the current sensitivity configuration for the specified motion detector.
 ## *isarmed*
 
 Returns whether the specified motion detector is enabled.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -501,10 +501,10 @@ Returns whether the specified motion detector is enabled.
 
 Sets the period of time during the day when the motion sensor is active and detecting motion. Any motion notifications outside of this period should be deferred until the start of the active period or cancelled if the notification is no longer valid. If this method is not called, then the active period is considered disabled and the sensor is armed 24 hours per day.  
 **Note:** The start time may be a higher value than the end time (for example, when a configured activation period spans across midnight from 09:00 pm to 01:00 am). Also, Daylight savings time (DST) may apply to the time zone where this feature is being used and the caller should be aware of the 23 hour and 25 hour days which occur during the shift days. For this reason it is advised that the caller reprograms the active period the day before and the day after the shift days to ensure reliable operation. If the caller is reprogramming this value every 24 hours then this should not be an issue.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -563,10 +563,10 @@ Sets the period of time during the day when the motion sensor is active and dete
 ## *setNoMotionPeriod*
 
 Sets the no-motion period, in seconds, for the specified motion detector. When a motion detector is set to detect motion, this is the period of time, in seconds, that MUST elapse with no motion before a motion event is generated. If motion is detected within this period of time, then the time is reset and the countdown begins again. When a motion detector is set to detect no motion, then this is the period of time with no motion detected that MUST elapse before a no-motion event is generated.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -619,10 +619,10 @@ Sets the sensitivity of the sensor for the specified motion detector. The argume
 * `value`: Used when the `sensitivityMode` is set to `1` requiring a sensitivity number within a valid range.  
   
 See `getMotionDetectors` to get the supported sensitivity mode.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 

--- a/docs/api/NetworkPlugin.md
+++ b/docs/api/NetworkPlugin.md
@@ -71,11 +71,11 @@ Network interface methods:
 <a name="getDefaultInterface"></a>
 ## *getDefaultInterface*
 
-Gets the default network interface. The active network interface is defined as the one that can make requests to the external network. Returns one of the supported interfaces as per `getInterfaces`, or an empty value which indicates that there is no default network interface. 
-  
-### Events 
+Gets the default network interface. The active network interface is defined as the one that can make requests to the external network. Returns one of the supported interfaces as per `getInterfaces`, or an empty value which indicates that there is no default network interface.
 
-  No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -117,11 +117,11 @@ This method takes no parameters.
 <a name="getInterfaces"></a>
 ## *getInterfaces*
 
-Returns a list of interfaces supported by this device including their state. 
-  
-### Events 
+Returns a list of interfaces supported by this device including their state.
 
-  No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -175,11 +175,11 @@ This method takes no parameters.
 <a name="getIPSettings"></a>
 ## *getIPSettings*
 
-Gets the IP setting for the given interface. 
-  
-### Events 
+Gets the IP setting for the given interface.
 
-  No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -245,11 +245,11 @@ Gets the IP setting for the given interface.
 <a name="getNamedEndpoints"></a>
 ## *getNamedEndpoints*
 
-Returns a list of endpoint names. Currently supported endpoint names are: `CMTS`. 
-  
-### Events 
+Returns a list of endpoint names. Currently supported endpoint names are: `CMTS`.
 
-  No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -294,11 +294,11 @@ This method takes no parameters.
 <a name="getQuirks"></a>
 ## *getQuirks*
 
-Get standard string `RDK-20093`. 
-  
-### Events 
+Get standard string `RDK-20093`.
 
-  No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -340,11 +340,11 @@ This method takes no parameters.
 <a name="getStbIp"></a>
 ## *getStbIp*
 
-Gets the IP address of the default interface. 
-  
-### Events 
+Gets the IP address of the default interface.
 
-  No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -386,11 +386,11 @@ This method takes no parameters.
 <a name="getSTBIPFamily"></a>
 ## *getSTBIPFamily*
 
-Gets the IP address of the default interface by address family. 
-  
-### Events 
+Gets the IP address of the default interface by address family.
 
-  No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -438,11 +438,11 @@ Gets the IP address of the default interface by address family.
 <a name="isConnectedToInternet"></a>
 ## *isConnectedToInternet*
 
-Whether the device has internet connectivity. This API might take up to 2s to validate internet connectivity. 
-  
-### Events 
+Whether the device has internet connectivity. This API might take up to 2s to validate internet connectivity.
 
-  No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -484,11 +484,11 @@ This method takes no parameters.
 <a name="isInterfaceEnabled"></a>
 ## *isInterfaceEnabled*
 
-Whether the specified interface is enabled. 
-  
-### Events 
+Whether the specified interface is enabled.
 
-  No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -536,11 +536,11 @@ Whether the specified interface is enabled.
 <a name="ping"></a>
 ## *ping*
 
-Pings the specified endpoint with the specified number of packets. 
-  
-### Events 
+Pings the specified endpoint with the specified number of packets.
 
-  No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -610,11 +610,11 @@ Pings the specified endpoint with the specified number of packets.
 <a name="pingNamedEndpoint"></a>
 ## *pingNamedEndpoint*
 
-Pings the specified named endpoint with the specified number of packets. Only names returned by `getNamedEndpoints` can be used. The named endpoint is resolved to a specific host or IP address on the device side based on the `endpointName`. 
-  
-### Events 
+Pings the specified named endpoint with the specified number of packets. Only names returned by `getNamedEndpoints` can be used. The named endpoint is resolved to a specific host or IP address on the device side based on the `endpointName`.
 
-  No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -684,11 +684,11 @@ Pings the specified named endpoint with the specified number of packets. Only na
 <a name="setConnectivityTestEndpoints"></a>
 ## *setConnectivityTestEndpoints*
 
-Sets the default list of endpoints used for a connectivity test. Maximum number of endpoints is 5. 
-  
-### Events 
+Sets the default list of endpoints used for a connectivity test. Maximum number of endpoints is 5.
 
-  No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -738,17 +738,15 @@ Sets the default list of endpoints used for a connectivity test. Maximum number 
 ## *setDefaultInterface*
 
 Sets the default interface. The call fails if the interface is not enabled.
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- | 
-| `onDefaultInterfaceChanged` | Triggered when device's default interface changed.| 
-| `onInterfaceStatusChanged` | Triggered when interface's status changes to enabled/disabled. | 
-| `onConnectionStatusChanged` | Triggered when the device connects to router. | 
-| `onIPAddressStatusChanged` | Triggered when each IP address is lost or acquired.|.
 
-Also see: [onInterfaceStatusChanged](#onInterfaceStatusChanged), [onConnectionStatusChanged](#onConnectionStatusChanged), [onIPAddressStatusChanged](#onIPAddressStatusChanged), [onDefaultInterfaceChanged](#onDefaultInterfaceChanged)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onInterfaceStatusChanged](#onInterfaceStatusChanged) | Triggered when device’s default interface changed. |
+| [onConnectionStatusChanged](#onConnectionStatusChanged) | Triggered when interface’s status changes to enabled/disabled. |
+| [onIPAddressStatusChanged](#onIPAddressStatusChanged) | Triggered when the device connects to router. |
+| [onDefaultInterfaceChanged](#onDefaultInterfaceChanged) | Triggered when each IP address is lost or acquired. |
 ### Parameters
 
 | Name | Type | Description |
@@ -796,14 +794,12 @@ Also see: [onInterfaceStatusChanged](#onInterfaceStatusChanged), [onConnectionSt
 ## *setInterfaceEnabled*
 
 Enables the specified interface.
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- | 
-| `onInterfaceStatusChanged` | Triggered when interface's status changes to enabled/disabled.|.
 
-Also see: [onInterfaceStatusChanged](#onInterfaceStatusChanged)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onInterfaceStatusChanged](#onInterfaceStatusChanged) | Triggered when interface’s status changes to enabled/disabled. |
 ### Parameters
 
 | Name | Type | Description |
@@ -852,15 +848,13 @@ Also see: [onInterfaceStatusChanged](#onInterfaceStatusChanged)
 <a name="setIPSettings"></a>
 ## *setIPSettings*
 
-Sets the IP settings.All the inputs are mandatory for v1. But for v2, the interface and autconfig params are mandatory input to autoconfig IP settings & other parameters not required. For manual IP, all the input parameters are mandatory except secondaryDNS 
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- | 
-| `onIPAddressStatusChanged` | Triggered when each IP address is lost or acquired.|.
+Sets the IP settings.All the inputs are mandatory for v1. But for v2, the interface and autconfig params are mandatory input to autoconfig IP settings & other parameters not required. For manual IP, all the input parameters are mandatory except secondaryDNS.
 
-Also see: [onIPAddressStatusChanged](#onIPAddressStatusChanged)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onIPAddressStatusChanged](#onIPAddressStatusChanged) | Triggered when each IP address is lost or acquired. |
 ### Parameters
 
 | Name | Type | Description |
@@ -921,11 +915,11 @@ Also see: [onIPAddressStatusChanged](#onIPAddressStatusChanged)
 <a name="getPublicIP"></a>
 ## *getPublicIP*
 
-It allows either zero parameter or with only interface and ipv6 parameter to determine WAN ip address. 
-  
-### Events 
+It allows either zero parameter or with only interface and ipv6 parameter to determine WAN ip address.
 
-  No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -975,11 +969,11 @@ It allows either zero parameter or with only interface and ipv6 parameter to det
 <a name="setStunEndPoint"></a>
 ## *setStunEndPoint*
 
-Set the Stun Endpoint used for getPublicIP. 
-  
-### Events 
+Set the Stun Endpoint used for getPublicIP.
 
-  No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -1033,11 +1027,11 @@ Set the Stun Endpoint used for getPublicIP.
 <a name="trace"></a>
 ## *trace*
 
-Traces the specified endpoint with the specified number of packets using `traceroute`. 
-  
-### Events 
+Traces the specified endpoint with the specified number of packets using `traceroute`.
 
-  No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -1091,11 +1085,11 @@ Traces the specified endpoint with the specified number of packets using `tracer
 <a name="traceNamedEndpoint"></a>
 ## *traceNamedEndpoint*
 
-Traces the specified named endpoint with the specified number of packets using `traceroute`. 
-  
-### Events 
+Traces the specified named endpoint with the specified number of packets using `traceroute`.
 
-  No Events.
+### Events
+
+No Events
 
 ### Parameters
 

--- a/docs/api/OCIContainerPlugin.md
+++ b/docs/api/OCIContainerPlugin.md
@@ -62,10 +62,10 @@ OCIContainer interface methods:
 ## *executeCommand*
 
 Executes a command inside a running container. The path to the executable must resolve within the container's namespace.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -116,10 +116,10 @@ Executes a command inside a running container. The path to the executable must r
 ## *getContainerInfo*
 
 Gets information about a running container such as CPU, memory, and GPU usage (GPU not supported on Xi6).
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -207,10 +207,10 @@ Gets information about a running container such as CPU, memory, and GPU usage (G
 ## *getContainerState*
 
 Gets the state of a currently running container.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -261,10 +261,10 @@ Gets the state of a currently running container.
 ## *listContainers*
 
 Lists all running OCI containers Dobby knows about.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -315,10 +315,10 @@ This method takes no parameters.
 ## *pauseContainer*
 
 Pauses a currently running container.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -365,10 +365,10 @@ Pauses a currently running container.
 ## *resumeContainer*
 
 Resumes a previously paused container.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -414,15 +414,13 @@ Resumes a previously paused container.
 <a name="startContainer"></a>
 ## *startContainer*
 
-Starts a new container from an existing OCI bundle. 
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- | 
-| `onContainerStarted` |  Triggers when a new container starts running.|.
+Starts a new container from an existing OCI bundle.
 
-Also see: [onContainerStarted](#onContainerStarted)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onContainerStarted](#onContainerStarted) | Triggers when a new container starts running. |
 ### Parameters
 
 | Name | Type | Description |
@@ -481,14 +479,12 @@ Also see: [onContainerStarted](#onContainerStarted)
 ## *startContainerFromDobbySpec*
 
 Starts a new container from a legacy Dobby JSON specification.
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- | 
-| `onContainerStarted` |  Triggers when a new container starts running.|.
 
-Also see: [onContainerStarted](#onContainerStarted)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onContainerStarted](#onContainerStarted) | Triggers when a new container starts running. |
 ### Parameters
 
 | Name | Type | Description |
@@ -541,15 +537,13 @@ Also see: [onContainerStarted](#onContainerStarted)
 <a name="stopContainer"></a>
 ## *stopContainer*
 
-Stops a currently running container. 
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- | 
-| `onContainerStopped` | Triggers when the container stops running.|.
+Stops a currently running container.
 
-Also see: [onContainerStopped](#onContainerStopped)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onContainerStopped](#onContainerStopped) | Triggers when the container stops running. |
 ### Parameters
 
 | Name | Type | Description |

--- a/docs/api/OpenCDMiPlugin.md
+++ b/docs/api/OpenCDMiPlugin.md
@@ -68,6 +68,10 @@ Provides access to the supported DRM systems.
 
 > This property is **read-only**.
 
+### Events
+
+No Events
+
 ### Value
 
 | Name | Type | Description |
@@ -113,6 +117,10 @@ Provides access to the supported DRM systems.
 Provides access to the DRM key systems.
 
 > This property is **read-only**.
+
+### Events
+
+No Events
 
 ### Value
 

--- a/docs/api/PackagerPlugin.md
+++ b/docs/api/PackagerPlugin.md
@@ -55,6 +55,10 @@ Packager interface methods:
 
 Installs a package given by a name, a URL, or a file path.
 
+### Events
+
+No Events
+
 ### Parameters
 
 | Name | Type | Description |
@@ -107,6 +111,10 @@ Installs a package given by a name, a URL, or a file path.
 ## *synchronize*
 
 Synchronizes the repository manifest with a repository.
+
+### Events
+
+No Events
 
 ### Parameters
 

--- a/docs/api/PersistentStorePlugin.md
+++ b/docs/api/PersistentStorePlugin.md
@@ -61,10 +61,10 @@ PersistentStore interface methods:
 ## *deleteKey*
 
 Deletes a key from the specified namespace.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -113,10 +113,10 @@ Deletes a key from the specified namespace.
 ## *deleteNamespace*
 
 Deletes the specified namespace.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -163,10 +163,10 @@ Deletes the specified namespace.
 ## *flushCache*
 
 Flushes the database cache by invoking `flush` in SQLite.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -207,10 +207,10 @@ This method takes no parameters.
 ## *getKeys*
 
 Returns the keys that are stored in the specified namespace.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -262,10 +262,10 @@ Returns the keys that are stored in the specified namespace.
 ## *getNamespaces*
 
 Returns the namespaces in the datastore.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -311,10 +311,10 @@ This method takes no parameters.
 ## *getStorageSize*
 
 Returns the size occupied by each namespace. This is a processing-intense operation. The total size of the datastore should not exceed more than 1MB in size. If the storage size is exceeded then, new values are not stored and the `onStorageExceeded` event is sent.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -362,10 +362,10 @@ This method takes no parameters.
 ## *getValue*
 
 Returns the value of a key from the specified namespace.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -416,15 +416,13 @@ Returns the value of a key from the specified namespace.
 ## *setValue*
 
 Sets the value of a key in the the specified namespace.
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- |
-| `onStorageExceeded`| Triggered if the storage size has surpassed 1 MB storage size|
-| `onValueChanged` | Triggered whenever any of the values stored are changed using setValue |.
 
-Also see: [onStorageExceeded](#onStorageExceeded), [onValueChanged](#onValueChanged)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onStorageExceeded](#onStorageExceeded) | Triggered if the storage size has surpassed 1 MB storage size |
+| [onValueChanged](#onValueChanged) | Triggered whenever any of the values stored are changed using setValue |
 ### Parameters
 
 | Name | Type | Description |

--- a/docs/api/PlayerInfoPlugin.md
+++ b/docs/api/PlayerInfoPlugin.md
@@ -55,11 +55,11 @@ PlayerInfo interface methods:
 <a name="audiocodecs"></a>
 ## *audiocodecs*
 
-Returns the audio codec supported by the platform. 
- 
-### Events 
- 
-No Events.
+Returns the audio codec supported by the platform.
+
+### Events
+
+No Events
 
 ### Parameters
 
@@ -100,10 +100,10 @@ This method takes no parameters.
 ## *videocodecs*
 
 Returns the video codec supported by the platform.
- 
-### Events 
- 
-No Events.
+
+### Events
+
+No Events
 
 ### Parameters
 
@@ -165,6 +165,10 @@ Provides access to the player general information.
 
 > This property is **read-only**.
 
+### Events
+
+No Events
+
 ### Value
 
 | Name | Type | Description |
@@ -211,6 +215,10 @@ Provides access to the current configured video output port resolution.
 
 > This property is **read-only**.
 
+### Events
+
+No Events
+
 ### Value
 
 | Name | Type | Description |
@@ -245,6 +253,10 @@ Provides access to the current configured video output port resolution.
 Provides access to the check for Loudness Equivalence in the platform.
 
 > This property is **read-only**.
+
+### Events
+
+No Events
 
 ### Value
 
@@ -281,6 +293,10 @@ Provides access to the atmos capabilities of Sink.
 
 > This property is **read-only**.
 
+### Events
+
+No Events
+
 ### Value
 
 | Name | Type | Description |
@@ -315,6 +331,10 @@ Provides access to the atmos capabilities of Sink.
 Provides access to the current sound mode.
 
 > This property is **read-only**.
+
+### Events
+
+No Events
 
 ### Value
 
@@ -351,6 +371,10 @@ Provides access to the audio output enablement for Atmos.
 
 > This property is **write-only**.
 
+### Events
+
+No Events
+
 ### Value
 
 | Name | Type | Description |
@@ -384,6 +408,10 @@ Provides access to the audio output enablement for Atmos.
 ## *dolby_mode*
 
 Provides access to the dolby mode.
+
+### Events
+
+No Events
 
 ### Value
 

--- a/docs/api/RDKShellPlugin.md
+++ b/docs/api/RDKShellPlugin.md
@@ -130,11 +130,11 @@ RDKShell interface methods:
 <a name="addAnimation"></a>
 ## *addAnimation*
 
-Performs the set of animations. 
- 
+Performs the set of animations.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -206,11 +206,11 @@ Performs the set of animations.
 <a name="addKeyIntercept"></a>
 ## *addKeyIntercept*
 
-Adds a key intercept to the client application specified. The keys are specified by a key code and a set of modifiers. Regardless of the application that has focus, key presses that match the key code and modifiers will be sent to the client application. 
- 
+Adds a key intercept to the client application specified. The keys are specified by a key code and a set of modifiers. Regardless of the application that has focus, key presses that match the key code and modifiers will be sent to the client application.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -265,11 +265,11 @@ Adds a key intercept to the client application specified. The keys are specified
 <a name="addKeyIntercepts"></a>
 ## *addKeyIntercepts*
 
-Adds the list of key intercepts. 
- 
+Adds the list of key intercepts.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -334,11 +334,11 @@ Adds the list of key intercepts.
 <a name="addKeyListener"></a>
 ## *addKeyListener*
 
-Adds a key listener to an application. The keys are bubbled up based on their z-order. 
- 
+Adds a key listener to an application. The keys are bubbled up based on their z-order.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -405,11 +405,11 @@ Adds a key listener to an application. The keys are bubbled up based on their z-
 <a name="addKeyMetadataListener"></a>
 ## *addKeyMetadataListener*
 
-Adds the key metadata listeners. 
- 
+Adds the key metadata listeners.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -457,11 +457,11 @@ Adds the key metadata listeners.
 <a name="createDisplay"></a>
 ## *createDisplay*
 
- Creates a display for the specified client using the configuration parameters. 
- 
+ Creates a display for the specified client using the configuration parameters.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -525,15 +525,13 @@ Adds the key metadata listeners.
 <a name="destroy"></a>
 ## *destroy*
 
-Destroys an application. 
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- |
-| `OnDestroyed` | Triggers when a runtime is successfully destroyed |.
+Destroys an application.
 
-Also see: [onDestroyed](#onDestroyed)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onDestroyed](#onDestroyed) | Triggers when a runtime is successfully destroyed |
 ### Parameters
 
 | Name | Type | Description |
@@ -578,11 +576,11 @@ Also see: [onDestroyed](#onDestroyed)
 <a name="enableInactivityReporting"></a>
 ## *enableInactivityReporting*
 
-Enables or disables inactivity reporting and events. 
- 
+Enables or disables inactivity reporting and events.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -628,11 +626,11 @@ Enables or disables inactivity reporting and events.
 <a name="enableKeyRepeats"></a>
 ## *enableKeyRepeats*
 
-Enables or disables key repeats. 
- 
+Enables or disables key repeats.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -678,11 +676,11 @@ Enables or disables key repeats.
 <a name="enableLogsFlushing"></a>
 ## *enableLogsFlushing*
 
-Enables or disables flushing all logs. 
- 
+Enables or disables flushing all logs.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -728,11 +726,11 @@ Enables or disables flushing all logs.
 <a name="enableVirtualDisplay"></a>
 ## *enableVirtualDisplay*
 
-Enables or disables a virtual display for the specified client. 
- 
+Enables or disables a virtual display for the specified client.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -782,11 +780,11 @@ Enables or disables a virtual display for the specified client.
 <a name="generateKey"></a>
 ## *generateKey*
 
-Triggers the key events (key press and release). 
- 
+Triggers the key events (key press and release).
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -849,11 +847,11 @@ Triggers the key events (key press and release).
 <a name="getAvailableTypes"></a>
 ## *getAvailableTypes*
 
-Returns the list of application types available on the firmware. 
- 
+Returns the list of application types available on the firmware.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -898,11 +896,11 @@ This method takes no parameters.
 <a name="getBounds"></a>
 ## *getBounds*
 
-Gets the bounds of the specified client. 
- 
+Gets the bounds of the specified client.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -961,11 +959,11 @@ Gets the bounds of the specified client.
 <a name="getClients"></a>
 ## *getClients*
 
-Gets a list of clients. 
- 
+Gets a list of clients.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -1010,11 +1008,11 @@ This method takes no parameters.
 <a name="getCursorSize"></a>
 ## *getCursorSize*
 
-Returns the currently set cursor size. 
- 
+Returns the currently set cursor size.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -1058,11 +1056,11 @@ This method takes no parameters.
 <a name="getHolePunch"></a>
 ## *getHolePunch*
 
-Returns whether video hole punching is enabled or disabled for the specified client. 
- 
+Returns whether video hole punching is enabled or disabled for the specified client.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -1112,11 +1110,11 @@ Returns whether video hole punching is enabled or disabled for the specified cli
 <a name="getKeyRepeatsEnabled"></a>
 ## *getKeyRepeatsEnabled*
 
-Returns whether key repeating is enabled or disabled. 
- 
+Returns whether key repeating is enabled or disabled.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -1158,11 +1156,11 @@ This method takes no parameters.
 <a name="getLastWakeupKey"></a>
 ## *getLastWakeupKey*
 
-Returns the last key press prior to a device wakeup. 
- 
+Returns the last key press prior to a device wakeup.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -1211,11 +1209,11 @@ This method takes no parameters.
 <a name="getLogLevel"></a>
 ## *getLogLevel*
 
-Returns the currently set logging level. 
- 
+Returns the currently set logging level.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -1257,11 +1255,11 @@ This method takes no parameters.
 <a name="getLogsFlushingEnabled"></a>
 ## *getLogsFlushingEnabled*
 
-Returns whether log flushing is enabled or disabled. 
- 
+Returns whether log flushing is enabled or disabled.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -1303,11 +1301,11 @@ This method takes no parameters.
 <a name="getOpacity"></a>
 ## *getOpacity*
 
-Gets the opacity of the specified client. 
- 
+Gets the opacity of the specified client.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -1355,11 +1353,11 @@ Gets the opacity of the specified client.
 <a name="getScale"></a>
 ## *getScale*
 
-Returns the scale of an application. 
- 
+Returns the scale of an application.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -1409,11 +1407,11 @@ Returns the scale of an application.
 <a name="getScreenResolution"></a>
 ## *getScreenResolution*
 
-Gets the screen resolution. 
- 
+Gets the screen resolution.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -1457,15 +1455,13 @@ This method takes no parameters.
 <a name="getScreenshot"></a>
 ## *getScreenshot*
 
-Captures a screenshot. 
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- |
-| `onScreenshotComplete` | Triggers when a screenshot is captured successfully |.
+Captures a screenshot.
 
-Also see: [onScreenshotComplete](#onScreenshotComplete)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onScreenshotComplete](#onScreenshotComplete) | Triggers when a screenshot is captured successfully |
 ### Parameters
 
 This method takes no parameters.
@@ -1505,10 +1501,10 @@ This method takes no parameters.
 ## *getState*
 
 Returns the state of all applications.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -1560,11 +1556,11 @@ This method takes no parameters.
 <a name="getSystemMemory"></a>
 ## *getSystemMemory*
 
-Gets the information of System Memory. 
- 
+Gets the information of System Memory.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -1610,11 +1606,11 @@ This method takes no parameters.
 <a name="getSystemResourceInfo"></a>
 ## *getSystemResourceInfo*
 
-Returns system resource information about each application. 
- 
+Returns system resource information about each application.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -1666,11 +1662,11 @@ This method takes no parameters.
 <a name="getVirtualDisplayEnabled"></a>
 ## *getVirtualDisplayEnabled*
 
-Returns whether virtual display is enabled or disabled for the specified client. 
- 
+Returns whether virtual display is enabled or disabled for the specified client.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -1721,10 +1717,10 @@ Returns whether virtual display is enabled or disabled for the specified client.
 ## *getVirtualResolution*
 
 Returns the virtual display resolution for the specified client.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -1776,11 +1772,11 @@ Returns the virtual display resolution for the specified client.
 <a name="getVisibility"></a>
 ## *getVisibility*
 
-Gets the visibility of the specified client. 
- 
+Gets the visibility of the specified client.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -1830,11 +1826,11 @@ Gets the visibility of the specified client.
 <a name="getZOrder"></a>
 ## *getZOrder*
 
-Returns an array of clients in Z order, starting with the top most application client first. 
- 
+Returns an array of clients in Z order, starting with the top most application client first.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -1881,6 +1877,10 @@ This method takes no parameters.
 
 Returns the current Graphics Frame Rate.
 
+### Events
+
+No Events
+
 ### Parameters
 
 This method takes no parameters.
@@ -1921,11 +1921,11 @@ This method takes no parameters.
 <a name="hideAllClients"></a>
 ## *hideAllClients*
 
-Hides/Unhides all the clients. 
- 
+Hides/Unhides all the clients.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -1971,11 +1971,11 @@ Hides/Unhides all the clients.
 <a name="hideCursor"></a>
 ## *hideCursor*
 
-Hides the cursor from showing on the display. The cursor is hidden by default. 
- 
+Hides the cursor from showing on the display. The cursor is hidden by default.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -2015,11 +2015,11 @@ This method takes no parameters.
 <a name="hideFullScreenImage"></a>
 ## *hideFullScreenImage*
 
-Hides the Full Screen Image. 
- 
+Hides the Full Screen Image.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -2059,11 +2059,11 @@ This method takes no parameters.
 <a name="hideSplashLogo"></a>
 ## *hideSplashLogo*
 
-Removes the splash screen. 
- 
+Removes the splash screen.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -2104,6 +2104,10 @@ This method takes no parameters.
 ## *ignoreKeyInputs*
 
 Blocks user key inputs.
+
+### Events
+
+No Events
 
 ### Parameters
 
@@ -2149,11 +2153,11 @@ Blocks user key inputs.
 <a name="injectKey"></a>
 ## *injectKey*
 
-Injects the keys. 
- 
+Injects the keys.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -2204,11 +2208,11 @@ Injects the keys.
 <a name="kill"></a>
 ## *kill*
 
-Kills the specified client. 
- 
+Kills the specified client.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -2256,15 +2260,13 @@ Kills the specified client.
 <a name="launch"></a>
 ## *launch*
 
-Launches an application. 
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- |
-| `onLaunched` | Triggers when the runtime of an application is launched successfully |.
+Launches an application.
 
-Also see: [onLaunched](#onLaunched)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onLaunched](#onLaunched) | Triggers when the runtime of an application is launched successfull |
 ### Parameters
 
 | Name | Type | Description |
@@ -2347,15 +2349,13 @@ Also see: [onLaunched](#onLaunched)
 <a name="launchApplication"></a>
 ## *launchApplication*
 
-Launches an application. 
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- |
-| `onApplicationLaunched` | Triggers when an application is launched successfully |.
+Launches an application.
 
-Also see: [onApplicationLaunched](#onApplicationLaunched)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onApplicationLaunched](#onApplicationLaunched) | Triggers when an application is launched successfully |
 ### Parameters
 
 | Name | Type | Description |
@@ -2408,11 +2408,11 @@ Also see: [onApplicationLaunched](#onApplicationLaunched)
 <a name="launchResidentApp"></a>
 ## *launchResidentApp*
 
-Launches the Resident application. 
- 
+Launches the Resident application.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -2452,11 +2452,11 @@ This method takes no parameters.
 <a name="moveBehind"></a>
 ## *moveBehind*
 
-Moves the specified client behind the specified target client. 
- 
+Moves the specified client behind the specified target client.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -2504,11 +2504,11 @@ Moves the specified client behind the specified target client.
 <a name="moveToBack"></a>
 ## *moveToBack*
 
-Moves the specified client to the back or bottom of the Z order. 
- 
+Moves the specified client to the back or bottom of the Z order.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -2556,11 +2556,11 @@ Moves the specified client to the back or bottom of the Z order.
 <a name="moveToFront"></a>
 ## *moveToFront*
 
-Moves the specified client to the front or top of the Z order. 
- 
+Moves the specified client to the front or top of the Z order.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -2608,11 +2608,11 @@ Moves the specified client to the front or top of the Z order.
 <a name="removeAllKeyIntercepts"></a>
 ## *removeAllKeyIntercepts*
 
-Removes all key intercepts. 
- 
+Removes all key intercepts.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -2652,11 +2652,11 @@ This method takes no parameters.
 <a name="removeAllKeyListeners"></a>
 ## *removeAllKeyListeners*
 
-Removes all key listeners. 
- 
+Removes all key listeners.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -2696,11 +2696,11 @@ This method takes no parameters.
 <a name="removeAnimation"></a>
 ## *removeAnimation*
 
-Removes the current animation for the specified client. 
- 
+Removes the current animation for the specified client.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -2748,11 +2748,11 @@ Removes the current animation for the specified client.
 <a name="removeKeyIntercept"></a>
 ## *removeKeyIntercept*
 
-Removes a key intercept. 
- 
+Removes a key intercept.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -2805,11 +2805,11 @@ Removes a key intercept.
 <a name="removeKeyListener"></a>
 ## *removeKeyListener*
 
-Removes a key listener for an application. 
- 
+Removes a key listener for an application.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -2870,11 +2870,11 @@ Removes a key listener for an application.
 <a name="removeKeyMetadataListener"></a>
 ## *removeKeyMetadataListener*
 
-Removes the key metadata listeners. 
- 
+Removes the key metadata listeners.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -2922,11 +2922,11 @@ Removes the key metadata listeners.
 <a name="resetInactivityTime"></a>
 ## *resetInactivityTime*
 
-Resets the inactivity notification interval. 
- 
+Resets the inactivity notification interval.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -2966,15 +2966,13 @@ This method takes no parameters.
 <a name="resumeApplication"></a>
 ## *resumeApplication*
 
-Resumes an application. 
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- |
-| `onApplicationResumed` | Triggers when an application resumes from a suspended state |.
+Resumes an application.
 
-Also see: [onApplicationResumed](#onApplicationResumed)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onApplicationResumed](#onApplicationResumed) | Triggers when an application resumes from a suspended state |
 ### Parameters
 
 | Name | Type | Description |
@@ -3019,11 +3017,11 @@ Also see: [onApplicationResumed](#onApplicationResumed)
 <a name="scaleToFit"></a>
 ## *scaleToFit*
 
-Scales the specified client to fit the current bounds. 
- 
+Scales the specified client to fit the current bounds.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -3079,11 +3077,11 @@ Scales the specified client to fit the current bounds.
 <a name="setBounds"></a>
 ## *setBounds*
 
-Sets the bounds of the specified client. 
- 
+Sets the bounds of the specified client.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -3139,11 +3137,11 @@ Sets the bounds of the specified client.
 <a name="setCursorSize"></a>
 ## *setCursorSize*
 
-Sets the cursor size. 
- 
+Sets the cursor size.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -3191,11 +3189,11 @@ Sets the cursor size.
 <a name="setFocus"></a>
 ## *setFocus*
 
-Sets focus to the specified client. 
- 
+Sets focus to the specified client.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -3243,11 +3241,11 @@ Sets focus to the specified client.
 <a name="setHolePunch"></a>
 ## *setHolePunch*
 
-Enables or disables video hole punching for the specified client. 
- 
+Enables or disables video hole punching for the specified client.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -3297,15 +3295,13 @@ Enables or disables video hole punching for the specified client.
 <a name="setInactivityInterval"></a>
 ## *setInactivityInterval*
 
-Sets the inactivity notification interval. 
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- |
-| `onUserInactivity` | Triggers only if the device is inactive for the specified time interval |.
+Sets the inactivity notification interval.
 
-Also see: [onUserInactivity](#onUserInactivity)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onUserInactivity](#onUserInactivity) | Triggers only if the device is inactive for the specified time interval |
 ### Parameters
 
 | Name | Type | Description |
@@ -3350,11 +3346,11 @@ Also see: [onUserInactivity](#onUserInactivity)
 <a name="setLogLevel"></a>
 ## *setLogLevel*
 
-Sets the logging level. 
- 
+Sets the logging level.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -3400,11 +3396,11 @@ Sets the logging level.
 <a name="setMemoryMonitor"></a>
 ## *setMemoryMonitor*
 
-Enables or disables RAM memory monitoring on the device. Upon enabling, triggers possible events are onDeviceLowRamWarning, onDeviceCriticallyLowRamWarning, onDeviceLowRamWarningCleared, and onDeviceCriticallyLowRamWarningCleared. 
- 
+Enables or disables RAM memory monitoring on the device. Upon enabling, triggers possible events are onDeviceLowRamWarning, onDeviceCriticallyLowRamWarning, onDeviceLowRamWarningCleared, and onDeviceCriticallyLowRamWarningCleared.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -3456,11 +3452,11 @@ Enables or disables RAM memory monitoring on the device. Upon enabling, triggers
 <a name="setOpacity"></a>
 ## *setOpacity*
 
-Sets the opacity of the specified client. 
- 
+Sets the opacity of the specified client.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -3508,11 +3504,11 @@ Sets the opacity of the specified client.
 <a name="setScale"></a>
 ## *setScale*
 
-Scales an application. 
- 
+Scales an application.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -3564,11 +3560,11 @@ Scales an application.
 <a name="setScreenResolution"></a>
 ## *setScreenResolution*
 
-Sets the screen resolution. 
- 
+Sets the screen resolution.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -3616,11 +3612,11 @@ Sets the screen resolution.
 <a name="setTopmost"></a>
 ## *setTopmost*
 
-Sets whether the specified client appears above all other clients on the display. 
- 
+Sets whether the specified client appears above all other clients on the display.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -3670,11 +3666,11 @@ Sets whether the specified client appears above all other clients on the display
 <a name="setVirtualResolution"></a>
 ## *setVirtualResolution*
 
-Sets the virtual resolution for the specified client. 
- 
+Sets the virtual resolution for the specified client.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -3724,11 +3720,11 @@ Sets the virtual resolution for the specified client.
 <a name="setVisibility"></a>
 ## *setVisibility*
 
-Sets whether the specified client should be visible. 
- 
+Sets whether the specified client should be visible.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -3778,11 +3774,11 @@ Sets whether the specified client should be visible.
 <a name="setGraphicsFrameRate"></a>
 ## *setGraphicsFrameRate*
 
-Set Graphics Frame Rate.. 
- 
+Set Graphics Frame Rate.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -3828,11 +3824,11 @@ Set Graphics Frame Rate..
 <a name="showCursor"></a>
 ## *showCursor*
 
-Shows the cursor on the display using the current cursor size. See `setCursorSize`. The cursor automatically disappears after 5 seconds of inactivity. 
- 
+Shows the cursor on the display using the current cursor size. See `setCursorSize`. The cursor automatically disappears after 5 seconds of inactivity.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -3872,11 +3868,11 @@ This method takes no parameters.
 <a name="showFullScreenImage"></a>
 ## *showFullScreenImage*
 
-Shows the Full Screen Image. 
- 
+Shows the Full Screen Image.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -3922,11 +3918,11 @@ Shows the Full Screen Image.
 <a name="showSplashLogo"></a>
 ## *showSplashLogo*
 
-Displays the splash screen. 
- 
+Displays the splash screen.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -3972,11 +3968,11 @@ Displays the splash screen.
 <a name="showWatermark"></a>
 ## *showWatermark*
 
-Sets whether a watermark shows on the display. 
- 
+Sets whether a watermark shows on the display.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -4022,15 +4018,13 @@ Sets whether a watermark shows on the display.
 <a name="suspend"></a>
 ## *suspend*
 
-Suspends an application. 
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- |
-| `onSuspended` | Triggers when the runtime of an application is suspended |.
+Suspends an application.
 
-Also see: [onSuspended](#onSuspended)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onSuspended](#onSuspended) | Triggers when the runtime of an application is suspended |
 ### Parameters
 
 | Name | Type | Description |
@@ -4075,15 +4069,13 @@ Also see: [onSuspended](#onSuspended)
 <a name="suspendApplication"></a>
 ## *suspendApplication*
 
-Suspends an application. 
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- |
-| `onApplicationSuspended` | Triggers when an application is suspended |.
+Suspends an application.
 
-Also see: [onApplicationSuspended](#onApplicationSuspended)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onApplicationSuspended](#onApplicationSuspended) | Triggers when an application is suspended |
 ### Parameters
 
 | Name | Type | Description |
@@ -4128,11 +4120,11 @@ Also see: [onApplicationSuspended](#onApplicationSuspended)
 <a name="keyRepeatConfig"></a>
 ## *keyRepeatConfig*
 
-Customizes key repeats. 
- 
+Customizes key repeats.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -4148,3 +4140,677 @@ Customizes key repeats.
 
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
+| result | object |  |
+| result.success | boolean | Whether the request succeeded |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.RDKShell.keyRepeatConfig",
+    "params": {
+        "input": "default",
+        "enabled": true,
+        "initialDelay": 500,
+        "repeatInterval": 250
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "success": true
+    }
+}
+```
+
+<a name="setAVBlocked"></a>
+## *setAVBlocked*
+
+adds/removes the list of applications with the given callsigns to/from the blacklist.
+
+### Events
+
+No Events
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.callsign | string | The application callsign |
+| params.blocked | boolean | Whether to block (`true`) or unblock (`false`) AV for the callsign |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.success | boolean | Whether the request succeeded |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.RDKShell.setAVBlocked",
+    "params": {
+        "callsign": "searchanddiscovery",
+        "blocked": true
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "success": true
+    }
+}
+```
+
+<a name="getBlockedAVApplications"></a>
+## *getBlockedAVApplications*
+
+Gets a list of blacklisted clients.
+
+### Events
+
+No Events
+
+### Parameters
+
+This method takes no parameters.
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.clients | array | A list of clients |
+| result.clients[#] | string |  |
+| result.success | boolean | Whether the request succeeded |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.RDKShell.getBlockedAVApplications"
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "clients": [
+            "org.rdk.Netflix"
+        ],
+        "success": true
+    }
+}
+```
+
+<a name="Notifications"></a>
+# Notifications
+
+Notifications are autonomous events, triggered by the internals of the implementation, and broadcasted via JSON-RPC to all registered observers. Refer to [[Thunder](#Thunder)] for information on how to register for a notification.
+
+The following events are provided by the org.rdk.RDKShell plugin:
+
+RDKShell interface events:
+
+| Event | Description |
+| :-------- | :-------- |
+| [onApplicationActivated](#onApplicationActivated) | Triggered when an application is activated |
+| [onApplicationConnected](#onApplicationConnected) | Triggered when a connection to an application succeeds |
+| [onApplicationDisconnected](#onApplicationDisconnected) | Triggered when an attempt to disconnect from an application succeeds |
+| [onApplicationFirstFrame](#onApplicationFirstFrame) | Triggered when the first frame of an application is loaded |
+| [onApplicationLaunched](#onApplicationLaunched) | Triggered when an application launches successfully |
+| [onApplicationResumed](#onApplicationResumed) | Triggered when an application resumes from a suspended state |
+| [onApplicationSuspended](#onApplicationSuspended) | Triggered when an application is suspended |
+| [onApplicationTerminated](#onApplicationTerminated) | Triggered when an application terminates |
+| [onDestroyed](#onDestroyed) | Triggered when a runtime is destroyed |
+| [onDeviceCriticallyLowRamWarning](#onDeviceCriticallyLowRamWarning) | Triggered when the RAM memory on the device exceeds the configured `criticallyLowRam` threshold value |
+| [onDeviceCriticallyLowRamWarningCleared](#onDeviceCriticallyLowRamWarningCleared) | Triggered when the RAM memory on the device no longer exceeds the configured `criticallyLowRam` threshold value |
+| [onDeviceLowRamWarning](#onDeviceLowRamWarning) | Triggered when the RAM memory on the device exceeds the configured `lowRam` threshold value |
+| [onDeviceLowRamWarningCleared](#onDeviceLowRamWarningCleared) | Triggered when the RAM memory on the device no longer exceeds the configured `lowRam` threshold value |
+| [onLaunched](#onLaunched) | Triggered when a runtime is launched |
+| [onSuspended](#onSuspended) | Triggered when a runtime is suspended |
+| [onUserInactivity](#onUserInactivity) | Triggered when a device has been inactive for a period of time |
+| [onWillDestroy](#onWillDestroy) | Triggered when an application is set to be destroyed |
+| [onPluginSuspended](#onPluginSuspended) | Triggered when a plugin is suspended |
+| [onScreenshotComplete](#onScreenshotComplete) | Triggered when a screenshot is captured successfully using `getScreenshot` method |
+| [onBlur](#onBlur) | Triggered when the focused client is blurred |
+| [onFocus](#onFocus) | Triggered when a client is set to focus |
+
+
+<a name="onApplicationActivated"></a>
+## *onApplicationActivated*
+
+Triggered when an application is activated.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.client | string | The client name |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.onApplicationActivated",
+    "params": {
+        "client": "org.rdk.Netflix"
+    }
+}
+```
+
+<a name="onApplicationConnected"></a>
+## *onApplicationConnected*
+
+Triggered when a connection to an application succeeds.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.client | string | The client name |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.onApplicationConnected",
+    "params": {
+        "client": "org.rdk.Netflix"
+    }
+}
+```
+
+<a name="onApplicationDisconnected"></a>
+## *onApplicationDisconnected*
+
+Triggered when an attempt to disconnect from an application succeeds.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.client | string | The client name |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.onApplicationDisconnected",
+    "params": {
+        "client": "org.rdk.Netflix"
+    }
+}
+```
+
+<a name="onApplicationFirstFrame"></a>
+## *onApplicationFirstFrame*
+
+Triggered when the first frame of an application is loaded.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.client | string | The client name |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.onApplicationFirstFrame",
+    "params": {
+        "client": "org.rdk.Netflix"
+    }
+}
+```
+
+<a name="onApplicationLaunched"></a>
+## *onApplicationLaunched*
+
+Triggered when an application launches successfully.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.client | string | The client name |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.onApplicationLaunched",
+    "params": {
+        "client": "org.rdk.Netflix"
+    }
+}
+```
+
+<a name="onApplicationResumed"></a>
+## *onApplicationResumed*
+
+Triggered when an application resumes from a suspended state.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.client | string | The client name |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.onApplicationResumed",
+    "params": {
+        "client": "org.rdk.Netflix"
+    }
+}
+```
+
+<a name="onApplicationSuspended"></a>
+## *onApplicationSuspended*
+
+Triggered when an application is suspended.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.client | string | The client name |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.onApplicationSuspended",
+    "params": {
+        "client": "org.rdk.Netflix"
+    }
+}
+```
+
+<a name="onApplicationTerminated"></a>
+## *onApplicationTerminated*
+
+Triggered when an application terminates.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.client | string | The client name |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.onApplicationTerminated",
+    "params": {
+        "client": "org.rdk.Netflix"
+    }
+}
+```
+
+<a name="onDestroyed"></a>
+## *onDestroyed*
+
+Triggered when a runtime is destroyed.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.client | string | The client name |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.onDestroyed",
+    "params": {
+        "client": "org.rdk.Netflix"
+    }
+}
+```
+
+<a name="onDeviceCriticallyLowRamWarning"></a>
+## *onDeviceCriticallyLowRamWarning*
+
+Triggered when the RAM memory on the device exceeds the configured `criticallyLowRam` threshold value. See `setMemoryMonitor`.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.ram | integer | The amount of free memory remaining in Kilobytes |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.onDeviceCriticallyLowRamWarning",
+    "params": {
+        "ram": 65536
+    }
+}
+```
+
+<a name="onDeviceCriticallyLowRamWarningCleared"></a>
+## *onDeviceCriticallyLowRamWarningCleared*
+
+Triggered when the RAM memory on the device no longer exceeds the configured `criticallyLowRam` threshold value. See `setMemoryMonitor`.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.ram | integer | The amount of free memory remaining in Kilobytes |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.onDeviceCriticallyLowRamWarningCleared",
+    "params": {
+        "ram": 65536
+    }
+}
+```
+
+<a name="onDeviceLowRamWarning"></a>
+## *onDeviceLowRamWarning*
+
+Triggered when the RAM memory on the device exceeds the configured `lowRam` threshold value. See `setMemoryMonitor`.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.ram | integer | The amount of free memory remaining in Kilobytes |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.onDeviceLowRamWarning",
+    "params": {
+        "ram": 65536
+    }
+}
+```
+
+<a name="onDeviceLowRamWarningCleared"></a>
+## *onDeviceLowRamWarningCleared*
+
+Triggered when the RAM memory on the device no longer exceeds the configured `lowRam` threshold value. See `setMemoryMonitor`.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.ram | integer | The amount of free memory remaining in Kilobytes |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.onDeviceLowRamWarningCleared",
+    "params": {
+        "ram": 65536
+    }
+}
+```
+
+<a name="onLaunched"></a>
+## *onLaunched*
+
+Triggered when a runtime is launched.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.client | string | The client name |
+| params.launchType | string | The launch type of an application (must be one of the following: *create*, *active*, *suspend*, *resume*) |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.onLaunched",
+    "params": {
+        "client": "org.rdk.Netflix",
+        "launchType": "create"
+    }
+}
+```
+
+<a name="onSuspended"></a>
+## *onSuspended*
+
+Triggered when a runtime is suspended.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.client | string | The client name |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.onSuspended",
+    "params": {
+        "client": "org.rdk.Netflix"
+    }
+}
+```
+
+<a name="onUserInactivity"></a>
+## *onUserInactivity*
+
+Triggered when a device has been inactive for a period of time. This event is broadcasted at the frequency specified by `setInactivityInterval` if the device is not active. The default frequency is 15 minutes.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.minutes | number | The number of minutes that the device has been inactive |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.onUserInactivity",
+    "params": {
+        "minutes": 5
+    }
+}
+```
+
+<a name="onWillDestroy"></a>
+## *onWillDestroy*
+
+Triggered when an application is set to be destroyed.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.callsign | string | The application callsign |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.onWillDestroy",
+    "params": {
+        "callsign": "Cobalt"
+    }
+}
+```
+
+<a name="onPluginSuspended"></a>
+## *onPluginSuspended*
+
+Triggered when a plugin is suspended.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.client | string | The client name |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.onPluginSuspended",
+    "params": {
+        "client": "searchanddiscovery"
+    }
+}
+```
+
+<a name="onScreenshotComplete"></a>
+## *onScreenshotComplete*
+
+Triggered when a screenshot is captured successfully using `getScreenshot` 
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.imageData | string | Base64 encoded image data |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.onScreenshotComplete",
+    "params": {
+        "imageData": "AAAAAAAAAA"
+    }
+}
+```
+
+<a name="onBlur"></a>
+## *onBlur*
+
+Triggered when the focused client is blurred.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.client | string | The client name |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.onBlur",
+    "params": {
+        "client": "searchanddiscovery"
+    }
+}
+```
+
+<a name="onFocus"></a>
+## *onFocus*
+
+Triggered when a client is set to focus.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.client | string | The client name |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.onFocus",
+    "params": {
+        "client": "HtmlApp"
+    }
+}
+```
+

--- a/docs/api/RemoteActionMappingPlugin.md
+++ b/docs/api/RemoteActionMappingPlugin.md
@@ -62,10 +62,10 @@ RemoteActionMapping interface methods:
 ## *cancelCodeDownload*
 
 Cancels downloading IR and five digit codes from the IRRF database.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -114,10 +114,10 @@ Cancels downloading IR and five digit codes from the IRRF database.
 ## *clearKeyActionMapping*
 
 Clears an action mapping for the specified keys.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -178,10 +178,10 @@ Clears an action mapping for the specified keys.
 ## *getApiVersionNumber*
 
 Returns the API version number.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -224,10 +224,10 @@ This method takes no parameters.
 ## *getFullKeyActionMapping*
 
 Returns the mapping of all action keys.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -298,10 +298,10 @@ Returns the mapping of all action keys.
 ## *getKeymap*
 
 Returns a hard-coded list of key names.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -357,10 +357,10 @@ Returns a hard-coded list of key names.
 ## *getLastUsedDeviceID*
 
 Returns the last used remote information.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -411,10 +411,10 @@ This method takes no parameters.
 ## *getSingleKeyActionMapping*
 
 Returns the mapping for a single action key.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -484,15 +484,12 @@ Returns the mapping for a single action key.
 ## *setFiveDigitCode*
 
 Sets the TV and AVR five digit code.
- 
-Events
- 
-| Event | Description | 
-| :-------- | :-------- | 
-| `onFiveDigitCodeLoad` | Triggered if new five digit codes are loaded successfully |.
 
-Also see: [onFiveDigitCodeLoad](#onFiveDigitCodeLoad)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onFiveDigitCodeLoad](#onFiveDigitCodeLoad) | Triggered if new five digit codes are loaded successfully |
 ### Parameters
 
 | Name | Type | Description |
@@ -544,15 +541,12 @@ Also see: [onFiveDigitCodeLoad](#onFiveDigitCodeLoad)
 ## *setKeyActionMapping*
 
 Sets the mapping of a single action key. This method is unavailable (returns error) if the remote supports 5 digit codes.
- 
-Events
- 
-| Event | Description | 
-| :-------- | :-------- | 
-| `onIRCodeLoad` | Triggered if new IR codes are loaded successfully |.
 
-Also see: [onIRCodeLoad](#onIRCodeLoad)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onIRCodeLoad](#onIRCodeLoad) | Triggered if new IR codes are loaded successfully |
 ### Parameters
 
 | Name | Type | Description |

--- a/docs/api/ScreenCapturePlugin.md
+++ b/docs/api/ScreenCapturePlugin.md
@@ -58,15 +58,12 @@ Takes a screenshot and uploads it to the specified URL. A screenshot is uploaded
 or,  
 `curl -F image=@/path/to/screenshot.png http://server/cgi-bin/upload.cgi`  
 For implementation details, see `bool ScreenCapture::uploadDataToUrl(std::vector<unsigned char> &data, const char *url, std::string &error_str)`.
- 
-Events
- 
-| Event | Description | 
-| :-------- | :-------- | 
-| `uploadComplete` | Triggered after uploading a screen capture with status and message |.
 
-Also see: [uploadComplete](#uploadComplete)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [uploadComplete](#uploadComplete) | Triggered after uploading a screen capture with status and message |
 ### Parameters
 
 | Name | Type | Description |

--- a/docs/api/SecurityAgentPlugin.md
+++ b/docs/api/SecurityAgentPlugin.md
@@ -58,6 +58,10 @@ SecurityAgent interface methods:
 
 Creates a signed JsonWeb token. On success, returns Signed JsonWeb token and on failure, returns error message and error code as mentioned in below Errors table.
 
+### Events
+
+No Events
+
 ### Parameters
 
 | Name | Type | Description |
@@ -113,6 +117,10 @@ Creates a signed JsonWeb token. On success, returns Signed JsonWeb token and on 
 ## *validate*
 
 Validates the token whether it is valid and properly signed.
+
+### Events
+
+No Events
 
 ### Parameters
 

--- a/docs/api/StateObserverPlugin.md
+++ b/docs/api/StateObserverPlugin.md
@@ -60,10 +60,10 @@ StateObserver interface methods:
 ## *getApiVersionNumber*
 
 Returns the API version number.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -106,10 +106,10 @@ This method takes no parameters.
 ## *getName*
 
 Returns the plugin name.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -152,10 +152,10 @@ This method takes no parameters.
 ## *getRegisteredPropertyNames*
 
 Returns all properties which have active listeners.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -210,10 +210,10 @@ Returns the values and errors for the specified properties.
 * `com.comcast.ecm_ip` - RDK-03004  
 * `com.comcast.dsg_ca_tunnel` - RDK-03003  
 * `com.comcast.cable_card` - RDK-03001.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -275,10 +275,10 @@ Returns the values and errors for the specified properties.
 ## *registerListeners*
 
 Register a listener on the specified properties for value change notifications. These properties are added to a registered properties list. Internally, this method calls the `getValues` method and hence it returns the current value of those properties.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -340,10 +340,10 @@ Register a listener on the specified properties for value change notifications. 
 ## *setApiVersionNumber*
 
 Sets the API version number.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -390,10 +390,10 @@ Sets the API version number.
 ## *unregisterListeners*
 
 Removes the listeners on the specified properties. The properties are removed from the registered properties list.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 

--- a/docs/api/SystemAudioPlayerPlugin.md
+++ b/docs/api/SystemAudioPlayerPlugin.md
@@ -69,10 +69,10 @@ SystemAudioPlayer interface methods:
 Closes the system audio player with the specified ID. The `SystemAudioPlayer` plugin destroys the player object. That is, if the player is playing, then it is stopped and closed. All volume mixer level settings are restored. 
 
  Also See: [open](#open).
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -119,10 +119,10 @@ Closes the system audio player with the specified ID. The `SystemAudioPlayer` pl
 ## *config*
 
 Configures playback for a PCM audio source (audio/x-raw) on the specified player. This method must be called before the [play](#play)  There may be more optional configuration parameters added in the future for PCM as well as for other audio types. Supported audio/x-raw configuration parameters can be found at https://gstreamer.freedesktop.org/documentation/rawparse/rawaudioparse.html#src.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -194,11 +194,11 @@ Configures playback for a PCM audio source (audio/x-raw) on the specified player
 <a name="getPlayerSessionId"></a>
 ## *getPlayerSessionId*
 
-Gets the session ID from the provided the URL. The session is the ID returned in open cal. 
- 
-### Events 
+Gets the session ID from the provided the URL. The session is the ID returned in open cal.
 
- No Events .
+### Events
+
+No Events
 
 ### Parameters
 
@@ -247,10 +247,10 @@ Gets the session ID from the provided the URL. The session is the ID returned in
 ## *isspeaking*
 
 Checks if playback is in progress.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -301,10 +301,10 @@ Opens a player instance and assigns it a unique ID. The player ID is used to ref
 **Note**: The `SystemAudioPlayer` plugin can have a maximum of 1 system and 1 application play mode player at a time.  
 
 Also See: [close](#close).
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -357,14 +357,12 @@ Also See: [close](#close).
 ## *pause*
 
 Pauses playback on the specified player. Pause is only supported for HTTP and file source types.
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- |
-| `onsapevents:PLAYBACK_PAUSED`| Triggered if the playback paused on the specified player.|.
 
-Also see: [onsapevents](#onsapevents)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onsapevents](#onsapevents) | Triggered if the playback paused on the specified player. |
 ### Parameters
 
 | Name | Type | Description |
@@ -412,15 +410,12 @@ Also see: [onsapevents](#onsapevents)
 Plays audio on the specified player.  
 
 **Note**: If a player is using one play mode and another player tries to play audio using the same play mode, then an error returns indicating that the hardware resource has already been acquired by the session and includes the player ID.
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- |
-| `onsapevents:PLAYBACK_STARTED`| Triggered if the playback is started to play on the specified player.|
-| `onsapevents:PLAYBACK_FINISHED`| Triggered if the playback is finished  normally on the specified player.|.
 
-Also see: [onsapevents](#onsapevents)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onsapevents](#onsapevents) | Triggered if the playback is started to play or finished normally on the specified player. |
 ### Parameters
 
 | Name | Type | Description |
@@ -468,14 +463,12 @@ Also see: [onsapevents](#onsapevents)
 ## *playbuffer*
 
 Buffers the audio playback on the specified player.
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- |
-| `onsapevents:NEED_DATA`| Triggered if  the buffer needs more data to play|.
 
-Also see: [onsapevents](#onsapevents)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onsapevents](#onsapevents) | Triggered if the buffer needs more data to play. |
 ### Parameters
 
 | Name | Type | Description |
@@ -523,14 +516,12 @@ Also see: [onsapevents](#onsapevents)
 ## *resume*
 
 Resumes playback on the specified player. Resume is only supported for HTTP and file source types.
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- |
-| `onsapevents:PLAYBACK_RESUMED`| Triggered if the playback resumed on the specified player.|.
 
-Also see: [onsapevents](#onsapevents)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onsapevents](#onsapevents) | Triggered if the playback resumed on the specified player. |
 ### Parameters
 
 | Name | Type | Description |
@@ -576,10 +567,10 @@ Also see: [onsapevents](#onsapevents)
 ## *setMixerLevels*
 
 Sets the audio level on the specified player. The `SystemAudioPlayer` plugin can control the volume of the content being played back as well as the primary program audio; thus, an application can duck down the volume on the primary program audio when system audio is played and then restore it back when the system audio playback is complete.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -630,10 +621,10 @@ Sets the audio level on the specified player. The `SystemAudioPlayer` plugin can
 ## *setSmartVolControl*
 
 Sets the smart volume audio control on the specified player. The plugin can control the smart volume of the content being played back as well as the primary program audio; thus, an application can duck down the volume on the primary program audio when system audio is played and then restore it back when the system audio playback is complete.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -690,10 +681,10 @@ Sets the smart volume audio control on the specified player. The plugin can cont
 ## *stop*
 
 Stops playback on the specified player.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 

--- a/docs/api/SystemPlugin.md
+++ b/docs/api/SystemPlugin.md
@@ -121,7 +121,7 @@ SystemServices interface methods:
 
 Checks if a key is present in the cache.
 
-> This API is **deprecated** and may be removed in the future. It is no longer recommended for use in new implementations.
+> This API is **deprecated** and may be removed in the future. It is no longer recommended for use in new implementations. [Refer this link for the new api]( https://rdkcentral.github.io/rdkservices/#/api/PersistentStorePlugin?id=getvalue)
 
 ### Events
 
@@ -463,7 +463,7 @@ This method takes no parameters.
 
 Gets the value of a key in the cache.
 
-> This API is **deprecated** and may be removed in the future. It is no longer recommended for use in new implementations.
+> This API is **deprecated** and may be removed in the future. It is no longer recommended for use in new implementations. [Refer this link for the new api](https://rdkcentral.github.io/rdkservices/#/api/PersistentStorePlugin?id=getvalue)
 
 ### Events
 
@@ -1059,7 +1059,7 @@ This method takes no parameters.
 
 Returns the list of milestones.
 
-> This API is **deprecated** and may be removed in the future. It is no longer recommended for use in new implementations.
+> This API is **deprecated** and may be removed in the future. It is no longer recommended for use in new implementations. [Refer this link for the new api](https://rdkcentral.github.io/rdkservices/#/api/DeviceDiagnosticsPlugin?id=getmilestones)
 
 ### Events
 
@@ -2495,7 +2495,7 @@ Requests that the system performs a reboot of the set-top box.
 
 Removes the cache key.
 
-> This API is **deprecated** and may be removed in the future. It is no longer recommended for use in new implementations.
+> This API is **deprecated** and may be removed in the future. It is no longer recommended for use in new implementations. [Refer this link for the new api](https://rdkcentral.github.io/rdkservices/#/api/PersistentStorePlugin?id=deletekey)
 
 ### Events
 
@@ -2643,7 +2643,7 @@ No Events
 
 Sets the value for a key in the cache.
 
-> This API is **deprecated** and may be removed in the future. It is no longer recommended for use in new implementations.
+> This API is **deprecated** and may be removed in the future. It is no longer recommended for use in new implementations. [Refer this link for the new api](https://rdkcentral.github.io/rdkservices/#/api/PersistentStorePlugin?id=setvalue)
 
 ### Events
 

--- a/docs/api/SystemPlugin.md
+++ b/docs/api/SystemPlugin.md
@@ -120,12 +120,12 @@ SystemServices interface methods:
 ## *cacheContains*
 
 Checks if a key is present in the cache.
- 
-### Events
- 
- No Events.
 
 > This API is **deprecated** and may be removed in the future. It is no longer recommended for use in new implementations.
+
+### Events
+
+No Events
 
 ### Parameters
 
@@ -172,10 +172,10 @@ Checks if a key is present in the cache.
 ## *clearLastDeepSleepReason*
 
 Clears the last deep sleep reason.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -216,10 +216,10 @@ This method takes no parameters.
 ## *deletePersistentPath*
 
 (Version 2) Deletes persistent path associated with a callsign.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -268,10 +268,10 @@ This method takes no parameters.
 ## *enableMoca*
 
 Enables (or disables) Moca support for the platform.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -318,10 +318,10 @@ Enables (or disables) Moca support for the platform.
 ## *enableXREConnectionRetention*
 
 Enables (or disables) XRE Connection Retention option.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -368,14 +368,12 @@ Enables (or disables) XRE Connection Retention option.
 ## *fireFirmwarePendingReboot*
 
 (Version 2) Notifies the device about a pending reboot.
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- |
-| `onFirmwarePendingReboot` | Triggers when the firmware has a pending reboot |.
 
-Also see: [onFirmwarePendingReboot](#onFirmwarePendingReboot)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onFirmwarePendingReboot](#onFirmwarePendingReboot) | Triggers when the firmware has a pending reboot |
 ### Parameters
 
 This method takes no parameters.
@@ -415,10 +413,10 @@ This method takes no parameters.
 ## *getAvailableStandbyModes*
 
 Queries the available standby modes.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -464,12 +462,12 @@ This method takes no parameters.
 ## *getCachedValue*
 
 Gets the value of a key in the cache.
- 
-### Events
- 
- No Events.
 
 > This API is **deprecated** and may be removed in the future. It is no longer recommended for use in new implementations.
+
+### Events
+
+No Events
 
 ### Parameters
 
@@ -518,10 +516,10 @@ Gets the value of a key in the cache.
 ## *getCoreTemperature*
 
 Returns the core temperature of the device. Not supported on all devices.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -571,10 +569,10 @@ Collects device details. Sample keys include:
 * imageVersion  
 * rf4ce_mac  
 * wifi_mac.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -626,10 +624,10 @@ Collects device details. Sample keys include:
 ## *getDownloadedFirmwareInfo*
 
 Returns information about firmware downloads.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -678,10 +676,10 @@ This method takes no parameters.
 ## *getFirmwareDownloadPercent*
 
 Gets the current download percentage.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -724,14 +722,12 @@ This method takes no parameters.
 ## *getFirmwareUpdateInfo*
 
 Checks the firmware update information.
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- |
-| `onFirmwareUpdateInfoReceived` | Triggers when the firmware update information is requested |.
 
-Also see: [onFirmwareUpdateInfoReceived](#onFirmwareUpdateInfoReceived)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onFirmwareUpdateInfoReceived](#onFirmwareUpdateInfoReceived) | Triggers when the firmware update information is requested |
 ### Parameters
 
 | Name | Type | Description |
@@ -779,10 +775,10 @@ Also see: [onFirmwareUpdateInfoReceived](#onFirmwareUpdateInfoReceived)
 ## *getFirmwareUpdateState*
 
 Checks the state of the firmware update.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -825,10 +821,10 @@ This method takes no parameters.
 ## *getLastDeepSleepReason*
 
 Retrieves the last deep sleep reason.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -871,10 +867,10 @@ This method takes no parameters.
 ## *getLastFirmwareFailureReason*
 
 (Version 2) Retrieves the last firmware failure reason.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -917,10 +913,10 @@ This method takes no parameters.
 ## *getLastWakeupKeyCode*
 
 (Version 2) Returns the last wakeup keycode.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -963,14 +959,12 @@ This method takes no parameters.
 ## *getMacAddresses*
 
 Gets the MAC address of the device.
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- |
-| `onMacAddressesRetreived` | Triggers when the MAC addresses are requested |.
 
-Also see: [onMacAddressesRetreived](#onMacAddressesRetreived)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onMacAddressesRetreived](#onMacAddressesRetreived) | Triggers when the MAC addresses are requested |
 ### Parameters
 
 | Name | Type | Description |
@@ -1018,10 +1012,10 @@ Also see: [onMacAddressesRetreived](#onMacAddressesRetreived)
 ## *getMfgSerialNumber*
 
 Gets the Manufacturing Serial Number.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -1064,12 +1058,12 @@ This method takes no parameters.
 ## *getMilestones*
 
 Returns the list of milestones.
- 
-### Events
- 
- No Events.
 
 > This API is **deprecated** and may be removed in the future. It is no longer recommended for use in new implementations.
+
+### Events
+
+No Events
 
 ### Parameters
 
@@ -1115,10 +1109,10 @@ This method takes no parameters.
 ## *getMode*
 
 Returns the currently set mode information.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -1166,10 +1160,10 @@ This method takes no parameters.
 ## *getNetworkStandbyMode*
 
 Returns the network standby mode of the device. If network standby is `true`, the device supports `WakeOnLAN` and `WakeOnWLAN` actions in STR (S3) mode.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -1212,10 +1206,10 @@ This method takes no parameters.
 ## *getOvertempGraceInterval*
 
 Returns the over-temperature grace interval value. Not supported on all devices.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -1258,10 +1252,10 @@ This method takes no parameters.
 ## *getPlatformConfiguration*
 
 (Version 2) Returns the supported features and device/account info.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -1361,10 +1355,10 @@ This method takes no parameters.
 ## *getPowerState*
 
 Returns the power state of the device.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -1407,10 +1401,10 @@ This method takes no parameters.
 ## *getPowerStateBeforeReboot*
 
 Returns the power state before reboot.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -1453,10 +1447,10 @@ This method takes no parameters.
 ## *getPowerStateIsManagedByDevice*
 
 Checks whether the power state is managed by the device.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -1499,10 +1493,10 @@ This method takes no parameters.
 ## *getPreferredStandbyMode*
 
 Returns the preferred standby mode. This method returns an empty string if the preferred mode has not been set.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -1545,10 +1539,10 @@ This method takes no parameters.
 ## *getPreviousRebootInfo*
 
 Returns basic information about a reboot.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -1599,10 +1593,10 @@ This method takes no parameters.
 ## *getPreviousRebootInfo2*
 
 Returns detailed information about a reboot.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -1656,10 +1650,10 @@ This method takes no parameters.
 ## *getPreviousRebootReason*
 
 Returns the last reboot reason.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -1702,10 +1696,10 @@ This method takes no parameters.
 ## *getRFCConfig*
 
 Returns information that is related to RDK Feature Control (RFC) configurations.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -1760,10 +1754,10 @@ Returns information that is related to RDK Feature Control (RFC) configurations.
 ## *getSerialNumber*
 
 Returns the device serial number.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -1806,10 +1800,10 @@ This method takes no parameters.
 ## *getStateInfo*
 
 Queries device state information of various properties.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -1858,10 +1852,10 @@ Queries device state information of various properties.
 ## *getStoreDemoLink*
 
 (Version 2) Returns the store demo video link.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -1904,10 +1898,10 @@ This method takes no parameters.
 ## *getSystemVersions*
 
 Returns system version details.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -1954,10 +1948,10 @@ This method takes no parameters.
 ## *getTemperatureThresholds*
 
 Returns temperature threshold values. Not supported on all devices.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -2007,10 +2001,10 @@ This method takes no parameters.
 ## *getTerritory*
 
 Gets the configured system territory and region. Territory is a ISO-3166-1 alpha-3 standard (see https://en.wikipedia.org/wiki/ISO_3166-1). Region is a ISO-3166-2 alpha-2 standard (see https://en.wikipedia.org/wiki/ISO_3166-2).
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -2055,10 +2049,10 @@ This method takes no parameters.
 ## *getTimeZones*
 
 (Version2) Gets the available timezones from the system's time zone database. This method is useful for determining time offsets per zone.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -2114,10 +2108,10 @@ This method takes no parameters.
 ## *getTimeZoneDST*
 
 Get the configured time zone from the file referenced by `TZ_FILE`. If the time zone is not set, then `null` is returned.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -2160,10 +2154,10 @@ This method takes no parameters.
 ## *getWakeupReason*
 
 (Version 2) Returns the reason for the device coming out of deep sleep.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -2206,10 +2200,10 @@ This method takes no parameters.
 ## *getXconfParams*
 
 Returns XCONF configuration parameters for the device.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -2261,10 +2255,10 @@ This method takes no parameters.
 ## *hasRebootBeenRequested*
 
 Checks whether a reboot has been requested.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -2307,12 +2301,12 @@ This method takes no parameters.
 ## *isGzEnabled*
 
 Checks whether GZ is enabled.
- 
-### Events
- 
- No Events.
 
 > This API is **deprecated** and may be removed in the future. It is no longer recommended for use in new implementations.
+
+### Events
+
+No Events
 
 ### Parameters
 
@@ -2355,10 +2349,10 @@ This method takes no parameters.
 ## *isOptOutTelemetry*
 
 Checks the telemetry opt-out status.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -2401,10 +2395,10 @@ This method takes no parameters.
 ## *queryMocaStatus*
 
 Checks whether MOCA is enabled.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -2447,14 +2441,12 @@ This method takes no parameters.
 ## *reboot*
 
 Requests that the system performs a reboot of the set-top box.
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- |
-| `onRebootRequest` | Triggers when a device reboot request is made |.
 
-Also see: [onRebootRequest](#onRebootRequest)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onRebootRequest](#onRebootRequest) | Triggers when a device reboot request is made |
 ### Parameters
 
 | Name | Type | Description |
@@ -2502,12 +2494,12 @@ Also see: [onRebootRequest](#onRebootRequest)
 ## *removeCacheKey*
 
 Removes the cache key.
- 
-### Events
- 
- No Events.
 
 > This API is **deprecated** and may be removed in the future. It is no longer recommended for use in new implementations.
+
+### Events
+
+No Events
 
 ### Parameters
 
@@ -2554,10 +2546,10 @@ Removes the cache key.
 ## *requestSystemUptime*
 
 Returns the device uptime.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -2599,10 +2591,11 @@ This method takes no parameters.
 <a name="setBootLoaderPattern"></a>
 ## *setBootLoaderPattern*
 
-Sets the boot loader pattern mode in MFR. 
+Sets the boot loader pattern mode in MFR.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -2649,12 +2642,12 @@ Sets the boot loader pattern mode in MFR.
 ## *setCachedValue*
 
 Sets the value for a key in the cache.
- 
-### Events
- 
- No Events.
 
 > This API is **deprecated** and may be removed in the future. It is no longer recommended for use in new implementations.
+
+### Events
+
+No Events
 
 ### Parameters
 
@@ -2703,10 +2696,10 @@ Sets the value for a key in the cache.
 ## *setDeepSleepTimer*
 
 Sets the deep sleep timeout period.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -2753,10 +2746,10 @@ Sets the deep sleep timeout period.
 ## *setFirmwareAutoReboot*
 
 (Version 2) Enables or disables the AutoReboot Feature. This method internally sets the tr181 `AutoReboot.Enable` parameter to `true` or `false`.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -2803,10 +2796,10 @@ Sets the deep sleep timeout period.
 ## *setFirmwareRebootDelay*
 
 (Version 2) Delays the firmware reboot.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -2853,12 +2846,12 @@ Sets the deep sleep timeout period.
 ## *setGzEnabled*
 
 Enables or disables GZ.
- 
-### Events
- 
- No Events.
 
 > This API is **deprecated** and may be removed in the future. It is no longer recommended for use in new implementations.
+
+### Events
+
+No Events
 
 ### Parameters
 
@@ -2908,14 +2901,12 @@ Sets the mode of the set-top box for a specific duration before returning to nor
 * `NORMAL` - The set-top box is operating in normal mode.  
 * `EAS` - The set-top box is operating in Emergency Alert System (EAS) mode. This mode is set when the device needs to perform certain tasks when entering EAS mode, such as setting the clock display or preventing the user from using the diagnostics menu.  
 * `WAREHOUSE` - The set-top box is operating in warehouse mode.
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- |
-| `onSystemModeChanged` | Triggers when the system mode is changed successfully |.
 
-Also see: [onSystemModeChanged](#onSystemModeChanged)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onSystemModeChanged](#onSystemModeChanged) | Triggers when the system mode is changed successfully |
 ### Parameters
 
 | Name | Type | Description |
@@ -2966,10 +2957,10 @@ Also see: [onSystemModeChanged](#onSystemModeChanged)
 ## *setNetworkStandbyMode*
 
 Enables or disables the network standby mode of the device. If network standby is enabled, the device supports `WakeOnLAN` and `WakeOnWLAN` actions in STR (S3) mode.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -3016,10 +3007,10 @@ Enables or disables the network standby mode of the device. If network standby i
 ## *setOptOutTelemetry*
 
 Sets the telemetry opt-out status.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -3066,10 +3057,10 @@ Sets the telemetry opt-out status.
 ## *setOvertempGraceInterval*
 
 Sets the over-temperature grace interval value. Not supported on all devices.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -3116,14 +3107,12 @@ Sets the over-temperature grace interval value. Not supported on all devices.
 ## *setPowerState*
 
 Sets the power state of the device.
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- |
-| `onSystemPowerStateChanged` | Triggers when the system power state changes |.
 
-Also see: [onSystemPowerStateChanged](#onSystemPowerStateChanged)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onSystemPowerStateChanged](#onSystemPowerStateChanged) | Triggers when the system power state changes |
 ### Parameters
 
 | Name | Type | Description |
@@ -3171,10 +3160,10 @@ Also see: [onSystemPowerStateChanged](#onSystemPowerStateChanged)
 ## *setPreferredStandbyMode*
 
 Sets and persists the preferred standby mode. See [getAvailableStandbyModes](#getAvailableStandbyModes) for valid modes. Invoking this function does not change the power state of the device. It only sets the user preference for the preferred action when the [setPowerState](#setPowerState) method is invoked with a value of `STANDBY`.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -3221,10 +3210,10 @@ Sets and persists the preferred standby mode. See [getAvailableStandbyModes](#ge
 ## *setTemperatureThresholds*
 
 Sets the temperature threshold values. Not supported on all devices.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -3276,10 +3265,10 @@ Sets the temperature threshold values. Not supported on all devices.
 ## *setTerritory*
 
 Sets the system territory and region.Territory is a ISO-3166-1 alpha-3 standard (see https://en.wikipedia.org/wiki/ISO_3166-1). Region is a ISO-3166-2 alpha-2 standard (see https://en.wikipedia.org/wiki/ISO_3166-2).
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -3328,10 +3317,10 @@ Sets the system territory and region.Territory is a ISO-3166-1 alpha-3 standard 
 ## *setTimeZoneDST*
 
 Sets the system time zone. See `getTimeZones` to get a list of available timezones on the system.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -3378,10 +3367,10 @@ Sets the system time zone. See `getTimeZones` to get a list of available timezon
 ## *setWakeupSrcConfiguration*
 
 Sets the wakeup source configuration.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -3430,10 +3419,10 @@ Sets the wakeup source configuration.
 ## *updateFirmware*
 
 Initiates a firmware update. This method has no affect if an update is not available.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -3474,10 +3463,10 @@ This method takes no parameters.
 ## *uploadLogs*
 
 (Version 2) Uploads logs to a URL returned by SSR.
- 
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 

--- a/docs/api/TelemetryPlugin.md
+++ b/docs/api/TelemetryPlugin.md
@@ -55,6 +55,10 @@ Telemtry interface methods:
 
 Sets the status of telemetry reporting.
 
+### Events
+
+No Events
+
 ### Parameters
 
 | Name | Type | Description |
@@ -100,6 +104,10 @@ Sets the status of telemetry reporting.
 ## *logApplicationEvent*
 
 Logs an application 
+
+### Events
+
+No Events
 
 ### Parameters
 

--- a/docs/api/TextToSpeechPlugin.md
+++ b/docs/api/TextToSpeechPlugin.md
@@ -65,15 +65,13 @@ TextToSpeech interface methods:
 <a name="cancel"></a>
 ## *cancel*
 
-Cancels the speech. Triggers the `onspeechinterrupted`   
- 
-### Events  
-| Event | Description | 
-| :----------- | :-----------| 
-|`onspeechinterrupted` | Triggered when ongoing speech is cancelled. Event is not triggered: if TTS is not enabled; if ongoing Speech is completed |.
+Cancels the speech. Triggers the `onspeechinterrupted` 
 
-Also see: [onspeechinterrupted](#onspeechinterrupted)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onspeechinterrupted](#onspeechinterrupted) | Triggered when ongoing speech is cancelled. Event is not triggered: if TTS is not enabled; if ongoing Speech is completed |
 ### Parameters
 
 | Name | Type | Description |
@@ -120,16 +118,14 @@ Also see: [onspeechinterrupted](#onspeechinterrupted)
 <a name="enabletts"></a>
 ## *enabletts*
 
-(For Resident App) Enables or disables the TTS conversion processing. Triggered `onttsstatechanged` event when state changes and `onspeechinterrupted` event when disabling TTS while speech is in-progress. 
- 
-### Events  
-| Event | Description | 
-| :----------- | :----------- | 
-| `onttsstatechanged` | `state` : `true` Triggered when TTS is enabled; `state` : `false` Triggered when TTS is disabled; otherwise `No event` When TTS enable or disable is in-progress | 
-| `onspeechinterrupted` | Triggered when disabling TTS while speech is in-progress.
+(For Resident App) Enables or disables the TTS conversion processing. Triggered `onttsstatechanged` event when state changes and `onspeechinterrupted` event when disabling TTS while speech is in-progress.
 
-Also see: [onttsstatechanged](#onttsstatechanged), [onspeechinterrupted](#onspeechinterrupted)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onttsstatechanged](#onttsstatechanged) | state : true Triggered when TTS is enabled; state : false Triggered when TTS is disabled; otherwise No event When TTS enable or disable is in-progress |
+| [onspeechinterrupted](#onspeechinterrupted) | Triggered when disabling TTS while speech is in-progress. |
 ### Parameters
 
 | Name | Type | Description |
@@ -177,10 +173,10 @@ Also see: [onttsstatechanged](#onttsstatechanged), [onspeechinterrupted](#onspee
 ## *getapiversion*
 
 Gets the API Version.
- 
-### Events 
 
-No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -223,10 +219,10 @@ This method takes no parameters.
 ## *getspeechstate*
 
 Returns the current state of the speech request.
-  
-### Events 
 
-No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -277,10 +273,10 @@ No Events.
 ## *getttsconfiguration*
 
 Gets the current TTS configuration.
-  
-### Events 
- 
-No Events.
+
+### Events
+
+No Events
 
 ### Parameters
 
@@ -335,10 +331,10 @@ This method takes no parameters.
 ## *isspeaking*
 
 Checks if speech is in progress.
-  
-### Event 
 
-No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -389,10 +385,10 @@ No Events.
 ## *isttsenabled*
 
 Returns whether the TTS engine is enabled or disabled. By default the TTS engine is disabled.
-  
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -436,11 +432,11 @@ This method takes no parameters.
 <a name="listvoices"></a>
 ## *listvoices*
 
-Lists the available voices for the specified language. For every language there is a set of pre-defined voices.  
-  
-### Events 
+Lists the available voices for the specified language. For every language there is a set of pre-defined voices.
 
-No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -490,15 +486,13 @@ No Events.
 <a name="pause"></a>
 ## *pause*
 
-Pauses the speech. Triggers the `onspeechpause`   
- 
-### Events  
-| Event | Description | 
-| :----------- | :----------- | 
-|  `onspeechpause` | Triggered when ongoing speech is paused. Event not triggered on following conditions: TTS is not enabled; Speech is already in pause; or Speech is completed | .
+Pauses the speech. Triggers the `onspeechpause` 
 
-Also see: [onspeechpause](#onspeechpause)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onspeechpause](#onspeechpause) | Triggered when ongoing speech is paused. Event not triggered on following conditions: TTS is not enabled; Speech is already in pause; or Speech is completed |
 ### Parameters
 
 | Name | Type | Description |
@@ -545,15 +539,13 @@ Also see: [onspeechpause](#onspeechpause)
 <a name="resume"></a>
 ## *resume*
 
-Resumes the speech. Triggers the `onspeechresume`  
- 
-### Events  
-| Event | Description | 
-| :----------- | :----------- | 
-| `onspeechresume` | Triggered when speech is resumed and speech output is available. Event not triggered under following conditions: TTS is not enabled; Speech is resumed already; or Speech is completed |.
+Resumes the speech. Triggers the `onspeechresume` 
 
-Also see: [onspeechresume](#onspeechresume)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onspeechresume](#onspeechresume) | Triggered when speech is resumed and speech output is available. Event not triggered under following conditions: TTS is not enabled; Speech is resumed already; or Speech is completed |
 ### Parameters
 
 | Name | Type | Description |
@@ -601,14 +593,12 @@ Also see: [onspeechresume](#onspeechresume)
 ## *setttsconfiguration*
 
 Sets the TTS configuration. Triggers the `onvoicechanged` 
- 
-### Events  
-| Event | Description | 
-| :----------- | :----------- | 
-|`onvoicechanged`|Triggered only when the voice configuration is changed| .
 
-Also see: [onvoicechanged](#onvoicechanged)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onvoicechanged](#onvoicechanged) | Triggered only when the voice configuration is changed |
 ### Parameters
 
 | Name | Type | Description |
@@ -681,20 +671,18 @@ Also see: [onvoicechanged](#onvoicechanged)
 <a name="speak"></a>
 ## *speak*
 
-Converts the input text to speech when TTS is enabled. Any ongoing speech is interrupted and the newly requested speech is processed. The clients of the previous speech is sent an `onspeechinterrupted`  Upon success, this API returns an ID, which is used as input to other API methods for controlling the speech (for example, `pause`, `resume`, and `cancel`)
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- |
-| `onwillspeak` | Triggered when speech conversion is about to start | 
-| `onspeechstart` | Triggered when conversion of text to speech is started | 
-| `onspeechcomplete `| Triggered when conversion from text to speech is completed | 
-| `onspeechinterrupted`| Current speech is interrupted either by a next speech request; by calling the `cancel` method; or by disabling TTS, when speech is in-progress | 
-| `onnetworkerror` | Triggered when failed to fetch audio from the endpoint |  
-| `onplaybackerror` | Triggered when an error occurs during playback including pipeline failures; Triggered when `speak` is called during TTS disabled |.
+Converts the input text to speech when TTS is enabled. Any ongoing speech is interrupted and the newly requested speech is processed. The clients of the previous speech is sent an `onspeechinterrupted`  Upon success, this API returns an ID, which is used as input to other API methods for controlling the speech (for example, `pause`, `resume`, and `cancel`).
 
-Also see: [onwillspeak](#onwillspeak), [onspeechstart](#onspeechstart), [onspeechinterrupted](#onspeechinterrupted), [onspeechcomplete](#onspeechcomplete), [onnetworkerror](#onnetworkerror), [onplaybackerror](#onplaybackerror)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onwillspeak](#onwillspeak) | Triggered when speech conversion is about to start |
+| [onspeechstart](#onspeechstart) | Triggered when conversion of text to speech is started |
+| [onspeechinterrupted](#onspeechinterrupted) | Current speech is interrupted either by a next speech request; by calling the cancel method; or by disabling TTS, when speech is in-progress |
+| [onspeechcomplete](#onspeechcomplete) | Triggered when conversion from text to speech is completed |
+| [onnetworkerror](#onnetworkerror) | Triggered when failed to fetch audio from the endpoint |
+| [onplaybackerror](#onplaybackerror) | Triggered when an error occurs during playback including pipeline failures; Triggered when speak is called during TTS disabled |
 ### Parameters
 
 | Name | Type | Description |
@@ -746,10 +734,10 @@ Also see: [onwillspeak](#onwillspeak), [onspeechstart](#onspeechstart), [onspeec
 ## *setACL*
 
 Configures app to speak. Allows the ResidentAPP to configure the particular app and provides access to `speak`  If not configured any then gives access to all apps to speak. Configuration does not retained after reboot.
-  
-### Events 
 
-No Events.
+### Events
+
+No Events
 
 ### Parameters
 

--- a/docs/api/TimerPlugin.md
+++ b/docs/api/TimerPlugin.md
@@ -59,10 +59,10 @@ Timer interface methods:
 ## *cancel*
 
 Stops the specified timer.
- 
+
 ### Events
- 
-No Events.
+
+No Events
 
 ### Parameters
 
@@ -109,10 +109,10 @@ No Events.
 ## *getTimers*
 
 Gets the status of all timers.
- 
+
 ### Events
- 
-No Events.
+
+No Events
 
 ### Parameters
 
@@ -171,10 +171,10 @@ This method takes no parameters.
 ## *getTimerStatus*
 
 Gets the status of the specified timer.
- 
+
 ### Events
- 
-No Events.
+
+No Events
 
 ### Parameters
 
@@ -231,10 +231,10 @@ No Events.
 ## *resume*
 
 Resumes the specified timer.
- 
+
 ### Events
- 
-No Events.
+
+No Events
 
 ### Parameters
 
@@ -281,16 +281,13 @@ No Events.
 ## *startTimer*
 
 Starts a timer with the specified interval. After the timer expires, a `timerExpired `notification is sent. The timer can execute once (one-shot mode) or repeatedly.
- 
+
 ### Events
- 
-| Event | Description | 
-| :-------- | :-------- | 
-| `timerExpired` | Triggered when a timer expires | 
-| `timerExpiryReminder` | Triggered to remind that, the timer will expire in remindBefore value in seconds |.
 
-Also see: [timerExpired](#timerExpired), [timerExpiryReminder](#timerExpiryReminder)
-
+| Event | Description |
+| :-------- | :-------- |
+| [timerExpired](#timerExpired) | Triggered when a timer expires |
+| [timerExpiryReminder](#timerExpiryReminder) | Triggered to remind that, the timer will expire in remindBefore value in seconds |
 ### Parameters
 
 | Name | Type | Description |
@@ -344,10 +341,10 @@ Also see: [timerExpired](#timerExpired), [timerExpiryReminder](#timerExpiryRemin
 ## *suspend*
 
 Suspends the specified timer.
- 
+
 ### Events
- 
-No Events.
+
+No Events
 
 ### Parameters
 

--- a/docs/api/TraceControlPlugin.md
+++ b/docs/api/TraceControlPlugin.md
@@ -60,11 +60,11 @@ TraceControl interface methods:
 <a name="set"></a>
 ## *set*
 
-Sets traces. Enables or disables all or select category traces for the specified module. 
-  
-### Events 
+Sets traces. Enables or disables all or select category traces for the specified module.
 
- No events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -111,11 +111,11 @@ Sets traces. Enables or disables all or select category traces for the specified
 <a name="status"></a>
 ## *status*
 
-Retrieves the actual trace status information for the specified module and category. If the category or module is not specified then, all the information is returned. If both module and category are not specified then, the result is empty. It retrieves the details about the console status and remote address (port and binding), if these are configured. 
- 
+Retrieves the actual trace status information for the specified module and category. If the category or module is not specified then, all the information is returned. If both module and category are not specified then, the result is empty. It retrieves the details about the console status and remote address (port and binding), if these are configured.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 

--- a/docs/api/UsbAccessPlugin.md
+++ b/docs/api/UsbAccessPlugin.md
@@ -60,10 +60,10 @@ UsbAccess interface methods:
 ## *clearLink*
 
 Clears or removes the symbolic link created by the `createLink` 
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -105,11 +105,11 @@ This method takes no parameters.
 <a name="createLink"></a>
 ## *createLink*
 
-Creates a symbolic link to the root folder of the USB drive. If called, and a link already exists, then it errors out. Symbolic link has read-only access. Use the name `usbdrive`. 
- 
-### Events 
+Creates a symbolic link to the root folder of the USB drive. If called, and a link already exists, then it errors out. Symbolic link has read-only access. Use the name `usbdrive`.
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -155,10 +155,10 @@ This method takes no parameters.
 
 (Version 2) Gets a list of firmware files on the device. These files should start with the PMI or model number for that device and end with `.bin`. For example `HSTP11MWR_4.11p5s1_VBN_sdy.bin`.  
 Firmware files are scanned in the root directories. If multiple USB devices are found, then the available firmware files are checked and listed from each device.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -204,10 +204,10 @@ This method takes no parameters.
 ## *getFileList*
 
 Gets a list of files and folders from the specified directory or path.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -266,10 +266,10 @@ Gets a list of files and folders from the specified directory or path.
 ## *getMounted*
 
 (Version 2) Returns a list of mounted USB devices.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -315,10 +315,10 @@ This method takes no parameters.
 ## *updateFirmware*
 
 (Version 2) Updates the firmware using the specified file retrieved from the `getAvailableFirmwareFiles` 
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -366,15 +366,13 @@ This method takes no parameters.
 <a name="ArchiveLogs"></a>
 ## *ArchiveLogs*
 
-(Version 2) Compresses and uploads device logs into attached USB drive from /opt/logs with a name comprises of Mac of the device , date and time in a `tgz` format. For example `18310C696834_Logs_10-13-21-04-42PM.tgz` `(<MAC address>_Logs_<unix epoch time>.tgz)`.
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- |
-| `onArchiveLogs`| Triggered to archive the device logs and returns the status of the archive |.
+(Version 2) Compresses and uploads device logs into attached USB drive from /opt/logs with a name comprises of Mac of the device , date and time in a `tgz` format. For example `18310C696834_Logs_10-13-21-04-42PM.tgz` `(<MAC address>_Logs_<unix epoch time>.tgz)`.Notifies about new messages in a room.
 
-Also see: [onArchiveLogs](#onArchiveLogs)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onArchiveLogs](#onArchiveLogs) | Triggered to archive the device logs and returns the status of the archive |
 ### Parameters
 
 This method takes no parameters.

--- a/docs/api/UserPreferencesPlugin.md
+++ b/docs/api/UserPreferencesPlugin.md
@@ -55,6 +55,10 @@ UserPreferences interface methods:
 
 Returns the preferred user interface language.
 
+### Events
+
+No Events
+
 ### Parameters
 
 This method takes no parameters.
@@ -96,6 +100,10 @@ This method takes no parameters.
 ## *setUILanguage*
 
 Sets the preferred user interface language.
+
+### Events
+
+No Events
 
 ### Parameters
 

--- a/docs/api/VoiceControlPlugin.md
+++ b/docs/api/VoiceControlPlugin.md
@@ -258,7 +258,7 @@ No Events
 
 Sends a voice session with a transcription string to simulate a real voice session for QA. Example use cases for this API call include rack and automation testing.
 
-> This API is **deprecated** and may be removed in the future. It is no longer recommended for use in new implementations.
+> This API is **deprecated** and may be removed in the future. It is no longer recommended for use in new implementations. [Refer this link for the new api](https://rdkcentral.github.io/rdkservices/#/api/VoiceControlPlugin?id=voicesessionrequest)
 
 ### Events
 

--- a/docs/api/VoiceControlPlugin.md
+++ b/docs/api/VoiceControlPlugin.md
@@ -68,11 +68,11 @@ Configures the RDK's voice stack. NOTE: The URL Scheme determines which API prot
 | ws/wss | VREX XR18 WS API |
 | vrng/vrngs | VREX NextGen WS API |
 | aows/aowss | Audio only over websockets with no protocol layer |
-| sdt | Simple data transfer for direct handling of audio in the protocol layer |
+| sdt | Simple data transfer for direct handling of audio in the protocol layer |.
 
 ### Events
 
- No Events.
+No Events
 
 ### Parameters
 
@@ -149,7 +149,7 @@ Sends a message to the Voice Server. The specification of this message is not in
 
 ### Events
 
- No Events.
+No Events
 
 ### Parameters
 
@@ -205,7 +205,7 @@ Sets the application metadata in the INIT message that gets sent to the Voice Se
 
 ### Events
 
- No Events.
+No Events
 
 ### Parameters
 
@@ -258,20 +258,17 @@ Sets the application metadata in the INIT message that gets sent to the Voice Se
 
 Sends a voice session with a transcription string to simulate a real voice session for QA. Example use cases for this API call include rack and automation testing.
 
+> This API is **deprecated** and may be removed in the future. It is no longer recommended for use in new implementations.
+
 ### Events
 
 | Event | Description |
 | :-------- | :-------- |
-| `onSessionBegin` |Triggers if the voice session begins |
-| `onStreamBegin` |Triggers if a device starts streaming voice data to the RDK|
-| `onServerMessage` |Triggers if a message is received from the Voice Server |
-| `onStreamEnd` |Triggers if streaming audio is stopped from the device |
-| `onSessionEnd` |Triggers if interaction with the server is end|.
-
-> This API is **deprecated** and may be removed in the future. It is no longer recommended for use in new implementations.
-
-Also see: [onSessionBegin](#onSessionBegin), [onStreamBegin](#onStreamBegin), [onServerMessage](#onServerMessage), [onStreamEnd](#onStreamEnd), [onSessionEnd](#onSessionEnd)
-
+| [onSessionBegin](#onSessionBegin) | Triggers if the voice session begins |
+| [onStreamBegin](#onStreamBegin) | Triggers if a device starts streaming voice data to the RDK |
+| [onServerMessage](#onServerMessage) | Triggers if a message is received from the Voice Server |
+| [onStreamEnd](#onStreamEnd) | Triggers if streaming audio is stopped from the device |
+| [onSessionEnd](#onSessionEnd) | Triggers if interaction with the server is end |
 ### Parameters
 
 | Name | Type | Description |
@@ -329,11 +326,11 @@ Retrieves the types of voice sessions which are supported by the platform.
 | mic_stream_multi | An audio based session using the urlHf routing url and the platform's multi-channel audio input format |
 | mic_tap_stream_single | An audio based session using the urlMicTap routing url and the platform's single channel audio input format |
 | mic_tap_stream_multi | An audio based session using the urlMicTap routing url and the platform's multi-channel audio input format |
-| mic_factory_test | An audio based session using the urlHf routing url and the platform's unprocessed multi-channel audio input format |
+| mic_factory_test | An audio based session using the urlHf routing url and the platform's unprocessed multi-channel audio input format |.
 
 ### Events
 
- No Events.
+No Events
 
 ### Parameters
 
@@ -384,14 +381,11 @@ Requests a voice session using the specified request type and optional parameter
 
 | Event | Description |
 | :-------- | :-------- |
-| `onSessionBegin` |Triggers if the voice session begins |
-| `onStreamBegin` |Triggers if a device starts streaming voice data to the RDK|
-| `onServerMessage` |Triggers if a message is received from the Voice Server |
-| `onStreamEnd` |Triggers if streaming audio is stopped from the device |
-| `onSessionEnd` |Triggers if interaction with the server is end|.
-
-Also see: [onSessionBegin](#onSessionBegin), [onStreamBegin](#onStreamBegin), [onServerMessage](#onServerMessage), [onStreamEnd](#onStreamEnd), [onSessionEnd](#onSessionEnd)
-
+| [onSessionBegin](#onSessionBegin) | Triggers if the voice session begins |
+| [onStreamBegin](#onStreamBegin) | Triggers if a device starts streaming voice data to the RDK |
+| [onServerMessage](#onServerMessage) | Triggers if a message is received from the Voice Server |
+| [onStreamEnd](#onStreamEnd) | Triggers if streaming audio is stopped from the device |
+| [onSessionEnd](#onSessionEnd) | Triggers if interaction with the server is end |
 ### Parameters
 
 | Name | Type | Description |
@@ -442,7 +436,7 @@ Terminates a voice session using the specified session identifier.
 
 ### Events
 
- No Events.
+No Events
 
 ### Parameters
 
@@ -492,7 +486,7 @@ Returns the current status of the RDK voice stack. This includes which URLs the 
 
 ### Events
 
- No Events.
+No Events
 
 ### Parameters
 

--- a/docs/api/WarehousePlugin.md
+++ b/docs/api/WarehousePlugin.md
@@ -60,11 +60,11 @@ Warehouse interface methods:
 <a name="executeHardwareTest"></a>
 ## *executeHardwareTest*
 
-(Version 2) Starts a hardware test on the device. See `getHardwareTestResults`. 
- 
+(Version 2) Starts a hardware test on the device. See `getHardwareTestResults`.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -104,11 +104,11 @@ This method takes no parameters.
 <a name="getDeviceInfo"></a>
 ## *getDeviceInfo*
 
-Returns STB device information gathered from `/lib/rdk/getDeviceDetails.sh`.(DEPRECATED - Use `getDeviceInfo` from `org.rdk.System` instead.) 
- 
+Returns STB device information gathered from `/lib/rdk/getDeviceDetails.sh`.(DEPRECATED - Use `getDeviceInfo` from `org.rdk.System` instead.).
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -172,11 +172,11 @@ This method takes no parameters.
 <a name="getHardwareTestResults"></a>
 ## *getHardwareTestResults*
 
-(Version 2) Returns the results of the last hardware test. 
- 
+(Version 2) Returns the results of the last hardware test.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -222,11 +222,11 @@ This method takes no parameters.
 <a name="internalReset"></a>
 ## *internalReset*
 
-Invokes the internal reset script, which reboots the Warehouse service (`/rebootNow.sh -s WarehouseService &`). Note that this method checks the `/version.txt` file for the image name and fails to run if the STB image version is marked as production (`PROD`). 
- 
+Invokes the internal reset script, which reboots the Warehouse service (`/rebootNow.sh -s WarehouseService &`). Note that this method checks the `/version.txt` file for the image name and fails to run if the STB image version is marked as production (`PROD`).
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -274,11 +274,11 @@ Invokes the internal reset script, which reboots the Warehouse service (`/reboot
 <a name="isClean"></a>
 ## *isClean*
 
-Checks the locations on the device where customer data may be stored. If there are contents contained in those folders, then the device is not clean. 
- 
+Checks the locations on the device where customer data may be stored. If there are contents contained in those folders, then the device is not clean.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -325,11 +325,11 @@ This method takes no parameters.
 <a name="lightReset"></a>
 ## *lightReset*
 
-Resets the application data. 
- 
+Resets the application data.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 
@@ -371,15 +371,13 @@ This method takes no parameters.
 <a name="resetDevice"></a>
 ## *resetDevice*
 
-Resets the STB to the warehouse state. 
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- |
-| `resetDone` | Triggers when the device reset is finished indicating a successful reset or failure|.
+Resets the STB to the warehouse state.
 
-Also see: [resetDone](#resetDone)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [resetDone](#resetDone) | Triggers when the device reset is finished indicating a successful reset or failure |
 ### Parameters
 
 | Name | Type | Description |
@@ -428,11 +426,11 @@ Also see: [resetDone](#resetDone)
 <a name="setFrontPanelState"></a>
 ## *setFrontPanelState*
 
-Sets the state of the front panel LEDs to indicate the download state of the STB software image. 
- 
+Sets the state of the front panel LEDs to indicate the download state of the STB software image.
+
 ### Events
- 
- No Events.
+
+No Events
 
 ### Parameters
 

--- a/docs/api/WebKitBrowserPlugin.md
+++ b/docs/api/WebKitBrowserPlugin.md
@@ -2,7 +2,7 @@
 <a name="WebKitBrowser_Plugin"></a>
 # WebKitBrowser Plugin
 
-**Version: [1.1.0](https://github.com/rdkcentral/rdkservices/blob/main/WebKitBrowser/CHANGELOG.md)**
+**Version: [1.1.1](https://github.com/rdkcentral/rdkservices/blob/main/WebKitBrowser/CHANGELOG.md)**
 
 A WebKitBrowser plugin for Thunder framework.
 
@@ -82,10 +82,10 @@ WebKitBrowser interface methods:
 ## *bridgeevent*
 
 Sends a legacy `$badger` 
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -126,10 +126,10 @@ Sends a legacy `$badger`
 ## *bridgereply*
 
 A response for legacy `$badger`.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -170,10 +170,10 @@ A response for legacy `$badger`.
 ## *delete*
 
 Removes the contents of a directory recursively from the persistent storage.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -246,6 +246,10 @@ Provides access to the current number of frames-per-second the browser is render
 
 > This property is **read-only**.
 
+### Events
+
+No Events
+
 ### Value
 
 | Name | Type | Description |
@@ -282,10 +286,10 @@ Provides access to the headers to send on all requests that the browser makes.
 ### Description
 
 Use this property to send on all requests that the browser makes.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Value
 
@@ -357,10 +361,10 @@ Provides access to the HTTP cookies accept policy.
 ### Description
 
 Use this property to accept HTTP cookie policy.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Value
 
@@ -425,10 +429,10 @@ Provides access to the user preferred languages.
 ### Description
 
 Use this property to return User preferred languages.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Value
 
@@ -492,10 +496,10 @@ Provides access to the local storage availability.
 ### Description
 
 Use this property to return Local storage availability.
- 
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Value
 
@@ -554,14 +558,12 @@ Provides access to the running state of the service.
 ### Description
 
 Use this property to return the running state of the service.
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- |
-| `statechange`| Triggered if the state of the service changes.|
 
-Also see: [statechange](#statechange)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [statechange](#statechange) | Triggered if the state of the service changes. |
 ### Value
 
 | Name | Type | Description |
@@ -619,16 +621,14 @@ Provides access to the URL loaded in the browser.
 ### Description
 
 Use this property to load URL in the browser.
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- |
-| `urlchange`| Triggered if the URL changes in the browser | 
- |`loadfinished`| Triggered if the `urlchange` event returns `true` as URL loaded successfully |
- |`loadfailed`| Triggered if the `urlchange` event returns `false` as URL failed to load |
 
-Also see: [urlchange](#urlchange)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [urlchange](#urlchange) | Triggered if the URL changes in the browser |
+| [loadfinished](#loadfinished) | Triggered if the urlchange event returns true as URL loaded successfully |
+| [loadfailed](#loadfailed) | Triggered if the urlchange event returns false as URL failed to load |
 ### Value
 
 | Name | Type | Description |
@@ -692,10 +692,10 @@ Provides access to the `UserAgent` string used by the browser.
 ### Description
 
 Use this property to return `UserAgent` string used by the browser.
- 
-### Events 
 
- No Events. 
+### Events
+
+No Events
 
 ### Value
 
@@ -754,14 +754,12 @@ Provides access to the current browser visibility.
 ### Description
 
 Use this property to return visibilty status of current browser.
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- |
-| `visibilitychange`| Triggered if the browser visibility changes.|
 
-Also see: [visibilitychange](#visibilitychange)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [visibilitychange](#visibilitychange) | Triggered if the urlchange event returns false as URL failed to load |
 ### Value
 
 | Name | Type | Description |

--- a/docs/api/WifiPlugin.md
+++ b/docs/api/WifiPlugin.md
@@ -69,16 +69,14 @@ WifiManager interface methods:
 <a name="cancelWPSPairing"></a>
 ## *cancelWPSPairing*
 
-Cancels the in-progress WPS pairing operation. The operation forcefully stops the in-progress pairing attempt and aborts the current scan. WPS pairing must be in-progress for the operation to succeed. 
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- | 
-| `onWIFIStateChanged` | Triggered when Wifi state changes to DISCONNECTED. | 
-| `onError` | Triggered when device fails to cancel the in-progress WPS pairing.|.
+Cancels the in-progress WPS pairing operation. The operation forcefully stops the in-progress pairing attempt and aborts the current scan. WPS pairing must be in-progress for the operation to succeed.
 
-Also see: [onWIFIStateChanged](#onWIFIStateChanged), [onError](#onError)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onWIFIStateChanged](#onWIFIStateChanged) | Triggered when Wifi state changes to DISCONNECTED. |
+| [onError](#onError) | Triggered when device fails to cancel the in-progress WPS pairing. |
 ### Parameters
 
 This method takes no parameters.
@@ -120,14 +118,12 @@ This method takes no parameters.
 ## *clearSSID*
 
 Clears the saved SSID. A `result` value of `0` indicates that the SSID was cleared. A nonzero value indicates that the SSID was not cleared.
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- | 
-| `onWIFIStateChanged` | Triggered when Wifi state changes to DISCONNECTED (only if currently connected).|.
 
-Also see: [onWIFIStateChanged](#onWIFIStateChanged)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onWIFIStateChanged](#onWIFIStateChanged) | Triggered when Wifi state changes to DISCONNECTED (only if currently connected). |
 ### Parameters
 
 This method takes no parameters.
@@ -168,16 +164,14 @@ This method takes no parameters.
 <a name="connect"></a>
 ## *connect*
 
-Attempts to connect to the specified SSID with the given passphrase. Passphrase can be `null` when the network security is `NONE`. When called with no arguments, this method attempts to connect to the saved SSID and password. See `saveSSID`. 
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- | 
-| `onWIFIStateChanged` | Triggered when Wifi state changes to CONNECTING, CONNECTED . | 
-| `onError` | Triggered when requested SSID connection fails.|.
+Attempts to connect to the specified SSID with the given passphrase. Passphrase can be `null` when the network security is `NONE`. When called with no arguments, this method attempts to connect to the saved SSID and password. See `saveSSID`.
 
-Also see: [onWIFIStateChanged](#onWIFIStateChanged), [onError](#onError)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onWIFIStateChanged](#onWIFIStateChanged) | Triggered when Wifi state changes to CONNECTING, CONNECTED . |
+| [onError](#onError) | Triggered when requested SSID connection fails. |
 ### Parameters
 
 | Name | Type | Description |
@@ -226,15 +220,13 @@ Also see: [onWIFIStateChanged](#onWIFIStateChanged), [onError](#onError)
 <a name="disconnect"></a>
 ## *disconnect*
 
-Disconnects from the SSID. A `result` value of `0` indicates that the SSID was disconnected. A nonzero value indicates that the SSID did not disconnect. 
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- | 
-| `onWIFIStateChanged` | Triggered when Wifi state changes to DISCONNECTED (only if currently connected).|.
+Disconnects from the SSID. A `result` value of `0` indicates that the SSID was disconnected. A nonzero value indicates that the SSID did not disconnect.
 
-Also see: [onWIFIStateChanged](#onWIFIStateChanged)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onWIFIStateChanged](#onWIFIStateChanged) | Triggered when Wifi state changes to DISCONNECTED (only if currently connected). |
 ### Parameters
 
 This method takes no parameters.
@@ -275,11 +267,11 @@ This method takes no parameters.
 <a name="getConnectedSSID"></a>
 ## *getConnectedSSID*
 
-Returns the connected SSID information. 
-  
-### Events 
+Returns the connected SSID information.
 
-  No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -341,11 +333,11 @@ Returns the current Wifi State. The possible Wifi states are as follows.
 * `3`: PAIRING - The device is in the process of pairing, but not yet connected to a network  
 * `4`: CONNECTING - The device is attempting to connect to a network  
 * `5`: CONNECTED - The device is successfully connected to a network  
-* `6`: FAILED - The device has encountered an unrecoverable error with the Wifi adapter. 
-  
-### Events 
+* `6`: FAILED - The device has encountered an unrecoverable error with the Wifi adapter.
 
-  No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -387,11 +379,11 @@ This method takes no parameters.
 <a name="getPairedSSID"></a>
 ## *getPairedSSID*
 
-Returns the SSID to which the device is currently paired. 
-  
-### Events 
+Returns the SSID to which the device is currently paired.
 
-  No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -433,11 +425,11 @@ This method takes no parameters.
 <a name="getPairedSSIDInfo"></a>
 ## *getPairedSSIDInfo*
 
-Returns the SSID and BSSID to which the device is currently paired. 
-  
-### Events 
+Returns the SSID and BSSID to which the device is currently paired.
 
-  No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -481,11 +473,11 @@ This method takes no parameters.
 <a name="getSupportedSecurityModes"></a>
 ## *getSupportedSecurityModes*
 
-(Version 2) Returns the Wifi security modes that the device supports. 
-  
-### Events 
+(Version 2) Returns the Wifi security modes that the device supports.
 
-  No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -561,15 +553,13 @@ This method takes no parameters.
 (Version 2) Initiates a connection using Wifi Protected Setup (WPS). An existing connection will be disconnected before attempting to initiate a new connection. Failure in WPS pairing will trigger an error 
 
 If the `method` parameter is set to `SERIALIZED_PIN`, then RDK retrieves the serialized pin using the Manufacturer (MFR) API. If the `method` parameter is set to `PIN`, then RDK use the pin supplied as part of the request. If the `method` parameter is set to `PBC`, then RDK uses Push Button Configuration (PBC) to obtain the pin.
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- | 
-| `onWIFIStateChanged` | Triggered when Wifi state changes to DISCONNECTED (only if currently connected), CONNECTING, CONNECTED. | 
-| `onError` | Triggered when WPS pairing fails.|.
 
-Also see: [onWIFIStateChanged](#onWIFIStateChanged), [onError](#onError)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onWIFIStateChanged](#onWIFIStateChanged) | Triggered when Wifi state changes to DISCONNECTED (only if currently connected), CONNECTING, CONNECTED. |
+| [onError](#onError) | Triggered when WPS pairing fails. |
 ### Parameters
 
 | Name | Type | Description |
@@ -620,11 +610,11 @@ Also see: [onWIFIStateChanged](#onWIFIStateChanged), [onError](#onError)
 <a name="isPaired"></a>
 ## *isPaired*
 
-Determines if the device is paired to an SSID. A `result` value of `0` indicates that this device has been previously paired (calling `saveSSID` marks this device as paired). A nonzero value indicates that the device is not paired. 
-  
-### Events 
+Determines if the device is paired to an SSID. A `result` value of `0` indicates that this device has been previously paired (calling `saveSSID` marks this device as paired). A nonzero value indicates that the device is not paired.
 
-  No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -666,11 +656,11 @@ This method takes no parameters.
 <a name="isSignalThresholdChangeEnabled"></a>
 ## *isSignalThresholdChangeEnabled*
 
-Returns whether `onWifiSignalThresholdChanged` event is enabled or not. 
-  
-### Events 
+Returns whether `onWifiSignalThresholdChanged` event is enabled or not.
 
-  No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -712,11 +702,11 @@ This method takes no parameters.
 <a name="saveSSID"></a>
 ## *saveSSID*
 
-Saves the SSID, passphrase, and security mode for future sessions. If an SSID was previously saved, the new SSID and passphrase overwrite the existing values. A `result` value of `0` indicates that the SSID was successfully saved. 
-  
-### Events 
+Saves the SSID, passphrase, and security mode for future sessions. If an SSID was previously saved, the new SSID and passphrase overwrite the existing values. A `result` value of `0` indicates that the SSID was successfully saved.
 
-  No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -768,11 +758,11 @@ Saves the SSID, passphrase, and security mode for future sessions. If an SSID wa
 <a name="setEnabled"></a>
 ## *setEnabled*
 
-Enables or disables the Wifi adapter for this device. 
-  
-### Events 
+Enables or disables the Wifi adapter for this device.
 
-  No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -819,14 +809,12 @@ Enables or disables the Wifi adapter for this device.
 ## *setSignalThresholdChangeEnabled*
 
 Enables `signalThresholdChange` events to be triggered.
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- | 
-| `onWifiSignalThresholdChanged` | Triggered when Wifi signal strength switches between Excellent, Good, Fair, Weak.|.
 
-Also see: [onWifiSignalThresholdChanged](#onWifiSignalThresholdChanged)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onWifiSignalThresholdChanged](#onWifiSignalThresholdChanged) | Triggered when Wifi signal strength switches between Excellent, Good, Fair, Weak. |
 ### Parameters
 
 | Name | Type | Description |
@@ -874,14 +862,12 @@ Also see: [onWifiSignalThresholdChanged](#onWifiSignalThresholdChanged)
 ## *startScan*
 
 Scans for available SSIDs. Available SSIDs are returned in an `onAvailableSSIDs` 
- 
-### Events 
-| Event | Description | 
-| :----------- | :----------- | 
-| `onAvailableSSIDs` | Triggered when list of SSIDs is available after the scan completes.|.
 
-Also see: [onAvailableSSIDs](#onAvailableSSIDs)
+### Events
 
+| Event | Description |
+| :-------- | :-------- |
+| [onAvailableSSIDs](#onAvailableSSIDs) | Triggered when list of SSIDs is available after the scan completes. |
 ### Parameters
 
 | Name | Type | Description |
@@ -933,10 +919,10 @@ Also see: [onAvailableSSIDs](#onAvailableSSIDs)
 ## *stopScan*
 
 Stops scanning for SSIDs. Any discovered SSIDs from the call to the `startScan` method up to the point where this method is called are still returned.
-  
-### Events 
 
-  No Events.
+### Events
+
+No Events
 
 ### Parameters
 

--- a/docs/api/XCastPlugin.md
+++ b/docs/api/XCastPlugin.md
@@ -63,10 +63,10 @@ XCast interface methods:
 ## *getApiVersionNumber*
 
 Gets the API version.
-  
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -109,10 +109,10 @@ This method takes no parameters.
 ## *getEnabled*
 
 Reports whether xcast is enabled or disabled.
-  
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -155,10 +155,10 @@ This method takes no parameters.
 ## *getFriendlyName*
 
 Returns the friendly name set by setFriendlyName API.
-  
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -201,10 +201,10 @@ This method takes no parameters.
 ## *getProtocolVersion*
 
 Returns the DIAL protocol version supported by the server.
-  
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -247,10 +247,10 @@ This method takes no parameters.
 ## *getStandbyBehavior*
 
 Gets the expected xcast behavior in standby mode.
-  
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -302,11 +302,11 @@ The following table provides a client error mapping example:
 | `forbidden` | The user is not allowed to change the state of the application. This is not related to user account authentication of the native application | HTTP 403 Forbidden |  
 | `unavailable` | The target native application is not available on the device | HTTP 404 Not Found |  
 | `invalid` | The request is invalid (bad parameter for example) | HTTP 400 Bad Request |  
-| `internal` | The server failed to fulfill the request (server error) | HTTP 500 Internal |
-  
-### Events 
+| `internal` | The server failed to fulfill the request (server error) | HTTP 500 Internal |.
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -359,10 +359,10 @@ The following table provides a client error mapping example:
 ## *registerApplications*
 
 Registers an application. This allows to whitelist the apps which support dial service. To dynamically update the app list, same API should be called with the updated list.
-  
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -409,10 +409,10 @@ Registers an application. This allows to whitelist the apps which support dial s
 ## *setEnabled*
 
 Enables or disables xcast.
-  
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -459,10 +459,10 @@ Enables or disables xcast.
 ## *setFriendlyName*
 
 Sets the friendly name of device. It allows an application to override the default friendly name value with the friendly name passed as an argument.
-  
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 
@@ -509,10 +509,10 @@ Sets the friendly name of device. It allows an application to override the defau
 ## *setStandbyBehavior*
 
 Sets the expected xcast behavior in standby mode. It allows an application to override controls on xcast behavior in standby mode. The default behavior in STANDBY mode is inactive, so client device can not discover the server. When STANDBY behavior is active, client device can discover the server.
-  
-### Events 
 
- No Events.
+### Events
+
+No Events
 
 ### Parameters
 


### PR DESCRIPTION
…ecated APIs

"RDK-38098: Provide link to Alternative API/s to use for Deprecated APIs
RDK-36673 : event section should be automatically generated"

Reason for change:
**RDK-38098**: APIs can be deprecated using the "deprecated" field in json schema. This would mark the API as deprecated in documentation. An alternate API to be used in place of this deprecated API. This alternate API is given as a link to the documentation for the new API. This new API is added in json file in thr method with key as "referenceUrl" that has deprecated value as "true"
**RDK-36673** : Currently Event section is not defined as a separate object instead it is hooked in the Summary part inside each method in Json file. This event section should be defined as a separate object inside each Method with an hyperlink to the existing event.

Test Procedure: Executed and verified by generating api documentation in docsify
Risks: Create None
Signed-off-by: Rekha Jayaram "[Rekha_Jayaram3@comcast.com](mailto:Rekha_Jayaram3@comcast.com)"

Jira link :
https://ccp.sys.comcast.net/browse/RDK-38098