### PR TITLE
DELIA-58055: Change the GetConnectedSSID to call netsrvmgr (#3207)

### DIFF
--- a/WifiManager/CHANGELOG.md
+++ b/WifiManager/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.0.2] - 2022-10-14
+### Changed
+-  Change the GetConnectedSSID to call netsrvmgr
+
 ## [1.0.1] - 2022-10-04
 ### Fixed
 - Fixed warnings that are treated as errors with "-Wall -Werror"

--- a/WifiManager/WifiManager.cpp
+++ b/WifiManager/WifiManager.cpp
@@ -177,32 +177,7 @@ namespace WPEFramework
 
         uint32_t WifiManager::getConnectedSSID(const JsonObject &parameters, JsonObject &response)
         {
-            bool result = false;
-
-            if(getConnectedSSID2(parameters, response))
-            {
-                result = true;
-            }
-            else
-            {
-                LOGWARN("getConnectedSSID2 Call get failed,ret value:%d\n",result);
-            }
-
-            returnResponse(result);
-        }
-
-        bool WifiManager::getConnectedSSID2(const JsonObject &parameters, JsonObject &response)
-        {
-            bool result = false;
-
-            if(wifiState.getConnectedSSID(parameters, response))
-            {
-                result = true;
-            }
-            else
-            {
-                LOGWARN("getConnectedSSID Call get failed,ret value:%d\n",result);
-            }
+            uint32_t result = wifiState.getConnectedSSID(parameters, response);
 
             return result;
         }
@@ -323,7 +298,6 @@ namespace WPEFramework
             if (!isLNF)
             {
                 wifiState.setWifiStateCache(true, state);
-                wifiState.resetWifiStateConnectedCache(false);
                 wifiWPS.updateWifiWPSCache(false);
             }
             sendNotify("onWIFIStateChanged", params);
@@ -354,7 +328,6 @@ namespace WPEFramework
         void WifiManager::onSSIDsChanged()
         {
             wifiWPS.updateWifiWPSCache(false);
-            wifiState.resetWifiStateConnectedCache(false);
             sendNotify("onSSIDsChanged", JsonObject());
             GetHandler(2)->Notify("onSSIDsChanged", JsonObject());
         }

--- a/WifiManager/WifiManager.h
+++ b/WifiManager/WifiManager.h
@@ -94,7 +94,6 @@ namespace WPEFramework {
 
             uint32_t getApiVersionNumber() const {return apiVersionNumber;};
             void setApiVersionNumber(uint32_t apiVersion) {apiVersionNumber = apiVersion;};
-            bool getConnectedSSID2(const JsonObject &parameters, JsonObject &response);
 
             //Internal methods
             static WifiManager& getInstance();

--- a/WifiManager/impl/WifiManagerSignalThreshold.cpp
+++ b/WifiManager/impl/WifiManagerSignalThreshold.cpp
@@ -30,14 +30,42 @@ namespace {
     const float signalStrengthThresholdGood = -60.0f;
     const float signalStrengthThresholdFair = -67.0f;
 
+    #define BUFFER_SIZE 512
+    #define Command "wpa_cli signal_poll"
+
+    std::string retrieveValues(const char *command, char *output_buffer, size_t output_buffer_size)
+    {
+        std::string key, value;
+        std::string rssi = "";
+
+        FILE *fp = popen(command, "r");
+        if (!fp)
+        {
+            LOGERR("Failed in getting output from command %s \n",command);
+            return rssi;
+        }
+        while ((!feof(fp)) && (fgets(output_buffer, output_buffer_size, fp) != NULL))
+        {
+            std::istringstream mystream(output_buffer);
+            if(std::getline(std::getline(mystream, key, '=') >> std::ws, value))
+                if (key == "RSSI") {
+                    rssi = value;
+                    break;
+                }
+        }
+        pclose(fp);
+
+        return rssi;
+    }
+
     void getSignalData(float &signalStrengthOut, std::string &strengthOut) {
         JsonObject response;
-        WifiManager::getInstance().getConnectedSSID2(JsonObject(), response);
+        char buff[BUFFER_SIZE] = {'\0'};
+
+        string signalStrength = retrieveValues(Command, buff, sizeof (buff));
 
         signalStrengthOut = 0.0f;
-        if (response.HasLabel("signalStrength")) {
-            signalStrengthOut = std::stof(response["signalStrength"].String());
-        }
+        signalStrengthOut = std::stof(signalStrength.c_str());
 
         if (signalStrengthOut >= signalStrengthThresholdExcellent && signalStrengthOut < 0)
         {

--- a/WifiManager/impl/WifiManagerState.h
+++ b/WifiManager/impl/WifiManagerState.h
@@ -32,15 +32,13 @@ namespace WPEFramework {
             WifiManagerState& operator=(const WifiManagerState&) = delete;
 
             uint32_t getCurrentState(const JsonObject& parameters, JsonObject& response);
-            bool getConnectedSSID(const JsonObject& parameters, JsonObject& response);
+            uint32_t getConnectedSSID(const JsonObject& parameters, JsonObject& response) const;
             uint32_t setEnabled(const JsonObject& parameters, JsonObject& response);
             uint32_t getSupportedSecurityModes(const JsonObject& parameters, JsonObject& response);
             void setWifiStateCache(bool value,WifiState state);
-            void resetWifiStateConnectedCache(bool value);
 
             std::atomic<bool> m_useWifiStateCache;
             WifiState m_wifiStateCache;
-            std::atomic<bool> m_useWifiConnectedCache;
             std::string m_ConnectedSSIDCache;
             std::string m_ConnectedBSSIDCache;
             int m_ConnectedSecurityModeCache;


### PR DESCRIPTION
Reason for change:
In-order to help Sky team and not to flood the wpeframework.log, it is decided that the WiFiManager plugin will be updated as below,
1. The Signal Threshold Monitoring API will not call getConnectedSSID API and instead check only the RSSI value locally.
2. The public API getConnectedSSID will NOT be using the caching logic and instead always calls NetSrvMgr. Fix above issue:
By doing the above 2, we should be able to see the Telemetry marker in the netsrvmgr.log file. Test Procedure:
Risks: High
Signed-off-by: Kumar Santhanam <Kumar_Santhanam@comcast.com>

Co-authored-by: Karunakaran A <48997923+karuna2git@users.noreply.github.com>
(cherry picked from commit c499d298cdb22cd67dba9ea0a1c3f5dbeed6bd22)