### PR TITLE
Rdk 38285

### DIFF
--- a/FrameRate/FrameRate.json
+++ b/FrameRate/FrameRate.json
@@ -35,7 +35,7 @@
     },
     "methods": {
         "getDisplayFrameRate": {
-            "summary": "(Version 2) Returns the current display frame rate values.",
+            "summary": "Returns the current display frame rate values.",
             "result": {
                 "type":"object",
                 "properties": {
@@ -53,7 +53,7 @@
             }
         },
         "getFrmMode": {
-            "summary": "(Version 2) Returns the current auto framerate mode.",
+            "summary": "Returns the current auto framerate mode.",
             "result": {
                 "type":"object",
                 "properties": {
@@ -88,7 +88,7 @@
             }
         },
         "setDisplayFrameRate": {
-            "summary": "(Version 2) Sets the display framerate values.",
+            "summary": "Sets the display framerate values.",
             "events": {
                 "onDisplayFrameRateChanging" : "Triggered when the framerate changes started.",
                 "onDisplayFrameRateChanged" : "Triggered when the framerate changed"
@@ -109,7 +109,7 @@
             }
         },
         "setFrmMode":{
-            "summary": "(Version 2) Sets the auto framerate mode.",
+            "summary": "Sets the auto framerate mode.",
             "params": {
                 "type":"object",
                 "properties": {

--- a/HdmiInput/HdmiInput.json
+++ b/HdmiInput/HdmiInput.json
@@ -74,7 +74,7 @@
             }
         },
         "getEdidVersion":{
-            "summary": "(Version 2) Returns the EDID version.",
+            "summary": "Returns the EDID version.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -105,7 +105,7 @@
             }
         },
         "getHDMISPD": {
-            "summary": "(Version 2) Returns the Source Data Product Descriptor (SPD) infoFrame packet information for the specified HDMI Input device. The SPD infoFrame packet includes vendor name, product description, and source information.",
+            "summary": "Returns the Source Data Product Descriptor (SPD) infoFrame packet information for the specified HDMI Input device. The SPD infoFrame packet includes vendor name, product description, and source information.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -136,7 +136,7 @@
             }
         },
         "getRawHDMISPD":{
-            "summary": "(Version 2) Returns the Source Data Product Descriptor (SPD) infoFrame packet information for the specified HDMI Input device as raw bits.",
+            "summary": "Returns the Source Data Product Descriptor (SPD) infoFrame packet information for the specified HDMI Input device as raw bits.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -236,7 +236,7 @@
             }            
         },
         "setEdidVersion": {
-            "summary": "(Version 2) Sets an HDMI EDID version.",
+            "summary": "Sets an HDMI EDID version.",
             "params": {
                 "type":"object",
                 "properties": {

--- a/SystemServices/System.json
+++ b/SystemServices/System.json
@@ -309,7 +309,7 @@
             }
         },
         "deletePersistentPath": {
-            "summary": "(Version 2) Deletes persistent path associated with a callsign.",
+            "summary": "Deletes persistent path associated with a callsign.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -371,7 +371,7 @@
             }
         },
         "fireFirmwarePendingReboot":{
-            "summary": "(Version 2) Notifies the device about a pending reboot.",
+            "summary": "Notifies the device about a pending reboot.",
             "events": {
                 "onFirmwarePendingReboot" : "Triggers when the firmware has a pending reboot"
             },
@@ -616,7 +616,7 @@
             }
         },
         "getLastFirmwareFailureReason": {
-            "summary": "(Version 2) Retrieves the last firmware failure reason.",
+            "summary": "Retrieves the last firmware failure reason.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -636,7 +636,7 @@
             }
         },
         "getLastWakeupKeyCode":{
-            "summary": "(Version 2) Returns the last wakeup keycode.",
+            "summary": "Returns the last wakeup keycode.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -785,7 +785,7 @@
             }
         },
         "getPlatformConfiguration": {
-            "summary": "(Version 2) Returns the supported features and device/account info.",
+            "summary": "Returns the supported features and device/account info.",
             "params": {
                 "type": "object",
                 "properties": {
@@ -1092,7 +1092,7 @@
             }
         },
         "getStoreDemoLink":{
-            "summary": "(Version 2) Returns the store demo video link.",
+            "summary": "Returns the store demo video link.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -1267,7 +1267,7 @@
             }
         },
         "getWakeupReason":{
-            "summary": "(Version 2) Returns the reason for the device coming out of deep sleep.",
+            "summary": "Returns the reason for the device coming out of deep sleep.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -1564,7 +1564,7 @@
             }
         },
         "setFirmwareAutoReboot": {
-            "summary": "(Version 2) Enables or disables the AutoReboot Feature. This method internally sets the tr181 `AutoReboot.Enable` parameter to `true` or `false`.",
+            "summary": "Enables or disables the AutoReboot Feature. This method internally sets the tr181 `AutoReboot.Enable` parameter to `true` or `false`.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1583,7 +1583,7 @@
             }
         },
         "setFirmwareRebootDelay": {
-            "summary": "(Version 2) Delays the firmware reboot.",
+            "summary": "Delays the firmware reboot.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -1831,7 +1831,7 @@
             }
         },
         "uploadLogs": {
-            "summary": "(Version 2) Uploads logs to a URL returned by SSR.",
+            "summary": "Uploads logs to a URL returned by SSR.",
             "params": {
                 "type": "object",
                 "properties": {
@@ -1851,7 +1851,7 @@
     },
     "events": {
         "onFirmwarePendingReboot":{
-            "summary": "(Version 2) Triggered when the `fireFirmwarePendingReboot` method is invoked",
+            "summary": "Triggered when the `fireFirmwarePendingReboot` method is invoked",
             "params": {
                 "type" :"object",
                 "properties": {

--- a/UsbAccess/UsbAccess.json
+++ b/UsbAccess/UsbAccess.json
@@ -58,7 +58,7 @@
             }
         },
         "getAvailableFirmwareFiles": {
-            "summary": "(Version 2) Gets a list of firmware files on the device. These files should start with the PMI or model number for that device and end with `.bin`. For example `HSTP11MWR_4.11p5s1_VBN_sdy.bin`.  \nFirmware files are scanned in the root directories. If multiple USB devices are found, then the available firmware files are checked and listed from each device.",
+            "summary": "Gets a list of firmware files on the device. These files should start with the PMI or model number for that device and end with `.bin`. For example `HSTP11MWR_4.11p5s1_VBN_sdy.bin`.  \nFirmware files are scanned in the root directories. If multiple USB devices are found, then the available firmware files are checked and listed from each device.",
             "result": {
                 "type": "object",
                 "properties": {
@@ -136,7 +136,7 @@
             }
         },
         "getMounted": {
-            "summary": "(Version 2) Returns a list of mounted USB devices.",
+            "summary": "Returns a list of mounted USB devices.",
                 "result": {
                 "type": "object",
                 "properties": {
@@ -159,7 +159,7 @@
             }
         },
         "updateFirmware": {
-            "summary": "(Version 2) Updates the firmware using the specified file retrieved from the `getAvailableFirmwareFiles` method.",
+            "summary": "Updates the firmware using the specified file retrieved from the `getAvailableFirmwareFiles` method.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -191,7 +191,7 @@
             }
         },
         "ArchiveLogs":{
-            "summary":"(Version 2) Compresses and uploads device logs into attached USB drive from /opt/logs with a name comprises of Mac of the device , date and time in a `tgz` format. For example `18310C696834_Logs_10-13-21-04-42PM.tgz` `(<MAC address>_Logs_<unix epoch time>.tgz)`.Notifies about new messages in a room.",
+            "summary":"Compresses and uploads device logs into attached USB drive from /opt/logs with a name comprises of Mac of the device , date and time in a `tgz` format. For example `18310C696834_Logs_10-13-21-04-42PM.tgz` `(<MAC address>_Logs_<unix epoch time>.tgz)`.Notifies about new messages in a room.",
             "events":{
                 "onArchiveLogs" : "Triggered to archive the device logs and returns the status of the archive"
             },
@@ -210,7 +210,7 @@
     },
     "events": {
         "onUSBMountChanged": {
-            "summary": "(Version 2) Triggered when a USB drive is mounted or unmounted",
+            "summary": "Triggered when a USB drive is mounted or unmounted",
             "params": {
                 "type":"object",
                 "properties": {
@@ -232,7 +232,7 @@
             }
         },
         "onArchiveLogs":{
-            "summary": "(Version 2) Triggered to archive the device logs and returns the status of the archive.",
+            "summary": "Triggered to archive the device logs and returns the status of the archive.",
             "params": {
                 "type":"object",
                 "properties": {

--- a/Warehouse/Warehouse.json
+++ b/Warehouse/Warehouse.json
@@ -18,7 +18,7 @@
     },
     "methods":{
         "executeHardwareTest": {
-            "summary": "(Version 2) Starts a hardware test on the device. See `getHardwareTestResults`.",
+            "summary": "Starts a hardware test on the device. See `getHardwareTestResults`.",
             "result": {
                 "$ref": "#/common/result"
             }
@@ -107,7 +107,7 @@
             }
         },
         "getHardwareTestResults": {
-            "summary": "(Version 2) Returns the results of the last hardware test.",
+            "summary": "Returns the results of the last hardware test.",
             "params": {
                 "type":"object",
                 "properties": {

--- a/WifiManager/Wifi.json
+++ b/WifiManager/Wifi.json
@@ -267,7 +267,7 @@
             }
         },
         "getSupportedSecurityModes":{
-            "summary": "(Version 2) Returns the Wifi security modes that the device supports.",
+            "summary": "Returns the Wifi security modes that the device supports.",
             "result": {
                 "type": "object",
                 "properties": {

--- a/docs/api/FrameRatePlugin.md
+++ b/docs/api/FrameRatePlugin.md
@@ -47,11 +47,11 @@ FrameRate interface methods:
 
 | Method | Description |
 | :-------- | :-------- |
-| [getDisplayFrameRate](#getDisplayFrameRate) | (Version 2) Returns the current display frame rate values |
-| [getFrmMode](#getFrmMode) | (Version 2) Returns the current auto framerate mode |
+| [getDisplayFrameRate](#getDisplayFrameRate) | Returns the current display frame rate values |
+| [getFrmMode](#getFrmMode) | Returns the current auto framerate mode |
 | [setCollectionFrequency](#setCollectionFrequency) | Sets the FPS data collection interval |
-| [setDisplayFrameRate](#setDisplayFrameRate) | (Version 2) Sets the display framerate values |
-| [setFrmMode](#setFrmMode) | (Version 2) Sets the auto framerate mode |
+| [setDisplayFrameRate](#setDisplayFrameRate) | Sets the display framerate values |
+| [setFrmMode](#setFrmMode) | Sets the auto framerate mode |
 | [startFpsCollection](#startFpsCollection) | Starts the FPS data collection |
 | [stopFpsCollection](#stopFpsCollection) | Stops the FPS data collection |
 | [updateFps](#updateFps) | Updates Fps values |
@@ -60,7 +60,7 @@ FrameRate interface methods:
 <a name="getDisplayFrameRate"></a>
 ## *getDisplayFrameRate*
 
-(Version 2) Returns the current display frame rate values.
+Returns the current display frame rate values.
 
 ### Events
 
@@ -106,7 +106,7 @@ This method takes no parameters.
 <a name="getFrmMode"></a>
 ## *getFrmMode*
 
-(Version 2) Returns the current auto framerate mode.
+Returns the current auto framerate mode.
 
 ### Events
 
@@ -202,7 +202,7 @@ No Events
 <a name="setDisplayFrameRate"></a>
 ## *setDisplayFrameRate*
 
-(Version 2) Sets the display framerate values.
+Sets the display framerate values.
 
 ### Events
 
@@ -254,7 +254,7 @@ No Events
 <a name="setFrmMode"></a>
 ## *setFrmMode*
 
-(Version 2) Sets the auto framerate mode.
+Sets the auto framerate mode.
 
 ### Events
 

--- a/docs/api/HdmiCecSinkPlugin.md
+++ b/docs/api/HdmiCecSinkPlugin.md
@@ -2,7 +2,7 @@
 <a name="HdmiCecSinkPlugin"></a>
 # HdmiCecSinkPlugin
 
-**Version: [1.0.2](https://github.com/rdkcentral/rdkservices/blob/main/HdmiCecSink/CHANGELOG.md)**
+**Version: [1.0.3](https://github.com/rdkcentral/rdkservices/blob/main/HdmiCecSink/CHANGELOG.md)**
 
 A org.rdk.HdmiCecSink plugin for Thunder framework.
 

--- a/docs/api/HdmiCec_2Plugin.md
+++ b/docs/api/HdmiCec_2Plugin.md
@@ -2,7 +2,7 @@
 <a name="HdmiCec_2Plugin"></a>
 # HdmiCec_2Plugin
 
-**Version: [1.0.1](https://github.com/rdkcentral/rdkservices/blob/main/HdmiCec_2/CHANGELOG.md)**
+**Version: [1.0.2](https://github.com/rdkcentral/rdkservices/blob/main/HdmiCec_2/CHANGELOG.md)**
 
 A org.rdk.HdmiCec_2 plugin for Thunder framework.
 
@@ -54,6 +54,7 @@ HdmiCec_2 interface methods:
 | [getOTPEnabled](#getOTPEnabled) | Returns HDMI-CEC OTP option enabled status |
 | [getVendorId](#getVendorId) | Returns the vendor ID set by the application |
 | [performOTPAction](#performOTPAction) | Turns on the TV and takes back the input to the device |
+| [sendKeyPressEvent](#sendKeyPressEvent) | Sends the CEC \<User Control Pressed\> and \<User Control Release\> message when TV remote key is pressed |
 | [sendStandbyMessage](#sendStandbyMessage) | Sends a CEC \<Standby\> message to the logical address of the device |
 | [setEnabled](#setEnabled) | Enables or disables HDMI-CEC driver |
 | [setOSDName](#setOSDName) | Sets the OSD name of the application |
@@ -382,6 +383,62 @@ This method takes no parameters.
     "jsonrpc": "2.0",
     "id": 42,
     "method": "org.rdk.HdmiCec_2.performOTPAction"
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "success": true
+    }
+}
+```
+
+<a name="sendKeyPressEvent"></a>
+## *sendKeyPressEvent*
+
+Sends the CEC \<User Control Pressed\> and \<User Control Release\> message when TV remote key is pressed.
+  
+### Event 
+
+ No Events.
+
+### Events
+
+No Events
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.logicalAddress | integer | Logical address of the device |
+| params.keyCode | integer | The key code for the pressed key |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.success | boolean | Whether the request succeeded |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.HdmiCec_2.sendKeyPressEvent",
+    "params": {
+        "logicalAddress": 0,
+        "keyCode": 65
+    }
 }
 ```
 

--- a/docs/api/HdmiInputPlugin.md
+++ b/docs/api/HdmiInputPlugin.md
@@ -48,13 +48,13 @@ HdmiInput interface methods:
 | Method | Description |
 | :-------- | :-------- |
 | [getHDMIInputDevices](#getHDMIInputDevices) | Returns an array of available HDMI Input ports |
-| [getEdidVersion](#getEdidVersion) | (Version 2) Returns the EDID version |
-| [getHDMISPD](#getHDMISPD) | (Version 2) Returns the Source Data Product Descriptor (SPD) infoFrame packet information for the specified HDMI Input device |
-| [getRawHDMISPD](#getRawHDMISPD) | (Version 2) Returns the Source Data Product Descriptor (SPD) infoFrame packet information for the specified HDMI Input device as raw bits |
+| [getEdidVersion](#getEdidVersion) | Returns the EDID version |
+| [getHDMISPD](#getHDMISPD) | Returns the Source Data Product Descriptor (SPD) infoFrame packet information for the specified HDMI Input device |
+| [getRawHDMISPD](#getRawHDMISPD) | Returns the Source Data Product Descriptor (SPD) infoFrame packet information for the specified HDMI Input device as raw bits |
 | [readEDID](#readEDID) | Returns the current EDID value |
 | [startHdmiInput](#startHdmiInput) | Activates the specified HDMI Input port as the primary video source |
 | [stopHdmiInput](#stopHdmiInput) | Deactivates the HDMI Input port currently selected as the primary video source |
-| [setEdidVersion](#setEdidVersion) | (Version 2) Sets an HDMI EDID version |
+| [setEdidVersion](#setEdidVersion) | Sets an HDMI EDID version |
 | [setVideoRectangle](#setVideoRectangle) | Sets an HDMI Input video window |
 | [writeEDID](#writeEDID) | Changes a current EDID value |
 | [getSupportedGameFeatures](#getSupportedGameFeatures) | Returns the list of supported game features |
@@ -120,7 +120,7 @@ This method takes no parameters.
 <a name="getEdidVersion"></a>
 ## *getEdidVersion*
 
-(Version 2) Returns the EDID version.
+Returns the EDID version.
 
 ### Events
 
@@ -172,7 +172,7 @@ No Events
 <a name="getHDMISPD"></a>
 ## *getHDMISPD*
 
-(Version 2) Returns the Source Data Product Descriptor (SPD) infoFrame packet information for the specified HDMI Input device. The SPD infoFrame packet includes vendor name, product description, and source information.
+Returns the Source Data Product Descriptor (SPD) infoFrame packet information for the specified HDMI Input device. The SPD infoFrame packet includes vendor name, product description, and source information.
 
 ### Events
 
@@ -224,7 +224,7 @@ No Events
 <a name="getRawHDMISPD"></a>
 ## *getRawHDMISPD*
 
-(Version 2) Returns the Source Data Product Descriptor (SPD) infoFrame packet information for the specified HDMI Input device as raw bits.
+Returns the Source Data Product Descriptor (SPD) infoFrame packet information for the specified HDMI Input device as raw bits.
 
 ### Events
 
@@ -425,7 +425,7 @@ This method takes no parameters.
 <a name="setEdidVersion"></a>
 ## *setEdidVersion*
 
-(Version 2) Sets an HDMI EDID version.
+Sets an HDMI EDID version.
 
 ### Events
 

--- a/docs/api/SystemPlugin.md
+++ b/docs/api/SystemPlugin.md
@@ -49,10 +49,10 @@ SystemServices interface methods:
 | :-------- | :-------- |
 | [cacheContains](#cacheContains) | Checks if a key is present in the cache |
 | [clearLastDeepSleepReason](#clearLastDeepSleepReason) | Clears the last deep sleep reason |
-| [deletePersistentPath](#deletePersistentPath) | (Version 2) Deletes persistent path associated with a callsign |
+| [deletePersistentPath](#deletePersistentPath) | Deletes persistent path associated with a callsign |
 | [enableMoca](#enableMoca) | Enables (or disables) Moca support for the platform |
 | [enableXREConnectionRetention](#enableXREConnectionRetention) | Enables (or disables) XRE Connection Retention option |
-| [fireFirmwarePendingReboot](#fireFirmwarePendingReboot) | (Version 2) Notifies the device about a pending reboot |
+| [fireFirmwarePendingReboot](#fireFirmwarePendingReboot) | Notifies the device about a pending reboot |
 | [getAvailableStandbyModes](#getAvailableStandbyModes) | Queries the available standby modes |
 | [getCachedValue](#getCachedValue) | Gets the value of a key in the cache |
 | [getCoreTemperature](#getCoreTemperature) | Returns the core temperature of the device |
@@ -62,15 +62,15 @@ SystemServices interface methods:
 | [getFirmwareUpdateInfo](#getFirmwareUpdateInfo) | Checks the firmware update information |
 | [getFirmwareUpdateState](#getFirmwareUpdateState) | Checks the state of the firmware update |
 | [getLastDeepSleepReason](#getLastDeepSleepReason) | Retrieves the last deep sleep reason |
-| [getLastFirmwareFailureReason](#getLastFirmwareFailureReason) | (Version 2) Retrieves the last firmware failure reason |
-| [getLastWakeupKeyCode](#getLastWakeupKeyCode) | (Version 2) Returns the last wakeup keycode |
+| [getLastFirmwareFailureReason](#getLastFirmwareFailureReason) | Retrieves the last firmware failure reason |
+| [getLastWakeupKeyCode](#getLastWakeupKeyCode) | Returns the last wakeup keycode |
 | [getMacAddresses](#getMacAddresses) | Gets the MAC address of the device |
 | [getMfgSerialNumber](#getMfgSerialNumber) | Gets the Manufacturing Serial Number |
 | [getMilestones](#getMilestones) | Returns the list of milestones |
 | [getMode](#getMode) | Returns the currently set mode information |
 | [getNetworkStandbyMode](#getNetworkStandbyMode) | Returns the network standby mode of the device |
 | [getOvertempGraceInterval](#getOvertempGraceInterval) | Returns the over-temperature grace interval value |
-| [getPlatformConfiguration](#getPlatformConfiguration) | (Version 2) Returns the supported features and device/account info |
+| [getPlatformConfiguration](#getPlatformConfiguration) | Returns the supported features and device/account info |
 | [getPowerState](#getPowerState) | Returns the power state of the device |
 | [getPowerStateBeforeReboot](#getPowerStateBeforeReboot) | Returns the power state before reboot |
 | [getPowerStateIsManagedByDevice](#getPowerStateIsManagedByDevice) | Checks whether the power state is managed by the device |
@@ -81,13 +81,13 @@ SystemServices interface methods:
 | [getRFCConfig](#getRFCConfig) | Returns information that is related to RDK Feature Control (RFC) configurations |
 | [getSerialNumber](#getSerialNumber) | Returns the device serial number |
 | [getStateInfo](#getStateInfo) | Queries device state information of various properties |
-| [getStoreDemoLink](#getStoreDemoLink) | (Version 2) Returns the store demo video link |
+| [getStoreDemoLink](#getStoreDemoLink) | Returns the store demo video link |
 | [getSystemVersions](#getSystemVersions) | Returns system version details |
 | [getTemperatureThresholds](#getTemperatureThresholds) | Returns temperature threshold values |
 | [getTerritory](#getTerritory) | Gets the configured system territory and region |
 | [getTimeZones](#getTimeZones) | (Version2) Gets the available timezones from the system's time zone database |
 | [getTimeZoneDST](#getTimeZoneDST) | Get the configured time zone from the file referenced by `TZ_FILE` |
-| [getWakeupReason](#getWakeupReason) | (Version 2) Returns the reason for the device coming out of deep sleep |
+| [getWakeupReason](#getWakeupReason) | Returns the reason for the device coming out of deep sleep |
 | [getXconfParams](#getXconfParams) | Returns XCONF configuration parameters for the device |
 | [hasRebootBeenRequested](#hasRebootBeenRequested) | Checks whether a reboot has been requested |
 | [isGzEnabled](#isGzEnabled) | Checks whether GZ is enabled |
@@ -99,8 +99,8 @@ SystemServices interface methods:
 | [setBootLoaderPattern](#setBootLoaderPattern) | Sets the boot loader pattern mode in MFR |
 | [setCachedValue](#setCachedValue) | Sets the value for a key in the cache |
 | [setDeepSleepTimer](#setDeepSleepTimer) | Sets the deep sleep timeout period |
-| [setFirmwareAutoReboot](#setFirmwareAutoReboot) | (Version 2) Enables or disables the AutoReboot Feature |
-| [setFirmwareRebootDelay](#setFirmwareRebootDelay) | (Version 2) Delays the firmware reboot |
+| [setFirmwareAutoReboot](#setFirmwareAutoReboot) | Enables or disables the AutoReboot Feature |
+| [setFirmwareRebootDelay](#setFirmwareRebootDelay) | Delays the firmware reboot |
 | [setGzEnabled](#setGzEnabled) | Enables or disables GZ |
 | [setMode](#setMode) | Sets the mode of the set-top box for a specific duration before returning to normal mode |
 | [setNetworkStandbyMode](#setNetworkStandbyMode) | Enables or disables the network standby mode of the device |
@@ -113,7 +113,7 @@ SystemServices interface methods:
 | [setTimeZoneDST](#setTimeZoneDST) | Sets the system time zone |
 | [setWakeupSrcConfiguration](#setWakeupSrcConfiguration) | Sets the wakeup source configuration |
 | [updateFirmware](#updateFirmware) | Initiates a firmware update |
-| [uploadLogs](#uploadLogs) | (Version 2) Uploads logs to a URL returned by SSR |
+| [uploadLogs](#uploadLogs) | Uploads logs to a URL returned by SSR |
 
 
 <a name="cacheContains"></a>
@@ -215,7 +215,7 @@ This method takes no parameters.
 <a name="deletePersistentPath"></a>
 ## *deletePersistentPath*
 
-(Version 2) Deletes persistent path associated with a callsign.
+Deletes persistent path associated with a callsign.
 
 ### Events
 
@@ -367,7 +367,7 @@ No Events
 <a name="fireFirmwarePendingReboot"></a>
 ## *fireFirmwarePendingReboot*
 
-(Version 2) Notifies the device about a pending reboot.
+Notifies the device about a pending reboot.
 
 ### Events
 
@@ -866,7 +866,7 @@ This method takes no parameters.
 <a name="getLastFirmwareFailureReason"></a>
 ## *getLastFirmwareFailureReason*
 
-(Version 2) Retrieves the last firmware failure reason.
+Retrieves the last firmware failure reason.
 
 ### Events
 
@@ -912,7 +912,7 @@ This method takes no parameters.
 <a name="getLastWakeupKeyCode"></a>
 ## *getLastWakeupKeyCode*
 
-(Version 2) Returns the last wakeup keycode.
+Returns the last wakeup keycode.
 
 ### Events
 
@@ -1251,7 +1251,7 @@ This method takes no parameters.
 <a name="getPlatformConfiguration"></a>
 ## *getPlatformConfiguration*
 
-(Version 2) Returns the supported features and device/account info.
+Returns the supported features and device/account info.
 
 ### Events
 
@@ -1851,7 +1851,7 @@ No Events
 <a name="getStoreDemoLink"></a>
 ## *getStoreDemoLink*
 
-(Version 2) Returns the store demo video link.
+Returns the store demo video link.
 
 ### Events
 
@@ -2153,7 +2153,7 @@ This method takes no parameters.
 <a name="getWakeupReason"></a>
 ## *getWakeupReason*
 
-(Version 2) Returns the reason for the device coming out of deep sleep.
+Returns the reason for the device coming out of deep sleep.
 
 ### Events
 
@@ -2745,7 +2745,7 @@ No Events
 <a name="setFirmwareAutoReboot"></a>
 ## *setFirmwareAutoReboot*
 
-(Version 2) Enables or disables the AutoReboot Feature. This method internally sets the tr181 `AutoReboot.Enable` parameter to `true` or `false`.
+Enables or disables the AutoReboot Feature. This method internally sets the tr181 `AutoReboot.Enable` parameter to `true` or `false`.
 
 ### Events
 
@@ -2795,7 +2795,7 @@ No Events
 <a name="setFirmwareRebootDelay"></a>
 ## *setFirmwareRebootDelay*
 
-(Version 2) Delays the firmware reboot.
+Delays the firmware reboot.
 
 ### Events
 
@@ -3462,7 +3462,7 @@ This method takes no parameters.
 <a name="uploadLogs"></a>
 ## *uploadLogs*
 
-(Version 2) Uploads logs to a URL returned by SSR.
+Uploads logs to a URL returned by SSR.
 
 ### Events
 
@@ -3520,7 +3520,7 @@ SystemServices interface events:
 
 | Event | Description |
 | :-------- | :-------- |
-| [onFirmwarePendingReboot](#onFirmwarePendingReboot) | (Version 2) Triggered when the `fireFirmwarePendingReboot` method is invoked |
+| [onFirmwarePendingReboot](#onFirmwarePendingReboot) | Triggered when the `fireFirmwarePendingReboot` method is invoked |
 | [onFirmwareUpdateInfoReceived](#onFirmwareUpdateInfoReceived) | Triggered when the `getFirmwareUpdateInfo` asynchronous method is invoked |
 | [onFirmwareUpdateStateChange](#onFirmwareUpdateStateChange) | Triggered when the state of a firmware update changes |
 | [onMacAddressesRetreived](#onMacAddressesRetreived) | Triggered when the `getMacAddresses` asynchronous method is invoked |
@@ -3535,7 +3535,7 @@ SystemServices interface events:
 <a name="onFirmwarePendingReboot"></a>
 ## *onFirmwarePendingReboot*
 
-(Version 2) Triggered when the `fireFirmwarePendingReboot` method is invoked.
+Triggered when the `fireFirmwarePendingReboot` method is invoked.
 
 ### Parameters
 

--- a/docs/api/UsbAccessPlugin.md
+++ b/docs/api/UsbAccessPlugin.md
@@ -49,11 +49,11 @@ UsbAccess interface methods:
 | :-------- | :-------- |
 | [clearLink](#clearLink) | Clears or removes the symbolic link created by the `createLink` method |
 | [createLink](#createLink) | Creates a symbolic link to the root folder of the USB drive |
-| [getAvailableFirmwareFiles](#getAvailableFirmwareFiles) | (Version 2) Gets a list of firmware files on the device |
+| [getAvailableFirmwareFiles](#getAvailableFirmwareFiles) | Gets a list of firmware files on the device |
 | [getFileList](#getFileList) | Gets a list of files and folders from the specified directory or path |
-| [getMounted](#getMounted) | (Version 2) Returns a list of mounted USB devices |
-| [updateFirmware](#updateFirmware) | (Version 2) Updates the firmware using the specified file retrieved from the `getAvailableFirmwareFiles` method |
-| [ArchiveLogs](#ArchiveLogs) | (Version 2) Compresses and uploads device logs into attached USB drive from /opt/logs with a name comprises of Mac of the device , date and time in a `tgz` format |
+| [getMounted](#getMounted) | Returns a list of mounted USB devices |
+| [updateFirmware](#updateFirmware) | Updates the firmware using the specified file retrieved from the `getAvailableFirmwareFiles` method |
+| [ArchiveLogs](#ArchiveLogs) | Compresses and uploads device logs into attached USB drive from /opt/logs with a name comprises of Mac of the device , date and time in a `tgz` format |
 
 
 <a name="clearLink"></a>
@@ -153,7 +153,7 @@ This method takes no parameters.
 <a name="getAvailableFirmwareFiles"></a>
 ## *getAvailableFirmwareFiles*
 
-(Version 2) Gets a list of firmware files on the device. These files should start with the PMI or model number for that device and end with `.bin`. For example `HSTP11MWR_4.11p5s1_VBN_sdy.bin`.  
+Gets a list of firmware files on the device. These files should start with the PMI or model number for that device and end with `.bin`. For example `HSTP11MWR_4.11p5s1_VBN_sdy.bin`.  
 Firmware files are scanned in the root directories. If multiple USB devices are found, then the available firmware files are checked and listed from each device.
 
 ### Events
@@ -265,7 +265,7 @@ No Events
 <a name="getMounted"></a>
 ## *getMounted*
 
-(Version 2) Returns a list of mounted USB devices.
+Returns a list of mounted USB devices.
 
 ### Events
 
@@ -314,7 +314,7 @@ This method takes no parameters.
 <a name="updateFirmware"></a>
 ## *updateFirmware*
 
-(Version 2) Updates the firmware using the specified file retrieved from the `getAvailableFirmwareFiles` 
+Updates the firmware using the specified file retrieved from the `getAvailableFirmwareFiles` 
 
 ### Events
 
@@ -366,7 +366,7 @@ No Events
 <a name="ArchiveLogs"></a>
 ## *ArchiveLogs*
 
-(Version 2) Compresses and uploads device logs into attached USB drive from /opt/logs with a name comprises of Mac of the device , date and time in a `tgz` format. For example `18310C696834_Logs_10-13-21-04-42PM.tgz` `(<MAC address>_Logs_<unix epoch time>.tgz)`.Notifies about new messages in a room.
+Compresses and uploads device logs into attached USB drive from /opt/logs with a name comprises of Mac of the device , date and time in a `tgz` format. For example `18310C696834_Logs_10-13-21-04-42PM.tgz` `(<MAC address>_Logs_<unix epoch time>.tgz)`.Notifies about new messages in a room.
 
 ### Events
 
@@ -419,14 +419,14 @@ UsbAccess interface events:
 
 | Event | Description |
 | :-------- | :-------- |
-| [onUSBMountChanged](#onUSBMountChanged) | (Version 2) Triggered when a USB drive is mounted or unmounted |
-| [onArchiveLogs](#onArchiveLogs) | (Version 2) Triggered to archive the device logs and returns the status of the archive |
+| [onUSBMountChanged](#onUSBMountChanged) | Triggered when a USB drive is mounted or unmounted |
+| [onArchiveLogs](#onArchiveLogs) | Triggered to archive the device logs and returns the status of the archive |
 
 
 <a name="onUSBMountChanged"></a>
 ## *onUSBMountChanged*
 
-(Version 2) Triggered when a USB drive is mounted or unmounted.
+Triggered when a USB drive is mounted or unmounted.
 
 ### Parameters
 
@@ -452,7 +452,7 @@ UsbAccess interface events:
 <a name="onArchiveLogs"></a>
 ## *onArchiveLogs*
 
-(Version 2) Triggered to archive the device logs and returns the status of the archive.
+Triggered to archive the device logs and returns the status of the archive.
 
 ### Parameters
 

--- a/docs/api/WarehousePlugin.md
+++ b/docs/api/WarehousePlugin.md
@@ -47,9 +47,9 @@ Warehouse interface methods:
 
 | Method | Description |
 | :-------- | :-------- |
-| [executeHardwareTest](#executeHardwareTest) | (Version 2) Starts a hardware test on the device |
+| [executeHardwareTest](#executeHardwareTest) | Starts a hardware test on the device |
 | [getDeviceInfo](#getDeviceInfo) | Returns STB device information gathered from `/lib/rdk/getDeviceDetails |
-| [getHardwareTestResults](#getHardwareTestResults) | (Version 2) Returns the results of the last hardware test |
+| [getHardwareTestResults](#getHardwareTestResults) | Returns the results of the last hardware test |
 | [internalReset](#internalReset) | Invokes the internal reset script, which reboots the Warehouse service (`/rebootNow |
 | [isClean](#isClean) | Checks the locations on the device where customer data may be stored |
 | [lightReset](#lightReset) | Resets the application data |
@@ -60,7 +60,7 @@ Warehouse interface methods:
 <a name="executeHardwareTest"></a>
 ## *executeHardwareTest*
 
-(Version 2) Starts a hardware test on the device. See `getHardwareTestResults`.
+Starts a hardware test on the device. See `getHardwareTestResults`.
 
 ### Events
 
@@ -172,7 +172,7 @@ This method takes no parameters.
 <a name="getHardwareTestResults"></a>
 ## *getHardwareTestResults*
 
-(Version 2) Returns the results of the last hardware test.
+Returns the results of the last hardware test.
 
 ### Events
 

--- a/docs/api/WifiPlugin.md
+++ b/docs/api/WifiPlugin.md
@@ -55,7 +55,7 @@ WifiManager interface methods:
 | [getCurrentState](#getCurrentState) | Returns the current Wifi State |
 | [getPairedSSID](#getPairedSSID) | Returns the SSID to which the device is currently paired |
 | [getPairedSSIDInfo](#getPairedSSIDInfo) | Returns the SSID and BSSID to which the device is currently paired |
-| [getSupportedSecurityModes](#getSupportedSecurityModes) | (Version 2) Returns the Wifi security modes that the device supports |
+| [getSupportedSecurityModes](#getSupportedSecurityModes) | Returns the Wifi security modes that the device supports |
 | [initiateWPSPairing](#initiateWPSPairing) | (Version 2) Initiates a connection using Wifi Protected Setup (WPS) |
 | [isPaired](#isPaired) | Determines if the device is paired to an SSID |
 | [isSignalThresholdChangeEnabled](#isSignalThresholdChangeEnabled) | Returns whether `onWifiSignalThresholdChanged` event is enabled or not |
@@ -473,7 +473,7 @@ This method takes no parameters.
 <a name="getSupportedSecurityModes"></a>
 ## *getSupportedSecurityModes*
 
-(Version 2) Returns the Wifi security modes that the device supports.
+Returns the Wifi security modes that the device supports.
 
 ### Events
 

--- a/docs/api/XCastPlugin.md
+++ b/docs/api/XCastPlugin.md
@@ -2,7 +2,7 @@
 <a name="XCast_Plugin"></a>
 # XCast Plugin
 
-**Version: [1.0.2](https://github.com/rdkcentral/rdkservices/blob/main/XCast/CHANGELOG.md)**
+**Version: [1.0.3](https://github.com/rdkcentral/rdkservices/blob/main/XCast/CHANGELOG.md)**
 
 A org.rdk.Xcast plugin for Thunder framework.
 
@@ -359,7 +359,7 @@ No Events
 <a name="registerApplications"></a>
 ## *registerApplications*
 
-This API allows application to whitelist the apps, which support dial service with xcast service. Application can register single or multiple apps by passing application list. Calling this api again, with a new set of APP names, will append those APPs to the existing whitelist. Passing an existing whitelisted APP name, with a modified property value, will update the curresponding field in the APP whitelist.
+Registers an application. This allows to whitelist the apps which support dial service. To dynamically update the app list, same API should be called with the updated list. so that app list will be appended to the existing XCast white list.
 
 ### Events
 
@@ -379,8 +379,8 @@ No Events
 | result | object |  |
 | result.success | boolean | Whether the request succeeded |
 
-### Example 1
-Following call will register NetflixApp to the dial dynamic list.
+### Example
+
 #### Request
 
 ```json
@@ -389,46 +389,7 @@ Following call will register NetflixApp to the dial dynamic list.
     "id": 42,
     "method": "org.rdk.Xcast.registerApplications",
     "params": {
-        "applications": {
-            "names":["Netflix"],
-            "cors":[".netflix.com"]
-         }
-    }
-}
-```
-
-#### Response
-
-```json
-{
-    "jsonrpc": "2.0",
-    "id": 42,
-    "result": {
-        "success": true
-    }
-}
-```
-### Example 2
-Following call will update the existing NetflixApp properties in the dial dynamic APP list and insert the new application YouTube.
-
-#### Request
-
-```json
-{
-    "jsonrpc":"2.0",
-    "id":"3",
-    "method": "org.rdk.Xcast.registerApplications",
-    "params":{
-        "applications":[{
-               "names":["Netflix"],
-               "cors":[".netflix.com"],
-               "properties":{"allowStop" :true}
-           },
-           {
-               "names":["YouTube"],
-               "cors":[".youtube.com"],
-               "properties":{"allowStop" :true}
-           }]
+        "applications": "NetflixApp"
     }
 }
 ```
@@ -448,18 +409,18 @@ Following call will update the existing NetflixApp properties in the dial dynami
 <a name="unregisterApplications"></a>
 ## *unregisterApplications*
 
-This API will remove the specified APP names from the existing whitelist. This API call will simply ignore the request and return success, if specified apps are not present in the whitelist. Invoking this API, with the empty list, will clear the whitelist and wont allow any of the applications to cast.
+Unregisters an application. This API allows to remove the specified applist from the XCast whitelist. To dynamically delete the specific app list, same API should be called with the app list to remove. so that mentioned app list will be removed from the XCast whitelist. Calling this API with empty list will clear the Xcast Whitelist.
 
 ### Events
 
- No Events.
+No Events
 
 ### Parameters
 
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
 | params | object |  |
-| params.applications | string | The application name to register |
+| params.applications | string | The application name to unregister |
 
 ### Result
 
@@ -468,8 +429,7 @@ This API will remove the specified APP names from the existing whitelist. This A
 | result | object |  |
 | result.success | boolean | Whether the request succeeded |
 
-### Example 1
-Following call will remove NetflixApp and YouTube from gdial whitelistied applications.
+### Example
 
 #### Request
 
@@ -479,35 +439,7 @@ Following call will remove NetflixApp and YouTube from gdial whitelistied applic
     "id": 42,
     "method": "org.rdk.Xcast.unregisterApplications",
     "params": {
-        "applications": ["NetflixApp", "YouTube"]
-    }
-}
-```
-
-#### Response
-
-```json
-{
-    "jsonrpc": "2.0",
-    "id": 42,
-    "result": {
-        "success": true
-    }
-}
-```
-
-### Example 2
-Following call will clear the gdial application whitelist. Once this call is invoked, it wont be able to cast any of the aaplications using XCast.
-
-#### Request
-
-```json
-{
-    "jsonrpc": "2.0",
-    "id": 42,
-    "method": "org.rdk.Xcast.unregisterApplications",
-    "params": {
-        "applications": []
+        "applications": "NetflixApp"
     }
 }
 ```


### PR DESCRIPTION
"RDK-38285: Remove "(version 2)" from the API description in Documentation"

Reason for change:
RDK-38285: Removing (Version 2) from the description in the documention as API versioning is tracked in the changelog

Test Procedure: Executed and verified by generating api documentation in docsify
Risks: Create None
Signed-off-by: Rekha Jayaram "[Rekha_Jayaram3@comcast.com](mailto:Rekha_Jayaram3@comcast.com)"