### PR TITLE
Updated python command

### DIFF
--- a/Tools/md_generator/generate_md.py
+++ b/Tools/md_generator/generate_md.py
@@ -19,7 +19,7 @@ def convert_json_to_md():
     print()
     filename = os.path.join(dirname, r"../../*/*Plugin.json")
     flist = glob.glob(os.path.join(filename))
-    jsongenpath ="python ../json_generator/generator_json.py"
+    jsongenpath ="python3 ../json_generator/generator_json.py"
 
     for file in flist:
         os.system(r"{} --docs "


### PR DESCRIPTION
**Reason for change:**

- The generate_md file contains python command to execute the json_generator file. 
- The minimum requirement to use the JSON generator script is Python 3.5 or higher with pip and must include the jsonref as per Joseph input. 
- Also the current Jenkins Job node has python version 3.  As per the inputs from the lab team, python3 command to be used for any python file execution in new node.
