### PR TITLE
Build Erro fix for thunder R3.5 upgrade

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -4902,7 +4902,8 @@ namespace WPEFramework {
                     message->Id = 0;
                     message->Designator = "Controller.1.activate";
                     message->Parameters = "{\"callsign\":\"org.rdk.HdmiCecSink\"}";
-                    auto resp = controller->Invoke("", ~0, *message);
+		    Core::JSONRPC::Context context(~0,0,"");
+                    auto resp = controller->Invoke(context, *message);
                     if (resp->Error.IsSet()) {
                         std::cout << "Call failed: " << message->Designator.Value() << " error: " << resp->Error.Text.Value() << "\n";
                     }


### PR DESCRIPTION
The function Invoke change to
"Core::ProxyType<Core::JSONRPC::Message> Invoke(const Core::JSONRPC::Context& token, const Core::JSONRPC::Message& inbound)"  in Thunder R3.5 from "Core::ProxyType<Core::JSONRPC::Message> Invoke(const string& token, const uint32_t channelId, const Core::JSONRPC::Message& inbound)"