### PR TITLE
XIONE-8955 : WPEFramework crash Display LinkType

### DIFF
--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -209,7 +209,6 @@ namespace WPEFramework {
             IARM_Bus_PWRMgr_PowerState_t getSystemPowerState();
 
 	    void getHdmiCecSinkPlugin();
-	    WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>* m_client;
 	    std::vector<std::string> m_clientRegisteredEventNames;
 	    uint32_t subscribeForHdmiCecSinkEvent(const char* eventName);
 	    bool setUpHdmiCecSinkArcRouting (bool arcEnable);


### PR DESCRIPTION
Reason for change:
WPEFramework crash Display LinkType issue fix
Global LinkType in displaySettings
Test Procedure: None
Risks: Low

Change-Id: I61b847b1f28566a96d911509e9bc739ec018191c Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>