### PR TITLE
LLAMA-8095: Fix for passing empty value to stof in getSignalData (#3396)

### DIFF
--- a/WifiManager/CHANGELOG.md
+++ b/WifiManager/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.0.3] - 2022-11-17
+### Fixed
+- Avoid throw invalid argument error
+
 ## [1.0.2] - 2022-10-18
 ### Changed
 - API access on all versions of the handler

--- a/WifiManager/impl/WifiManagerSignalThreshold.cpp
+++ b/WifiManager/impl/WifiManagerSignalThreshold.cpp
@@ -65,7 +65,13 @@ namespace {
         string signalStrength = retrieveValues(Command, buff, sizeof (buff));
 
         signalStrengthOut = 0.0f;
-        signalStrengthOut = std::stof(signalStrength.c_str());
+        if (!signalStrength.empty())
+            signalStrengthOut = std::stof(signalStrength.c_str());
+        else {
+            LOGERR("signalStrength is empty\n");
+            strengthOut = "Disconnected";
+            return;
+        }
 
         if (signalStrengthOut >= signalStrengthThresholdExcellent && signalStrengthOut < 0)
         {


### PR DESCRIPTION
Reason for change: Avoid throw invalid argument error Fix above issue: Checking before passing string is empty or not Test Procedure:
Risks: High
Signed-off-by: Kumar Santhanam <Kumar_Santhanam@comcast.com>
(cherry picked from commit 66abf8584239c89584c4b53ee6ba7780c3694dc9)