### PR TITLE
Configure below options to be in par with wpe-2.28 (glib implementation)

### DIFF
--- a/WebKitBrowser/WebKitImplementation.cpp
+++ b/WebKitBrowser/WebKitImplementation.cpp
@@ -2965,6 +2965,15 @@ static GSourceFuncs _handlerIntervention =
                 WKRelease(contentTypes);
             }
 
+            if (_config.SpatialNavigation.IsSet() == true) {
+                // Turn on/off spatial navigation
+                WKPreferencesSetSpatialNavigationEnabled(preferences, _config.SpatialNavigation.Value());
+                WKPreferencesSetTabsToLinks(preferences, _config.SpatialNavigation.Value());
+            }
+
+            // Turn on scroll to focused element
+            WKPreferencesSetScrollToFocusedElementEnabled(preferences, true);
+
             WKPageGroupSetPreferences(pageGroup, preferences);
 
             _userContentController = WKUserContentControllerCreate();


### PR DESCRIPTION
* Spatial navitagion
* Scroll to focused Element
* Set Tabs to Links

Reason for change: Navigation on Diagnostic Page is not working
Signed-off-by: Vivek.A <vivek_arumugam@comcast.com>