### PR TITLE
LLAMA-7846 : Fix for Incorrect OSD

### DIFF
--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -1719,7 +1719,25 @@ namespace WPEFramework
 				{
 					LOGINFO(" addr = %d, portID = %d", phy_addr.getByteValue(0), hdmiInputs[i].m_portID);
 					if (phy_addr.getByteValue(0) == (hdmiInputs[i].m_portID + 1)) {
-						hdmiInputs[i].addChild(logicalAddress, phy_addr);
+						/* If two logical adress being sent from the same audio device,
+						   map Audio device LA to the HdmiPortMap */
+                                                if ((phy_addr.getByteValue(0) ==
+                                                                        hdmiInputs[i].m_physicalAddr.getByteValue(0) &&
+                                                        phy_addr.getByteValue(1) ==
+                                                                        hdmiInputs[i].m_physicalAddr.getByteValue(1) &&
+                                                        phy_addr.getByteValue(2) ==
+                                                                        hdmiInputs[i].m_physicalAddr.getByteValue(2) &&
+                                                        phy_addr.getByteValue(3) ==
+                                                                       hdmiInputs[i].m_physicalAddr.getByteValue(3)) &&
+                                                    hdmiInputs[i].m_logicalAddr.toInt() != LogicalAddress::UNREGISTERED) {
+                                                    if (hdmiInputs[i].m_logicalAddr.toInt() != LogicalAddress::AUDIO_SYSTEM){
+                                                        LOGINFO("Adding Audio device");
+                                                        hdmiInputs[i].addChild(logicalAddress, phy_addr);
+                                                    }
+                                                } else {
+                                                    LOGINFO("Adding Child");
+                                                    hdmiInputs[i].addChild(logicalAddress, phy_addr);
+                                                }
 					}
 				}
 			}
@@ -2009,6 +2027,9 @@ namespace WPEFramework
 					  catch(Exception &e)
 					  {
 						LOGWARN("Ping device: 0x%x caught %s \r\n", i, e.what());
+						if ( _instance->deviceList[i].m_isDevicePresent ) {
+                                                        --i;
+                                                }
                                                 usleep(50000);
                                                 continue;
 					  }

--- a/HdmiCecSink/HdmiCecSink.h
+++ b/HdmiCecSink/HdmiCecSink.h
@@ -286,7 +286,11 @@ namespace WPEFramework {
 				LOGINFO(" logicalAddr = %d, phisicalAddr = %s", m_logicalAddr.toInt(), physical_addr.toString().c_str());
 				
 				if ( m_logicalAddr.toInt() != LogicalAddress::UNREGISTERED &&
-						m_logicalAddr.toInt() != logical_addr.toInt() )
+						m_logicalAddr.toInt() != logical_addr.toInt() &&
+                                                (physical_addr.getByteValue(0) != m_physicalAddr.getByteValue(0) ||
+                                                physical_addr.getByteValue(1) != m_physicalAddr.getByteValue(1) ||
+                                                physical_addr.getByteValue(2) != m_physicalAddr.getByteValue(2) ||
+                                                physical_addr.getByteValue(3) != m_physicalAddr.getByteValue(3)) )
 				{
 					LOGINFO(" update own logicalAddr = %d, new devcie logicalAddress = %d", m_logicalAddr.toInt(), logical_addr.toInt() );
 					/* check matching with this port's physical address */


### PR DESCRIPTION
Reason for change: Incorrect OSD name is displayed on a non-hdcp source HDMI input tile
Test Procedure: Refer Ticket
Risks: Create None
Signed-off-by: jijonath kannath jijonath.kannath@sky.uk