### PR TITLE
SecurityAgent: Secure REST API methods in a granular way

### DIFF
--- a/SecurityAgent/AccessControlList.h
+++ b/SecurityAgent/AccessControlList.h
@@ -40,7 +40,7 @@ namespace {
         string regex = input;
         
         // order of replacing is important
-        ReplaceString(regex,"*","^[a-zA-Z0-9.]+$");
+        ReplaceString(regex,"*","^[a-zA-Z0-9.]*");
         ReplaceString(regex,".","\\.");
         
         return regex;
@@ -57,7 +57,7 @@ namespace {
         ReplaceString(regex,":*",":[0-9]+");
         ReplaceString(regex,"*:","[a-z]+:");
         ReplaceString(regex,".","\\.");
-        ReplaceString(regex,"*","[a-zA-Z0-9\\.\\-]+");
+        ReplaceString(regex,"*","[a-zA-Z0-9\\.\\-]*");
         regex.insert(regex.begin(),'(');
         regex.insert(regex.end(),')');
         regex.insert(regex.begin(),'^');
@@ -295,7 +295,7 @@ namespace Plugin {
                     while ((index != _methods.end()) && (found == false)) { 
                         std::regex expression(index->c_str());
                         std::smatch matchList;
-                        found = std::regex_search(method, matchList, expression);
+                        found = std::regex_match(method, matchList, expression);
                         if (found == false) {
                             index++;
                         }
@@ -338,7 +338,7 @@ namespace Plugin {
                 while ((index != _plugins.end()) && (pluginFound == false)) {
                     std::regex expression(index->first.c_str());
                     std::smatch matchList;
-                    pluginFound = std::regex_search(callsign, matchList, expression);
+                    pluginFound = std::regex_match(callsign, matchList, expression);
                     if (pluginFound == false) {
                         index++;
                     }

--- a/SecurityAgent/SecurityAgent.cpp
+++ b/SecurityAgent/SecurityAgent.cpp
@@ -95,8 +95,11 @@ namespace Plugin {
         Config config;
         config.FromString(service->ConfigLine());
         string version = service->Version();
+        string webPrefix = service->WebPrefix();
+        string callsign = service->Callsign();
 
-        _skipURL = static_cast<uint8_t>(service->WebPrefix().length());
+        _skipURL = static_cast<uint8_t>(webPrefix.length());
+        _servicePrefix = webPrefix.substr(0, webPrefix.find(callsign));
         Core::File aclFile(service->PersistentPath() + config.ACL.Value(), true);
 
         PluginHost::ISubSystem* subSystem = service->SubSystems();
@@ -137,7 +140,7 @@ namespace Plugin {
             } else {
                 if (subSystem != nullptr) {
                     Core::SystemInfo::SetEnvironment(_T("SECURITYAGENT_PATH"), _dispatcher->Connector().c_str(), true);
-                    Core::Sink<SecurityCallsign> information(service->Callsign());
+                    Core::Sink<SecurityCallsign> information(callsign);
 
                     if (subSystem->IsActive(PluginHost::ISubSystem::SECURITY) != false) {
                         SYSLOG(Logging::Startup, (_T("Security is not defined as External !!")));
@@ -200,7 +203,7 @@ namespace Plugin {
 
             if (load != static_cast<uint16_t>(~0)) {
                 // Seems like we extracted a valid payload, time to create an security context
-                result = Core::Service<SecurityContext>::Create<SecurityContext>(&_acl, load, payload);
+                result = Core::Service<SecurityContext>::Create<SecurityContext>(&_acl, load, payload, _servicePrefix);
             }
         }
         return (result);

--- a/SecurityAgent/SecurityAgent.h
+++ b/SecurityAgent/SecurityAgent.h
@@ -164,6 +164,7 @@ namespace Plugin {
         uint8_t _skipURL;
         std::unique_ptr<TokenDispatcher> _dispatcher; 
         Core::ProxyType<RPC::InvokeServer> _engine;
+        string _servicePrefix;
     };
 
 } // namespace Plugin

--- a/SecurityAgent/SecurityContext.h
+++ b/SecurityAgent/SecurityContext.h
@@ -57,7 +57,7 @@ namespace Plugin {
         SecurityContext(const SecurityContext&) = delete;
         SecurityContext& operator=(const SecurityContext&) = delete;
 
-        SecurityContext(const AccessControlList* acl, const uint16_t length, const uint8_t payload[]);
+        SecurityContext(const AccessControlList* acl, const uint16_t length, const uint8_t payload[], const string& servicePrefix);
         virtual ~SecurityContext();
 
         //! Allow a websocket upgrade to be checked if it is allowed to be opened.
@@ -81,6 +81,7 @@ namespace Plugin {
         string _token;
         Payload _context;
         const AccessControlList::Filter* _accessControlList;
+        string _servicePrefix;
     };
 }
 }


### PR DESCRIPTION
This PR brings in the changes to secure REST API methods in a granular way. It also fixes some issues related to regex comparisons.

v1(https://github.com/rdkcentral/rdkservices/pull/3437) -> v2
Removed the change in `CreateRegex()` to treat `. `as a wildcard character