### PR TITLE
LLAMA-8021 : [LLDEV-29794] - IP - Llama Technical Test – Putting

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -4116,13 +4116,12 @@ namespace WPEFramework {
                                 }
                             
                             }
-                            m_arcPendingSADRequest = false;
                         }
                         else{
                             device::AudioStereoMode mode = device::AudioStereoMode::kStereo;  //default to stereo
                             mode = aPort.getStereoMode(); //get Last User set stereo mode and set
                             if((mode == device::AudioStereoMode::kPassThru) && (types & dsAUDIOARCSUPPORT_ARC)
-                                              && (m_arcAudioEnabled != pEnable)){
+                                              && ((m_arcAudioEnabled != pEnable) || ( m_arcPendingSADRequest == true))){
                                 if (!DisplaySettings::_instance->requestShortAudioDescriptor()) {
                                     LOGERR("DisplaySettings::setEnableAudioPort (ARC-Passthru): requestShortAudioDescriptor failed !!!\n");;
                                 }
@@ -4132,6 +4131,7 @@ namespace WPEFramework {
                             }
                             aPort.setStereoMode(mode.toString(), true);
                         }
+                        m_arcPendingSADRequest = false;
                     }
 
                     if(types & dsAUDIOARCSUPPORT_eARC) {


### PR DESCRIPTION
In/Out of Standby the AVR, audio Auto setting doesn’t really persist Adding for passthrough mode also
Reason for change: Invoke the SAD on ARC InitiationEvent Test Procedure: SEE JIRA
Risks: None.

Signed-off-by: shafi.ahmed@sky.uk <shafi.ahmed@sky.uk>