### PR TITLE
XIONE-8729: Delete pingoutput text files (#3222)

### DIFF
--- a/Network/CHANGELOG.md
+++ b/Network/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.0.4] - 2022-10-21
+### Fixed
+- pingoutput text files that are not deleted in failure cases are now deleted.
+
 ## [1.0.3] - 2022-10-18
 ### Changed
 - API access on all versions of the handler

--- a/Network/PingNotifier.cpp
+++ b/Network/PingNotifier.cpp
@@ -187,7 +187,10 @@ namespace WPEFramework
                     }
                 }
                 fclose(fp);
+            }
 
+            if(!outputFile.empty())
+            {
                 // clear up
                 remove(outputFile.c_str());
             }


### PR DESCRIPTION
Reason for change: pingoutput text files are
not deleted in failure cases.

Test Procedure: Build and verify.
Risks: low
Signed-off-by:Zameerun Rasheed M S <zmamoo711@cable.comcast.com>

Co-authored-by: Zameerun Rasheed M S <ZameerunRasheed_MamoonSyed@comcast.com>
Co-authored-by: Karunakaran A <48997923+karuna2git@users.noreply.github.com>