### PR TITLE
Redirect logs to another systemd service.

### DIFF
--- a/WebKitBrowser/CMakeLists.txt
+++ b/WebKitBrowser/CMakeLists.txt
@@ -49,6 +49,7 @@ option(PLUGIN_WEBKITBROWSER_ENABLE_DFG "Enable the use of DFG javascript optimal
 option(PLUGIN_APPS_ENABLE_JIT "Enable the use of JIT javascript optimalization" OFF)
 option(PLUGIN_APPS_ENABLE_DFG "Enable the use of DFG javascript optimalization" OFF)
 option(PLUGIN_WEBKITBROWSER_CLOUD_COOKIEJAR "Enable support for exporting/importing cookie jar" OFF)
+option(PLUGIN_WEBKITBROWSER_LOGGING_UTILS "Enable possibility to redirect stdout/err to specific systemd service" OFF)
 
 set(PLUGIN_WEBKITBROWSER_IMPLEMENTATION "${MODULE_NAME}Impl" CACHE STRING "Specify a library with a webkit implementation." )
 
@@ -211,6 +212,11 @@ if (PLUGIN_WEBKITBROWSER_CLOUD_COOKIEJAR)
         ENABLE_CLOUD_COOKIE_JAR=1)
     target_sources(${PLUGIN_WEBKITBROWSER_IMPLEMENTATION} PRIVATE CookieJar.cpp)
     include(CookieJarCrypto/CMakeLists.txt)
+endif()
+
+if (PLUGIN_WEBKITBROWSER_LOGGING_UTILS)
+    target_compile_definitions(${PLUGIN_WEBKITBROWSER_IMPLEMENTATION} PRIVATE ENABLE_LOGGING_UTILS)
+    target_sources(${PLUGIN_WEBKITBROWSER_IMPLEMENTATION} PRIVATE LoggingUtils.cpp)
 endif()
 
 if(WPE_WEBKIT_DEPRECATED_API)

--- a/WebKitBrowser/JSPP.config
+++ b/WebKitBrowser/JSPP.config
@@ -125,6 +125,7 @@ map()
             kv(value "/opt/QT/home")
         end()
 
+    kv(loggingtarget "sky-jspp.service")
 end()
 ans(configuration)
 

--- a/WebKitBrowser/LoggingUtils.cpp
+++ b/WebKitBrowser/LoggingUtils.cpp
@@ -1,0 +1,132 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stddef.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include <syslog.h>
+#include <signal.h>
+#include <glib.h>
+
+#include "Module.h"
+
+namespace WPEFramework {
+namespace Plugin {
+
+bool RedirectAllLogsToService(const string& target_service)
+{
+  if (target_service.empty()) {
+    fprintf(stderr, "RedirectLog: Invalid argument. Logs target service expected\n");
+    return false;
+  }
+  const string kServiceExt = ".service";
+  if (target_service.size() <= kServiceExt.size() ||
+      target_service.substr(target_service.size() - kServiceExt.size(), kServiceExt.size()) != kServiceExt) {
+    fprintf(stderr, "RedirectLog: Invalid serivce name: *.service format expected\n");
+    return false;
+  }
+
+  const string targetServiceName = target_service.substr(0, target_service.size() - kServiceExt.size());
+  const string kSystemdCgroupTargetTasksFilePath = "/sys/fs/cgroup/systemd/system.slice/" + target_service + "/tasks";
+  if (!g_file_test(kSystemdCgroupTargetTasksFilePath.c_str(), G_FILE_TEST_EXISTS)) {
+    fprintf(stderr, "RedirectLog: %s unit cgroup doesn't exist\n", target_service.c_str());
+    return false;
+  }
+
+  // Add all threads of current process to target systemd cgroup
+  WPEFramework::Core::Directory taskDir("/proc/self/task");
+  while (taskDir.Next() == true) {
+    if (taskDir.Name() == "." || taskDir.Name() == "..")
+      continue;
+    FILE* f = fopen(kSystemdCgroupTargetTasksFilePath.c_str(), "a");
+    if (f) {
+      fprintf(f, "%s", taskDir.Name().c_str());
+      fclose(f);
+    } else {
+      fprintf(stderr, "RedirectLog: cannot move %s thread to '%s': %s\n",
+              taskDir.Name().c_str(), kSystemdCgroupTargetTasksFilePath.c_str(), strerror(errno));
+    }
+  }
+
+  // Redirect stdout / stderr
+  sockaddr_un sa;
+  memset (&sa, 0, sizeof (sa));
+  sa.sun_family = AF_UNIX;
+  g_strlcpy (sa.sun_path, "/run/systemd/journal/stdout", sizeof(sa.sun_path));
+
+  int fd = -1;
+  fd = socket(AF_UNIX, SOCK_STREAM, 0);
+  if (fd < 0) {
+    perror("RedirectLog: socket() failed");
+    return false;
+  }
+
+  int r = connect(fd, (const sockaddr*)&sa, sizeof(sa));
+  if (r < 0) {
+    perror("RedirectLog: couldn't connect");
+    close(fd);
+    return false;
+  }
+
+  shutdown(fd, SHUT_RD);
+
+  int value = (8*1024*1024);
+  setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &value, sizeof(value));
+
+  char* header = g_strdup_printf("%s\n%s\n%i\n%i\n0\n0\n0\n", targetServiceName.c_str(), target_service.c_str(), (LOG_DAEMON|LOG_INFO), 1);
+  char *p = header;
+  size_t nbytes = strlen(header);
+
+  do {
+    ssize_t k;
+    k = write(fd, p, nbytes);
+    if (k < 0) {
+      if (errno == EINTR)
+        continue;
+      perror("RedirectLog: write() failed");
+      break;
+    }
+    p += k;
+    nbytes -= k;
+  }
+  while (nbytes > 0);
+  g_free(header);
+
+  if (nbytes != 0) {
+    perror("RedirectLog: write() not completed");
+    close(fd);
+    return false;
+  }
+
+#ifdef SIGPIPE
+  signal (SIGPIPE, SIG_IGN);
+#endif
+
+  dup3(fd, STDOUT_FILENO, 0);
+  dup3(fd, STDERR_FILENO, 0);
+
+  close(fd);
+  return true;
+}
+
+}
+}

--- a/WebKitBrowser/LoggingUtils.h
+++ b/WebKitBrowser/LoggingUtils.h
@@ -1,0 +1,30 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <core/Portability.h>
+
+namespace WPEFramework {
+namespace Plugin {
+
+bool RedirectAllLogsToService(const string& target_service);
+
+}
+}

--- a/WebKitBrowser/WebKitImplementation.cpp
+++ b/WebKitBrowser/WebKitImplementation.cpp
@@ -74,6 +74,10 @@ WK_EXPORT void WKPreferencesSetPageCacheEnabled(WKPreferencesRef preferences, bo
 #include <libsoup/soup.h>
 #endif
 
+#if defined(ENABLE_LOGGING_UTILS)
+#include "LoggingUtils.h"
+#endif
+
 namespace WPEFramework {
 namespace Plugin {
 
@@ -538,6 +542,7 @@ static GSourceFuncs _handlerIntervention =
                 , CookieAcceptPolicy()
                 , EnvironmentVariables()
                 , ContentFilter()
+                , LoggingTarget()
             {
                 Add(_T("useragent"), &UserAgent);
                 Add(_T("url"), &URL);
@@ -602,6 +607,7 @@ static GSourceFuncs _handlerIntervention =
                 Add(_T("cookieacceptpolicy"), &CookieAcceptPolicy);
                 Add(_T("environmentvariables"), &EnvironmentVariables);
                 Add(_T("contentfilter"), &ContentFilter);
+                Add(_T("loggingtarget"), &LoggingTarget);
             }
             ~Config()
             {
@@ -671,6 +677,7 @@ static GSourceFuncs _handlerIntervention =
             Core::JSON::EnumType<HTTPCookieAcceptPolicyType> CookieAcceptPolicy;
             Core::JSON::ArrayType<EnvironmentVariable> EnvironmentVariables;
             Core::JSON::String ContentFilter;
+            Core::JSON::String LoggingTarget;
         };
 
         class HangDetector
@@ -2114,6 +2121,14 @@ static GSourceFuncs _handlerIntervention =
                         configLine.c_str()));
                 return (Core::ERROR_INCOMPLETE_CONFIG);
             }
+
+            #if defined(ENABLE_LOGGING_UTILS)
+            if (!_config.LoggingTarget.Value().empty()) {
+                if (!RedirectAllLogsToService(_config.LoggingTarget.Value())) {
+                    SYSLOG(Logging::Error, (_T("Could not redirect logs to %s"), _config.LoggingTarget.Value().c_str()));
+                }
+            }
+            #endif
 
             bool environmentOverride(WebKitBrowser::EnvironmentOverride(_config.EnvironmentOverride.Value()));
 


### PR DESCRIPTION
With rdkbrowser2 all browser logs were part of a parent service. Webkit browser plugin prints logs as wpeframework service.

This change adds possibility to redirect all webkit browser plugin logs (stdout and stderr) to another systemd service to preserve any logging monitors and file watchers still working.