### PR TITLE
RDKTV-20401: TV did not enter to Deepsleep , and stayed ~14 hrs in th…

### DIFF
--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -94,6 +94,9 @@ string notifyStatusToString(Maint_notify_status_t &status)
         case MAINTENANCE_INCOMPLETE:
             ret_status="MAINTENANCE_INCOMPLETE";
             break;
+        case MAINTENANCE_STOPPED:
+            ret_status="MAINTENANCE_STOPPED";
+            break;
         default:
             ret_status="MAINTENANCE_ERROR";
     }
@@ -1334,6 +1337,10 @@ namespace WPEFramework {
                 if(m_thread.joinable()){
                     m_thread.join();
                 }
+
+		LOGINFO("stopMaintenance method was executed and hence Maintenance was stopped \n");
+                MaintenanceManager::_instance->onMaintenanceStatusChange(MAINTENANCE_STOPPED);
+
 		m_statusMutex.unlock();
                 return result;
         }


### PR DESCRIPTION
…e standby state.

Maintenance window is open for long time and it was not completed successfully and hence TV didn't went to deepsleep.

Whenever stopMaintenance Api executed, it will terminate the task which is currently running and will send that event status to MM, also it will update the status of remaining tasks as well. Since MM didn't trigger those scripts it will simply ignore those events and so maintenance was not completed.