### PR TITLE
RDKTV-20401: TV did not enter to Deepsleep , and stayed ~14 hrs in th…

### DIFF
--- a/MaintenanceManager/CHANGELOG.md
+++ b/MaintenanceManager/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.0.8] - 2022-11-16
+### Fixed
+- Send MAINTENANCE_ERROR event from stopMaintenance()
+
 ## [1.0.7] - 2022-10-07
 ### Fixed
 - Fixed race condition in MM while checking for network connectivity"

--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -685,7 +685,7 @@ namespace WPEFramework {
                         case MAINT_RFC_COMPLETE :
                             if(task_status_RFC->second != true) {
                                  LOGINFO("Ignoring Event RFC_COMPLETE");
-                                 return;
+                                 break;
                             }
                             else {
                                  SET_STATUS(g_task_status,RFC_SUCCESS);
@@ -697,7 +697,7 @@ namespace WPEFramework {
                         case MAINT_DCM_COMPLETE :
                             if(task_status_DCM->second != true) {
                                  LOGINFO("Ignoring Event DCM_COMPLETE");
-                                 return;
+                                 break;
                             }
                             else {
                                 SET_STATUS(g_task_status,DCM_SUCCESS);
@@ -709,7 +709,7 @@ namespace WPEFramework {
                         case MAINT_FWDOWNLOAD_COMPLETE :
                             if(task_status_FWDLD->second != true) {
                                  LOGINFO("Ignoring Event MAINT_FWDOWNLOAD_COMPLETE");
-                                 return;
+                                 break;
                             }
                             else {
                                 SET_STATUS(g_task_status,DIFD_SUCCESS);
@@ -721,7 +721,7 @@ namespace WPEFramework {
                        case MAINT_LOGUPLOAD_COMPLETE :
                             if(task_status_LOGUPLD->second != true) {
                                  LOGINFO("Ignoring Event MAINT_LOGUPLOAD_COMPLETE");
-                                 return;
+                                 break;
                             }
                             else {
                                 SET_STATUS(g_task_status,LOGUPLOAD_SUCCESS);
@@ -749,6 +749,7 @@ namespace WPEFramework {
                         case MAINT_DCM_ERROR:
                             if(task_status_DCM->second != true) {
                                  LOGINFO("Ignoring Event DCM_ERROR");
+                                 break;
                             }
                             else {
                                 SET_STATUS(g_task_status,DCM_COMPLETE);
@@ -760,7 +761,7 @@ namespace WPEFramework {
                         case MAINT_RFC_ERROR:
                             if(task_status_RFC->second != true) {
                                  LOGINFO("Ignoring Event RFC_ERROR");
-                                 return;
+                                 break;
                             }
                             else {
                                  SET_STATUS(g_task_status,RFC_COMPLETE);
@@ -773,7 +774,7 @@ namespace WPEFramework {
                         case MAINT_LOGUPLOAD_ERROR:
                             if(task_status_LOGUPLD->second != true) {
                                   LOGINFO("Ignoring Event MAINT_LOGUPLOAD_ERROR");
-                                  return;
+                                  break;
                             }
                             else {
                                 SET_STATUS(g_task_status,LOGUPLOAD_COMPLETE);
@@ -786,7 +787,7 @@ namespace WPEFramework {
                        case MAINT_FWDOWNLOAD_ERROR:
                             if(task_status_FWDLD->second != true) {
                                  LOGINFO("Ignoring Event MAINT_FWDOWNLOAD_ERROR");
-                                 return;
+                                 break;
                             }
                             else {
                                 SET_STATUS(g_task_status,DIFD_COMPLETE);

--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -873,6 +873,9 @@ namespace WPEFramework {
                 LOGWARN("Ignoring unexpected event - owner: %s, eventId: %d!!", owner, eventId);
             }
           }
+          else {
+              LOGINFO("Abort flag has been set and hence ignoring the event");
+          }
           m_statusMutex.unlock();
         }
         void MaintenanceManager::DeinitializeIARM()

--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -874,7 +874,7 @@ namespace WPEFramework {
             }
           }
           else {
-              LOGINFO("Abort flag has been set and hence ignoring the event");
+              LOGINFO("Maintenance has been aborted. Hence ignoring the event");
           }
           m_statusMutex.unlock();
         }
@@ -1329,6 +1329,7 @@ namespace WPEFramework {
                     m_thread.join();
                     LOGINFO("Thread joined successfully\n");
                 }
+                LOGINFO("Maintenance has been stopped. Hence setting maintenance status to MAINTENANCE_ERROR\n");
                 MaintenanceManager::_instance->onMaintenanceStatusChange(MAINTENANCE_ERROR);
 		m_statusMutex.unlock();
 


### PR DESCRIPTION
…e standby state

Maintenance window is open for long time and it was not completed successfully and hence TV didn't went to deepsleep.

Whenever stopMaintenance Api executed, it will terminate the task which is currently running and will send that event status to MM, also it will update the status of remaining tasks as well. Since MM didn't trigger those scripts it will simply ignore those events and so maintenance was not completed. Hence added changes to directly send the MAINTENANCE_ERROR event from stopMaintenance()