### PR TITLE
RDKTV-9523: Enhance getSinkAtmosCapability() API

### DIFF
--- a/DisplaySettings/CHANGELOG.md
+++ b/DisplaySettings/CHANGELOG.md
@@ -15,6 +15,11 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+## [1.1.11] - 2022-11-08
+### Changed
+- Handled identifying Atmos sink capability for all audio output ports and host capability
+
+
 ## [1.0.11] - 2022-10-14
 ### Changed
 - Updated changes for new power manager.

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -78,7 +78,7 @@ using namespace std;
 #define ZOOM_SETTINGS_DIRECTORY "/opt/persistent/rdkservices"
 
 #define API_VERSION_NUMBER_MAJOR 1
-#define API_VERSION_NUMBER_MINOR 0
+#define API_VERSION_NUMBER_MINOR 1
 #define API_VERSION_NUMBER_PATCH 11
 
 static bool isCecArcRoutingThreadEnabled = false;
@@ -3760,30 +3760,66 @@ namespace WPEFramework {
         uint32_t DisplaySettings::getSinkAtmosCapability (const JsonObject& parameters, JsonObject& response) 
         {   //sample servicemanager response:
             LOGINFOMETHOD();
-			bool success = true;
-			dsATMOSCapability_t atmosCapability;
+            bool success = true;
+            bool isValidAudioPort =  false;
+            dsATMOSCapability_t atmosCapability;
+            string audioPort = parameters.HasLabel("audioPort") ? parameters["audioPort"].String() : "NULL";
             try
             {
-                if (device::Host::getInstance().isHDMIOutPortPresent())
+                if(audioPort != "NULL") {
+                    device::List<device::AudioOutputPort> aPorts = device::Host::getInstance().getAudioOutputPorts();
+                    for (size_t i = 0; i < aPorts.size(); i++)
+                    {
+                        device::AudioOutputPort port = aPorts.at(i);
+                        if(audioPort == port.getName()) {
+                            isValidAudioPort = true;
+                            break;
+                        }
+                    }
+
+                    if(isValidAudioPort != true) {
+                         success = false;
+                         LOGERR("getSinkAtmosCapability failure: Unsupported Audio Port!!!\n");
+                         returnResponse(success);
+                    }
+		}
+
+                if (device::Host::getInstance().isHDMIOutPortPresent()) //STB
                 {
                     device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort("HDMI0");
+                    if(isValidAudioPort) {
+                        aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
+                    }
                     if (aPort.isConnected()) {
                         aPort.getSinkDeviceAtmosCapability (atmosCapability);
                         response["atmos_capability"] = (int)atmosCapability;
                     }
                     else {
-                        LOGERR("getSinkAtmosCapability failure: HDMI0 not connected!\n");
+                        LOGERR("getSinkAtmosCapability failure: %s not connected!\n", aPort.getName().c_str());
                         success = false;
                     }
                 }
-                else {
-                    device::Host::getInstance().getSinkDeviceAtmosCapability (atmosCapability);
-                    response["atmos_capability"] = (int)atmosCapability;
+                else { //TV
+                    if(isValidAudioPort) {
+                        device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
+                        if ( (aPort.getName() == "HDMI_ARC0" && aPort.isConnected() && m_arcAudioEnabled == true) || (aPort.getName() != "HDMI_ARC0" && aPort.isConnected()) )  {
+                            aPort.getSinkDeviceAtmosCapability (atmosCapability);
+                            response["atmos_capability"] = (int)atmosCapability;
+                        }
+                        else {
+                            LOGERR("getSinkAtmosCapability failure: %s not connected!\n", audioPort.c_str());
+                            success = false;
+                        }
+                    }
+                    else {
+                        device::Host::getInstance().getSinkDeviceAtmosCapability (atmosCapability);
+                        response["atmos_capability"] = (int)atmosCapability;
+                    }
                 }
             }
             catch(const device::Exception& err)
             {
-                LOG_DEVICE_EXCEPTION1(string("HDMI0"));
+                LOG_DEVICE_EXCEPTION1(audioPort);
                 success = false;
             }
             returnResponse(success);

--- a/DisplaySettings/DisplaySettings.json
+++ b/DisplaySettings/DisplaySettings.json
@@ -951,6 +951,17 @@
         },
         "getSinkAtmosCapability":{
             "summary": "Returns the ATMOS capability of the sink (HDMI0).",
+	    "params": {
+                "type":"object",
+                "properties": {
+                    "audioPort": {
+                        "$ref": "#/definitions/audioPort1"
+                    }
+                },
+                "required": [
+                    ""
+                ]
+            },
             "result": {
                 "type":"object",
                 "properties": {


### PR DESCRIPTION
Reason for change: Handled for all audio output
ports and host capability
Test Procedure: Refer Ticket
Risks: Low

Signed-off-by: Deekshit Devadas deekshit.devadasy@sky.uk