### PR TITLE
RDKCOM-3430: Remove old workaround for PersistentStore config

### DIFF
--- a/PersistentStore/PersistentStore.cpp
+++ b/PersistentStore/PersistentStore.cpp
@@ -71,17 +71,6 @@ const string PersistentStore::Initialize(PluginHost::IShell *service)
     ASSERT(service != nullptr);
 
     string configLine = service->ConfigLine();
-
-    // TODO
-    if (configLine == "{}") {
-        configLine = "{\n"
-                     "\"path\":\"/opt/secure/persistent/rdkservicestore\",\n"
-                     "\"key\":null,\n"
-                     "\"maxsize\":1000000,\n"
-                     "\"maxvalue\":1000\n"
-                     "}";
-    }
-
     _config.FromString(configLine);
 
     ASSERT(!_config.Path.Value().empty());


### PR DESCRIPTION
Reason for change: Workaround is no longer needed.
Test Procedure: PersistentStore activates.
Risks: None
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>