### PR TITLE
AMLOGIC-3747: [Passthru] Audio loss on HDMI Hotplug during MAT playback

### DIFF
--- a/DisplaySettings/CHANGELOG.md
+++ b/DisplaySettings/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+## [1.1.12] - 2022-11-08
+### Fixed
+- Fixed No Audio issue while playing Dolby Mat and HDMI hotplug
+
 ## [1.1.11] - 2022-11-08
 ### Changed
 - Handled identifying Atmos sink capability for all audio output ports and host capability

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -79,7 +79,7 @@ using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 1
-#define API_VERSION_NUMBER_PATCH 11
+#define API_VERSION_NUMBER_PATCH 12
 
 static bool isCecArcRoutingThreadEnabled = false;
 static bool isCecEnabled = false;
@@ -4240,7 +4240,7 @@ namespace WPEFramework {
                     device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
 
                     aPort.getSupportedARCTypes(&types);
-                    if((aPort.isConnected()) && (m_hdmiCecAudioDeviceDetected)) {
+                    if((aPort.isConnected()) && (m_hdmiCecAudioDeviceDetected || m_hdmiInAudioDeviceConnected)) {
                         LOGINFO("DisplaySettings::setEnableAudioPort Configuring User set Audio mode before starting ARC/eARC Playback...\n");
                         if(aPort.getStereoAuto() == true) {
                             if(types & dsAUDIOARCSUPPORT_eARC) {


### PR DESCRIPTION
Reason for change: SAD request was missed intermittently durin Hotplug Test Procedure: As described in ticket
Risks: Low

Signed-off-by: shashank.kumar@sky.uk <shashank.kumar@sky.uk>