### PR TITLE
LLAMA-8021 : [LLDEV-29794] - IP - Llama Technical Test – Putting

### DIFF
--- a/DisplaySettings/CHANGELOG.md
+++ b/DisplaySettings/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+## [1.0.12] - 2022-10-17
+### Fixed
+- Fixed Invoke the SAD on ARC InitiationEvent Test
+
 ## [1.0.11] - 2022-10-14
 ### Changed
 - Updated changes for new power manager.

--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -234,6 +234,7 @@ namespace WPEFramework {
 	    std::condition_variable arcRoutingCV;
 	    bool m_hdmiInAudioDeviceConnected;
         bool m_arcAudioEnabled;
+            bool m_arcPendingSADRequest;
             bool m_isPwrMgr2RFCEnabled;
 	    bool m_hdmiCecAudioDeviceDetected;
 	    JsonObject m_audioOutputPortConfig;


### PR DESCRIPTION
In/Out of Standby the AVR, audio Auto setting doesn’t really persist Adding for passthrough mode also
Reason for change: Invoke the SAD on ARC InitiationEvent Test Procedure: SEE JIRA
Risks: None.

Signed-off-by: shafi.ahmed@sky.uk <shafi.ahmed@sky.uk>