### PR TITLE
LLAMA-8021 : [LLDEV-29794] - IP - Llama Technical Test – Putting

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -277,6 +277,7 @@ namespace WPEFramework {
 	    m_currentArcRoutingState = ARC_STATE_ARC_TERMINATED;
 	    m_cecArcRoutingThreadRun = false;
 	    isCecArcRoutingThreadEnabled = true;
+            m_arcInitiationEvent = false;
         }
 
         DisplaySettings::~DisplaySettings()
@@ -4106,14 +4107,16 @@ namespace WPEFramework {
                             if(types & dsAUDIOARCSUPPORT_eARC) {
                                 aPort.setStereoAuto(true,true);
                             }
-                            else if (types & dsAUDIOARCSUPPORT_ARC && (m_arcAudioEnabled != pEnable)) {
+                            else if (types & dsAUDIOARCSUPPORT_ARC && ((m_arcAudioEnabled != pEnable) || ( m_arcInitiationEvent == true))) {
                                 if (!DisplaySettings::_instance->requestShortAudioDescriptor()) {
                                     LOGERR("DisplaySettings::setEnableAudioPort (ARC-Auto): requestShortAudioDescriptor failed !!!\n");;
                                 }
                                 else {
                                     LOGINFO("DisplaySettings::setEnableAudioPort (ARC-Auto): requestShortAudioDescriptor successful\n");
                                 }
+                            
                             }
+                            m_arcInitiationEvent = false;
                         }
                         else{
                             device::AudioStereoMode mode = device::AudioStereoMode::kStereo;  //default to stereo
@@ -4546,6 +4549,7 @@ namespace WPEFramework {
 			        LOGINFO("onARCInitiationEventHandler: Enable ARC\n");
                                 aPort.enableARC(dsAUDIOARCSUPPORT_ARC, true);
                                 m_arcAudioEnabled = true;
+                                m_arcInitiationEvent = true;
 			    }
                         }
                         else {

--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -232,6 +232,7 @@ namespace WPEFramework {
 	    std::condition_variable arcRoutingCV;
 	    bool m_hdmiInAudioDeviceConnected;
         bool m_arcAudioEnabled;
+            bool m_arcInitiationEvent;   
 	    bool m_hdmiCecAudioDeviceDetected;
 	    JsonObject m_audioOutputPortConfig;
             JsonObject getAudioOutputPortConfig() { return m_audioOutputPortConfig; }


### PR DESCRIPTION
In/Out of Standby the AVR, audio Auto setting doesn’t really persist Reason for change: Invoke the SAD on ARC InitiationEvent Test Procedure: SEE JIRA
Risks: None.

Signed-off-by: shafi.ahmed@sky.uk <shafi.ahmed@sky.uk>