### PR TITLE
LLAMA-8095: Fix for if passing empty string to stof in getSignalData

### DIFF
--- a/WifiManager/impl/WifiManagerSignalThreshold.cpp
+++ b/WifiManager/impl/WifiManagerSignalThreshold.cpp
@@ -65,7 +65,13 @@ namespace {
         string signalStrength = retrieveValues(Command, buff, sizeof (buff));
 
         signalStrengthOut = 0.0f;
-        signalStrengthOut = std::stof(signalStrength.c_str());
+        if (!signalStrength.empty())
+            signalStrengthOut = std::stof(signalStrength.c_str());
+        else {
+            LOGERR("signalStrength is empty\n");
+            strengthOut = "Disconnected";
+            return;
+        }
 
         if (signalStrengthOut >= signalStrengthThresholdExcellent && signalStrengthOut < 0)
         {


### PR DESCRIPTION
Reason for change: Avoid throw invalid argument error Fix above issue: Checking before passing string is empty or not Test Procedure:
Risks: High
Signed-off-by: Kumar Santhanam <Kumar_Santhanam@comcast.com>