### PR TITLE
RDK-37628 Adapted RustBridge into rdkservices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ if(COMCAST_CONFIG)
 endif()
 
 option(PLUGIN_OCICONTAINER "Include OCIContainer plugin" OFF)
+option(PLUGIN_RUSTBRIDGE "Include RustBridge plugin" OFF)
 
 # Library installation section
 string(TOLOWER ${NAMESPACE} STORAGE_DIRECTORY)
@@ -60,6 +61,9 @@ if(PLUGIN_VOICECONTROL)
     add_subdirectory(VoiceControl)
 endif()
 
+if(PLUGIN_RUSTBRIDGE)
+    add_subdirectory(RustBridge)
+endif()
 
 if(PLUGIN_SYSTEMSERVICES)
     add_subdirectory(SystemServices)

--- a/NOTICE
+++ b/NOTICE
@@ -21,3 +21,6 @@ Licensed under the BSD-2 license
 
 Copyright Synamedia, All rights reserved
 Licensed under the Apache License, Version 2.0
+
+Copyright 2022 Metrological
+Licensed under the Apache License, Version 2.0

--- a/RustBridge/CMakeLists.txt
+++ b/RustBridge/CMakeLists.txt
@@ -33,7 +33,8 @@ set_target_properties(${MODULE_NAME} PROPERTIES
 target_link_libraries(${MODULE_NAME} 
     PRIVATE
         CompileSettingsDebug::CompileSettingsDebug
-        ${NAMESPACE}Plugins::${NAMESPACE}Plugins)
+        ${NAMESPACE}Plugins::${NAMESPACE}Plugins
+        ${NAMESPACE}Protocols::${NAMESPACE}Protocols)
 
 install(TARGETS ${MODULE_NAME} 
     DESTINATION lib/${STORAGE_DIRECTORY}/plugins)

--- a/RustBridge/CMakeLists.txt
+++ b/RustBridge/CMakeLists.txt
@@ -1,0 +1,41 @@
+# If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2022 Metrological
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set(PLUGIN_NAME RustBridge)
+set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
+
+find_package(${NAMESPACE}Plugins REQUIRED)
+find_package(CompileSettingsDebug CONFIG REQUIRED)
+
+add_library(${MODULE_NAME} SHARED
+    RustBridge.cpp
+	RustBridgeImplementation.cpp
+    Module.cpp)
+
+set_target_properties(${MODULE_NAME} PROPERTIES
+        CXX_STANDARD 11
+        CXX_STANDARD_REQUIRED YES)
+
+target_link_libraries(${MODULE_NAME} 
+    PRIVATE
+        CompileSettingsDebug::CompileSettingsDebug
+        ${NAMESPACE}Plugins::${NAMESPACE}Plugins)
+
+install(TARGETS ${MODULE_NAME} 
+    DESTINATION lib/${STORAGE_DIRECTORY}/plugins)
+
+write_config(${PLUGIN_NAME})

--- a/RustBridge/Module.cpp
+++ b/RustBridge/Module.cpp
@@ -1,0 +1,22 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Module.h"
+
+MODULE_NAME_DECLARATION(BUILD_REFERENCE)

--- a/RustBridge/Module.h
+++ b/RustBridge/Module.h
@@ -1,0 +1,29 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef MODULE_NAME
+#define MODULE_NAME Plugin_RustBridge
+#endif
+
+#include <plugins/plugins.h>
+
+#undef EXTERNAL
+#define EXTERNAL

--- a/RustBridge/RustBridge.config
+++ b/RustBridge/RustBridge.config
@@ -1,0 +1,1 @@
+set (autostart true)

--- a/RustBridge/RustBridge.cpp
+++ b/RustBridge/RustBridge.cpp
@@ -1,0 +1,416 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "RustBridge.h"
+
+namespace WPEFramework {
+	namespace Plugin {
+
+		namespace {
+
+			static Metadata<RustBridge> metadata(
+				// Version
+				1, 0, 0,
+				// Preconditions
+				{},
+				// Terminations
+				{},
+				// Controls
+				{}
+			);
+		}
+
+		class Registration : public Core::JSON::Container {
+		public:
+			Registration(const Registration&) = delete;
+			Registration& operator=(const Registration&) = delete;
+
+			Registration()
+				: Core::JSON::Container()
+				, Event()
+				, Callsign()
+			{
+				Add(_T("event"), &Event);
+				Add(_T("id"), &Callsign);
+			}
+			~Registration() override = default;
+
+		public:
+			Core::JSON::String Event;
+			Core::JSON::String Callsign;
+		};
+
+		// -------------------------------------------------------------------------------------------------------
+		//   IPluginExtended methods
+		// -------------------------------------------------------------------------------------------------------
+		const string RustBridge::Initialize(PluginHost::IShell* service) /* override */
+		{
+			string message;
+
+			ASSERT(_module == nullptr);
+			ASSERT(_service == nullptr);
+			ASSERT(service != nullptr);
+			ASSERT(_connectionId == 0);
+
+			// Setup skip URL for right offset.
+			_service = service;
+			_service->AddRef();
+
+			Config config;
+			config.FromString(service->ConfigLine());
+			_skipURL = static_cast<uint8_t>(service->WebPrefix().length());
+			_callsign = service->Callsign();
+			_service = service;
+			_timeOut = (config.TimeOut.Value() * Core::Time::TicksPerMillisecond);
+
+			// Register the Process::Notification stuff. The Remote process might die before we get a
+			// change to "register" the sink for these events !!! So do it ahead of instantiation.
+			_service->Register(&_notification);
+
+			_module = _service->Root<Exchange::IRustBridge>(_connectionId, 2000, _T("RustBridgeImplementation"));
+
+			if (_module == nullptr) {
+				message = _T("RustBridge could not be instantiated.");
+			}
+			else {
+				uint32_t result = _module->Configure(_service, &_callback);
+
+				if (result != Core::ERROR_NONE) {
+					message = _T("RustBridge could not be configured, error: ") + Core::NumberType<uint32_t>(result).Text();
+				}
+			}
+
+			if (message.length() != 0) {
+				Deinitialize(service);
+			}
+
+			// On success return empty, to indicate there is no error text.
+			return (message);
+		}
+
+		void RustBridge::Deinitialize(PluginHost::IShell* service) /* override */
+		{
+			ASSERT(_service == _service);
+
+			_service->Unregister(&_notification);
+
+			if (_module != nullptr) {
+
+				RPC::IRemoteConnection* connection(_service->RemoteConnection(_connectionId));
+
+				// Stop processing of the rustbridge:
+				VARIABLE_IS_NOT_USED uint32_t result = _module->Release();
+				_module = nullptr;
+
+				// It should have been the last reference we are releasing,
+				// so it should endup in a DESTRUCTION_SUCCEEDED, if not we
+				// are leaking...
+				ASSERT(result == Core::ERROR_DESTRUCTION_SUCCEEDED);
+
+				// The process can disappear in the meantime...
+				if (connection != nullptr) {
+					// But if it did not dissapear in the meantime, forcefully terminate it. Shoot to kill :-)
+					connection->Terminate();
+					connection->Release();
+				}
+
+			}
+
+			_service->Release();
+			_service = nullptr;
+			_connectionId = 0;
+		}
+
+		string RustBridge::Information() const /* override */
+		{
+			// No additional info to report.
+			return (string());
+		}
+
+		bool RustBridge::Attach(PluginHost::Channel& channel) /* override */ {
+			bool assigned = false;
+
+			// The expectation is that the JavaScript service opens up a connection to us, so we can forward the 
+			// incomming requests, to be handled by the Service.
+			if (_javascriptService == 0) {
+				Web::ProtocolsArray protocols = channel.Protocols();
+				if (std::find(protocols.begin(), protocols.end(), string(_T("json"))) != protocols.end()) {
+					_javascriptService = channel.Id();
+					assigned = true;
+				}
+			}
+			return(assigned);
+		}
+
+		void RustBridge::Detach(PluginHost::Channel& channel) /* override */ {
+			// Hopefull this does not happen as than we are loosing the actual service :-) We could do proper error handling
+			// if this happens :-)
+			_javascriptService = 0;
+		}
+
+		// -------------------------------------------------------------------------------------------------------
+		//   IDispatcher methods
+		// -------------------------------------------------------------------------------------------------------
+		Core::ProxyType<Core::JSONRPC::Message> RustBridge::Invoke(const Core::JSONRPC::Context& context, const Core::JSONRPC::Message& inbound) /* override */
+		{
+			string method;
+			Registration info;
+
+			Core::ProxyType<Core::JSONRPC::Message> message(PluginHost::IFactories::Instance().JSONRPC());
+			string designator(inbound.Designator.Value());
+
+			if (inbound.Id.IsSet() == true) {
+				message->JSONRPC = Core::JSONRPC::Message::DefaultVersion;
+				message->Id = inbound.Id.Value();
+			}
+
+			switch (Destination(designator, method)) {
+			case state::STATE_INCORRECT_HANDLER:
+				message->Error.SetError(Core::ERROR_INVALID_DESIGNATOR);
+				message->Error.Text = _T("Destined invoke failed.");
+				break;
+			case state::STATE_INCORRECT_VERSION:
+				message->Error.SetError(Core::ERROR_INVALID_SIGNATURE);
+				message->Error.Text = _T("Requested version is not supported.");
+				break;
+			case state::STATE_UNKNOWN_METHOD:
+				message->Error.SetError(Core::ERROR_UNKNOWN_KEY);
+				message->Error.Text = _T("Unknown method.");
+				break;
+			case state::STATE_REGISTRATION:
+				info.FromString(inbound.Parameters.Value());
+				Subscribe(context.ChannelId(), info.Event.Value(), info.Callsign.Value(), *message);
+				break;
+			case state::STATE_UNREGISTRATION:
+				info.FromString(inbound.Parameters.Value());
+				Unsubscribe(context.ChannelId(), info.Event.Value(), info.Callsign.Value(), *message);
+				break;
+			case state::STATE_EXISTS:
+				message->Result = Core::NumberType<uint32_t>(Core::ERROR_UNKNOWN_KEY).Text();
+				break;
+			case state::STATE_NONE_EXISTING:
+				message->Result = Core::NumberType<uint32_t>(Core::ERROR_NONE).Text();
+				break;
+			case state::STATE_CUSTOM:
+				// Let's on behalf of the request forward it and update 
+				uint32_t newId = Core::_InterlockedIncrement(_sequenceId);
+				Core::Time waitTill = Core::Time::Now() + _timeOut;
+
+				_pendingRequests.emplace(std::piecewise_construct,
+					std::forward_as_tuple(newId),
+					std::forward_as_tuple(context.ChannelId(), message->Id.Value(), waitTill));
+
+				TRACE(Trace::Information, (_T("Request: [%d] from [%d], method: [%s]"), newId, context.ChannelId(), method.c_str()));
+
+				// Time to fire of the request to RUST ->
+				_module->Request(newId, context.Token(), method, inbound.Parameters.Value());
+
+				// Wait for ID to return, we can not report anything back yet...
+				message.Release();
+
+				if (_timeOut != 0) {
+					_cleaner.Reschedule(waitTill);
+				}
+
+				break;
+			}
+
+			return (Core::ProxyType<Core::JSONRPC::Message>(message));
+		}
+
+		void RustBridge::Activate(PluginHost::IShell* /* service */) /* override */ {
+			// We did what we needed to do in the Intialize.
+		}
+
+		void RustBridge::Deactivate() /* override */ {
+			// We did what we needed to do in the Deintialize.
+		}
+
+		void RustBridge::Close(const uint32_t channelId) /* override */ {
+
+			_adminLock.Lock();
+
+			ObserverMap::iterator index = _observers.begin();
+
+			while (index != _observers.end()) {
+				ObserverList::iterator loop(index->second.begin());
+
+				while (loop != index->second.end()) {
+					if (loop->Id() != channelId) {
+						loop++;
+					}
+					else {
+						loop = index->second.erase(loop);
+					}
+				}
+
+				index++;
+			}
+
+			_adminLock.Unlock();
+		}
+
+		// -------------------------------------------------------------------------------------------------------
+		//   Private methods
+		// -------------------------------------------------------------------------------------------------------
+		void RustBridge::Cleanup() {
+			// Lets see if there are still any pending request we should report Missing In Action :-)
+			Core::Time now(Core::Time::Now());
+			Core::Time nextSlot;
+
+			_adminLock.Lock();
+			PendingMap::iterator index(_pendingRequests.begin());
+			while (index != _pendingRequests.end()) {
+				if (now >= index->second.Issued()) {
+					// Send and Error to the requester..
+					Core::ProxyType<Core::JSONRPC::Message> message(PluginHost::IFactories::Instance().JSONRPC());
+					message->Error.SetError(Core::ERROR_TIMEDOUT);
+					message->Error.Text = _T("There is no response form the server within time!!!");
+					message->Id = index->second.SequenceId();
+
+					TRACE(Trace::Warning, (_T("Got a timeout on channelId [%d] for request [%d]"), index->second.ChannelId(), message->Id.Value()));
+
+					_service->Submit(index->second.ChannelId(), Core::ProxyType<Core::JSON::IElement>(message));
+					index = _pendingRequests.erase(index);
+				}
+				else {
+					if ((nextSlot.IsValid() == false) || (nextSlot > index->second.Issued())) {
+						nextSlot = index->second.Issued();
+					}
+					index++;
+				}
+			}
+			_adminLock.Unlock();
+
+			if (nextSlot.IsValid()) {
+				_cleaner.Reschedule(nextSlot);
+			}
+		}
+
+		bool RustBridge::InternalMessage(const string& eventName, const string& parameters) {
+			bool result = false;
+
+			if (eventName == _T("registerjsonrpcmethods")) {
+				result = true;
+				Core::JSON::ArrayType<Core::JSON::String> parameter;
+				parameter.FromString(parameters);
+				Core::JSON::ArrayType<Core::JSON::String>::Iterator index(parameter.Elements());
+
+				_supportedVersions.clear();
+
+				while (index.Next() == true) {
+					string entry = index.Current().Value();
+					uint8_t version = Core::JSONRPC::Message::Version(entry);
+					string method = Core::JSONRPC::Message::Method(entry);
+					VersionMap::iterator placement = _supportedVersions.find(version);
+
+					if (placement == _supportedVersions.end()) {
+						auto newEntry = _supportedVersions.emplace(std::piecewise_construct,
+							std::forward_as_tuple(version),
+							std::forward_as_tuple());
+
+						newEntry.first->second.push_back(method);
+					}
+					else if (std::find(placement->second.begin(), placement->second.end(), method) == placement->second.end()) {
+						// Check if this label does not already exist
+						placement->second.push_back(method);
+					}
+				}
+			}
+
+			return (result);
+		}
+
+		void RustBridge::Deactivated(RPC::IRemoteConnection* connection)
+		{
+			// This can potentially be called on a socket thread, so the deactivation (wich in turn kills this object) must be done
+			// on a seperate thread. Also make sure this call-stack can be unwound before we are totally destructed.
+			if (_connectionId == connection->Id()) {
+
+				ASSERT(_service != nullptr);
+
+				Core::IWorkerPool::Instance().Submit(PluginHost::IShell::Job::Create(_service, PluginHost::IShell::DEACTIVATED, PluginHost::IShell::FAILURE));
+			}
+		}
+
+		void RustBridge::RustInvoke(const string& context, const string& method, const string& parmeters, string& response, uint32_t& result) {
+
+		}
+
+		void RustBridge::RustEvent(const string& eventName, const string& parameters) {
+
+			// Check for control messages between server and us..
+			if (InternalMessage(eventName, parameters) == false) {
+
+				// This is an event, we need event handling..
+				_adminLock.Lock();
+
+				ObserverMap::iterator index = _observers.find(eventName);
+
+				if (index != _observers.end()) {
+					for (const Observer& entry : index->second) {
+						Core::ProxyType<Core::JSONRPC::Message> outbound(PluginHost::IFactories::Instance().JSONRPC());
+						outbound->Designator = (entry.Designator().empty() == false ? entry.Designator() + '.' + eventName : eventName);
+						outbound->Parameters = parameters;
+
+						_service->Submit(entry.Id(), Core::ProxyType<Core::JSON::IElement>(outbound));
+					}
+				}
+
+				_adminLock.Unlock();
+			}
+		}
+
+		void RustBridge::RustResponse(const uint32_t id, const string& response, const uint32_t error) {
+
+			uint32_t requestId, channelId = 0;
+
+			// This is the response to an invoked method, Let's see who should get this repsonse :-)
+			_adminLock.Lock();
+			PendingMap::iterator index = _pendingRequests.find(id);
+			if (index != _pendingRequests.end()) {
+				channelId = index->second.ChannelId();
+				requestId = index->second.SequenceId();
+				_pendingRequests.erase(index);
+			}
+			_adminLock.Unlock();
+
+			if (channelId != 0) {
+				Core::ProxyType<PluginHost::JSONRPCMessage> message = PluginHost::IFactories::Instance().JSONRPC();
+
+				TRACE(Trace::Information, (_T("Response: [%d] to [%d]"), requestId, channelId));
+
+				// Oke, there is someone waiting for a response!
+				message->Id = requestId;
+
+				if (response.empty() == true) {
+					message->Error.Code = error;
+					message->Error.Data = _T("FAILED");
+				}
+				else {
+					message->Result = response;
+				}
+
+				_service->Submit(channelId, Core::ProxyType<Core::JSON::IElement>(message));
+			}
+		}
+
+
+	} // namespace Plugin
+} // namespace WPEFramework

--- a/RustBridge/RustBridge.h
+++ b/RustBridge/RustBridge.h
@@ -255,13 +255,13 @@ namespace WPEFramework {
             // IDispatcher
             // -------------------------------------------------------------------------------------------------------
             //! ==================================== CALLED ON THREADPOOL THREAD ======================================
-            Core::ProxyType<Core::JSONRPC::Message> Invoke(const Core::JSONRPC::Context& context, const Core::JSONRPC::Message& message) override;
+            Core::ProxyType<Core::JSONRPC::Message> Invoke(const string& token, const uint32_t channelId, const Core::JSONRPC::Message& inbound) override;
             //! ==================================== CALLED ON THREADPOOL THREAD ======================================
             void Activate(PluginHost::IShell* service) override;
             //! ==================================== CALLED ON THREADPOOL THREAD ======================================
             void Deactivate() override;
             //! ==================================== CALLED ON THREADPOOL THREAD ======================================
-            void Close(const uint32_t id) override;
+            void Close(const uint32_t id);
 
             // IPluginExtended
             // -------------------------------------------------------------------------------------------------------

--- a/RustBridge/RustBridge.h
+++ b/RustBridge/RustBridge.h
@@ -275,8 +275,8 @@ namespace WPEFramework {
             bool InternalMessage(const string& message, const string& parameters);
 
             bool HasMethodSupport(const VersionMap::const_iterator& index, const string& method) const {
-                bool result = false;
-
+                bool result = true;
+/*
                 if (index != _supportedVersions.cend()) {
                     result = (std::find(index->second.cbegin(), index->second.cend(), method) != index->second.cend());
                 }
@@ -288,7 +288,7 @@ namespace WPEFramework {
                         index++;
                     }
                 }
-
+*/
                 return (result);
             }
             state Destination(const string& designator, string& handler) const

--- a/RustBridge/RustBridge.h
+++ b/RustBridge/RustBridge.h
@@ -1,0 +1,416 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "Module.h"
+#include <interfaces/IRustBridge.h>
+
+namespace WPEFramework {
+    namespace Plugin {
+
+        class RustBridge :
+            public PluginHost::IPluginExtended,
+            public PluginHost::IDispatcher
+        {
+        private:
+            enum class state {
+                STATE_INCORRECT_HANDLER,
+                STATE_INCORRECT_VERSION,
+                STATE_UNKNOWN_METHOD,
+                STATE_REGISTRATION,
+                STATE_UNREGISTRATION,
+                STATE_EXISTS,
+                STATE_NONE_EXISTING,
+                STATE_CUSTOM
+            };
+            class BridgeCallback : public Exchange::IRustBridge::ICallback {
+            public:
+                BridgeCallback() = delete;
+                BridgeCallback(const BridgeCallback&) = delete;
+
+                explicit BridgeCallback(RustBridge& parent)
+                    : _parent(parent)
+                {
+                }
+                ~BridgeCallback() override = default;
+
+            public:
+                // ALLOW RUST -> THUNDER (Invoke and Event)
+                // The synchronous Invoke from a JSONRPC is coming from the RUST world,
+                // synchronously handle this in the Thunder world.
+                void Invoke(const string& context, const string& method, const string& parameters, string& response /* @out */, uint32_t& result /* @out */) override {
+                   _parent.RustInvoke(context, method, parameters, response, result);
+                }
+
+                // Allow RUST to send an event to the interested subscribers in the Thunder
+                // world.
+                void Event(const string& event, const string& parameters) override {
+                    _parent.RustEvent(event, parameters);
+                }
+
+                void Response(const uint32_t id, const string& response, const uint32_t error) override {
+                    _parent.RustResponse(id, response, error);
+                }
+
+                BEGIN_INTERFACE_MAP(BridgeCallback)
+                    INTERFACE_ENTRY(Exchange::IRustBridge::ICallback)
+                END_INTERFACE_MAP
+
+            private:
+                RustBridge& _parent;
+            };
+            class Notification : public RPC::IRemoteConnection::INotification {
+            public:
+                Notification() = delete;
+                Notification(const Notification&) = delete;
+
+                explicit Notification(RustBridge& parent)
+                    : _parent(parent)
+                {
+                }
+                ~Notification() override = default;
+
+            public:
+                void Activated(RPC::IRemoteConnection* /* connection */) override
+                {
+                }
+                void Deactivated(RPC::IRemoteConnection* connectionId) override
+                {
+                    _parent.Deactivated(connectionId);
+                }
+
+                BEGIN_INTERFACE_MAP(Notification)
+                    INTERFACE_ENTRY(RPC::IRemoteConnection::INotification)
+                END_INTERFACE_MAP
+
+            private:
+                RustBridge& _parent;
+            };
+
+            class Observer {
+            public:
+                Observer(const Observer&) = delete;
+                Observer& operator=(const Observer&) = delete;
+
+                Observer(const uint32_t id, const string& designator)
+                    : _id(id)
+                    , _designator(designator)
+                {
+                }
+                ~Observer() = default;
+
+            public:
+                bool operator==(const Observer& rhs) const
+                {
+                    return ((rhs._id == _id) && (rhs._designator == _designator));
+                }
+                bool operator!=(const Observer& rhs) const
+                {
+                    return (!operator==(rhs));
+                }
+
+                uint32_t Id() const
+                {
+                    return (_id);
+                }
+                const string& Designator() const
+                {
+                    return (_designator);
+                }
+
+            private:
+                uint32_t _id;
+                string _designator;
+            };
+            class Request {
+            public:
+                Request() = delete;
+                Request(const Request&) = delete;
+                Request& operator=(const Request&) = delete;
+
+                Request(const uint32_t channelId, const uint32_t sequenceId, const Core::Time& timeOut)
+                    : _channelId(channelId)
+                    , _sequenceId(sequenceId)
+                    , _issued(timeOut) {
+                }
+                ~Request() = default;
+
+            public:
+                uint32_t ChannelId() const {
+                    return (_channelId);
+                }
+                uint32_t SequenceId() const {
+                    return (_sequenceId);
+                }
+                const Core::Time& Issued() const {
+                    return (_issued);
+                }
+
+            private:
+                uint32_t _channelId;
+                uint32_t _sequenceId;
+                Core::Time _issued;
+            };
+            class Cleaner {
+            private:
+                using BaseClass = Core::IWorkerPool::JobType<Cleaner>;
+
+            public:
+                Cleaner(const Cleaner&) = delete;
+                Cleaner& operator=(const Cleaner&) = delete;
+
+                Cleaner(RustBridge& parent) : _parent(parent) {
+                }
+                ~Cleaner() = default;
+
+            public:
+                void Dispatch() {
+                    _parent.Cleanup();
+                }
+
+            private:
+                RustBridge& _parent;
+            };
+
+            using ObserverList = std::list<Observer>;
+            using ObserverMap = std::map<string, ObserverList>;
+            using MethodList = std::vector<string>;
+            using VersionMap = std::map<uint8_t, MethodList>;
+            using PendingMap = std::map<uint32_t, Request>;
+
+        public:
+            class Config : public Core::JSON::Container {
+            public:
+                Config()
+                    : Core::JSON::Container()
+                    , TimeOut(3000)
+                {
+                    Add(_T("timeout"), &TimeOut);
+                }
+                ~Config() override = default;
+
+            public:
+                Core::JSON::DecUInt16 TimeOut;
+            };
+
+        public:
+            RustBridge(const RustBridge&) = delete;
+            RustBridge& operator=(const RustBridge&) = delete;
+
+            //PUSH_WARNING(DISABLE_WARNING_THIS_IN_MEMBER_INITIALIZER_LIST)
+                RustBridge()
+                : _adminLock()
+                , _skipURL(0)
+                , _service(nullptr)
+                , _callsign()
+                , _supportedVersions()
+                , _observers()
+                , _pendingRequests()
+                , _javascriptService(0)
+                , _sequenceId(1)
+                , _timeOut(0)
+                , _connectionId(0)
+                , _module(nullptr)
+                , _notification(*this)
+                , _callback(*this)
+                , _cleaner(*this)
+            {
+            }
+//POP_WARNING()
+            ~RustBridge() override = default;
+
+            BEGIN_INTERFACE_MAP(RustBridge)
+                INTERFACE_ENTRY(PluginHost::IPlugin)
+                INTERFACE_ENTRY(PluginHost::IPluginExtended)
+                INTERFACE_ENTRY(PluginHost::IDispatcher)
+            END_INTERFACE_MAP
+
+        public:
+            //   IPlugin methods
+            // -------------------------------------------------------------------------------------------------------
+            //! ==================================== CALLED ON THREADPOOL THREAD ======================================
+            const string Initialize(PluginHost::IShell* service) override;
+            //! ==================================== CALLED ON THREADPOOL THREAD ======================================
+            void Deinitialize(PluginHost::IShell* service) override;
+            //! ==================================== CALLED ON THREADPOOL THREAD ======================================
+            string Information() const override;
+
+            // IDispatcher
+            // -------------------------------------------------------------------------------------------------------
+            //! ==================================== CALLED ON THREADPOOL THREAD ======================================
+            Core::ProxyType<Core::JSONRPC::Message> Invoke(const Core::JSONRPC::Context& context, const Core::JSONRPC::Message& message) override;
+            //! ==================================== CALLED ON THREADPOOL THREAD ======================================
+            void Activate(PluginHost::IShell* service) override;
+            //! ==================================== CALLED ON THREADPOOL THREAD ======================================
+            void Deactivate() override;
+            //! ==================================== CALLED ON THREADPOOL THREAD ======================================
+            void Close(const uint32_t id) override;
+
+            // IPluginExtended
+            // -------------------------------------------------------------------------------------------------------
+            //! ================================== CALLED ON COMMUNICATION THREAD =====================================
+            bool Attach(PluginHost::Channel& channel) override;
+            //! ================================== CALLED ON COMMUNICATION THREAD =====================================
+            void Detach(PluginHost::Channel& channel) override;
+
+        private:
+            void Cleanup();
+            bool InternalMessage(const string& message, const string& parameters);
+
+            bool HasMethodSupport(const VersionMap::const_iterator& index, const string& method) const {
+                bool result = false;
+
+                if (index != _supportedVersions.cend()) {
+                    result = (std::find(index->second.cbegin(), index->second.cend(), method) != index->second.cend());
+                }
+                else {
+                    VersionMap::const_iterator index = _supportedVersions.begin();
+
+                    while ((result == false) && (index != _supportedVersions.end())) {
+                        result = (std::find(index->second.cbegin(), index->second.cend(), method) != index->second.cend());
+                        index++;
+                    }
+                }
+
+                return (result);
+            }
+            state Destination(const string& designator, string& handler) const
+            {
+                state result = state::STATE_INCORRECT_HANDLER;
+                string callsign(Core::JSONRPC::Message::Callsign(designator));
+
+                // If the message is routed through the controlelr, the callsign is empty by now!
+                if ((callsign.empty()) || (callsign == _callsign)) {
+                    // Seems we are on the right handler..
+                    // now see if someone supports this version
+                    uint8_t version = Core::JSONRPC::Message::Version(designator);
+                    VersionMap::const_iterator methods = _supportedVersions.cend();
+
+                    // See if there was a version given..
+                    if (version != static_cast<uint8_t>(~0)) {
+                        methods = _supportedVersions.find(version);
+                        if (methods == _supportedVersions.cend()) {
+                            result = state::STATE_INCORRECT_VERSION;
+                        }
+                    }
+
+                    if (result == state::STATE_INCORRECT_HANDLER) {
+                        string method = Core::JSONRPC::Message::Method(designator);
+
+                        if (method == _T("register")) {
+                            result = state::STATE_REGISTRATION;
+                        }
+                        else if (method == _T("unregister")) {
+                            result = state::STATE_UNREGISTRATION;
+                        }
+                        else if (method == _T("exists")) {
+                            result = HasMethodSupport(methods, method) ? state::STATE_EXISTS : state::STATE_NONE_EXISTING;
+                        }
+                        else if (HasMethodSupport(methods, method) == true) {
+                            result = state::STATE_CUSTOM;
+                            handler = method;
+                        }
+                        else {
+                            result = state::STATE_UNKNOWN_METHOD;
+                        }
+                    }
+                }
+                return (result);
+            }
+            void Subscribe(const uint32_t channelId, const string& eventName, const string& callsign, Core::JSONRPC::Message& response)
+            {
+                _adminLock.Lock();
+
+                ObserverMap::iterator index = _observers.find(eventName);
+
+                if (index == _observers.end()) {
+                    _observers[eventName].emplace_back(channelId, callsign);
+                    response.Result = _T("0");
+                }
+                else if (std::find(index->second.begin(), index->second.end(), Observer(channelId, callsign)) == index->second.end()) {
+                    index->second.emplace_back(channelId, callsign);
+                    response.Result = _T("0");
+                }
+                else {
+                    response.Error.SetError(Core::ERROR_DUPLICATE_KEY);
+                    response.Error.Text = _T("Duplicate registration. Only 1 remains!!!");
+                }
+
+                _adminLock.Unlock();
+            }
+            void Unsubscribe(const uint32_t channelId, const string& eventName, const string& callsign, Core::JSONRPC::Message& response)
+            {
+                _adminLock.Lock();
+
+                ObserverMap::iterator index = _observers.find(eventName);
+
+                if (index != _observers.end()) {
+                    ObserverList& clients = index->second;
+                    ObserverList::iterator loop = clients.begin();
+                    Observer key(channelId, callsign);
+
+                    while ((loop != clients.end()) && (*loop != key)) {
+                        loop++;
+                    }
+
+                    if (loop != clients.end()) {
+                        clients.erase(loop);
+                        if (clients.empty() == true) {
+                            _observers.erase(index);
+                        }
+                        response.Result = _T("0");
+                    }
+                }
+
+                if (response.Result.IsSet() == false) {
+                    response.Error.SetError(Core::ERROR_UNKNOWN_KEY);
+                    response.Error.Text = _T("Registration not found!!!");
+                }
+
+                _adminLock.Unlock();
+            }
+
+        private:
+            void Deactivated(RPC::IRemoteConnection* connection);
+            void RustInvoke(const string& context, const string& method, const string& parmeters, string& response, uint32_t& result);
+            void RustEvent(const string & event, const string & parmeters);
+            void RustResponse(const uint32_t id, const string& response, const uint32_t error);
+
+
+        private:
+            Core::CriticalSection _adminLock;
+            uint8_t _skipURL;
+            PluginHost::IShell* _service;
+            string _callsign;
+            VersionMap _supportedVersions;
+            ObserverMap _observers;
+            PendingMap _pendingRequests;
+            uint32_t _javascriptService;
+            uint32_t _sequenceId;
+            uint32_t _timeOut;
+            uint32_t _connectionId;
+            Exchange::IRustBridge* _module;
+            Core::Sink<Notification> _notification;
+            Core::Sink< BridgeCallback> _callback;
+            Core::WorkerPool::JobType<Cleaner> _cleaner;
+        };
+
+    } // namespace Plugin
+} // namespace WPEFramework

--- a/RustBridge/RustBridge.vcxproj
+++ b/RustBridge/RustBridge.vcxproj
@@ -1,0 +1,193 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>15.0</VCProjectVersion>
+    <ProjectGuid>{6C8F7539-796C-4598-9C9F-4F4E2D968D55}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>RustBridge</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)..\artifacts\$(Configuration)\</OutDir>
+    <IntDir>$(OutDir)Plugins\$(TargetName)\</IntDir>
+    <TargetName>lib$(ProjectName)</TargetName>
+    <TargetExt>.so</TargetExt>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)..\artifacts\$(Configuration)\</OutDir>
+    <IntDir>$(OutDir)Plugins\$(TargetName)\</IntDir>
+    <TargetName>lib$(ProjectName)</TargetName>
+    <TargetExt>.so</TargetExt>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)..\artifacts\$(Configuration)\</OutDir>
+    <IntDir>$(OutDir)Plugins\$(TargetName)\</IntDir>
+    <TargetName>lib$(ProjectName)</TargetName>
+    <TargetExt>.so</TargetExt>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)..\artifacts\$(Configuration)\</OutDir>
+    <IntDir>$(OutDir)Plugins\$(TargetName)\</IntDir>
+    <TargetName>lib$(ProjectName)</TargetName>
+    <TargetExt>.so</TargetExt>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_DEBUG;DEVICEINFO_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(FrameworkPath);$(ContractsPath);$(WindowsPath);$(WindowsPath)zlib</AdditionalIncludeDirectories>
+      <UseStandardPreprocessor>true</UseStandardPreprocessor>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(OutDir)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(IntDir)$(TargetName).pdb</ProgramDatabaseFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;DEVICEINFO_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(FrameworkPath);$(ContractsPath);$(WindowsPath);$(WindowsPath)zlib</AdditionalIncludeDirectories>
+      <UseStandardPreprocessor>true</UseStandardPreprocessor>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(OutDir)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(IntDir)$(TargetName).pdb</ProgramDatabaseFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;DEVICEINFO_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(FrameworkPath);$(ContractsPath);$(WindowsPath);$(WindowsPath)zlib</AdditionalIncludeDirectories>
+      <UseStandardPreprocessor>true</UseStandardPreprocessor>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(OutDir)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(IntDir)$(TargetName).pdb</ProgramDatabaseFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;NDEBUG;DEVICEINFO_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(FrameworkPath);$(ContractsPath);$(WindowsPath);$(WindowsPath)zlib</AdditionalIncludeDirectories>
+      <UseStandardPreprocessor>true</UseStandardPreprocessor>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(OutDir)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>$(IntDir)$(TargetName).pdb</ProgramDatabaseFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="Module.cpp" />
+    <ClCompile Include="RustBridge.cpp" />
+    <ClCompile Include="RustBridgeImplementation.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="Module.h" />
+    <ClInclude Include="RustBridge.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/RustBridge/RustBridge.vcxproj.filters
+++ b/RustBridge/RustBridge.vcxproj.filters
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClInclude Include="Module.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="RustBridge.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{ed48a750-01f9-4d2b-94e5-e3960397e2d3}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{46ea12fc-cda5-4a4e-9aa0-607682cd9d25}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="Module.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="RustBridge.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="RustBridgeImplementation.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/RustBridge/RustBridgeImplementation.cpp
+++ b/RustBridge/RustBridgeImplementation.cpp
@@ -294,8 +294,10 @@ namespace WPEFramework {
 					
 					searchPath.push_back(framework->DataPath());
 					searchPath.push_back(framework->PersistentPath());
-					searchPath.push_back(framework->SystemPath());
-					searchPath.push_back(framework->PluginPath());
+					//searchPath.push_back(framework->SystemPath());
+					//searchPath.push_back(framework->PluginPath());
+					searchPath.push_back(framework->VolatilePath());
+					searchPath.push_back("/usr/lib/wpeframework/plugins/");
 					
 					_callback = callback;
 

--- a/RustBridge/RustBridgeImplementation.cpp
+++ b/RustBridge/RustBridgeImplementation.cpp
@@ -1,0 +1,383 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "RustBridge.h"
+
+namespace WPEFramework {
+
+	namespace Plugin {
+
+		namespace Rust {
+			struct RequestContext {
+				uint32_t    id;
+				const char* auth_token;
+			};
+
+			struct PluginContext;
+
+			struct Plugin;
+		}
+	}
+}
+
+extern "C" void wpe_send_to(uint32_t id, const char* json, WPEFramework::Plugin::Rust::PluginContext* p_ctx);
+
+namespace WPEFramework {
+
+	namespace Plugin {
+
+		class RustBridgeImplementation :  public Exchange::IRustBridge {
+		private:
+			class Config : public Core::JSON::Container {
+			public:
+				Config(const Config&) = delete;
+				Config& operator=(const Config&) = delete;
+				Config() 
+					: Core::JSON::Container()
+					, ModuleName()
+				{
+					Add(_T("module"), &ModuleName);
+				}
+				~Config() override = default;
+				
+			public:
+				Core::JSON::String ModuleName;
+			};
+			
+			class Connector {
+			private:
+				using fn_SendTo = void (*)(uint32_t, const char *, Rust::PluginContext *);
+				using fn_Create = Rust::Plugin *(*)(const char *name, fn_SendTo send_to, Rust::PluginContext *, void *);
+				using fn_Destroy = void (*)(Rust::Plugin *p);
+				using fn_Init = void (*)(Rust::Plugin *p, const char *json);
+				using fn_Invoke = void (*)(Rust::Plugin *p, const char *json_req, Rust::RequestContext req_ctx);
+
+				// TODO: Discuss this since I think these are not needed. I assume it is to send events using the 
+				// fn_SendTo function, propse to make it an explicit function called events or so and signal this 
+				// pluginthat all interested ones should recive that event, with that parameter
+				using fn_OnClientConnect = void (*)(Rust::Plugin *p, uint32_t channel_id);
+				using fn_OnClientDisconnect = void (*)(Rust::Plugin *p, uint32_t channel_id);
+							
+			public:
+				Connector() = delete;
+				Connector(const Connector&) = delete;
+				Connector& operator= (const Connector&) = delete;
+
+				Connector(RustBridgeImplementation& parent)
+					: _parent(parent)
+					, _library()
+					, _fn_create(nullptr)
+					, _fn_destroy(nullptr)
+					, _fn_init(nullptr)
+					, _fn_invoke(nullptr)
+					, _fn_on_client_connect(nullptr)
+					, _fn_on_client_disconnect(nullptr) {
+				}
+				~Connector() = default;
+				
+			public:
+				bool IsValid() const {
+					return (_library.IsLoaded() == true);
+				}
+				uint32_t Initialize(const std::vector<string>& thunderPaths, const string& locator, const string& className, const string& configLine) {
+					
+					uint32_t result = Load(thunderPaths, locator);
+					
+					if (result == Core::ERROR_NONE) {
+						ASSERT(_library.IsLoaded() == true);
+						ASSERT(_fn_create != nullptr);
+						ASSERT(_fn_init != nullptr);
+						
+						// TODO: Discuss why we want to pass back a function durint the create that is already part of the 
+						// rust library where we are sending the information. I guess we can drop it (_fn_service_metadata)
+						_plugin = _fn_create(className.c_str(), &wpe_send_to, reinterpret_cast<Rust::PluginContext*>(&_parent), _fn_service_metadata);
+
+						if (_plugin != nullptr) {
+							// TODO: indeed the initialize seems a bit redundant. Can we drop it and pass the configuration during the create?
+							_fn_init(_plugin, configLine.c_str());
+						}
+						else {
+							// Oops could not create a plugin. Send out a message
+							TRACE(Trace::Fatal, (Core::Format(_T("Creating the %s RUST plugin failed"), locator.c_str())));
+							result = Core::ERROR_BAD_REQUEST;
+						}
+					}					
+					
+					return (result);
+				}
+				uint32_t Deinitialize() {
+					uint32_t result = Core::ERROR_NONE;
+					
+					if (_library.IsLoaded() == true) {
+						ASSERT(_fn_destroy != nullptr);
+						ASSERT(_plugin != nullptr);
+
+						_fn_destroy(_plugin);
+						
+						_fn_create               = nullptr;
+						_fn_init                 = nullptr;
+						_fn_destroy              = nullptr;
+						_fn_invoke               = nullptr;
+						_fn_on_client_connect    = nullptr;
+						_fn_on_client_disconnect = nullptr;
+						_library = Core::Library();
+					}		
+
+					return (result);
+				}
+				void Request(const uint32_t id, const string& token, const string& method, const string& parameters) {
+					Core::JSONRPC::Message message;
+
+					message.Id = id;
+					message.Designator = method;
+					message.Parameters = parameters;
+			
+					string result;
+					message.ToString(result);
+
+					Rust::RequestContext context;
+
+					context.auth_token = token.c_str();
+					context.id = id;
+
+					// TODO: As invoke suggests a synchronous call, which it actually is not ;-) can we rename it to Request ?
+					_fn_invoke(_plugin, result.c_str(), context);
+				}
+
+			private:
+				uint32_t LoadLibrary(const string& name) {
+					uint32_t result = Core::ERROR_NOT_EXIST;
+					
+					Core::File libraryToLoad(name);
+
+					if (libraryToLoad.Exists() == true) {
+						Core::Library myLib(name.c_str());
+						
+						if (myLib.IsLoaded() == false) {
+							TRACE(Trace::Fatal, (Core::Format(_T("Could not load the library: %s, error: %s"), name.c_str(), myLib.Error().c_str())));
+							result = Core::ERROR_OPENING_FAILED;
+						}
+						else {
+							_fn_create = reinterpret_cast<fn_Create>(myLib.LoadFunction(_T("wpe_rust_plugin_create")));
+							_fn_init = reinterpret_cast<fn_Init>(myLib.LoadFunction(_T("wpe_rust_plugin_init")));
+							_fn_destroy = reinterpret_cast<fn_Destroy>(myLib.LoadFunction(_T("wpe_rust_plugin_destroy")));
+							_fn_invoke = reinterpret_cast<fn_Invoke>(myLib.LoadFunction(_T("wpe_rust_plugin_invoke")));
+							_fn_on_client_connect = reinterpret_cast<fn_OnClientConnect>(myLib.LoadFunction(_T("wpe_rust_plugin_on_client_connect")));
+							_fn_on_client_disconnect = reinterpret_cast<fn_OnClientDisconnect>(myLib.LoadFunction(_T("wpe_rust_plugin_on_client_disconnect")));
+							_fn_service_metadata = myLib.LoadFunction(_T("thunder_service_metadata"));
+							
+							if ( (_fn_create               != nullptr) &&
+								 (_fn_init                 != nullptr) &&
+								 (_fn_destroy              != nullptr) &&
+								 (_fn_invoke               != nullptr) &&
+								 (_fn_on_client_connect    != nullptr) &&
+								 (_fn_on_client_disconnect != nullptr) ) {
+								_library = myLib;
+								result = Core::ERROR_NONE;
+							}
+							else {
+								TRACE(Trace::Fatal, (Core::Format(_T("Could not load all the symbols from library: %s"), name.c_str())));
+								
+								_fn_create               = nullptr;
+								_fn_init                 = nullptr;
+								_fn_destroy              = nullptr;
+								_fn_invoke               = nullptr;
+								_fn_on_client_connect    = nullptr;
+								_fn_on_client_disconnect = nullptr;
+								_fn_service_metadata     = nullptr;
+								
+								result = Core::ERROR_UNAVAILABLE;
+							}
+						}
+					}
+					return (result);
+				}
+				uint32_t Load(const std::vector<string>& thunderPaths, const string& locator) {
+					
+					uint32_t result = Core::ERROR_NOT_EXIST;
+					
+					ASSERT (locator.empty() == false);
+					
+					// By definitions we start in the usual locations for the plugins..
+					std::vector<string>::const_iterator index(thunderPaths.cbegin());
+					while ((index != thunderPaths.cend()) && ((result = LoadLibrary(*index + locator)) != Core::ERROR_NONE)) {
+						++index;
+					}	
+					
+					if (result != Core::ERROR_NONE) {
+						
+						string value;
+						
+						// As this is RUST, maybe we can find it in the LD_LIBRARY_PATH fromt he linux system..
+						if (Core::SystemInfo::GetEnvironment(_T("LD_LIBRARY_PATH"), value) == true) {
+							Core::TextSegmentIterator iterator (Core::TextFragment(value), true, _T(":"));
+
+							while ( (iterator.Next() == true) && (result != Core::ERROR_NONE) ) {
+								result = LoadLibrary(iterator.Current().Text() + locator);
+							}
+						}
+					}
+					
+					return (result);
+				}
+				
+			private:
+				RustBridgeImplementation&	_parent;
+				Rust::Plugin*				_plugin;
+				Core::Library				_library;
+				fn_Create					_fn_create;
+				fn_Destroy					_fn_destroy;
+				fn_Init						_fn_init;
+				fn_Invoke					_fn_invoke;
+				fn_OnClientConnect			_fn_on_client_connect;
+				fn_OnClientDisconnect		_fn_on_client_disconnect;
+				void*						_fn_service_metadata;
+			};
+			
+
+		public:
+			RustBridgeImplementation(const RustBridgeImplementation&) = delete;
+			RustBridgeImplementation& operator= (const RustBridgeImplementation&) = delete;
+			
+			RustBridgeImplementation()
+				: _service(nullptr)
+				, _connector(*this)
+				, _callback(nullptr) {
+			}
+			~RustBridgeImplementation() {
+				_connector.Deinitialize();
+				if (_callback != nullptr) {
+					_callback->Release();
+					_callback = nullptr;
+				}
+
+				if (_service != nullptr) {
+					_service->Release();
+					_service = nullptr;
+				}
+			}
+
+		public:
+			uint32_t Configure(PluginHost::IShell* framework, ICallback* callback) override {
+				uint32_t result = Core::ERROR_INCOMPLETE_CONFIG;
+				Config config;
+				
+				config.FromString(framework->ConfigLine());
+				
+				if (callback != nullptr) {
+					string rustModule;
+					std::vector<string> searchPath;
+					string className(framework->ClassName());
+
+					if (config.ModuleName.Value().empty() == true) {
+						rustModule = framework->Callsign() + _T(".so");
+					}
+					else {
+						rustModule = config.ModuleName.Value();
+					}
+					
+					searchPath.push_back(framework->DataPath());
+					searchPath.push_back(framework->PersistentPath());
+					searchPath.push_back(framework->SystemPath());
+					searchPath.push_back(framework->PluginPath());
+					
+					_callback = callback;
+
+					result = _connector.Initialize(searchPath, rustModule, className, framework->ConfigLine());
+					
+					if (result != Core::ERROR_NONE) {
+						_callback = nullptr;
+					}
+					else {
+						_callback->AddRef();		
+						_service = framework;
+						_service->AddRef();
+					}
+				}
+				
+				return (result);
+			}
+			
+			// ALLOW THUNDER -> RUST (Invoke and Event)
+			// The synchronous Invoke from a JSONRPC perspective has been splitup into an 
+			// a-synchronous communication to RUST. First we send a Request with an id,
+			// Than it is up to RUST to send a response (with the same id) to complete
+			// the a-synchronous request, RUST calls the Response() moethod or signals an
+			// error on this Request, using the Error() method.
+			void Request(const uint32_t id, const string& context, const string& method, const string& parameters) override {
+				ASSERT(_connector.IsValid() == true);
+
+				_connector.Request(id, context, method, parameters);
+			}
+			
+			// Allow THUNDER to send an event to the interested subscribers in the RUST
+			// world.
+			void Event(const string& event, const string& parmeters) override {
+				_callback->Event(event, parmeters);
+			}
+
+			void Response(const uint32_t id, const string& response, const int32_t errorCode) {
+				ASSERT(_callback != nullptr);
+				_callback->Response(id, response, errorCode);
+			}
+			
+
+			BEGIN_INTERFACE_MAP(RustBridgeImplementation)
+				INTERFACE_ENTRY(Exchange::IRustBridge)
+			END_INTERFACE_MAP
+
+		private:
+			PluginHost::IShell* _service;
+			Connector _connector;
+			ICallback* _callback;
+		};
+		
+		SERVICE_REGISTRATION(RustBridgeImplementation, 1, 0);
+	}
+} // namespace WPEFramework
+
+using namespace WPEFramework;
+
+// this function is passed into Rust as a pointer
+extern "C" void wpe_send_to(uint32_t id, const char* json, Plugin::Rust::PluginContext * plugin)
+{
+	Plugin::RustBridgeImplementation* implementation = reinterpret_cast<Plugin::RustBridgeImplementation*>(plugin);
+
+	if (implementation != nullptr) {
+		if ((id == 0) && (json[0] == '[')) {
+			// TODO: Can we make an explicit call for this or return the methods on the fn_create ?
+			// Hacky way to get a JSON list of the supported methods in the class
+			implementation->Event(_T("registerjsonrpcmethods"), json);
+		}
+		else {
+			Core::JSONRPC::Message convert;
+			convert.FromString(json);
+
+			if (convert.Error.IsSet() == true) {
+				implementation->Response(id, Core::emptyString, convert.Error.Code.Value());
+			}
+			else if (convert.Result.Value().empty() == true) {
+				implementation->Response(id, string(Core::JSON::IElement::NullTag), 0);
+			}
+			else {
+				implementation->Response(id, convert.Result.Value(), 0);
+			}
+		}
+	}
+}

--- a/RustBridge/rust/Cargo.toml
+++ b/RustBridge/rust/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "thunder_rs"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+
+[lib]
+name = "thunder_rs"
+crate-type = ["lib"]

--- a/RustBridge/rust/examples/calculator/Cargo.toml
+++ b/RustBridge/rust/examples/calculator/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "calculator"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+thunder_rs = { path = "../../" }
+json = { version = "0.12.4" }
+
+[lib]
+name        = "calculator"
+path        = "src/lib.rs"
+crate-type  = ["dylib"]

--- a/RustBridge/rust/examples/calculator/calc_client.js
+++ b/RustBridge/rust/examples/calculator/calc_client.js
@@ -1,0 +1,23 @@
+const WebSocket = require('ws');
+const client = new WebSocket("ws://127.0.0.1:55555/Service/calculator", ["jsonrpc"]);
+
+function send_message() {
+  let req = {};
+  req.jsonrpc = "2.0"
+  req.id = 5;
+  req.method = "calculator.add";
+  req.params = [2, 2]
+
+  const s = JSON.stringify(req);
+  console.log("send:" + s)
+  client.send(s)
+}
+
+client.onopen = function(e) {
+  send_message()
+}
+
+client.onmessage = function(msg) {
+  console.log("recv:" + msg.data)
+  client.close();
+}

--- a/RustBridge/rust/examples/calculator/calculator.json
+++ b/RustBridge/rust/examples/calculator/calculator.json
@@ -1,0 +1,6 @@
+{
+ "locator":"libWPEFrameworkRustAdapter.so",
+ "classname":"RustAdapter",
+ "callsign":"calculator",
+ "autostart":true
+}

--- a/RustBridge/rust/examples/calculator/src/lib.rs
+++ b/RustBridge/rust/examples/calculator/src/lib.rs
@@ -1,0 +1,94 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+struct Calculator { 
+  proto: Box<dyn thunder_rs::PluginProtocol>
+}
+
+impl Calculator {
+  
+  fn dispatch_request(&mut self, req: json::JsonValue, ctx: thunder_rs::RequestContext) {
+    if let Some(method) = req["method"].as_str() {
+      match method {
+		/* suggest not to work with the "calculator" prefix here. It is */
+		/* already verified by thunder. here we just would like to work */
+        /* on the method name. */
+        "add" => { self.add(req, ctx); }
+        "mul" => { self.mul(req, ctx); }
+        _ => {
+          println!("method {} not handled here", method);
+        }
+      }
+    }
+  }
+
+  fn add(&mut self, req: json::JsonValue, ctx: thunder_rs::RequestContext) {
+    let mut sum = 0;
+    for val in req["params"].members() {
+      if let Some(n) = val.as_u32() {
+        sum += n;
+      }
+    }
+
+    let res = json::object!{
+      "jsonrpc": "2.0",
+      "id": req["id"].as_u32(),
+      "result": sum
+    };
+
+    self.send_response(res, ctx);
+  }
+
+  fn mul(&mut self, req: json::JsonValue, ctx: thunder_rs::RequestContext) {
+    let mut product = 0;
+    for val in req["params"].members() {
+      if let Some(n) = val.as_u32() {
+        product *= n
+      }
+    }
+
+    let res = json::object!{
+      "jsonrpc": "2.0",
+      "id": req["id"].as_u32(),
+      "result": product
+    };
+
+    self.send_response(res, ctx);
+  }
+
+  fn send_response(&mut self, res: json::JsonValue, ctx: thunder_rs::RequestContext) {
+    let s = json::stringify(res);
+    self.proto.send_to(ctx.channel_id, s);
+  }
+}
+
+impl thunder_rs::Plugin for Calculator {
+  fn on_message(&mut self, json: String, ctx: thunder_rs::RequestContext) {
+    let req: json::JsonValue = json::parse(json.as_str())
+      .unwrap();
+    self.dispatch_request(req, ctx);
+  }
+  fn on_client_connect(&mut self, _channel_id: u32) { }
+  fn on_client_disconnect(&mut self, _channel_id: u32) { }
+}
+
+fn sample_plugin_init(proto: Box<dyn thunder_rs::PluginProtocol>) -> Box<dyn thunder_rs::Plugin> {
+  Box::new(Calculator{ proto: proto})
+}
+
+thunder_rs::export_plugin!("Calculator", (1,0,0), sample_plugin_init);

--- a/RustBridge/rust/examples/hello_world/Cargo.toml
+++ b/RustBridge/rust/examples/hello_world/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "hello_world"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+thunder_rs = { path = "../../" }
+
+[lib]
+name        = "hello_world"
+path        = "src/lib.rs"
+crate-type  = ["dylib"]

--- a/RustBridge/rust/examples/hello_world/SampleRustPlugin.json
+++ b/RustBridge/rust/examples/hello_world/SampleRustPlugin.json
@@ -1,0 +1,9 @@
+{
+ "locator":"libWPEFrameworkRustAdapter.so",
+ "classname":"RustAdapter",
+ "callsign":"hello_world",
+ "autostart":true,
+ "configuration": {
+   "outofprocess": true
+ }
+}

--- a/RustBridge/rust/examples/hello_world/sample_plugin_client.js
+++ b/RustBridge/rust/examples/hello_world/sample_plugin_client.js
@@ -1,0 +1,37 @@
+const WebSocket = require('ws');
+const client = new WebSocket("ws://127.0.0.1:55555/Service/hello_world", ["jsonrpc"]);
+
+next_id = 10
+
+function send_message() {
+  let req = {};
+  req.jsonrpc = "2.0"
+  req.id = next_id++
+
+  if (next_id % 2 == 0) {
+    req.method = "settings.onRequestSettings",
+    req.params = [1, 2, 3, 4, 5];
+  }
+  else {
+    req.method = "keyboard.onKeyPress",
+    req.params = { 
+      a: "a",
+      b: "b"
+    }
+  }
+
+  const s = JSON.stringify(req);
+  console.log("send:" + s)
+  client.send(s)
+}
+
+client.onopen = function(e) {
+  send_message()
+}
+
+client.onmessage = function(msg) {
+  console.log("recv:" + msg.data)
+  const req = JSON.parse(msg.data)
+  // console.log("recv:" + JSON.stringify(req))
+  setTimeout(send_message, 1000)
+}

--- a/RustBridge/rust/examples/hello_world/src/lib.rs
+++ b/RustBridge/rust/examples/hello_world/src/lib.rs
@@ -1,0 +1,55 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+struct SamplePlugin { 
+  proto: Box<dyn thunder_rs::PluginProtocol>
+}
+
+impl thunder_rs::Plugin for SamplePlugin {
+  fn on_message(&mut self, json: String, ctx: thunder_rs::RequestContext) {
+    println!("TODO: dispatch incoming message {}", json);
+    println!("\tchannel_id:{0}", ctx.channel_id);
+    println!("\tauth_token:{0}", ctx.auth_token);
+
+    let res: String = String::from("{\"jsonrpc\":\"2.0\", \"id\":4, \"result\":\"hello from rust\"}");
+
+    // the channel_id is unique per client. if you ever want to send a message to
+    // client, whether that be synchronously responding to a request, asynchronously
+    // responding to a request, or emitting an event, use this API
+    self.proto.send_to(ctx.channel_id, res);
+  }
+
+  // TODO: we should probably add the auth_token to this call. At the current time
+  // this isn't too useful. Applications will likely ignore and just lazily track
+  // connected clients when the make calls that get delivered via on_message
+  fn on_client_connect(&mut self, channel_id: u32) {
+    println!("client_connect:{}", channel_id);
+  }
+
+  // TODO: If you're tracking state about a client, you also would like to know
+  // when that client disconnects. you get that inication here
+  fn on_client_disconnect(&mut self, channel_id: u32) {
+    println!("client_disconnect:{}", channel_id);
+  }
+}
+
+fn sample_plugin_init(proto: Box<dyn thunder_rs::PluginProtocol>) -> Box<dyn thunder_rs::Plugin> {
+  Box::new(SamplePlugin{ proto: proto})
+}
+
+thunder_rs::export_plugin!("SampleRustPlugin", (1,0,0), sample_plugin_init);

--- a/RustBridge/rust/src/lib.rs
+++ b/RustBridge/rust/src/lib.rs
@@ -1,0 +1,224 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::ffi::CStr;
+use std::ffi::CString;
+use std::os::raw::{c_char, c_void};
+
+type SendToFunction = unsafe extern "C" fn (u32, *const c_char, plugin_ctx: *const c_void);
+
+pub trait PluginProtocol {
+  fn send_to(&mut self,  channel_id: u32, json: String);
+}
+
+pub trait Plugin {
+  fn on_message(&mut self, json: String, ctx: RequestContext);
+  fn on_client_connect(&mut self, channel_id: u32);
+  fn on_client_disconnect(&mut self, channel_id: u32);
+}
+
+pub struct RequestContext {
+  pub channel_id: u32,
+  pub auth_token: String
+}
+
+pub struct ServiceMetadata {
+  pub name: &'static str,
+  pub version: (u32, u32, u32),
+  pub create: fn (Box<dyn PluginProtocol>) -> Box<dyn Plugin>
+}
+
+#[macro_export]
+macro_rules! export_plugin {
+  ($name:expr, $version:expr,  $create:expr) => {
+    #[no_mangle]
+    pub static thunder_service_metadata : $crate::ServiceMetadata =
+      $crate::ServiceMetadata {
+        name: $name,
+        version: $version,
+        create: $create
+      };
+  };
+}
+
+//===============================================================================
+// Internal code only below here
+//===============================================================================
+
+#[repr(C)]
+pub struct CRequestContext {
+  channel_id: u32,
+  auth_token: *const c_char
+}
+
+fn cstr_to_string(s : *const c_char) -> String {
+  if s.is_null() {
+    String::new()
+  }
+  else {
+    let c_str: &CStr = unsafe{ CStr::from_ptr(s) };
+    let slice: &str = c_str.to_str().unwrap();
+    let t: String = slice.to_owned();
+    t
+  }
+}
+
+pub struct CPlugin {
+  pub name: String,
+  pub plugin: Box<dyn Plugin>
+}
+
+struct DefaultPluginProtocol {
+  send_func: SendToFunction,
+  send_ctx: *const c_void
+}
+
+impl PluginProtocol for DefaultPluginProtocol {
+  fn send_to(&mut self, channel_id: u32, json: String) {
+    let c_str = CString::new(json).unwrap();
+    unsafe {
+      (self.send_func)(channel_id, c_str.as_ptr(), self.send_ctx);
+    }
+  }
+}
+
+impl CPlugin {
+  fn on_incoming_message(&mut self, json_req: *const c_char, ctx: CRequestContext) {
+    let req = cstr_to_string(json_req);
+    let req_ctx = RequestContext {
+      channel_id: ctx.channel_id,
+      auth_token: cstr_to_string(ctx.auth_token)
+    };
+    self.plugin.on_message(req, req_ctx);
+  }
+  fn on_client_connect(&mut self, channel_id: u32) {
+    self.plugin.on_client_connect(channel_id);
+  }
+  fn on_client_disconnect(&mut self, channel_id: u32) {
+    self.plugin.on_client_disconnect(channel_id);
+  }
+}
+
+#[no_mangle]
+pub extern fn wpe_rust_plugin_create(_name: *const c_char, send_func: SendToFunction,
+  plugin_ctx: *const c_void, meta_data: *mut ServiceMetadata) -> *mut CPlugin
+{
+  assert!(!meta_data.is_null());
+
+  let service_metadata = unsafe{ &*meta_data };
+  let proto: Box<dyn PluginProtocol> = Box::new(DefaultPluginProtocol {
+    send_func: send_func,
+    send_ctx: plugin_ctx});
+
+  let plugin: Box<dyn Plugin> = (service_metadata.create)(proto);
+  let name: String = service_metadata.name.to_string();
+  let c_plugin: Box<CPlugin> = Box::new(CPlugin {
+    name: name,
+    plugin: plugin 
+  });
+  
+  /* Sorry for the lack of RUST knowledge, this was the only way we */
+  /* could send back a list with the methods supported by this Rust */
+  /* plugin. Prefer to send it so Thudner can already filter on non */
+  /* existing methods. Suggest to return this string as a parameter */
+  /* on this method call.. */ 
+  let methods = CString::new("[ \"add\", \"mul\" ]").unwrap();
+  unsafe {
+	// let c_buf = methods.unwrap();
+    //let c_str: &CStr = unsafe { CStr::from_ptr(c_buf) };
+    //let str_slice: &str = c_str.to_str().unwrap();
+    send_func(0, methods.as_ptr(), plugin_ctx);
+  }
+
+  Box::into_raw(c_plugin)
+}
+
+#[no_mangle]
+pub extern fn wpe_rust_plugin_destroy(ptr: *mut CPlugin) {
+  assert!(!ptr.is_null());
+
+  unsafe {
+    drop(Box::from_raw(ptr));
+  }
+}
+
+#[no_mangle]
+pub extern fn wpe_rust_plugin_init(_ptr: *mut CPlugin, _json: *const c_char) {
+  // assert!(!ptr.is_null());
+
+  // XXX: Create + Init doesn't seem to fit the Rust style. wpe_rust_plugin_create 
+  // is probably enough. Consider getting rid of this function
+
+  // let plugin = unsafe{ &mut *ptr };
+  // println!("{}.init", plugin.name);
+}
+
+#[no_mangle]
+pub extern fn wpe_rust_plugin_invoke(ptr: *mut CPlugin, json_req: *const c_char, req_ctx: CRequestContext) {
+  assert!(!ptr.is_null());
+  assert!(!json_req.is_null());
+
+  let plugin = unsafe{ &mut *ptr };
+  let uncaught_error = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+    plugin.on_incoming_message(json_req, req_ctx);
+  }));
+
+  match uncaught_error {
+    Err(cause) => {
+      println!("Error calling on_incoming_message");
+      println!("{:?}", cause);
+    }
+    Ok(_) => { }
+  }
+}
+
+#[no_mangle]
+pub extern fn wpe_rust_plugin_on_client_connect(ptr: *mut CPlugin, channel_id: u32) {
+  assert!(!ptr.is_null());
+
+  let plugin = unsafe{ &mut *ptr };
+  let uncaught_error = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+    plugin.on_client_connect(channel_id);
+  }));
+
+  match uncaught_error {
+    Err(cause) => {
+      println!("Error calling on_client_connect");
+      println!("{:?}", cause);
+    }
+    Ok(_) => { }
+  }
+}
+
+#[no_mangle]
+pub extern fn wpe_rust_plugin_on_client_disconnect(ptr: *mut CPlugin, channel_id: u32) {
+  assert!(!ptr.is_null());
+
+  let plugin = unsafe{ &mut *ptr };
+  let uncaught_error = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+    plugin.on_client_disconnect(channel_id);
+  }));
+
+  match uncaught_error {
+    Err(cause) => {
+      println!("Error calling on_client_disconnect");
+      println!("{:?}", cause);
+    }
+    Ok(_) => { }
+  }
+}


### PR DESCRIPTION
Adapted RustBridge from https://github.com/rdkcentral/ThunderNanoServices/tree/master/RustBridge so it can work as rdkservice. It requires a change like [0001_rust_bridge_interface.txt](https://github.com/rdkcentral/rdkservices/files/9797315/0001_rust_bridge_interface.txt) in the ThunderInterfaces.

Reason for change: There should be possibility of running thunder plugin that are written in rust with a full support of thunder features (RustAdapter is spawning other processes which is not fully thunder-like behaviour)
Test Procedure: Use hello-world plugin to test RustBridge
Risks: Low
Signed-off-by: Marcin Koczwara (marcin.koczwara@consult.red)