### PR TITLE
RDK-34568: Expand AVInput RDK Service to include HDMI&CompositeInput …

### DIFF
--- a/AVInput/AVInput.cpp
+++ b/AVInput/AVInput.cpp
@@ -18,16 +18,59 @@
 **/
 
 #include "AVInput.h"
-
 #include "dsMgr.h"
 #include "hdmiIn.hpp"
+#include "compositeIn.hpp"
 
 #include "UtilsJsonRpc.h"
 #include "UtilsIarm.h"
 
+#include "exception.hpp"
+#include <vector>
+#include <algorithm>
+
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
 #define API_VERSION_NUMBER_PATCH 0
+
+#define HDMI 0
+#define COMPOSITE 1
+#define AV_HOT_PLUG_EVENT_CONNECTED 0
+#define AV_HOT_PLUG_EVENT_DISCONNECTED 1
+#define AVINPUT_METHOD_NUMBER_OF_INPUTS "numberOfInputs"
+#define AVINPUT_METHOD_GET_INPUT_DEVICES "getInputDevices"
+#define AVINPUT_METHOD_WRITE_EDID "writeEDID"
+#define AVINPUT_METHOD_READ_EDID "readEDID"
+#define AVINPUT_METHOD_READ_RAWSPD "getRawSPD"
+#define AVINPUT_METHOD_READ_SPD "getSPD"
+#define AVINPUT_METHOD_SET_EDID_VERSION "setEdidVersion"
+#define AVINPUT_METHOD_GET_EDID_VERSION "getEdidVersion"
+#define AVINPUT_METHOD_START_INPUT "startInput"
+#define AVINPUT_METHOD_STOP_INPUT "stopInput"
+#define AVINPUT_METHOD_SCALE_INPUT "setVideoRectangle"
+#define AVINPUT_METHOD_CURRENT_VIDEO_MODE "currentVideoMode"
+#define AVINPUT_METHOD_CONTENT_PROTECTED "contentProtected"
+#define AVINPUT_METHOD_SUPPORTED_GAME_FEATURES "getSupportedGameFeatures"
+#define AVINPUT_METHOD_GAME_FEATURE_STATUS "getGameFeatureStatus"
+
+#define AVINPUT_EVENT_ON_DEVICES_CHANGED "onDevicesChanged"
+#define AVINPUT_EVENT_ON_SIGNAL_CHANGED "onSignalChanged"
+#define AVINPUT_EVENT_ON_STATUS_CHANGED "onInputStatusChanged"
+#define AVINPUT_EVENT_ON_VIDEO_MODE_UPDATED "videoStreamInfoUpdate"
+#define AVINPUT_EVENT_ON_GAME_FEATURE_STATUS_CHANGED "gameFeatureStatusUpdate"
+
+using namespace std;
+int getTypeOfInput(string sType)
+{
+    int iType = -1;
+    if (strcmp (sType.c_str(), "HDMI") == 0)
+        iType = HDMI;
+    else if (strcmp (sType.c_str(), "COMPOSITE") ==0)
+        iType = COMPOSITE;
+    else
+        throw "Invalide type of INPUT, please specify HDMI/COMPOSITE";
+    return iType;
+}
 
 namespace WPEFramework {
 namespace {
@@ -45,31 +88,6 @@ namespace {
 }
 
 namespace Plugin {
-
-namespace {
-void dsHdmiEventHandler(const char *, IARM_EventId_t eventId, void *, size_t)
-{
-    if ((IARM_BUS_DSMGR_EVENT_HDMI_IN_HOTPLUG == eventId) &&
-        (AVInput::_instance != nullptr)) {
-        try {
-            int num = device::HdmiInput::getInstance().getNumberOfInputs();
-            if (num > 0) {
-                for (int i = 0; i < num; i++) {
-                    if (device::HdmiInput::getInstance().isPortConnected(i)) {
-                        AVInput::_instance->event_onAVInputActive(i);
-                    }
-                    else {
-                        AVInput::_instance->event_onAVInputInactive(i);
-                    }
-                }
-            }
-        }
-        catch (...) {
-            LOGERR("Exception caught");
-        }
-    }
-}
-}
 
 SERVICE_REGISTRATION(AVInput, API_VERSION_NUMBER_MAJOR, API_VERSION_NUMBER_MINOR, API_VERSION_NUMBER_PATCH);
 
@@ -112,7 +130,35 @@ void AVInput::InitializeIARM()
         IARM_CHECK(IARM_Bus_RegisterEventHandler(
             IARM_BUS_DSMGR_NAME,
             IARM_BUS_DSMGR_EVENT_HDMI_IN_HOTPLUG,
-            dsHdmiEventHandler));
+            dsAVEventHandler));
+        IARM_CHECK(IARM_Bus_RegisterEventHandler(
+            IARM_BUS_DSMGR_NAME,
+            IARM_BUS_DSMGR_EVENT_HDMI_IN_SIGNAL_STATUS,
+            dsAVSignalStatusEventHandler));
+        IARM_CHECK(IARM_Bus_RegisterEventHandler(
+            IARM_BUS_DSMGR_NAME,
+            IARM_BUS_DSMGR_EVENT_HDMI_IN_STATUS,
+            dsAVStatusEventHandler));
+        IARM_CHECK(IARM_Bus_RegisterEventHandler(
+            IARM_BUS_DSMGR_NAME,
+            IARM_BUS_DSMGR_EVENT_HDMI_IN_VIDEO_MODE_UPDATE,
+            dsAVVideoModeEventHandler));
+        IARM_CHECK(IARM_Bus_RegisterEventHandler(
+            IARM_BUS_DSMGR_NAME,
+            IARM_BUS_DSMGR_EVENT_HDMI_IN_ALLM_STATUS,
+            dsAVGameFeatureStatusEventHandler));
+        IARM_CHECK(IARM_Bus_RegisterEventHandler(
+            IARM_BUS_DSMGR_NAME,
+            IARM_BUS_DSMGR_EVENT_COMPOSITE_IN_HOTPLUG,
+            dsAVEventHandler));
+        IARM_CHECK(IARM_Bus_RegisterEventHandler(
+            IARM_BUS_DSMGR_NAME,
+            IARM_BUS_DSMGR_EVENT_COMPOSITE_IN_SIGNAL_STATUS,
+            dsAVSignalStatusEventHandler));
+        IARM_CHECK(IARM_Bus_RegisterEventHandler(
+            IARM_BUS_DSMGR_NAME,
+            IARM_BUS_DSMGR_EVENT_COMPOSITE_IN_STATUS,
+            dsAVStatusEventHandler));
     }
 }
 
@@ -123,21 +169,78 @@ void AVInput::DeinitializeIARM()
         IARM_CHECK(IARM_Bus_UnRegisterEventHandler(
             IARM_BUS_DSMGR_NAME,
             IARM_BUS_DSMGR_EVENT_HDMI_IN_HOTPLUG));
+        IARM_CHECK(IARM_Bus_UnRegisterEventHandler(
+            IARM_BUS_DSMGR_NAME,
+            IARM_BUS_DSMGR_EVENT_HDMI_IN_SIGNAL_STATUS));
+        IARM_CHECK(IARM_Bus_UnRegisterEventHandler(
+            IARM_BUS_DSMGR_NAME,
+            IARM_BUS_DSMGR_EVENT_HDMI_IN_STATUS));
+        IARM_CHECK(IARM_Bus_UnRegisterEventHandler(
+            IARM_BUS_DSMGR_NAME,
+            IARM_BUS_DSMGR_EVENT_HDMI_IN_VIDEO_MODE_UPDATE));
+        IARM_CHECK(IARM_Bus_UnRegisterEventHandler(
+            IARM_BUS_DSMGR_NAME,
+            IARM_BUS_DSMGR_EVENT_HDMI_IN_ALLM_STATUS));
+        IARM_CHECK(IARM_Bus_UnRegisterEventHandler(
+            IARM_BUS_DSMGR_NAME,
+            IARM_BUS_DSMGR_EVENT_COMPOSITE_IN_HOTPLUG));
+        IARM_CHECK(IARM_Bus_UnRegisterEventHandler(
+            IARM_BUS_DSMGR_NAME,
+            IARM_BUS_DSMGR_EVENT_COMPOSITE_IN_SIGNAL_STATUS));
+        IARM_CHECK(IARM_Bus_UnRegisterEventHandler(
+            IARM_BUS_DSMGR_NAME,
+            IARM_BUS_DSMGR_EVENT_COMPOSITE_IN_STATUS));
     }
 }
 
 void AVInput::RegisterAll()
 {
-    Register<JsonObject, JsonObject>(_T("numberOfInputs"), &AVInput::endpoint_numberOfInputs, this);
-    Register<JsonObject, JsonObject>(_T("currentVideoMode"), &AVInput::endpoint_currentVideoMode, this);
-    Register<JsonObject, JsonObject>(_T("contentProtected"), &AVInput::endpoint_contentProtected, this);
+    Register<JsonObject, JsonObject>(_T(AVINPUT_METHOD_NUMBER_OF_INPUTS), &AVInput::endpoint_numberOfInputs, this);
+    Register<JsonObject, JsonObject>(_T(AVINPUT_METHOD_CURRENT_VIDEO_MODE), &AVInput::endpoint_currentVideoMode, this);
+    Register<JsonObject, JsonObject>(_T(AVINPUT_METHOD_CONTENT_PROTECTED), &AVInput::endpoint_contentProtected, this);
+    Register<JsonObject, JsonObject>(_T(AVINPUT_METHOD_GET_INPUT_DEVICES), &AVInput::getInputDevicesWrapper, this);
+    Register<JsonObject, JsonObject>(_T(AVINPUT_METHOD_WRITE_EDID), &AVInput::writeEDIDWrapper, this);
+    Register<JsonObject, JsonObject>(_T(AVINPUT_METHOD_READ_EDID), &AVInput::readEDIDWrapper, this);
+    Register<JsonObject, JsonObject>(_T(AVINPUT_METHOD_READ_RAWSPD), &AVInput::getRawSPDWrapper, this);
+    Register<JsonObject, JsonObject>(_T(AVINPUT_METHOD_READ_SPD), &AVInput::getSPDWrapper, this);
+    Register<JsonObject, JsonObject>(_T(AVINPUT_METHOD_SET_EDID_VERSION), &AVInput::setEdidVersionWrapper, this);
+    Register<JsonObject, JsonObject>(_T(AVINPUT_METHOD_GET_EDID_VERSION), &AVInput::getEdidVersionWrapper, this);
+    Register<JsonObject, JsonObject>(_T(AVINPUT_METHOD_START_INPUT), &AVInput::startInput, this);
+    Register<JsonObject, JsonObject>(_T(AVINPUT_METHOD_STOP_INPUT), &AVInput::stopInput, this);
+    Register<JsonObject, JsonObject>(_T(AVINPUT_METHOD_SCALE_INPUT), &AVInput::setVideoRectangleWrapper, this);
+    Register<JsonObject, JsonObject>(_T(AVINPUT_METHOD_SUPPORTED_GAME_FEATURES), &AVInput::getSupportedGameFeatures, this);
+    Register<JsonObject, JsonObject>(_T(AVINPUT_METHOD_GAME_FEATURE_STATUS), &AVInput::getGameFeatureStatusWrapper, this);
 }
 
 void AVInput::UnregisterAll()
 {
-    Unregister(_T("numberOfInputs"));
-    Unregister(_T("currentVideoMode"));
-    Unregister(_T("contentProtected"));
+    Unregister(_T(AVINPUT_METHOD_NUMBER_OF_INPUTS));
+    Unregister(_T(AVINPUT_METHOD_CURRENT_VIDEO_MODE));
+    Unregister(_T(AVINPUT_METHOD_CONTENT_PROTECTED));
+    Unregister(_T(AVINPUT_METHOD_GET_INPUT_DEVICES));
+    Unregister(_T(AVINPUT_METHOD_WRITE_EDID));
+    Unregister(_T(AVINPUT_METHOD_READ_EDID));
+    Unregister(_T(AVINPUT_METHOD_READ_RAWSPD));
+    Unregister(_T(AVINPUT_METHOD_READ_SPD));
+    Unregister(_T(AVINPUT_METHOD_SET_EDID_VERSION));
+    Unregister(_T(AVINPUT_METHOD_GET_EDID_VERSION));
+    Unregister(_T(AVINPUT_METHOD_START_INPUT));
+    Unregister(_T(AVINPUT_METHOD_STOP_INPUT));
+    Unregister(_T(AVINPUT_METHOD_SCALE_INPUT));
+    Unregister(_T(AVINPUT_METHOD_SUPPORTED_GAME_FEATURES));
+    Unregister(_T(AVINPUT_METHOD_GAME_FEATURE_STATUS));
+}
+
+void setResponseArray(JsonObject& response, const char* key, const vector<string>& items)
+{
+    JsonArray arr;
+    for(auto& i : items) arr.Add(JsonValue(i));
+
+    response[key] = arr;
+
+    string json;
+    response.ToString(json);
+    LOGINFO("%s: result json %s\n", __FUNCTION__, json.c_str());
 }
 
 uint32_t AVInput::endpoint_numberOfInputs(const JsonObject &parameters, JsonObject &response)
@@ -178,20 +281,6 @@ uint32_t AVInput::endpoint_contentProtected(const JsonObject &parameters, JsonOb
     returnResponse(true);
 }
 
-void AVInput::event_onAVInputActive(int id)
-{
-    JsonObject params;
-    params[_T("url")] = "avin://input" + std::to_string(id);
-    sendNotify(_T("onAVInputActive"), params);
-}
-
-void AVInput::event_onAVInputInactive(int id)
-{
-    JsonObject params;
-    params[_T("url")] = "avin://input" + std::to_string(id);
-    sendNotify(_T("onAVInputInactive"), params);
-}
-
 int AVInput::numberOfInputs(bool &success)
 {
     int result = 0;
@@ -222,6 +311,914 @@ string AVInput::currentVideoMode(bool &success)
     }
 
     return result;
+}
+
+
+uint32_t AVInput::startInput(const JsonObject& parameters, JsonObject& response)
+{
+    LOGINFOMETHOD();
+
+    string sType = parameters["typeOfInput"].String();
+    int portId = 0;
+    int iType = 0;
+
+    if (parameters.HasLabel("portId") && parameters.HasLabel("typeOfInput"))
+    {
+        try {
+            portId = parameters["portId"].Number();
+            iType = getTypeOfInput (sType);
+        }catch (...) {
+            LOGWARN("Invalid Arguments");
+            return Core::ERROR_BAD_REQUEST;
+        }
+    }
+    else {
+        LOGWARN("Required parameters are not passed");
+        return Core::ERROR_BAD_REQUEST;
+    }
+
+    try
+    {
+        if (iType == HDMI) {
+            device::HdmiInput::getInstance().selectPort(portId);
+    }
+    else if(iType == COMPOSITE) {
+            device::CompositeInput::getInstance().selectPort(portId);
+        }
+    }
+    catch (const device::Exception& err) {
+        LOG_DEVICE_EXCEPTION1(std::to_string(portId));
+        return Core::ERROR_GENERAL;
+    }
+    return Core::ERROR_NONE;
+}
+
+uint32_t AVInput::stopInput(const JsonObject& parameters, JsonObject& response)
+{
+    LOGINFOMETHOD();
+
+    string sType = parameters["typeOfInput"].String();
+    int iType = 0;
+
+    if (parameters.HasLabel("typeOfInput"))
+        try {
+            iType = getTypeOfInput (sType);
+        }catch (...) {
+            LOGWARN("Invalid Arguments");
+            return Core::ERROR_BAD_REQUEST;
+        }
+    else {
+        LOGWARN("Required parameters are not passed");
+        return Core::ERROR_BAD_REQUEST;
+    }
+
+    try
+    {
+        if (iType == HDMI) {
+            device::HdmiInput::getInstance().selectPort(-1);
+        }
+        else if (iType == COMPOSITE) {
+            device::CompositeInput::getInstance().selectPort(-1);
+        }
+    }
+    catch (const device::Exception& err) {
+        LOGWARN("AVInputService::stopInput Failed");
+        return Core::ERROR_GENERAL;
+    }
+    return Core::ERROR_NONE;
+}
+
+uint32_t AVInput::setVideoRectangleWrapper(const JsonObject& parameters, JsonObject& response)
+{
+    LOGINFOMETHOD();
+
+    bool result = true;
+    if (!parameters.HasLabel("x") && !parameters.HasLabel("y")) {
+        result = false;
+        LOGWARN("please specif coordinates (x,y)");
+    }
+
+    if (!parameters.HasLabel("w") && !parameters.HasLabel("h")) {
+        result = false;
+        LOGWARN("please specify window width and height (w,h)");
+    }
+
+    if (!parameters.HasLabel("typeOfInput")) {
+        result = false;
+        LOGWARN("please specify type of input HDMI/COMPOSITE");
+    }
+
+    if (result) {
+        int x = 0;
+        int y = 0;
+        int w = 0;
+        int h = 0;
+        int t = 0;
+        string sType;
+
+        try {
+            if (parameters.HasLabel("x")) {
+                x = parameters["x"].Number();
+            }
+            if (parameters.HasLabel("y")) {
+                y = parameters["y"].Number();
+            }
+            if (parameters.HasLabel("w")) {
+                w = parameters["w"].Number();
+            }
+            if (parameters.HasLabel("h")) {
+                h = parameters["h"].Number();
+            }
+            if (parameters.HasLabel("typeOfInput")) {
+                sType = parameters["typeOfInput"].String();
+                t = getTypeOfInput (sType);
+            }
+        }
+        catch (...) {
+            LOGWARN("Invalid Arguments");
+            return Core::ERROR_BAD_REQUEST;
+        }
+
+        result = setVideoRectangle(x, y, w, h, t);
+        if (false == result) {
+            LOGWARN("AVInputService::setVideoRectangle Failed");
+            return Core::ERROR_GENERAL;
+        }
+        return Core::ERROR_NONE;
+    }
+    return Core::ERROR_BAD_REQUEST;
+}
+
+bool AVInput::setVideoRectangle(int x, int y, int width, int height, int type)
+{
+    bool ret = true;
+
+    try
+    {
+        if (type == HDMI) {
+            device::HdmiInput::getInstance().scaleVideo(x, y, width, height);
+        }
+        else {
+            device::CompositeInput::getInstance().scaleVideo(x, y, width, height);
+        }
+    }
+    catch (const device::Exception& err) {
+        ret = false;
+    }
+
+    return ret;
+}
+
+uint32_t AVInput::getInputDevicesWrapper(const JsonObject& parameters, JsonObject& response)
+{
+    LOGINFOMETHOD();
+
+    if (parameters.HasLabel("typeOfInput")) {
+        string sType = parameters["typeOfInput"].String();
+        int iType = 0;
+        try {
+            iType = getTypeOfInput (sType);
+        }catch (...) {
+            LOGWARN("Invalid Arguments");
+            return Core::ERROR_BAD_REQUEST;
+        }
+        response["devices"] = getInputDevices(iType);
+    }
+    else {
+        JsonArray listHdmi = getInputDevices(HDMI);
+        JsonArray listComposite = getInputDevices(COMPOSITE);
+        for (int i = 0; i < listComposite.Length(); i++) {
+            listHdmi.Add(listComposite.Get(i));
+        }
+        response["devices"] = listHdmi;
+    }
+    return Core::ERROR_NONE;
+}
+
+uint32_t AVInput::writeEDIDWrapper(const JsonObject& parameters, JsonObject& response)
+{
+    LOGINFOMETHOD();
+
+    int portId;
+    std::string message;
+
+    if (parameters.HasLabel("portId") && parameters.HasLabel("message")) {
+        portId = parameters["portId"].Number();
+        message = parameters["message"].String();
+    }
+    else {
+        LOGWARN("Required parameters are not passed");
+        return Core::ERROR_BAD_REQUEST;
+    }
+
+    writeEDID(portId, message);
+    return Core::ERROR_NONE;
+}
+
+uint32_t AVInput::readEDIDWrapper(const JsonObject& parameters, JsonObject& response)
+{
+    LOGINFOMETHOD();
+
+    int portId = 0;
+    try {
+        portId = parameters["portId"].Number();
+    }catch (...) {
+            LOGWARN("Invalid Arguments");
+            return Core::ERROR_BAD_REQUEST;
+    }
+
+    string edid = readEDID (portId);
+    if (edid.empty()) {
+        return Core::ERROR_GENERAL;
+    }
+    else {
+        response["EDID"] = edid;
+        return Core::ERROR_NONE;
+    }
+}
+
+JsonArray AVInput::getInputDevices(int iType)
+{
+    JsonArray list;
+    try
+    {
+        int num = 0;
+        if (iType == HDMI) {
+            num = device::HdmiInput::getInstance().getNumberOfInputs();
+        }
+        else if (iType == COMPOSITE) {
+            num = device::CompositeInput::getInstance().getNumberOfInputs();
+        }
+        if (num > 0) {
+            int i = 0;
+            for (i = 0; i < num; i++) {
+                //Input ID is aleays 0-indexed, continuous number starting 0
+                JsonObject hash;
+                hash["id"] = i;
+                std::stringstream locator;
+                if (iType == HDMI) {
+                    locator << "hdmiin://localhost/deviceid/" << i;
+                    hash["connected"] = device::HdmiInput::getInstance().isPortConnected(i);
+                }
+                else if (iType == COMPOSITE) {
+                    locator << "cvbsin://localhost/deviceid/" << i;
+                    hash["connected"] = device::CompositeInput::getInstance().isPortConnected(i);
+                }
+                hash["locator"] = locator.str();
+                LOGWARN("AVInputService::getInputDevices id %d, locator=[%s], connected=[%d]", i, hash["locator"].String().c_str(), hash["connected"].Boolean());
+                list.Add(hash);
+            }
+        }
+    }
+    catch (const std::exception &e) {
+        LOGWARN("AVInputService::getInputDevices Failed");
+    }
+    return list;
+}
+
+void AVInput::writeEDID(int portId, std::string message)
+{
+}
+
+std::string AVInput::readEDID(int iPort)
+{
+    vector<uint8_t> edidVec({'u','n','k','n','o','w','n' });
+    string edidbase64 = "";
+    try {
+        vector<uint8_t> edidVec2;
+        device::HdmiInput::getInstance().getEDIDBytesInfo (iPort, edidVec2);
+        edidVec = edidVec2;//edidVec must be "unknown" unless we successfully get to this line
+
+        //convert to base64
+        uint16_t size = min(edidVec.size(), (size_t)numeric_limits<uint16_t>::max());
+
+        LOGWARN("AVInput::readEDID size:%d edidVec.size:%zu", size, edidVec.size());
+        if(edidVec.size() > (size_t)numeric_limits<uint16_t>::max()) {
+            LOGERR("Size too large to use ToString base64 wpe api");
+            return edidbase64;
+        }
+        Core::ToString((uint8_t*)&edidVec[0], size, true, edidbase64);
+    }
+    catch (const device::Exception& err) {
+        LOG_DEVICE_EXCEPTION1(std::to_string(iPort));
+    }
+    return edidbase64;
+}
+
+/**
+ * @brief This function is used to translate HDMI/COMPOSITE input hotplug to
+ * deviceChanged event.
+ *
+ * @param[in] input Number of input port integer.
+ * @param[in] connection status of input port integer.
+ */
+void AVInput::AVInputHotplug( int input , int connect, int type)
+{
+    LOGWARN("AVInputHotplug [%d, %d, %d]", input, connect, type);
+
+    JsonObject params;
+    params["devices"] = getInputDevices(type);
+    sendNotify(AVINPUT_EVENT_ON_DEVICES_CHANGED, params);
+}
+
+/**
+ * @brief This function is used to translate HDMI/COMPOSITE input signal change to
+ * signalChanged event.
+ *
+ * @param[in] port HDMI/COMPOSITE In port id.
+ * @param[in] signalStatus signal status of HDMI/COMPOSITE In port.
+ */
+void AVInput::AVInputSignalChange( int port , int signalStatus, int type)
+{
+    LOGWARN("AVInputSignalStatus [%d, %d, %d]", port, signalStatus, type);
+
+    JsonObject params;
+    params["id"] = port;
+    std::stringstream locator;
+    if (type == HDMI) {
+        locator << "hdmiin://localhost/deviceid/" << port;
+    }
+    else {
+        locator << "cvbsin://localhost/deviceid/" << port;
+    }
+    params["locator"] = locator.str();
+    /* values of dsHdmiInSignalStatus_t and dsCompInSignalStatus_t are same
+   Hence used only HDMI macro for case statement */
+    switch (signalStatus) {
+        case dsHDMI_IN_SIGNAL_STATUS_NOSIGNAL:
+            params["signalStatus"] = "noSignal";
+            break;
+
+        case dsHDMI_IN_SIGNAL_STATUS_UNSTABLE:
+            params["signalStatus"] = "unstableSignal";
+            break;
+
+        case dsHDMI_IN_SIGNAL_STATUS_NOTSUPPORTED:
+            params["signalStatus"] = "notSupportedSignal";
+            break;
+
+        case dsHDMI_IN_SIGNAL_STATUS_STABLE:
+            params["signalStatus"] = "stableSignal";
+            break;
+
+        default:
+            params["signalStatus"] = "none";
+            break;
+    }
+    sendNotify(AVINPUT_EVENT_ON_SIGNAL_CHANGED, params);
+}
+
+/**
+ * @brief This function is used to translate HDMI/COMPOSITE input status change to
+ * inputStatusChanged event.
+ *
+ * @param[in] port HDMI/COMPOSITE In port id.
+ * @param[bool] isPresented HDMI/COMPOSITE In presentation started/stopped.
+ */
+void AVInput::AVInputStatusChange( int port , bool isPresented, int type)
+{
+    LOGWARN("avInputStatus [%d, %d, %d]", port, isPresented, type);
+
+    JsonObject params;
+    params["id"] = port;
+    std::stringstream locator;
+    if (type == HDMI) {
+        locator << "hdmiin://localhost/deviceid/" << port;
+    }
+    else if (type == COMPOSITE) {
+        locator << "cvbsin://localhost/deviceid/" << port;
+    }
+    params["locator"] = locator.str();
+
+    if(isPresented) {
+        params["status"] = "started";
+    }
+    else {
+        params["status"] = "stopped";
+    }
+    sendNotify(AVINPUT_EVENT_ON_STATUS_CHANGED, params);
+}
+
+/**
+ * @brief This function is used to translate HDMI input video mode change to
+ * videoStreamInfoUpdate event.
+ *
+ * @param[in] port HDMI In port id.
+ * @param[dsVideoPortResolution_t] video resolution data
+ */
+void AVInput::AVInputVideoModeUpdate( int port , dsVideoPortResolution_t resolution)
+{
+    LOGWARN("AVInputVideoModeUpdate [%d]", port);
+
+    JsonObject params;
+    params["id"] = port;
+    std::stringstream locator;
+    locator << "hdmiin://localhost/deviceid/" << port;
+    params["locator"] = locator.str();
+
+    switch(resolution.pixelResolution) {
+        case dsVIDEO_PIXELRES_720x480:
+            params["width"] = 720;
+            params["height"] = 480;
+            break;
+
+        case dsVIDEO_PIXELRES_720x576:
+            params["width"] = 720;
+            params["height"] = 576;
+            break;
+
+        case dsVIDEO_PIXELRES_1280x720:
+            params["width"] = 1280;
+            params["height"] = 720;
+            break;
+
+        case dsVIDEO_PIXELRES_1920x1080:
+            params["width"] = 1920;
+            params["height"] = 1080;
+            break;
+
+        case dsVIDEO_PIXELRES_3840x2160:
+            params["width"] = 3840;
+            params["height"] = 2160;
+            break;
+
+        case dsVIDEO_PIXELRES_4096x2160:
+            params["width"] = 4096;
+            params["height"] = 2160;
+            break;
+
+        default:
+            params["width"] = 1920;
+            params["height"] = 1080;
+            break;
+    }
+
+    params["progressive"] = (!resolution.interlaced);
+
+    switch(resolution.frameRate) {
+        case dsVIDEO_FRAMERATE_24:
+            params["frameRateN"] = 24000;
+            params["frameRateD"] = 1000;
+            break;
+
+        case dsVIDEO_FRAMERATE_25:
+            params["frameRateN"] = 25000;
+            params["frameRateD"] = 1000;
+            break;
+
+        case dsVIDEO_FRAMERATE_30:
+            params["frameRateN"] = 30000;
+            params["frameRateD"] = 1000;
+            break;
+
+        case dsVIDEO_FRAMERATE_50:
+            params["frameRateN"] = 50000;
+            params["frameRateD"] = 1000;
+            break;
+
+        case dsVIDEO_FRAMERATE_60:
+            params["frameRateN"] = 60000;
+            params["frameRateD"] = 1000;
+            break;
+
+        case dsVIDEO_FRAMERATE_23dot98:
+            params["frameRateN"] = 24000;
+            params["frameRateD"] = 1001;
+            break;
+
+        case dsVIDEO_FRAMERATE_29dot97:
+            params["frameRateN"] = 30000;
+            params["frameRateD"] = 1001;
+            break;
+
+        case dsVIDEO_FRAMERATE_59dot94:
+            params["frameRateN"] = 60000;
+            params["frameRateD"] = 1001;
+            break;
+
+        default:
+            params["frameRateN"] = 60000;
+            params["frameRateD"] = 1000;
+            break;
+    }
+
+    sendNotify(AVINPUT_EVENT_ON_VIDEO_MODE_UPDATED, params);
+}
+
+void AVInput::dsAVEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
+{
+    if(!AVInput::_instance)
+        return;
+
+    IARM_Bus_DSMgr_EventData_t *eventData = (IARM_Bus_DSMgr_EventData_t *)data;
+    if (IARM_BUS_DSMGR_EVENT_HDMI_IN_HOTPLUG == eventId) {
+        int hdmiin_hotplug_port = eventData->data.hdmi_in_connect.port;
+        int hdmiin_hotplug_conn = eventData->data.hdmi_in_connect.isPortConnected;
+        LOGWARN("Received IARM_BUS_DSMGR_EVENT_HDMI_IN_HOTPLUG  event data:%d", hdmiin_hotplug_port);
+        AVInput::_instance->AVInputHotplug(hdmiin_hotplug_port, hdmiin_hotplug_conn ? AV_HOT_PLUG_EVENT_CONNECTED : AV_HOT_PLUG_EVENT_DISCONNECTED, HDMI);
+    }
+    else if (IARM_BUS_DSMGR_EVENT_COMPOSITE_IN_HOTPLUG == eventId) {
+        int compositein_hotplug_port = eventData->data.composite_in_connect.port;
+        int compositein_hotplug_conn = eventData->data.composite_in_connect.isPortConnected;
+        LOGWARN("Received IARM_BUS_DSMGR_EVENT_COMPOSITE_IN_HOTPLUG  event data:%d", compositein_hotplug_port);
+        AVInput::_instance->AVInputHotplug(compositein_hotplug_port, compositein_hotplug_conn ? AV_HOT_PLUG_EVENT_CONNECTED : AV_HOT_PLUG_EVENT_DISCONNECTED, COMPOSITE);
+    }
+}
+
+void AVInput::dsAVSignalStatusEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
+{
+    if(!AVInput::_instance)
+        return;
+    IARM_Bus_DSMgr_EventData_t *eventData = (IARM_Bus_DSMgr_EventData_t *)data;
+    if (IARM_BUS_DSMGR_EVENT_HDMI_IN_SIGNAL_STATUS == eventId) {
+        int hdmi_in_port = eventData->data.hdmi_in_sig_status.port;
+        int hdmi_in_signal_status = eventData->data.hdmi_in_sig_status.status;
+        LOGWARN("Received IARM_BUS_DSMGR_EVENT_HDMI_IN_SIGNAL_STATUS  event  port: %d, signal status: %d", hdmi_in_port,hdmi_in_signal_status);
+        AVInput::_instance->AVInputSignalChange(hdmi_in_port, hdmi_in_signal_status, HDMI);
+    }
+    else if (IARM_BUS_DSMGR_EVENT_COMPOSITE_IN_SIGNAL_STATUS == eventId) {
+        int composite_in_port = eventData->data.composite_in_sig_status.port;
+        int composite_in_signal_status = eventData->data.composite_in_sig_status.status;
+        LOGWARN("Received IARM_BUS_DSMGR_EVENT_COMPOSITE_IN_SIGNAL_STATUS  event  port: %d, signal status: %d", composite_in_port,composite_in_signal_status);
+        AVInput::_instance->AVInputSignalChange(composite_in_port, composite_in_signal_status, COMPOSITE);
+    }
+}
+
+void AVInput::dsAVStatusEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
+{
+    if(!AVInput::_instance)
+        return;
+    IARM_Bus_DSMgr_EventData_t *eventData = (IARM_Bus_DSMgr_EventData_t *)data;
+    if (IARM_BUS_DSMGR_EVENT_HDMI_IN_STATUS == eventId) {
+        int hdmi_in_port = eventData->data.hdmi_in_status.port;
+        bool hdmi_in_status = eventData->data.hdmi_in_status.isPresented;
+        LOGWARN("Received IARM_BUS_DSMGR_EVENT_HDMI_IN_STATUS  event  port: %d, started: %d", hdmi_in_port,hdmi_in_status);
+        AVInput::_instance->AVInputStatusChange(hdmi_in_port, hdmi_in_status, HDMI);
+    }
+    else if (IARM_BUS_DSMGR_EVENT_COMPOSITE_IN_STATUS == eventId) {
+        int composite_in_port = eventData->data.composite_in_status.port;
+        bool composite_in_status = eventData->data.composite_in_status.isPresented;
+        LOGWARN("Received IARM_BUS_DSMGR_EVENT_COMPOSITE_IN_STATUS  event  port: %d, started: %d", composite_in_port,composite_in_status);
+        AVInput::_instance->AVInputStatusChange(composite_in_port, composite_in_status, COMPOSITE);
+    }
+}
+
+void AVInput::dsAVVideoModeEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
+{
+    if(!AVInput::_instance)
+        return;
+
+    if (IARM_BUS_DSMGR_EVENT_HDMI_IN_VIDEO_MODE_UPDATE == eventId) {
+        IARM_Bus_DSMgr_EventData_t *eventData = (IARM_Bus_DSMgr_EventData_t *)data;
+        int hdmi_in_port = eventData->data.hdmi_in_video_mode.port;
+        dsVideoPortResolution_t resolution;
+        resolution.pixelResolution =  eventData->data.hdmi_in_video_mode.resolution.pixelResolution;
+        resolution.interlaced =  eventData->data.hdmi_in_video_mode.resolution.interlaced;
+        resolution.frameRate =  eventData->data.hdmi_in_video_mode.resolution.frameRate;
+        LOGWARN("Received IARM_BUS_DSMGR_EVENT_HDMI_IN_VIDEO_MODE_UPDATE  event  port: %d, pixelResolution: %d, interlaced : %d, frameRate: %d \n", hdmi_in_port,resolution.pixelResolution, resolution.interlaced, resolution.frameRate);
+        AVInput::_instance->AVInputVideoModeUpdate(hdmi_in_port, resolution);
+    }
+}
+
+void AVInput::dsAVGameFeatureStatusEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
+{
+    if(!AVInput::_instance)
+        return;
+
+    if (IARM_BUS_DSMGR_EVENT_HDMI_IN_ALLM_STATUS == eventId)
+    {
+        IARM_Bus_DSMgr_EventData_t *eventData = (IARM_Bus_DSMgr_EventData_t *)data;
+        int hdmi_in_port = eventData->data.hdmi_in_allm_mode.port;
+        bool allm_mode = eventData->data.hdmi_in_allm_mode.allm_mode;
+        LOGWARN("Received IARM_BUS_DSMGR_EVENT_HDMI_IN_ALLM_STATUS  event  port: %d, ALLM Mode: %d", hdmi_in_port,allm_mode);
+
+        AVInput::_instance->AVInputALLMChange(hdmi_in_port, allm_mode);
+    }
+}
+
+void AVInput::AVInputALLMChange( int port , bool allm_mode)
+{
+    JsonObject params;
+    params["id"] = port;
+    params["gameFeature"] = "ALLM";
+    params["mode"] = allm_mode;
+
+    sendNotify(AVINPUT_EVENT_ON_GAME_FEATURE_STATUS_CHANGED, params);
+}
+
+uint32_t AVInput::getSupportedGameFeatures(const JsonObject& parameters, JsonObject& response)
+{
+    LOGINFOMETHOD();
+    vector<string> supportedFeatures;
+    try
+    {
+        device::HdmiInput::getInstance().getSupportedGameFeatures (supportedFeatures);
+        for (size_t i = 0; i < supportedFeatures.size(); i++)
+        {
+            LOGINFO("Supported Game Feature [%zu]:  %s\n",i,supportedFeatures.at(i).c_str());
+        }
+    }
+    catch (const device::Exception& err)
+    {
+        LOG_DEVICE_EXCEPTION0();
+    }
+
+    if (supportedFeatures.empty()) {
+        return Core::ERROR_GENERAL;
+    }
+    else {
+        setResponseArray(response, "suppoortedGameFeatures", supportedFeatures);
+        return Core::ERROR_NONE;
+    }
+}
+
+uint32_t AVInput::getGameFeatureStatusWrapper(const JsonObject& parameters, JsonObject& response)
+{
+    string sGameFeature = "";
+    int portId = 0;
+
+    LOGINFOMETHOD();
+    if (parameters.HasLabel("portId") && parameters.HasLabel("gameFeature"))
+    {
+        try {
+            portId = parameters["portId"].Number();
+            sGameFeature = parameters["gameFeature"].String();
+        }catch (...) {
+            LOGWARN("Invalid Arguments");
+            return Core::ERROR_BAD_REQUEST;
+        }
+    }
+    else {
+        LOGWARN("Required parameters are not passed");
+        return Core::ERROR_BAD_REQUEST;
+    }
+
+    if (strcmp (sGameFeature.c_str(), "ALLM") == 0)
+    {
+        bool allm = getALLMStatus(portId);
+        LOGWARN("AVInput::getGameFeatureStatusWrapper ALLM MODE:%d", allm);
+        response["mode"] = allm;
+    }
+    else
+    {
+        LOGWARN("AVInput::getGameFeatureStatusWrapper Mode is not supported. Supported mode: ALLM");
+        return Core::ERROR_BAD_REQUEST;
+    }
+    return Core::ERROR_NONE;
+}
+
+bool AVInput::getALLMStatus(int iPort)
+{
+    bool allm = false;
+
+    try
+    {
+        device::HdmiInput::getInstance().getHdmiALLMStatus (iPort, &allm);
+        LOGWARN("AVInput::getALLMStatus ALLM MODE: %d", allm);
+    }
+    catch (const device::Exception& err)
+    {
+        LOG_DEVICE_EXCEPTION1(std::to_string(iPort));
+    }
+    return allm;
+}
+
+uint32_t AVInput::getRawSPDWrapper(const JsonObject& parameters, JsonObject& response)
+{
+    LOGINFOMETHOD();
+
+    int portId = 0;
+    if (parameters.HasLabel("portId"))
+    {
+        try {
+            portId = parameters["portId"].Number();
+        }catch (...) {
+            LOGWARN("Invalid Arguments");
+            return Core::ERROR_BAD_REQUEST;
+        }
+    }
+    else {
+        LOGWARN("Required parameters are not passed");
+        return Core::ERROR_BAD_REQUEST;
+    }
+
+    string spdInfo = getRawSPD (portId);
+    response["HDMISPD"] = spdInfo;
+    if (spdInfo.empty()) {
+        return Core::ERROR_GENERAL;
+    }
+    else {
+        return Core::ERROR_NONE;
+    }
+}
+
+uint32_t AVInput::getSPDWrapper(const JsonObject& parameters, JsonObject& response)
+{
+    LOGINFOMETHOD();
+
+    int portId = 0;
+    if (parameters.HasLabel("portId"))
+    {
+        try {
+        portId = parameters["portId"].Number();
+        }catch (...) {
+            LOGWARN("Invalid Arguments");
+            return Core::ERROR_BAD_REQUEST;
+        }
+    }
+    else {
+        LOGWARN("Required parameters are not passed");
+        return Core::ERROR_BAD_REQUEST;
+    }
+
+    string spdInfo = getSPD (portId);
+    response["HDMISPD"] = spdInfo;
+    if (spdInfo.empty()) {
+        return Core::ERROR_GENERAL;
+    }
+    else {
+        return Core::ERROR_NONE;
+    }
+}
+
+std::string AVInput::getRawSPD(int iPort)
+{
+    LOGINFO("AVInput::getSPDInfo");
+    vector<uint8_t> spdVect({'u','n','k','n','o','w','n' });
+    std::string spdbase64 = "";
+    try {
+        LOGWARN("AVInput::getSPDInfo");
+        vector<uint8_t> spdVect2;
+        device::HdmiInput::getInstance().getHDMISPDInfo(iPort, spdVect2);
+        spdVect = spdVect2;//edidVec must be "unknown" unless we successfully get to this line
+
+        //convert to base64
+        uint16_t size = min(spdVect.size(), (size_t)numeric_limits<uint16_t>::max());
+
+        LOGWARN("AVInput::getSPD size:%d spdVec.size:%zu", size, spdVect.size());
+
+        if(spdVect.size() > (size_t)numeric_limits<uint16_t>::max()) {
+            LOGERR("Size too large to use ToString base64 wpe api");
+            return spdbase64;
+        }
+
+        LOGINFO("------------getSPD: ");
+        for (size_t itr =0; itr < spdVect.size(); itr++) {
+            LOGINFO("%02X ", spdVect[itr]);
+        }
+        Core::ToString((uint8_t*)&spdVect[0], size, false, spdbase64);
+    }
+    catch (const device::Exception& err) {
+        LOG_DEVICE_EXCEPTION1(std::to_string(iPort));
+    }
+    return spdbase64;
+}
+
+std::string AVInput::getSPD(int iPort)
+{
+    LOGINFO("AVInput::getSPDInfo");
+    vector<uint8_t> spdVect({'u','n','k','n','o','w','n' });
+    std::string spdbase64 = "";
+    try {
+        LOGWARN("AVInput::getSPDInfo");
+        vector<uint8_t> spdVect2;
+        device::HdmiInput::getInstance().getHDMISPDInfo(iPort, spdVect2);
+        spdVect = spdVect2;//edidVec must be "unknown" unless we successfully get to this line
+
+        //convert to base64
+        uint16_t size = min(spdVect.size(), (size_t)numeric_limits<uint16_t>::max());
+
+        LOGWARN("AVInput::getSPD size:%d spdVec.size:%zu", size, spdVect.size());
+
+        if(spdVect.size() > (size_t)numeric_limits<uint16_t>::max()) {
+            LOGERR("Size too large to use ToString base64 wpe api");
+            return spdbase64;
+        }
+
+        LOGINFO("------------getSPD: ");
+        for (size_t itr =0; itr < spdVect.size(); itr++) {
+          LOGINFO("%02X ", spdVect[itr]);
+        }
+        if (spdVect.size() > 0) {
+            struct dsSpd_infoframe_st pre;
+            memcpy(&pre,spdVect.data(),sizeof(struct dsSpd_infoframe_st));
+
+            char str[200] = {0};
+            sprintf(str, "Packet Type:%02X,Version:%u,Length:%u,vendor name:%s,product des:%s,source info:%02X",
+            pre.pkttype,pre.version,pre.length,pre.vendor_name,pre.product_des,pre.source_info);
+            spdbase64 = str;
+        }
+    }
+    catch (const device::Exception& err) {
+        LOG_DEVICE_EXCEPTION1(std::to_string(iPort));
+    }
+    return spdbase64;
+}
+
+uint32_t AVInput::setEdidVersionWrapper(const JsonObject& parameters, JsonObject& response)
+{
+    LOGINFOMETHOD();
+    int portId = 0;
+    string sVersion = "";
+    if (parameters.HasLabel("portId") && parameters.HasLabel("edidVersion"))
+    {
+        try {
+            portId = parameters["portId"].Number();
+            sVersion = parameters["edidVersion"].String();
+        }catch (...) {
+            LOGWARN("Invalid Arguments");
+            return Core::ERROR_BAD_REQUEST;
+        }
+    }
+    else {
+        LOGWARN("Required parameters are not passed");
+        return Core::ERROR_BAD_REQUEST;
+    }
+
+    int edidVer = -1;
+    if (strcmp (sVersion.c_str(), "HDMI1.4") == 0) {
+        edidVer = HDMI_EDID_VER_14;
+    }
+    else if (strcmp (sVersion.c_str(), "HDMI2.0") == 0) {
+        edidVer = HDMI_EDID_VER_20;
+    }
+
+    if (edidVer < 0) {
+        return Core::ERROR_GENERAL;
+    }
+    bool result = setEdidVersion (portId, edidVer);
+    if (result == false) {
+        return Core::ERROR_GENERAL;
+    }
+    else {
+        return Core::ERROR_NONE;
+    }
+}
+
+int AVInput::setEdidVersion(int iPort, int iEdidVer)
+{
+    bool ret = true;
+    try {
+        device::HdmiInput::getInstance().setEdidVersion (iPort, iEdidVer);
+        LOGWARN("AVInput::setEdidVersion EDID Version:%d", iEdidVer);
+    }
+    catch (const device::Exception& err) {
+        LOG_DEVICE_EXCEPTION1(std::to_string(iPort));
+        ret = false;
+    }
+    return ret;
+}
+
+uint32_t AVInput::getEdidVersionWrapper(const JsonObject& parameters, JsonObject& response)
+{
+    int portId = 0;
+
+    LOGINFOMETHOD();
+    if (parameters.HasLabel("portId"))
+    {
+        try {
+            portId = parameters["portId"].Number();
+        }
+        catch (...) {
+            LOGWARN("Invalid Arguments");
+            return Core::ERROR_BAD_REQUEST;
+        }
+    }
+    else {
+        LOGWARN("Required parameters are not passed");
+        return Core::ERROR_BAD_REQUEST;
+    }
+
+    int edidVer = getEdidVersion (portId);
+    switch (edidVer) {
+        case HDMI_EDID_VER_14:
+            response["edidVersion"] = "HDMI1.4";
+            break;
+        case HDMI_EDID_VER_20:
+            response["edidVersion"] = "HDMI2.0";
+            break;
+    }
+
+    if (edidVer < 0) {
+        return Core::ERROR_GENERAL;;
+    }
+    else {
+        return Core::ERROR_NONE;
+    }
+}
+
+int AVInput::getEdidVersion(int iPort)
+{
+    int edidVersion = -1;
+
+    try {
+        device::HdmiInput::getInstance().getEdidVersion (iPort, &edidVersion);
+        LOGWARN("AVInput::getEdidVersion EDID Version:%d", edidVersion);
+    }
+    catch (const device::Exception& err) {
+        LOG_DEVICE_EXCEPTION1(std::to_string(iPort));
+    }
+    return edidVersion;
 }
 
 } // namespace Plugin

--- a/AVInput/AVInput.h
+++ b/AVInput/AVInput.h
@@ -20,6 +20,8 @@
 #pragma once
 
 #include "Module.h"
+#include "libIBus.h"
+#include "dsTypes.h"
 
 namespace WPEFramework {
 namespace Plugin {
@@ -46,10 +48,6 @@ public:
     virtual void Deinitialize(PluginHost::IShell *service) override;
     virtual string Information() const override;
 
-public:
-    void event_onAVInputActive(int id);
-    void event_onAVInputInactive(int id);
-
 protected:
     void InitializeIARM();
     void DeinitializeIARM();
@@ -64,6 +62,46 @@ protected:
 private:
     static int numberOfInputs(bool &success);
     static string currentVideoMode(bool &success);
+
+    //Begin methods
+    uint32_t getInputDevicesWrapper(const JsonObject& parameters, JsonObject& response);
+    uint32_t writeEDIDWrapper(const JsonObject& parameters, JsonObject& response);
+    uint32_t readEDIDWrapper(const JsonObject& parameters, JsonObject& response);
+    uint32_t getRawSPDWrapper(const JsonObject& parameters, JsonObject& response);
+    uint32_t getSPDWrapper(const JsonObject& parameters, JsonObject& response);
+    uint32_t setEdidVersionWrapper(const JsonObject& parameters, JsonObject& response);
+    uint32_t getEdidVersionWrapper(const JsonObject& parameters, JsonObject& response);
+    uint32_t startInput(const JsonObject& parameters, JsonObject& response);
+    uint32_t stopInput(const JsonObject& parameters, JsonObject& response);
+    uint32_t setVideoRectangleWrapper(const JsonObject& parameters, JsonObject& response);
+    uint32_t getSupportedGameFeatures(const JsonObject& parameters, JsonObject& response);
+    uint32_t getGameFeatureStatusWrapper(const JsonObject& parameters, JsonObject& response);
+    //End methods
+
+    JsonArray getInputDevices(int iType);
+    void writeEDID(int deviceId, std::string message);
+    std::string readEDID(int iPort);
+    std::string getRawSPD(int iPort);
+    std::string getSPD(int iPort);
+    int setEdidVersion(int iPort, int iEdidVer);
+    int getEdidVersion(int iPort);
+    bool setVideoRectangle(int x, int y, int width, int height, int type);
+    bool getALLMStatus(int iPort);
+
+    void AVInputHotplug(int input , int connect, int type);
+    static void dsAVEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
+
+    void AVInputSignalChange( int port , int signalStatus, int type);
+    static void dsAVSignalStatusEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
+
+    void AVInputStatusChange( int port , bool isPresented, int type);
+    static void dsAVStatusEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
+
+    void AVInputVideoModeUpdate( int port , dsVideoPortResolution_t resolution);
+    static void dsAVVideoModeEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
+
+    void AVInputALLMChange( int port , bool allmMode);
+    static void dsAVGameFeatureStatusEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
 
 public:
     static AVInput* _instance;

--- a/AVInput/AVInput.json
+++ b/AVInput/AVInput.json
@@ -10,7 +10,54 @@
         "$ref": "../common/common.json"
     },
     "definitions": {
-        
+        "devices":{
+            "summary": "An object [] that describes each HDMI/Composite Input port",
+            "type":"array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "$ref": "#/definitions/id"
+                    },
+                    "locator": {
+                        "$ref": "#/definitions/locator"
+                    },
+                    "connected": {
+                        "$ref": "#/definitions/connected"
+                    }
+                },
+                "required": [
+                    "id",
+                    "locator",
+                    "connected"
+                ]
+            }
+        },
+        "id": {
+            "summary": "The port identifier for the HDMI/Composite Input",
+            "type": "number",
+            "example": 0
+        },
+        "locator": {
+            "summary": "A URL corresponding to the HDMI/Composite Input port",
+            "type": "string",
+            "example": "hdmiin://localhost/deviceid/0"
+        },
+        "connected": {
+            "summary": "Whether a device is currently connected to this HDMI/Composite Input port",
+            "type": "boolean",
+            "example": true
+        },
+        "portId":{
+            "summary": "An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method",
+            "type": "number",
+            "example": "0"
+        },
+        "typeOfInput":{
+            "summary": "The type of Input - HDMI/COMPOSITE",
+            "type": "string",
+            "example": "HDMI"
+        }
     },
     "methods": {
         "contentProtected": {
@@ -99,40 +146,561 @@
                     "success"
                 ]
             }
+        },
+        "getInputDevices": {
+            "summary": "Returns an array of available HDMI/Composite Input ports.",
+            "params": {
+                "type": "object",
+                "properties": {
+                    "typeOfInput": {
+                        "$ref": "#/definitions/typeOfInput"
+                    }
+                }
+            },
+            "result": {
+                "type": "object",
+                "properties": {
+                    "devices": {
+                        "$ref": "#/definitions/devices"
+                    }
+                },
+                "required": [
+                    "devices"
+                ]
+            },
+            "errors": [
+                {
+                    "description": "Type of Input is invalid",
+                    "$ref": "#/common/errors/badrequest"
+                }
+            ]
+        },
+        "getEdidVersion":{
+            "summary": "Returns the EDID version.",
+            "params": {
+                "type":"object",
+                "properties": {
+                    "portId":{
+                        "$ref": "#/definitions/portId"
+                    }
+                },
+                "required": [
+                    "portid"
+                ]
+            },
+            "result": {
+                "type": "object",
+                "properties": {
+                    "edidVersion": {
+                        "summary": "The EDID version",
+                        "type": "string",
+                        "example": "HDMI2.0"
+                    }
+                },
+                "required": [
+                    "edidVersion"
+                ]
+            },
+            "errors": [
+                {
+                    "description": "General error",
+                    "$ref": "#/common/errors/general"
+                },
+                {
+                  "description": "portId is invalid",
+                  "$ref": "#/common/errors/badrequest"
+                }
+            ]
+        },
+        "getSPD": {
+            "summary": "Returns the Source Data Product Descriptor (SPD) infoFrame packet information for the specified HDMI Input device. The SPD infoFrame packet includes vendor name, product description, and source information.",
+            "params": {
+                "type":"object",
+                "properties": {
+                    "portId":{
+                        "$ref": "#/definitions/portId"
+                    }
+                },
+                "required": [
+                    "portid"
+                ]
+            },
+            "result": {
+                "type": "object",
+                "properties": {
+                    "HDMISPD": {
+                        "summary": "The SPD information",
+                        "type": "string",
+                        "example": ""
+                    }
+                },
+                "required": [
+                    "HDMISPD"
+                ]
+            },
+            "errors": [
+                {
+                    "description": "General error",
+                    "$ref": "#/common/errors/general"
+                },
+                {
+                  "description": "portId is invalid",
+                  "$ref": "#/common/errors/badrequest"
+                }
+            ]
+        },
+        "getRawSPD":{
+            "summary": "Returns the Source Data Product Descriptor (SPD) infoFrame packet information for the specified HDMI Input device as raw bits.",
+            "params": {
+                "type":"object",
+                "properties": {
+                    "portId":{
+                        "$ref": "#/definitions/portId"
+                    }
+                },
+                "required": [
+                    "portId"
+                ]
+            },
+            "result": {
+                "type": "object",
+                "properties": {
+                    "HDMISPD": {
+                        "summary": "The SPD information as raw bits",
+                        "type": "string",
+                        "example": ""
+                    }
+                },
+                "required": [
+                    "HDMISPD"
+                ]
+            },
+            "errors": [
+                {
+                    "description": "General error",
+                    "$ref": "#/common/errors/general"
+                },
+                {
+                  "description": "portId is invalid",
+                  "$ref": "#/common/errors/badrequest"
+                }
+            ]
+        },
+        "readEDID":{
+            "summary": "Returns the current EDID value.",
+            "params": {
+                "type":"object",
+                "properties": {
+                    "portId":{
+                        "$ref": "#/definitions/portId"
+                    }
+                },
+                "required": [
+                    "portId"
+                ]
+            },
+            "result": {
+                "type": "object",
+                "properties": {
+                    "EDID": {
+                        "summary": "The EDID Value",
+                        "type": "string",
+                        "example": ""
+                    }
+                },
+                "required": [
+                    "EDID"
+                ]
+            },
+            "errors": [
+                {
+                    "description": "General error",
+                    "$ref": "#/common/errors/general"
+                },
+                {
+                  "description": "portId is invalid",
+                  "$ref": "#/common/errors/badrequest"
+                }
+            ]
+        },
+        "startInput": {
+            "summary": "Activates the specified HDMI/Composite Input port as the primary video source.",
+            "events": {
+                "onInputStatusChanged" : "Triggers the event when HDMI/Composite Input source is activated and Input status changes to `started`",
+                "onSignalChanged" : "Triggers the event when HDMI/Composite Input signal changes (must be one of the following:noSignal, unstableSignal, notSupportedSignal, stableSignal)"
+            },
+            "params": {
+                "type":"object",
+                "properties": {
+                    "portId":{
+                        "$ref": "#/definitions/portId"
+                    },
+                    "typeOfInput":{
+                        "$ref": "#/definitions/typeOfInput"
+                    }
+                },
+                "required": [
+                    "portid",
+                    "typeOfInput"
+                ]
+            },
+            "result": {
+                "$ref": "#/common/results/void"
+            },
+            "errors": [
+                {
+                    "description": "General error",
+                    "$ref": "#/common/errors/general"
+                },
+                {
+                    "description": "portId/Type of Input is invalid",
+                    "$ref": "#/common/errors/badrequest"
+                }
+            ]
+        },
+        "stopInput": {
+            "summary": "Deactivates the HDMI/Composite Input port currently selected as the primary video source.",
+            "events": {
+                "onInputStatusChanged" : "Triggers the event when HDMI/Composite Input source is deactivated and Input status changes to `stopped`"
+            },
+            "params": {
+                "type":"object",
+                "properties": {
+                    "typeOfInput":{
+                        "$ref": "#/definitions/typeOfInput"
+                    }
+                },
+                "required": [
+                    "typeOfInput"
+                ]
+            },
+            "result": {
+                "$ref": "#/common/results/void"
+            },
+            "errors": [
+                {
+                    "description": "General error",
+                    "$ref": "#/common/errors/general"
+                },
+                {
+                    "description": "Type of Input is invalid",
+                    "$ref": "#/common/errors/badrequest"
+                }
+            ]
+        },
+        "setEdidVersion": {
+            "summary": "Sets an HDMI EDID version.",
+            "params": {
+                "type":"object",
+                "properties": {
+                    "portId":{
+                        "$ref": "#/definitions/portId"
+                    },
+                    "edidVersion":{
+                        "summary": "The EDID version",
+                        "type": "string",
+                        "example": "HDMI2.0"
+                    }
+                },
+                "required": [
+                    "portId",
+                    "edidVersion"
+                ]
+            },
+            "result": {
+                "$ref": "#/common/results/void"
+            },
+            "errors": [
+                {
+                    "description": "General error",
+                    "$ref": "#/common/errors/general"
+                },
+                {
+                    "description": "portId/edidVersion is invalid",
+                    "$ref": "#/common/errors/badrequest"
+                }
+            ]
+        },
+        "setVideoRectangle": {
+            "summary": "Sets an HDMI/Composite Input video window.",
+            "params": {
+                "type":"object",
+                "properties": {
+                    "x":{
+                        "summary": "The x-coordinate of the video rectangle",
+                        "type": "integer",
+                        "example": 0
+                    },
+                    "y":{
+                        "summary": "The y-coordinate of the video rectangle",
+                        "type": "integer",
+                        "example": 0
+                    },
+                    "w":{
+                        "summary": "The width of the video rectangle",
+                        "type": "integer",
+                        "example": 1920
+                    },
+                    "h":{
+                        "summary": "The height of the video rectangle",
+                        "type": "integer",
+                        "example": 1080
+                    },
+                    "typeOfInput":{
+                        "$ref": "#/definitions/typeOfInput"
+                    }
+                },
+                "required": [
+                    "x",
+                    "y",
+                    "w",
+                    "h",
+                    "typeOfInput"
+                ]
+            },
+            "result": {
+                "$ref": "#/common/results/void"
+            },
+            "errors": [
+                {
+                    "description": "General error",
+                    "$ref": "#/common/errors/general"
+                },
+                {
+                    "description": "Coordinates/Type of Input is invalid",
+                    "$ref": "#/common/errors/badrequest"
+                }
+            ]
+        },
+        "writeEDID": {
+            "summary": "Changes a current EDID value.",
+            "params": {
+                "type":"object",
+                "properties": {
+                    "portId":{
+                        "$ref": "#/definitions/portId"
+                    },
+                    "message":{
+                        "summary": "A new EDID value",
+                        "type": "string",
+                        "example": "EDID"
+                    }
+                },
+                "required": [
+                    "portId",
+                    "message"
+                ]
+            },
+            "result": {
+                "$ref": "#/common/results/void"
+            },
+            "errors": [
+                {
+                    "description": "Coordinates/Type of Input is invalid",
+                    "$ref": "#/common/errors/badrequest"
+                }
+            ]
+        },
+       "getSupportedGameFeatures":{
+            "summary": "Returns the list of supported game features.",
+            "result": {
+                "type": "object",
+                "properties": {
+                    "supportedGameFeatures": {
+                        "summary": "The supported game Features",
+                        "type": "array",
+                        "items": {
+                            "type":"string",
+                            "example": "ALLM"
+                        }
+                    }
+                },
+                "required": [
+                    "supportedGameFeatures"
+                ]
+            },
+            "errors": [
+                {
+                    "description": "General error",
+                    "$ref": "#/common/errors/general"
+                }
+            ]
+        },
+       "getGameFeatureStatus":{
+            "summary": "Returns the Game Feature Status. For example: ALLM.",
+            "params": {
+                "type":"object",
+                "properties": {
+                    "portId":{
+                        "$ref": "#/definitions/portId"
+                    },
+                     "gameFeature": {
+                        "summary": "Game Feature to which current status requested",
+                        "type": "string",
+                        "example": "ALLM"
+                    }
+               },
+                "required": [
+                    "portid",
+                    "gameFeature"
+                ]
+            },
+            "result": {
+                "type": "object",
+                "properties": {
+                    "mode": {
+                        "summary": "The current game feature status. Mode is required only for ALLM. Need to add support for future game features",
+                        "type": "boolean",
+                        "example": true
+                    }
+                },
+                "required": [
+                    "mode"
+                ]
+            },
+            "errors": [
+                {
+                    "description": "Coordinates/Type of Input is invalid",
+                    "$ref": "#/common/errors/badrequest"
+                }
+            ]
         }
     },
     "events": {
-        "onAVInputActive":{
-            "summary": "Triggered when an active device is connected to an AVInput port",
+        "onDevicesChanged": {
+            "summary": "Triggered whenever a new HDMI/Composite device is connected to an HDMI/Composite Input",
             "params": {
                 "type":"object",
                 "properties": {
-                    "url": {
-                        "summary": "The URL of the port with an active device",
-                        "type": "string",
-                        "example": "avin://input0"
+                    "devices":{
+                        "$ref": "#/definitions/devices"
                     }
                 },
                 "required": [
-                    "url"
+                    "devices"
                 ]
             }
         },
-        "onAVInputInActive": {
-            "summary": "Triggered when an active device is disconnected from an AVInput port or when the device becomes inactive",
+        "onInputStatusChanged": {
+            "summary": "Triggered whenever the status changes for an HDMI/Composite Input",
             "params": {
-                "type":"object",
+                "type": "object",
                 "properties": {
-                    "url": {
-                        "summary": "The URL of the port with an inactive device",
+                    "id": {
+                        "$ref": "#/definitions/id"
+                    },
+                    "locator": {
+                        "$ref": "#/definitions/locator"
+                    },
+                    "status": {
+                        "summary": "Status of the HDMI/Composite Input. Valid values are `started` or `stopped`.",
                         "type": "string",
-                        "example": "avin://input0"
+                        "example": "started"
                     }
                 },
                 "required": [
-                    "url"
+                    "id",
+                    "locator",
+                    "status"
                 ]
-                
+            }
+        },
+        "onSignalChanged": {
+            "summary": "Triggered whenever the signal status changes for an HDMI/Composite Input",
+            "params": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "$ref": "#/definitions/id"
+                    },
+                    "locator": {
+                        "$ref": "#/definitions/locator"
+                    },
+                    "signalStatus": {
+                        "summary": "Signal Status of the HDMI/Composite Input. Valid values are `noSignal`, `unstableSignal`, `notSupportedSignal`, `stableSignal`.",
+                        "type": "string",
+                        "example": "stableSignal"
+                    }
+                },
+                "required": [
+                    "id",
+                    "locator",
+                    "signalStatus"
+                ]
+            }
+        },
+        "videoStreamInfoUpdate": {
+            "summary": "Triggered whenever there is an update in HDMI Input video stream info",
+            "params": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "$ref": "#/definitions/id"
+                    },
+                    "locator": {
+                        "$ref": "#/definitions/locator"
+                    },
+                    "width": {
+                        "summary": "Width of the Video Stream",
+                        "type": "integer",
+                        "example": 3840
+                    },
+                    "height": {
+                        "summary": "Height of the Video Stream",
+                        "type": "integer",
+                        "example": 2160
+                    },
+                    "progressive": {
+                        "summary": "Whether the streaming video is progressive or not?",
+                        "type": "boolean",
+                        "example": true
+                    },
+                    "frameRateN": {
+                        "summary": "FrameRate Numerator",
+                        "type": "integer",
+                        "example": 60000
+                    },
+                    "frameRateD": {
+                        "summary": "FrameRate Denomirator",
+                        "type": "integer",
+                        "example": 1001
+                    }
+                },
+                "required": [
+                    "id",
+                    "locator",
+                    "width",
+                    "height",
+                    "progressive",
+                    "frameRateN",
+                    "frameRateD"
+                ]
+            }
+        },
+        "gameFeatureStatusUpdate": {
+            "summary": "Triggered whenever game feature(ALLM) status changes for an HDMI Input",
+            "params": {
+                "type": "object",
+                "properties": {
+                   "id": {
+                        "$ref": "#/definitions/id"
+                    },
+                     "gameFeature": {
+                        "summary": "Game Feature to which current status requested",
+                        "type": "string",
+                        "example": "ALLM"
+                    },
+                    "mode": {
+                        "summary": "The current game feature status. Mode is required only for ALLM. Need to add support for future game features",
+                        "type": "boolean",
+                        "example": true
+                    }
+                },
+                "required": [
+                    "id",
+                    "gameFeature",
+                    "mode"
+                ]
             }
         }
     }

--- a/AVInput/AVInputPlugin.json
+++ b/AVInput/AVInputPlugin.json
@@ -5,7 +5,7 @@
       "callsign": "org.rdk.AVInput",
       "locator": "libWPEFrameworkAVInput.so",
       "status": "production",
-      "description": "The `AVInput` plugin facilitates interactions with the Parker STB HDMI input. The HDMI input is presented by using a `VideoResource` whose URL starts with `avin:`. For example: `avin://input1`."
+      "description": "The `AVInput` plugin allows you to control the Hdmi and Composite input source on a device."
     },
     "interface": {
       "$ref": "AVInput.json#"

--- a/AVInput/CHANGELOG.md
+++ b/AVInput/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.0.1] - 2022-10-10
+### Added
+- Combine HdmiInput and CompositeInput Plugins into AVInput
+
 ## [1.0.0] - 2022-05-11
 ### Added
 - Add CHANGELOG

--- a/Tests/headers/rdk/ds/compositeIn.hpp
+++ b/Tests/headers/rdk/ds/compositeIn.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <stdint.h>
+
+namespace device {
+class CompositeInputImpl {
+public:
+    virtual ~CompositeInputImpl() = default;
+    virtual uint8_t getNumberOfInputs        () const = 0 ;
+    virtual bool    isPortConnected          (int8_t Port) const = 0 ;
+    virtual void    selectPort               (int8_t Port) const = 0 ;
+    virtual void    scaleVideo               (int32_t x, int32_t y, int32_t width, int32_t height) const = 0 ;
+};
+
+class CompositeInput {
+public:
+    static CompositeInput & getInstance()
+    {
+        static CompositeInput instance;
+        return instance;
+    }
+    
+    CompositeInputImpl* impl;
+
+    uint8_t getNumberOfInputs() const
+    {
+        return impl->getNumberOfInputs();
+    }
+    bool isPortConnected(int8_t Port) const
+    {
+        return impl->isPortConnected(Port);
+    }
+    void selectPort(int8_t Port) const
+    {
+        return impl->selectPort(Port);
+    }
+    void scaleVideo(int32_t x, int32_t y, int32_t width, int32_t height) const
+    {
+        return impl->scaleVideo(x,y,width,height);
+    }
+};
+
+}

--- a/Tests/headers/rdk/ds/dsMgr.h
+++ b/Tests/headers/rdk/ds/dsMgr.h
@@ -6,8 +6,68 @@ typedef enum _DSMgr_EventId_t {
     IARM_BUS_DSMGR_EVENT_DISPLAY_FRAMRATE_PRECHANGE,
     IARM_BUS_DSMGR_EVENT_DISPLAY_FRAMRATE_POSTCHANGE,
     IARM_BUS_DSMGR_EVENT_HDMI_IN_HOTPLUG,
+    IARM_BUS_DSMGR_EVENT_HDMI_IN_SIGNAL_STATUS,
+    IARM_BUS_DSMGR_EVENT_HDMI_IN_STATUS,
+    IARM_BUS_DSMGR_EVENT_HDMI_IN_VIDEO_MODE_UPDATE,
+    IARM_BUS_DSMGR_EVENT_HDMI_IN_ALLM_STATUS,
+    IARM_BUS_DSMGR_EVENT_COMPOSITE_IN_HOTPLUG,
+    IARM_BUS_DSMGR_EVENT_COMPOSITE_IN_SIGNAL_STATUS,
+    IARM_BUS_DSMGR_EVENT_COMPOSITE_IN_STATUS,
 } IARM_Bus_DSMgr_EventId_t;
 
 typedef enum _dsHDRStandard_t {
     dsHDRSTANDARD_NONE = 0x0,
 } dsHDRStandard_t;
+
+/*! DS Manager  Event Data */
+typedef struct _DSMgr_EventData_t {
+    union {
+        struct _HDMI_IN_CONNECT_DATA
+        {
+            dsHdmiInPort_t port;
+            bool           isPortConnected;
+        }hdmi_in_connect;
+
+        struct _HDMI_IN_STATUS_DATA{
+         /* Declare HDMI Input status*/
+            dsHdmiInPort_t port;
+            bool           isPresented;
+        }hdmi_in_status; /*HDMI in status change detect*/
+
+        struct _HDMI_IN_SIG_STATUS_DATA{
+         /* Declare HDMI In signal status*/
+            dsHdmiInPort_t port;
+            dsHdmiInSignalStatus_t status;
+        }hdmi_in_sig_status; /*HDMI in signal change detect*/
+
+        struct _HDMI_IN_VIDEO_MODE_DATA{
+         /* Declare HDMI In signal status*/
+            dsHdmiInPort_t port;
+            dsVideoPortResolution_t resolution;
+        }hdmi_in_video_mode; /*HDMI in video mode update*/
+
+        struct _COMPOSITE_IN_CONNECT_DATA
+        {
+            dsCompositeInPort_t port;
+            bool           isPortConnected;
+        }composite_in_connect;
+
+        struct _COMPOSITE_IN_STATUS_DATA{
+         /* Declare Composite Input status*/
+            dsCompositeInPort_t port;
+            bool           isPresented;
+        }composite_in_status; /*Composite in status change detect*/
+
+        struct _COMPOSITE_IN_SIG_STATUS_DATA{
+         /* Declare Composite In signal status*/
+            dsCompositeInPort_t port;
+            dsCompInSignalStatus_t status;
+        }composite_in_sig_status; /*Composite in signal change detect*/
+
+        struct _HDMI_IN_ALLM_MODE_DATA{
+         /* Declare HDMI In ALLM Mode*/
+            dsHdmiInPort_t port;
+            bool allm_mode;
+        }hdmi_in_allm_mode; /*HDMI in ALLM Mode change*/
+    } data;
+}IARM_Bus_DSMgr_EventData_t;

--- a/Tests/headers/rdk/ds/dsTypes.h
+++ b/Tests/headers/rdk/ds/dsTypes.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef _DS_TYPES_H_
+#define _DS_TYPES_H_
 
 typedef enum _dsHdcpProtocolVersion_t {
     dsHDCP_VERSION_1X = 0,
@@ -25,3 +27,142 @@ typedef enum _dsMS12Capabilities_t {
     dsMS12SUPPORT_DialogueEnhancer = 0x04,
     dsMS12SUPPORT_Invalid = 0x80,
 } dsMS12Capabilities_t;
+
+/**
+ * This enumeration defines all of the standard video port resolutions that can be used.
+ */
+typedef enum _dsVideoResolution_t{
+    dsVIDEO_PIXELRES_720x480,     /**< 720x480 Resolution.                         */
+    dsVIDEO_PIXELRES_720x576,     /**< 720x576 Resolution.                         */
+    dsVIDEO_PIXELRES_1280x720,    /**< 1280x720 Resolution.                        */
+    dsVIDEO_PIXELRES_1920x1080,   /**< 1920x1080 Resolution.                       */
+
+    dsVIDEO_PIXELRES_3840x2160,   /**< 3840x2160 Resolution.                       */
+    dsVIDEO_PIXELRES_4096x2160,   /**< 3840x2160 Resolution.                       */
+
+    dsVIDEO_PIXELRES_MAX         /**< Maximum index for Video ouptut resolutions. */
+}dsVideoResolution_t;
+
+/**
+ * This enumeration defines all of the standard frame rates at which video may be played out of the video port.
+ */
+typedef enum _dsVideoFrameRate_t{
+    dsVIDEO_FRAMERATE_UNKNOWN,    /**< Unknown frame rate.                       */
+    dsVIDEO_FRAMERATE_24,         /**< Played at 24 frames per second.           */
+    dsVIDEO_FRAMERATE_25,         /**< Played at 25 frames per second.           */
+    dsVIDEO_FRAMERATE_30,         /**< Played at 30 frames per second.           */
+    dsVIDEO_FRAMERATE_60,         /**< Played at 60 frames per second.           */
+    dsVIDEO_FRAMERATE_23dot98,    /**< Played at 23.98 frames per second.        */
+    dsVIDEO_FRAMERATE_29dot97,    /**< Played at 29.97 frames per second.        */
+    dsVIDEO_FRAMERATE_50,         /**< Played at 50 frames per second.           */
+    dsVIDEO_FRAMERATE_59dot94,    /**< Played at 59.94 frames per second.        */
+    dsVIDEO_FRAMERATE_MAX         /**< Maximum index for video frame rates.      */
+}dsVideoFrameRate_t;
+
+/**
+ * This enumeration defines all of the standard video aspect ratios.
+ */
+typedef enum _dsVideoAspectRatio_t{
+    dsVIDEO_ASPECT_RATIO_4x3,     /**< 4:3 aspect ratio.                      */
+    dsVIDEO_ASPECT_RATIO_16x9,    /**< 16:9 aspect ratio.                     */
+    dsVIDEO_ASPECT_RATIO_MAX     /**< Maximum index for video aspect ratios. */
+}dsVideoAspectRatio_t;
+
+/**
+ * This enumeration defines all of the standard video Stereo Scopic modes.
+ */
+typedef enum _dsVideoStereoScopicMode_t {
+    dsVIDEO_SSMODE_UNKNOWN = 0,          /**< Unknown mode.                                */
+    dsVIDEO_SSMODE_2D,                   /**< 2D mode.                                     */
+    dsVIDEO_SSMODE_3D_SIDE_BY_SIDE,      /**< 3D side by side (L/R) stereo mode.           */
+    dsVIDEO_SSMODE_3D_TOP_AND_BOTTOM,    /**< 3D top & bottom stereo mode.                 */
+    dsVIDEO_SSMODE_MAX                   /**< Maximum index for video stereoscopic modes.  */
+}dsVideoStereoScopicMode_t;
+
+/**
+ * @ingroup DSHAL_VIDEOPORT_TYPES
+ * @brief Structure that defines video port resolution settings of output video device.
+ */
+typedef struct _dsVideoPortResolution_t {
+    char name[32];                                    /**< Name the resolution (e.g. 480i, 480p, 1080p24).   */
+    dsVideoResolution_t  pixelResolution;           /**< The resolution associated with the name.                 */
+    dsVideoAspectRatio_t  aspectRatio;              /**< The associated aspect ratio.                             */
+    dsVideoStereoScopicMode_t  stereoScopicMode;    /**< The associated stereoscopic mode.                        */
+    dsVideoFrameRate_t  frameRate;                  /**< The associated frame rate.                               */
+    bool interlaced;                                /**< The associated scan mode(@a true if interlaced, @a false if progressive). */
+}dsVideoPortResolution_t;
+
+ /** @addtogroup DSHAL_HDMI_IN_TYPES Device Settings HAL HDMI IN Type Definitions
+ *  @ingroup DSHAL_HDMI_IN
+ *  @{
+ */
+typedef enum _dsHdmiInPort_t
+{
+    dsHDMI_IN_PORT_NONE = -1,
+    dsHDMI_IN_PORT_0,
+    dsHDMI_IN_PORT_1,
+    dsHDMI_IN_PORT_2,
+    dsHDMI_IN_PORT_MAX
+} dsHdmiInPort_t;
+
+/** @addtogroup DSHAL_HDMI_IN_TYPES Device Settings HAL HDMI IN Signal Status Definitions
+ *  @ingroup DSHAL_HDMI_IN
+ *  @{
+ */
+typedef enum _dsHdmiInSignalStatus_t
+{
+    dsHDMI_IN_SIGNAL_STATUS_NONE = -1,
+    dsHDMI_IN_SIGNAL_STATUS_NOSIGNAL,
+    dsHDMI_IN_SIGNAL_STATUS_UNSTABLE,
+    dsHDMI_IN_SIGNAL_STATUS_NOTSUPPORTED,
+    dsHDMI_IN_SIGNAL_STATUS_STABLE,
+    dsHDMI_IN_SIGNAL_STATUS_MAX
+} dsHdmiInSignalStatus_t;
+
+typedef enum tv_hdmi_edid_version_e {
+    HDMI_EDID_VER_14 = 0,
+    HDMI_EDID_VER_20,
+    HDMI_EDID_VER_MAX,
+} tv_hdmi_edid_version_t;
+
+/** @addtogroup DSHAL_COMPOSITE_IN_TYPES Device Settings HAL Composite IN Signal Status Definitions
+ *  @ingroup DSHAL_COMPOSITE_IN
+ *  @{
+ */
+typedef enum _dsCompInSignalStatus_t
+{
+    dsCOMP_IN_SIGNAL_STATUS_NONE = -1,
+    dsCOMP_IN_SIGNAL_STATUS_NOSIGNAL,
+    dsCOMP_IN_SIGNAL_STATUS_UNSTABLE,
+    dsCOMP_IN_SIGNAL_STATUS_NOTSUPPORTED,
+    dsCOMP_IN_SIGNAL_STATUS_STABLE,
+    dsCOMP_IN_SIGNAL_STATUS_MAX
+} dsCompInSignalStatus_t;
+
+ /** @addtogroup DSHAL_HDMI_IN_TYPES Device Settings HAL COMPOSITE IN Type Definitions
+ *  @ingroup DSHAL_COMPOSITE_IN
+ *  @{
+ */
+typedef enum _dsCompositeInPort_t
+{
+    dsCOMPOSITE_IN_PORT_NONE = -1,
+    dsCOMPOSITE_IN_PORT_0,
+    dsCOMPOSITE_IN_PORT_1,
+    dsCOMPOSITE_IN_PORT_MAX
+} dsCompositeInPort_t;
+
+struct dsSpd_infoframe_st {
+    uint8_t pkttype;
+    uint8_t version;
+    uint8_t length;             /*length=25*/
+    uint8_t rsd;
+    uint8_t checksum;
+    /*Vendor Name Character*/
+    uint8_t vendor_name[8];
+    /*Product Description Character*/
+    uint8_t product_des[16];
+    /*byte 25*/
+    uint8_t source_info;
+} ;
+
+#endif

--- a/Tests/headers/rdk/ds/hdmiIn.hpp
+++ b/Tests/headers/rdk/ds/hdmiIn.hpp
@@ -11,6 +11,14 @@ public:
     virtual uint8_t getNumberOfInputs() const = 0;
     virtual bool isPortConnected(int8_t Port) const = 0;
     virtual std::string getCurrentVideoMode() const = 0;
+    virtual void selectPort (int8_t Port) const = 0;
+    virtual void scaleVideo (int32_t x, int32_t y, int32_t width, int32_t height) const = 0;
+    virtual void getEDIDBytesInfo (int iHdmiPort, std::vector<uint8_t> &edid) const = 0;
+    virtual void getHDMISPDInfo (int iHdmiPort, std::vector<uint8_t> &data) const = 0;
+    virtual void setEdidVersion (int iHdmiPort, int iEdidVersion) const = 0;
+    virtual void getEdidVersion (int iHdmiPort, int *iEdidVersion) const = 0;
+    virtual void getHdmiALLMStatus (int iHdmiPort, bool *allmStatus) const = 0;
+    virtual void getSupportedGameFeatures (std::vector<std::string> &featureList) const = 0;
 };
 
 class HdmiInput {
@@ -34,6 +42,38 @@ public:
     std::string getCurrentVideoMode() const
     {
         return impl->getCurrentVideoMode();
+    }
+    void selectPort (int8_t Port) const
+    {
+        return impl->selectPort(Port);
+    }
+    void scaleVideo (int32_t x, int32_t y, int32_t width, int32_t height) const
+    {
+        return impl->scaleVideo (x, y, width, height);
+    }
+    void getEDIDBytesInfo (int iHdmiPort, std::vector<uint8_t> &edid) const
+    {
+        return impl->getEDIDBytesInfo(iHdmiPort, edid);
+    }
+    void getHDMISPDInfo (int iHdmiPort, std::vector<uint8_t> &data) const
+    {
+        return impl->getHDMISPDInfo(iHdmiPort, data);
+    }
+    void setEdidVersion (int iHdmiPort, int iEdidVersion) const
+    {
+        return impl->setEdidVersion(iHdmiPort, iEdidVersion);
+    }
+    void getEdidVersion (int iHdmiPort, int *iEdidVersion) const
+    {
+        return impl->getEdidVersion(iHdmiPort,iEdidVersion);
+    }
+    void getHdmiALLMStatus (int iHdmiPort, bool *allmStatus) const
+    {
+        return impl->getHdmiALLMStatus(iHdmiPort, allmStatus);
+    }
+    void getSupportedGameFeatures (std::vector<std::string> &featureList) const
+    {
+        return impl->getSupportedGameFeatures(featureList);
     }
 };
 

--- a/Tests/mocks/devicesettings/HdmiInputMock.h
+++ b/Tests/mocks/devicesettings/HdmiInputMock.h
@@ -11,4 +11,12 @@ public:
     MOCK_METHOD(uint8_t, getNumberOfInputs, (), (const, override));
     MOCK_METHOD(bool, isPortConnected, (int8_t Port), (const, override));
     MOCK_METHOD(std::string, getCurrentVideoMode, (), (const, override));
+    MOCK_METHOD(void, selectPort, (int8_t Port), (const, override));
+    MOCK_METHOD(void, scaleVideo, (int32_t x, int32_t y, int32_t width, int32_t height), (const, override));
+    MOCK_METHOD(void, getEDIDBytesInfo, (int iHdmiPort, std::vector<uint8_t> &edid), (const, override));
+    MOCK_METHOD(void, getHDMISPDInfo, (int iHdmiPort, std::vector<uint8_t> &data), (const, override));
+    MOCK_METHOD(void, setEdidVersion, (int iHdmiPort, int iEdidVersion), (const, override));
+    MOCK_METHOD(void, getEdidVersion, (int iHdmiPort, int *iEdidVersion), (const, override));
+    MOCK_METHOD(void, getHdmiALLMStatus, (int iHdmiPort, bool *allmStatus), (const, override));
+    MOCK_METHOD(void, getSupportedGameFeatures, (std::vector<std::string> &featureList), (const, override));
 };

--- a/Tests/tests/test_AVInput.cpp
+++ b/Tests/tests/test_AVInput.cpp
@@ -109,10 +109,10 @@ TEST_F(AVInputTestFixture, Plugin)
 
     // called by AVInput::InitializeIARM
     EXPECT_CALL(iarmBusImplMock, IARM_Bus_RegisterEventHandler(::testing::_, ::testing::_, ::testing::_))
-        .Times(1)
-        .WillOnce(::testing::Invoke(
+        .Times(8)
+        .WillRepeatedly(::testing::Invoke(
             [&](const char* ownerName, IARM_EventId_t eventId, IARM_EventHandler_t handler) {
-                if ((string(IARM_BUS_DSMGR_NAME) == string(ownerName)) && (eventId == IARM_BUS_DSMGR_EVENT_HDMI_IN_HOTPLUG)) {
+                if (string(IARM_BUS_DSMGR_NAME) == string(ownerName)) {
                     dsHdmiEventHandler = handler;
                     return IARM_RESULT_SUCCESS;
                 }
@@ -121,10 +121,10 @@ TEST_F(AVInputTestFixture, Plugin)
 
     // called by AVInput::DeinitializeIARM
     EXPECT_CALL(iarmBusImplMock, IARM_Bus_UnRegisterEventHandler(::testing::_, ::testing::_))
-        .Times(1)
-        .WillOnce(::testing::Invoke(
+        .Times(8)
+        .WillRepeatedly(::testing::Invoke(
             [&](const char* ownerName, IARM_EventId_t eventId) {
-                if ((string(IARM_BUS_DSMGR_NAME) == string(ownerName)) && (eventId == IARM_BUS_DSMGR_EVENT_HDMI_IN_HOTPLUG)) {
+                if (string(IARM_BUS_DSMGR_NAME) == string(ownerName)) {
                     dsHdmiEventHandler = nullptr;
                     return IARM_RESULT_SUCCESS;
                 }
@@ -135,13 +135,8 @@ TEST_F(AVInputTestFixture, Plugin)
 
     // called by AVInput::numberOfInputs, dsHdmiEventHandler
     EXPECT_CALL(hdmiInputImplMock, getNumberOfInputs())
-        .Times(2)
-        .WillRepeatedly(::testing::Return(1));
-
-    // called by dsHdmiEventHandler
-    EXPECT_CALL(hdmiInputImplMock, isPortConnected(::testing::_))
         .Times(1)
-        .WillRepeatedly(::testing::Return(true));
+        .WillRepeatedly(::testing::Return(1));
 
     // called by AVInput::currentVideoMode
     EXPECT_CALL(hdmiInputImplMock, getCurrentVideoMode())
@@ -149,22 +144,6 @@ TEST_F(AVInputTestFixture, Plugin)
         .WillRepeatedly(::testing::Return(string("unknown")));
 
     // IShell expectations
-
-    // called by AVInput::event_onAVInputActive
-    EXPECT_CALL(service, Submit(::testing::_, ::testing::_))
-        .Times(1)
-        .WillOnce(::testing::Invoke(
-            [&](const uint32_t, const Core::ProxyType<Core::JSON::IElement>& json) {
-                string text;
-                EXPECT_TRUE(json->ToString(text));
-                EXPECT_EQ(text, string(_T("{"
-                                          "\"jsonrpc\":\"2.0\","
-                                          "\"method\":\"org.rdk.AVInput.onAVInputActive\","
-                                          "\"params\":{\"url\":\"avin:\\/\\/input0\"}"
-                                          "}")));
-
-                return Core::ERROR_NONE;
-            }));
 
     // Initialize
 

--- a/docs/api/AVInputPlugin.md
+++ b/docs/api/AVInputPlugin.md
@@ -1,32 +1,70 @@
 <!-- Generated automatically, DO NOT EDIT! -->
-<a name="AVInput_Plugin"></a>
+<a name="head.AVInput_Plugin"></a>
 # AVInput Plugin
 
-**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/AVInput/CHANGELOG.md)**
+**Version: 1.0**
 
-A org.rdk.AVInput plugin for Thunder framework.
+**Status: :black_circle::black_circle::black_circle:**
+
+org.rdk.AVInput plugin for Thunder framework.
 
 ### Table of Contents
 
-- [Abbreviation, Acronyms and Terms](#Abbreviation,_Acronyms_and_Terms)
-- [Description](#Description)
-- [Configuration](#Configuration)
-- [Methods](#Methods)
-- [Notifications](#Notifications)
+- [Introduction](#head.Introduction)
+- [Description](#head.Description)
+- [Configuration](#head.Configuration)
+- [Methods](#head.Methods)
+- [Notifications](#head.Notifications)
 
-<a name="Abbreviation,_Acronyms_and_Terms"></a>
-# Abbreviation, Acronyms and Terms
+<a name="head.Introduction"></a>
+# Introduction
 
-[[Refer to this link](userguide/aat.md)]
+<a name="head.Scope"></a>
+## Scope
 
-<a name="Description"></a>
+This document describes purpose and functionality of the org.rdk.AVInput plugin. It includes detailed specification about its configuration, methods provided and notifications sent.
+
+<a name="head.Case_Sensitivity"></a>
+## Case Sensitivity
+
+All identifiers of the interfaces described in this document are case-sensitive. Thus, unless stated otherwise, all keywords, entities, properties, relations and actions should be treated as such.
+
+<a name="head.Acronyms,_Abbreviations_and_Terms"></a>
+## Acronyms, Abbreviations and Terms
+
+The table below provides and overview of acronyms used in this document and their definitions.
+
+| Acronym | Description |
+| :-------- | :-------- |
+| <a name="acronym.API">API</a> | Application Programming Interface |
+| <a name="acronym.HTTP">HTTP</a> | Hypertext Transfer Protocol |
+| <a name="acronym.JSON">JSON</a> | JavaScript Object Notation; a data interchange format |
+| <a name="acronym.JSON-RPC">JSON-RPC</a> | A remote procedure call protocol encoded in JSON |
+
+The table below provides and overview of terms and abbreviations used in this document and their definitions.
+
+| Term | Description |
+| :-------- | :-------- |
+| <a name="term.callsign">callsign</a> | The name given to an instance of a plugin. One plugin can be instantiated multiple times, but each instance the instance name, callsign, must be unique. |
+
+<a name="head.References"></a>
+## References
+
+| Ref ID | Description |
+| :-------- | :-------- |
+| <a name="ref.HTTP">[HTTP](http://www.w3.org/Protocols)</a> | HTTP specification |
+| <a name="ref.JSON-RPC">[JSON-RPC](https://www.jsonrpc.org/specification)</a> | JSON-RPC 2.0 specification |
+| <a name="ref.JSON">[JSON](http://www.json.org/)</a> | JSON specification |
+| <a name="ref.Thunder">[Thunder](https://github.com/WebPlatformForEmbedded/Thunder/blob/master/doc/WPE%20-%20API%20-%20WPEFramework.docx)</a> | Thunder API Reference |
+
+<a name="head.Description"></a>
 # Description
 
-The `AVInput` plugin facilitates interactions with the Parker STB HDMI input. The HDMI input is presented by using a `VideoResource` whose URL starts with `avin:`. For example: `avin://input1`.
+The `AVInput` plugin allows you to control the Hdmi and Composite input source on a device.
 
-The plugin is designed to be loaded and executed within the Thunder framework. For more information about the framework refer to [[Thunder](#Thunder)].
+The plugin is designed to be loaded and executed within the Thunder framework. For more information about the framework refer to [[Thunder](#ref.Thunder)].
 
-<a name="Configuration"></a>
+<a name="head.Configuration"></a>
 # Configuration
 
 The table below lists configuration options of the plugin.
@@ -38,7 +76,7 @@ The table below lists configuration options of the plugin.
 | locator | string | Library name: *libWPEFrameworkAVInput.so* |
 | autostart | boolean | Determines if the plugin shall be started automatically along with the framework |
 
-<a name="Methods"></a>
+<a name="head.Methods"></a>
 # Methods
 
 The following methods are provided by the org.rdk.AVInput plugin:
@@ -47,19 +85,27 @@ AVInput interface methods:
 
 | Method | Description |
 | :-------- | :-------- |
-| [contentProtected](#contentProtected) | Returns `true` if the content coming in the HDMI input is protected; otherwise, it returns `false` |
-| [currentVideoMode](#currentVideoMode) | Returns a string encoding the video mode being supplied by the device currently attached to the HDMI input |
-| [numberOfInputs](#numberOfInputs) | Returns an integer that specifies the number of available inputs |
+| [contentProtected](#method.contentProtected) | Returns `true` if the content coming in the HDMI input is protected; otherwise, it returns `false` |
+| [currentVideoMode](#method.currentVideoMode) | Returns a string encoding the video mode being supplied by the device currently attached to the HDMI input |
+| [numberOfInputs](#method.numberOfInputs) | Returns an integer that specifies the number of available inputs |
+| [getInputDevices](#method.getInputDevices) | Returns an array of available HDMI/Composite Input ports |
+| [getEdidVersion](#method.getEdidVersion) | Returns the EDID version |
+| [getSPD](#method.getSPD) | Returns the Source Data Product Descriptor (SPD) infoFrame packet information for the specified HDMI Input device |
+| [getRawSPD](#method.getRawSPD) | Returns the Source Data Product Descriptor (SPD) infoFrame packet information for the specified HDMI Input device as raw bits |
+| [readEDID](#method.readEDID) | Returns the current EDID value |
+| [startInput](#method.startInput) | Activates the specified HDMI/Composite Input port as the primary video source |
+| [stopInput](#method.stopInput) | Deactivates the HDMI/Composite Input port currently selected as the primary video source |
+| [setEdidVersion](#method.setEdidVersion) | Sets an HDMI EDID version |
+| [setVideoRectangle](#method.setVideoRectangle) | Sets an HDMI/Composite Input video window |
+| [writeEDID](#method.writeEDID) | Changes a current EDID value |
+| [getSupportedGameFeatures](#method.getSupportedGameFeatures) | Returns the list of supported game features |
+| [getGameFeatureStatus](#method.getGameFeatureStatus) | Returns the Game Feature Status |
 
 
-<a name="contentProtected"></a>
-## *contentProtected*
+<a name="method.contentProtected"></a>
+## *contentProtected [<sup>method</sup>](#head.Methods)*
 
 Returns `true` if the content coming in the HDMI input is protected; otherwise, it returns `false`. If the content is protected, then it is only presented if the component and composite outputs of the box are disabled.
-
-### Events
-
-No Events
 
 ### Parameters
 
@@ -83,7 +129,7 @@ No Events
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.AVInput.contentProtected",
+    "method": "org.rdk.AVInput.1.contentProtected",
     "params": {}
 }
 ```
@@ -101,14 +147,10 @@ No Events
 }
 ```
 
-<a name="currentVideoMode"></a>
-## *currentVideoMode*
+<a name="method.currentVideoMode"></a>
+## *currentVideoMode [<sup>method</sup>](#head.Methods)*
 
 Returns a string encoding the video mode being supplied by the device currently attached to the HDMI input. The format of the string is the same format used for the `resolutionName` parameter of the XRE `setResolution` messages. HDMI input is presentable if its resolution is less than or equal to the current Parker display resolution.
-
-### Events
-
-No Events
 
 ### Parameters
 
@@ -133,7 +175,7 @@ No Events
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.AVInput.currentVideoMode",
+    "method": "org.rdk.AVInput.1.currentVideoMode",
     "params": {}
 }
 ```
@@ -152,14 +194,10 @@ No Events
 }
 ```
 
-<a name="numberOfInputs"></a>
-## *numberOfInputs*
+<a name="method.numberOfInputs"></a>
+## *numberOfInputs [<sup>method</sup>](#head.Methods)*
 
 Returns an integer that specifies the number of available inputs. For example, a value of `2` indicates that there are two available inputs that can be selected using `avin://input0` and `avin://input1`.
-
-### Events
-
-No Events
 
 ### Parameters
 
@@ -184,7 +222,7 @@ No Events
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.AVInput.numberOfInputs",
+    "method": "org.rdk.AVInput.1.numberOfInputs",
     "params": {}
 }
 ```
@@ -203,10 +241,654 @@ No Events
 }
 ```
 
-<a name="Notifications"></a>
+<a name="method.getInputDevices"></a>
+## *getInputDevices [<sup>method</sup>](#head.Methods)*
+
+Returns an array of available HDMI/Composite Input ports.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.typeOfInput | string | The type of Input - HDMI/COMPOSITE |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.devices | array | An object [] that describes each HDMI/Composite Input port |
+| result.devices[#] | object |  |
+| result.devices[#].id | number | The port identifier for the HDMI/Composite Input |
+| result.devices[#].locator | string | A URL corresponding to the HDMI/Composite Input port |
+| result.devices[#].connected | boolean | Whether a device is currently connected to this HDMI/Composite Input port |
+
+### Errors
+
+| Code | Message | Description |
+| :-------- | :-------- | :-------- |
+| 30 | ```ERROR_BAD_REQUEST``` | Type of Input is invalid |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.AVInput.1.getInputDevices",
+    "params": {
+        "typeOfInput": "HDMI"
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "devices": [
+            {
+                "id": 0,
+                "locator": "hdmiin://localhost/deviceid/0",
+                "connected": true
+            }
+        ]
+    }
+}
+```
+
+<a name="method.getEdidVersion"></a>
+## *getEdidVersion [<sup>method</sup>](#head.Methods)*
+
+Returns the EDID version.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params?.portId | number | <sup>*(optional)*</sup> An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.edidVersion | string | The EDID version |
+
+### Errors
+
+| Code | Message | Description |
+| :-------- | :-------- | :-------- |
+| 1 | ```ERROR_GENERAL``` | General error |
+| 30 | ```ERROR_BAD_REQUEST``` | portId is invalid |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.AVInput.1.getEdidVersion",
+    "params": {
+        "portId": 0
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "edidVersion": "HDMI2.0"
+    }
+}
+```
+
+<a name="method.getSPD"></a>
+## *getSPD [<sup>method</sup>](#head.Methods)*
+
+Returns the Source Data Product Descriptor (SPD) infoFrame packet information for the specified HDMI Input device. The SPD infoFrame packet includes vendor name, product description, and source information.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params?.portId | number | <sup>*(optional)*</sup> An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.HDMISPD | string | The SPD information |
+
+### Errors
+
+| Code | Message | Description |
+| :-------- | :-------- | :-------- |
+| 1 | ```ERROR_GENERAL``` | General error |
+| 30 | ```ERROR_BAD_REQUEST``` | portId is invalid |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.AVInput.1.getSPD",
+    "params": {
+        "portId": 0
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "HDMISPD": "..."
+    }
+}
+```
+
+<a name="method.getRawSPD"></a>
+## *getRawSPD [<sup>method</sup>](#head.Methods)*
+
+Returns the Source Data Product Descriptor (SPD) infoFrame packet information for the specified HDMI Input device as raw bits.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.portId | number | An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.HDMISPD | string | The SPD information as raw bits |
+
+### Errors
+
+| Code | Message | Description |
+| :-------- | :-------- | :-------- |
+| 1 | ```ERROR_GENERAL``` | General error |
+| 30 | ```ERROR_BAD_REQUEST``` | portId is invalid |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.AVInput.1.getRawSPD",
+    "params": {
+        "portId": 0
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "HDMISPD": "..."
+    }
+}
+```
+
+<a name="method.readEDID"></a>
+## *readEDID [<sup>method</sup>](#head.Methods)*
+
+Returns the current EDID value.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.portId | number | An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.EDID | string | The EDID Value |
+
+### Errors
+
+| Code | Message | Description |
+| :-------- | :-------- | :-------- |
+| 1 | ```ERROR_GENERAL``` | General error |
+| 30 | ```ERROR_BAD_REQUEST``` | portId is invalid |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.AVInput.1.readEDID",
+    "params": {
+        "portId": 0
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "EDID": "..."
+    }
+}
+```
+
+<a name="method.startInput"></a>
+## *startInput [<sup>method</sup>](#head.Methods)*
+
+Activates the specified HDMI/Composite Input port as the primary video source.
+
+Also see: [onInputStatusChanged](#event.onInputStatusChanged), [onSignalChanged](#event.onSignalChanged)
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params?.portId | number | <sup>*(optional)*</sup> An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method |
+| params.typeOfInput | string | The type of Input - HDMI/COMPOSITE |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | null | Always null |
+
+### Errors
+
+| Code | Message | Description |
+| :-------- | :-------- | :-------- |
+| 1 | ```ERROR_GENERAL``` | General error |
+| 30 | ```ERROR_BAD_REQUEST``` | portId/Type of Input is invalid |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.AVInput.1.startInput",
+    "params": {
+        "portId": 0,
+        "typeOfInput": "HDMI"
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": null
+}
+```
+
+<a name="method.stopInput"></a>
+## *stopInput [<sup>method</sup>](#head.Methods)*
+
+Deactivates the HDMI/Composite Input port currently selected as the primary video source.
+
+Also see: [onInputStatusChanged](#event.onInputStatusChanged)
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.typeOfInput | string | The type of Input - HDMI/COMPOSITE |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | null | Always null |
+
+### Errors
+
+| Code | Message | Description |
+| :-------- | :-------- | :-------- |
+| 1 | ```ERROR_GENERAL``` | General error |
+| 30 | ```ERROR_BAD_REQUEST``` | Type of Input is invalid |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.AVInput.1.stopInput",
+    "params": {
+        "typeOfInput": "HDMI"
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": null
+}
+```
+
+<a name="method.setEdidVersion"></a>
+## *setEdidVersion [<sup>method</sup>](#head.Methods)*
+
+Sets an HDMI EDID version.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.portId | number | An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method |
+| params.edidVersion | string | The EDID version |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | null | Always null |
+
+### Errors
+
+| Code | Message | Description |
+| :-------- | :-------- | :-------- |
+| 1 | ```ERROR_GENERAL``` | General error |
+| 30 | ```ERROR_BAD_REQUEST``` | portId/edidVersion is invalid |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.AVInput.1.setEdidVersion",
+    "params": {
+        "portId": 0,
+        "edidVersion": "HDMI2.0"
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": null
+}
+```
+
+<a name="method.setVideoRectangle"></a>
+## *setVideoRectangle [<sup>method</sup>](#head.Methods)*
+
+Sets an HDMI/Composite Input video window.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.x | integer | The x-coordinate of the video rectangle |
+| params.y | integer | The y-coordinate of the video rectangle |
+| params.w | integer | The width of the video rectangle |
+| params.h | integer | The height of the video rectangle |
+| params.typeOfInput | string | The type of Input - HDMI/COMPOSITE |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | null | Always null |
+
+### Errors
+
+| Code | Message | Description |
+| :-------- | :-------- | :-------- |
+| 1 | ```ERROR_GENERAL``` | General error |
+| 30 | ```ERROR_BAD_REQUEST``` | Coordinates/Type of Input is invalid |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.AVInput.1.setVideoRectangle",
+    "params": {
+        "x": 0,
+        "y": 0,
+        "w": 1920,
+        "h": 1080,
+        "typeOfInput": "HDMI"
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": null
+}
+```
+
+<a name="method.writeEDID"></a>
+## *writeEDID [<sup>method</sup>](#head.Methods)*
+
+Changes a current EDID value.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.portId | number | An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method |
+| params.message | string | A new EDID value |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | null | Always null |
+
+### Errors
+
+| Code | Message | Description |
+| :-------- | :-------- | :-------- |
+| 30 | ```ERROR_BAD_REQUEST``` | Coordinates/Type of Input is invalid |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.AVInput.1.writeEDID",
+    "params": {
+        "portId": 0,
+        "message": "EDID"
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": null
+}
+```
+
+<a name="method.getSupportedGameFeatures"></a>
+## *getSupportedGameFeatures [<sup>method</sup>](#head.Methods)*
+
+Returns the list of supported game features.
+
+### Parameters
+
+This method takes no parameters.
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.supportedGameFeatures | array | The supported game Features |
+| result.supportedGameFeatures[#] | string |  |
+
+### Errors
+
+| Code | Message | Description |
+| :-------- | :-------- | :-------- |
+| 1 | ```ERROR_GENERAL``` | General error |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.AVInput.1.getSupportedGameFeatures"
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "supportedGameFeatures": [
+            "ALLM"
+        ]
+    }
+}
+```
+
+<a name="method.getGameFeatureStatus"></a>
+## *getGameFeatureStatus [<sup>method</sup>](#head.Methods)*
+
+Returns the Game Feature Status. For example: ALLM.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params?.portId | number | <sup>*(optional)*</sup> An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method |
+| params.gameFeature | string | Game Feature to which current status requested |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.mode | boolean | The current game feature status. Mode is required only for ALLM. Need to add support for future game features |
+
+### Errors
+
+| Code | Message | Description |
+| :-------- | :-------- | :-------- |
+| 30 | ```ERROR_BAD_REQUEST``` | Coordinates/Type of Input is invalid |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.AVInput.1.getGameFeatureStatus",
+    "params": {
+        "portId": 0,
+        "gameFeature": "ALLM"
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "mode": true
+    }
+}
+```
+
+<a name="head.Notifications"></a>
 # Notifications
 
-Notifications are autonomous events, triggered by the internals of the implementation, and broadcasted via JSON-RPC to all registered observers. Refer to [[Thunder](#Thunder)] for information on how to register for a notification.
+Notifications are autonomous events, triggered by the internals of the implementation, and broadcasted via JSON-RPC to all registered observers. Refer to [[Thunder](#ref.Thunder)] for information on how to register for a notification.
 
 The following events are provided by the org.rdk.AVInput plugin:
 
@@ -214,54 +896,163 @@ AVInput interface events:
 
 | Event | Description |
 | :-------- | :-------- |
-| [onAVInputActive](#onAVInputActive) | Triggered when an active device is connected to an AVInput port |
-| [onAVInputInActive](#onAVInputInActive) | Triggered when an active device is disconnected from an AVInput port or when the device becomes inactive |
+| [onDevicesChanged](#event.onDevicesChanged) | Triggered whenever a new HDMI/Composite device is connected to an HDMI/Composite Input |
+| [onInputStatusChanged](#event.onInputStatusChanged) | Triggered whenever the status changes for an HDMI/Composite Input |
+| [onSignalChanged](#event.onSignalChanged) | Triggered whenever the signal status changes for an HDMI/Composite Input |
+| [videoStreamInfoUpdate](#event.videoStreamInfoUpdate) | Triggered whenever there is an update in HDMI Input video stream info |
+| [gameFeatureStatusUpdate](#event.gameFeatureStatusUpdate) | Triggered whenever game feature(ALLM) status changes for an HDMI Input |
 
 
-<a name="onAVInputActive"></a>
-## *onAVInputActive*
+<a name="event.onDevicesChanged"></a>
+## *onDevicesChanged [<sup>event</sup>](#head.Notifications)*
 
-Triggered when an active device is connected to an AVInput port.
+Triggered whenever a new HDMI/Composite device is connected to an HDMI/Composite Input.
 
 ### Parameters
 
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
 | params | object |  |
-| params.url | string | The URL of the port with an active device |
+| params.devices | array | An object [] that describes each HDMI/Composite Input port |
+| params.devices[#] | object |  |
+| params.devices[#].id | number | The port identifier for the HDMI/Composite Input |
+| params.devices[#].locator | string | A URL corresponding to the HDMI/Composite Input port |
+| params.devices[#].connected | boolean | Whether a device is currently connected to this HDMI/Composite Input port |
 
 ### Example
 
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.onAVInputActive",
+    "method": "client.events.1.onDevicesChanged",
     "params": {
-        "url": "avin://input0"
+        "devices": [
+            {
+                "id": 0,
+                "locator": "hdmiin://localhost/deviceid/0",
+                "connected": true
+            }
+        ]
     }
 }
 ```
 
-<a name="onAVInputInActive"></a>
-## *onAVInputInActive*
+<a name="event.onInputStatusChanged"></a>
+## *onInputStatusChanged [<sup>event</sup>](#head.Notifications)*
 
-Triggered when an active device is disconnected from an AVInput port or when the device becomes inactive.
+Triggered whenever the status changes for an HDMI/Composite Input.
 
 ### Parameters
 
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
 | params | object |  |
-| params.url | string | The URL of the port with an inactive device |
+| params.id | number | The port identifier for the HDMI/Composite Input |
+| params.locator | string | A URL corresponding to the HDMI/Composite Input port |
+| params.status | string | Status of the HDMI/Composite Input. Valid values are `started` or `stopped` |
 
 ### Example
 
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.onAVInputInActive",
+    "method": "client.events.1.onInputStatusChanged",
     "params": {
-        "url": "avin://input0"
+        "id": 0,
+        "locator": "hdmiin://localhost/deviceid/0",
+        "status": "started"
+    }
+}
+```
+
+<a name="event.onSignalChanged"></a>
+## *onSignalChanged [<sup>event</sup>](#head.Notifications)*
+
+Triggered whenever the signal status changes for an HDMI/Composite Input.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.id | number | The port identifier for the HDMI/Composite Input |
+| params.locator | string | A URL corresponding to the HDMI/Composite Input port |
+| params.signalStatus | string | Signal Status of the HDMI/Composite Input. Valid values are `noSignal`, `unstableSignal`, `notSupportedSignal`, `stableSignal` |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.1.onSignalChanged",
+    "params": {
+        "id": 0,
+        "locator": "hdmiin://localhost/deviceid/0",
+        "signalStatus": "stableSignal"
+    }
+}
+```
+
+<a name="event.videoStreamInfoUpdate"></a>
+## *videoStreamInfoUpdate [<sup>event</sup>](#head.Notifications)*
+
+Triggered whenever there is an update in HDMI Input video stream info.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.id | number | The port identifier for the HDMI/Composite Input |
+| params.locator | string | A URL corresponding to the HDMI/Composite Input port |
+| params.width | integer | Width of the Video Stream |
+| params.height | integer | Height of the Video Stream |
+| params.progressive | boolean | Whether the streaming video is progressive or not? |
+| params.frameRateN | integer | FrameRate Numerator |
+| params.frameRateD | integer | FrameRate Denomirator |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.1.videoStreamInfoUpdate",
+    "params": {
+        "id": 0,
+        "locator": "hdmiin://localhost/deviceid/0",
+        "width": 3840,
+        "height": 2160,
+        "progressive": true,
+        "frameRateN": 60000,
+        "frameRateD": 1001
+    }
+}
+```
+
+<a name="event.gameFeatureStatusUpdate"></a>
+## *gameFeatureStatusUpdate [<sup>event</sup>](#head.Notifications)*
+
+Triggered whenever game feature(ALLM) status changes for an HDMI Input.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.id | number | The port identifier for the HDMI/Composite Input |
+| params.gameFeature | string | Game Feature to which current status requested |
+| params.mode | boolean | The current game feature status. Mode is required only for ALLM. Need to add support for future game features |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.1.gameFeatureStatusUpdate",
+    "params": {
+        "id": 0,
+        "gameFeature": "ALLM",
+        "mode": true
     }
 }
 ```


### PR DESCRIPTION
…APIs

Reason for change: Combine HdmiInput and CompositeInput Plugins into AVInput
Test Procedure: sanity testases on HDMI and COMPOSITE inputs
Risks: Low
Signed-off-by: Dhivya Ilangovan <dhivya.dilangovan@sky.uk>