### PR TITLE
RDK-37915: Unit Testcases for Network plugin

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -249,6 +249,7 @@ jobs:
           -DPLUGIN_HDMIINPUT=ON
           -DPLUGIN_HDCPPROFILE=ON
           -DPLUGIN_TRACECONTROL=ON
+          -DPLUGIN_NETWORK=ON
           -DPLUGIN_WIFIMANAGER=ON
           -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
@@ -260,6 +261,9 @@ jobs:
 
       - name: Install valgrind
         run: sudo apt update && sudo apt install -y valgrind
+
+      - name: Install traceroute
+        run: sudo apt update && sudo apt install -y traceroute
 
       - name: Set up files
         run: >

--- a/Network/CMakeLists.txt
+++ b/Network/CMakeLists.txt
@@ -30,6 +30,10 @@ add_library(${MODULE_NAME} SHARED
         PingNotifier.cpp
         Module.cpp)
 
+set_source_files_properties(
+	Network.cpp
+        PROPERTIES COMPILE_FLAGS "-fexceptions")
+
 set_target_properties(${MODULE_NAME} PROPERTIES
         CXX_STANDARD 11
         CXX_STANDARD_REQUIRED YES)

--- a/Network/Network.cpp
+++ b/Network/Network.cpp
@@ -64,73 +64,6 @@ using namespace std;
 // TODO: remove this
 #define registerMethod(...) for (uint8_t i = 1; GetHandler(i); i++) GetHandler(i)->Register<JsonObject, JsonObject>(__VA_ARGS__)
 
-typedef enum _NetworkManager_EventId_t {
-    IARM_BUS_NETWORK_MANAGER_EVENT_SET_INTERFACE_ENABLED=50,
-    IARM_BUS_NETWORK_MANAGER_EVENT_SET_INTERFACE_CONTROL_PERSISTENCE,
-    IARM_BUS_NETWORK_MANAGER_EVENT_WIFI_INTERFACE_STATE,
-    IARM_BUS_NETWORK_MANAGER_EVENT_INTERFACE_ENABLED_STATUS,
-    IARM_BUS_NETWORK_MANAGER_EVENT_INTERFACE_CONNECTION_STATUS,
-    IARM_BUS_NETWORK_MANAGER_EVENT_INTERFACE_IPADDRESS,
-    IARM_BUS_NETWORK_MANAGER_EVENT_DEFAULT_INTERFACE,
-    IARM_BUS_NETWORK_MANAGER_MAX,
-} IARM_Bus_NetworkManager_EventId_t;
-
-typedef struct _IARM_BUS_NetSrvMgr_Iface_EventData_t {
-    union {
-        char activeIface[INTERFACE_SIZE];
-        char allNetworkInterfaces[INTERFACE_LIST];
-        char setInterface[INTERFACE_SIZE];
-        char activeIfaceIpaddr[MAX_IP_ADDRESS_LEN];
-    };
-    char interfaceCount;
-    bool isInterfaceEnabled;
-    bool persist;
-    char ipfamily[MAX_IP_FAMILY_SIZE];
-} IARM_BUS_NetSrvMgr_Iface_EventData_t;
-
-typedef struct
-{
-    unsigned char size;
-    char          endpoints[MAX_ENDPOINTS][MAX_ENDPOINT_SIZE];
-} IARM_BUS_NetSrvMgr_Iface_TestEndpoints_t;
-
-typedef struct {
-    char interface[16];
-    char gateway[MAX_IP_ADDRESS_LEN];
-} IARM_BUS_NetSrvMgr_DefaultRoute_t;
-
-typedef struct {
-    char interface[16];
-    bool status;
-} IARM_BUS_NetSrvMgr_Iface_EventInterfaceStatus_t;
-
-typedef IARM_BUS_NetSrvMgr_Iface_EventInterfaceStatus_t IARM_BUS_NetSrvMgr_Iface_EventInterfaceEnabledStatus_t;
-typedef IARM_BUS_NetSrvMgr_Iface_EventInterfaceStatus_t IARM_BUS_NetSrvMgr_Iface_EventInterfaceConnectionStatus_t;
-
-typedef struct {
-    char interface[16];
-    char ip_address[MAX_IP_ADDRESS_LEN];
-    bool is_ipv6;
-    bool acquired;
-} IARM_BUS_NetSrvMgr_Iface_EventInterfaceIPAddress_t;
-
-typedef struct {
-    char oldInterface[16];
-    char newInterface[16];
-} IARM_BUS_NetSrvMgr_Iface_EventDefaultInterface_t;
-
-typedef struct
-{
-    char server[MAX_HOST_NAME_LEN];
-    uint16_t port;
-    bool ipv6;
-    char interface[16];
-    uint16_t bind_timeout;
-    uint16_t cache_timeout;
-    bool sync;
-    char public_ip[MAX_IP_ADDRESS_LEN];
-} IARM_BUS_NetSrvMgr_Iface_StunRequest_t;
-
 namespace WPEFramework
 {
     
@@ -1441,12 +1374,12 @@ namespace WPEFramework
         {
             if (strcmp(owner, IARM_BUS_NM_SRV_MGR_NAME) != 0)
             {
-                LOGERR("ERROR - unexpected event: owner %s, eventId: %d, data: %p, size: %d.", owner, (int)eventId, data, len);
+                LOGERR("ERROR - unexpected event: owner %s, eventId: %d, data: %p, size: %d.", owner, (int)eventId, data, (int)len);
                 return;
             }
             if (data == nullptr || len == 0)
             {
-                LOGERR("ERROR - event with NO DATA: eventId: %d, data: %p, size: %d.", (int)eventId, data, len);
+                LOGERR("ERROR - event with NO DATA: eventId: %d, data: %p, size: %d.", (int)eventId, data, (int)len);
                 return;
             }
 

--- a/Network/Network.h
+++ b/Network/Network.h
@@ -19,7 +19,6 @@
 
 #pragma once
 
-#include <cjson/cJSON.h>
 #include <string>
 #include <atomic>
 
@@ -33,6 +32,18 @@
 //#define USE_NETLINK
 #define MAX_IP_ADDRESS_LEN 46
 #define NETSRVMGR_INTERFACES_MAX 16
+
+typedef enum _NetworkManager_EventId_t {
+    IARM_BUS_NETWORK_MANAGER_EVENT_SET_INTERFACE_ENABLED=50,
+    IARM_BUS_NETWORK_MANAGER_EVENT_SET_INTERFACE_CONTROL_PERSISTENCE,
+    IARM_BUS_NETWORK_MANAGER_EVENT_WIFI_INTERFACE_STATE,
+    IARM_BUS_NETWORK_MANAGER_EVENT_INTERFACE_ENABLED_STATUS,
+    IARM_BUS_NETWORK_MANAGER_EVENT_INTERFACE_CONNECTION_STATUS,
+    IARM_BUS_NETWORK_MANAGER_EVENT_INTERFACE_IPADDRESS,
+    IARM_BUS_NETWORK_MANAGER_EVENT_DEFAULT_INTERFACE,
+    IARM_BUS_NETWORK_MANAGER_MAX,
+} IARM_Bus_NetworkManager_EventId_t;
+
 
 typedef struct {
     char name[16];
@@ -68,6 +79,49 @@ typedef struct {
     bool isSupported;
     NetworkManager_GetIPSettings_ErrorCode_t errCode;
 } IARM_BUS_NetSrvMgr_Iface_Settings_t;
+
+typedef struct
+{
+    unsigned char size;
+    char          endpoints[MAX_ENDPOINTS][MAX_ENDPOINT_SIZE];
+} IARM_BUS_NetSrvMgr_Iface_TestEndpoints_t;
+
+typedef struct {
+    char interface[16];
+    char gateway[MAX_IP_ADDRESS_LEN];
+} IARM_BUS_NetSrvMgr_DefaultRoute_t;
+
+typedef struct {
+    char interface[16];
+    bool status;
+} IARM_BUS_NetSrvMgr_Iface_EventInterfaceStatus_t;
+
+typedef IARM_BUS_NetSrvMgr_Iface_EventInterfaceStatus_t IARM_BUS_NetSrvMgr_Iface_EventInterfaceEnabledStatus_t;
+typedef IARM_BUS_NetSrvMgr_Iface_EventInterfaceStatus_t IARM_BUS_NetSrvMgr_Iface_EventInterfaceConnectionStatus_t;
+
+typedef struct {
+    char interface[16];
+    char ip_address[MAX_IP_ADDRESS_LEN];
+    bool is_ipv6;
+    bool acquired;
+} IARM_BUS_NetSrvMgr_Iface_EventInterfaceIPAddress_t;
+
+typedef struct {
+    char oldInterface[16];
+    char newInterface[16];
+} IARM_BUS_NetSrvMgr_Iface_EventDefaultInterface_t;
+
+typedef struct
+{
+    char server[MAX_HOST_NAME_LEN];
+    uint16_t port;
+    bool ipv6;
+    char interface[16];
+    uint16_t bind_timeout;
+    uint16_t cache_timeout;
+    bool sync;
+    char public_ip[MAX_IP_ADDRESS_LEN];
+} IARM_BUS_NetSrvMgr_Iface_StunRequest_t;
 
 namespace WPEFramework {
     namespace Plugin {

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -63,6 +63,7 @@ include_directories(../LocationSync
         ../HdmiInput
         ../HdcpProfile
         ../TraceControl
+        ../Network
 	../WifiManager
         )
 link_directories(../LocationSync
@@ -85,6 +86,7 @@ link_directories(../LocationSync
         ../HdmiInput
         ../HdcpProfile
         ../TraceControl
+        ../Network
 	../WifiManager
         )
 
@@ -112,7 +114,8 @@ target_link_libraries(${PROJECT_NAME}
         ${NAMESPACE}HdmiInput
         ${NAMESPACE}HdcpProfile
         ${NAMESPACE}TraceControl
-        ${NAMESPACE}WifiManager
+	${NAMESPACE}Network
+	${NAMESPACE}WifiManager
         )
 
 target_include_directories(${PROJECT_NAME}

--- a/Tests/mocks/Iarm.h
+++ b/Tests/mocks/Iarm.h
@@ -28,6 +28,7 @@ public:
     virtual IARM_Result_t IARM_Bus_UnRegisterEventHandler(const char* ownerName, IARM_EventId_t eventId) = 0;
     virtual IARM_Result_t IARM_Bus_Call(const char* ownerName, const char* methodName, void* arg, size_t argLen) = 0;
     virtual IARM_Result_t IARM_Bus_RegisterCall(const char* methodName, IARM_BusCall_t handler) = 0;
+    virtual IARM_Result_t IARM_Bus_Call_with_IPCTimeout(const char *ownerName,  const char *methodName, void *arg, size_t argLen, int timeout) = 0;
 };
 
 class IarmBus {
@@ -73,6 +74,11 @@ public:
     {
         return getInstance().impl->IARM_Bus_RegisterCall(methodName, handler);
     }
+
+    static IARM_Result_t IARM_Bus_Call_with_IPCTimeout(const char *ownerName,  const char *methodName, void *arg, size_t argLen, int timeout)
+    {
+        return getInstance().impl->IARM_Bus_Call_with_IPCTimeout(ownerName, methodName, arg, argLen, timeout);
+    }
 };
 
 constexpr auto IARM_Bus_Init = &IarmBus::IARM_Bus_Init;
@@ -82,6 +88,7 @@ constexpr auto IARM_Bus_RegisterEventHandler = &IarmBus::IARM_Bus_RegisterEventH
 constexpr auto IARM_Bus_UnRegisterEventHandler = &IarmBus::IARM_Bus_UnRegisterEventHandler;
 constexpr auto IARM_Bus_Call = &IarmBus::IARM_Bus_Call;
 constexpr auto IARM_Bus_RegisterCall = &IarmBus::IARM_Bus_RegisterCall;
+constexpr auto IARM_Bus_Call_with_IPCTimeout = &IarmBus::IARM_Bus_Call_with_IPCTimeout;
 
 #define IARM_BUS_COMMON_API_SysModeChange "SysModeChange"
 
@@ -871,26 +878,51 @@ typedef enum _IARM_Bus_NMgr_WiFi_EventId_t {
     IARM_BUS_WIFI_MGR_EVENT_MAX,           		/*!< Maximum event id*/
 } IARM_Bus_NMgr_WiFi_EventId_t;
 
-/* ############################# netsrvmgrIarm.h ################################# */
-
+/* ############################## Network Manager ####################### */
+#define IARM_BUS_NM_SRV_MGR_NAME "NET_SRV_MGR"
 #define INTERFACE_SIZE 10
 #define INTERFACE_LIST 50
-#define NETSRVMGR_INTERFACES_MAX 16
 #define MAX_IP_ADDRESS_LEN 46
 #define MAX_IP_FAMILY_SIZE 10
 #define MAX_HOST_NAME_LEN 128
-
+#define MAX_ENDPOINTS 5
+#define MAX_ENDPOINT_SIZE 260 // 253 + 1 + 5 + 1 (domain name max length + ':' + port number max chars + '\0')
+#define IARM_BUS_NETSRVMGR_API_getActiveInterface "getActiveInterface"
+#define IARM_BUS_NETSRVMGR_API_getNetworkInterfaces "getNetworkInterfaces"
+#define IARM_BUS_NETSRVMGR_API_getInterfaceList "getInterfaceList"
+#define IARM_BUS_NETSRVMGR_API_getDefaultInterface "getDefaultInterface"
+#define IARM_BUS_NETSRVMGR_API_setDefaultInterface "setDefaultInterface"
+#define IARM_BUS_NETSRVMGR_API_isInterfaceEnabled "isInterfaceEnabled"
 #define IARM_BUS_NETSRVMGR_API_setInterfaceEnabled "setInterfaceEnabled"
+#define IARM_BUS_NETSRVMGR_API_getSTBip "getSTBip"
+#define IARM_BUS_NETSRVMGR_API_setIPSettings "setIPSettings"
+#define IARM_BUS_NETSRVMGR_API_getIPSettings "getIPSettings"
+#define IARM_BUS_NETSRVMGR_API_getSTBip_family "getSTBip_family"
+#define IARM_BUS_NETSRVMGR_API_isConnectedToInternet "isConnectedToInternet"
+#define IARM_BUS_NETSRVMGR_API_setConnectivityTestEndpoints "setConnectivityTestEndpoints"
+#define IARM_BUS_NETSRVMGR_API_isAvailable "isAvailable"
+#define IARM_BUS_NETSRVMGR_API_getPublicIP "getPublicIP"
 
+// TODO: remove this
+#define registerMethod(...) for (uint8_t i = 1; GetHandler(i); i++) GetHandler(i)->Register<JsonObject, JsonObject>(__VA_ARGS__)
+
+/* Netsrvmgr Based Macros & Structures */
 typedef struct _IARM_BUS_NetSrvMgr_Iface_EventData_t {
-   union {
+    union {
         char activeIface[INTERFACE_SIZE];
         char allNetworkInterfaces[INTERFACE_LIST];
         char setInterface[INTERFACE_SIZE];
-	char activeIfaceIpaddr[MAX_IP_ADDRESS_LEN];
-	};
-   char interfaceCount;
-   bool isInterfaceEnabled;
-   bool persist;
-   char ipfamily[MAX_IP_FAMILY_SIZE];
+        char activeIfaceIpaddr[MAX_IP_ADDRESS_LEN];
+    };
+    char interfaceCount;
+    bool isInterfaceEnabled;
+    bool persist;
+    char ipfamily[MAX_IP_FAMILY_SIZE];
 } IARM_BUS_NetSrvMgr_Iface_EventData_t;
+
+#define IARM_BUS_SYSMGR_API_RunScript "RunScript"
+/*! Parameter for RunScript call*/
+typedef struct _IARM_Bus_SYSMgr_RunScript_t{
+    char script_path [256];   //[in]  Null terminated path name of the script.
+    int  return_value;        //[out] Returns the ret value of system.
+} IARM_Bus_SYSMgr_RunScript_t;

--- a/Tests/mocks/IarmBusMock.h
+++ b/Tests/mocks/IarmBusMock.h
@@ -28,6 +28,8 @@ public:
             .WillByDefault(::testing::Return(IARM_RESULT_SUCCESS));
         ON_CALL(*this, IARM_Bus_RegisterCall(::testing::_, ::testing::_))
             .WillByDefault(::testing::Return(IARM_RESULT_SUCCESS));
+        ON_CALL(*this, IARM_Bus_Call_with_IPCTimeout(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_))
+            .WillByDefault(::testing::Return(IARM_RESULT_SUCCESS));
     }
     virtual ~IarmBusImplMock() = default;
 
@@ -38,4 +40,5 @@ public:
     MOCK_METHOD(IARM_Result_t, IARM_Bus_UnRegisterEventHandler, (const char* ownerName, IARM_EventId_t eventId), (override));
     MOCK_METHOD(IARM_Result_t, IARM_Bus_Call, (const char* ownerName, const char* methodName, void* arg, size_t argLen), (override));
     MOCK_METHOD(IARM_Result_t, IARM_Bus_RegisterCall, (const char* methodName, IARM_BusCall_t handler), (override));
+    MOCK_METHOD(IARM_Result_t, IARM_Bus_Call_with_IPCTimeout, (const char *ownerName,  const char *methodName, void *arg, size_t argLen, int timeout), (override));
 };

--- a/Tests/tests/test_Network.cpp
+++ b/Tests/tests/test_Network.cpp
@@ -1,0 +1,487 @@
+#include <gtest/gtest.h>
+#include <fstream>
+#include <iostream>
+#include "Network.h"
+
+#include "FactoriesImplementation.h"
+#include "ServiceMock.h"
+#include "IarmBusMock.h"
+#include "WrapsMock.h"
+
+using namespace std;
+using namespace WPEFramework;
+extern "C" FILE* __real_popen(const char* command, const char* type);
+
+class NetworkTestBase : public ::testing::Test {
+public:
+
+    WrapsImplMock wrapsImplMock;
+    IarmBusImplMock iarmBusImplMock;
+
+    NetworkTestBase()
+    {
+        Wraps::getInstance().impl = &wrapsImplMock;
+        IarmBus::getInstance().impl = &iarmBusImplMock;
+
+        ofstream file("/etc/device.properties");
+        file << "DEVICE_TYPE=mediaclient\n";
+        file << "WIFI_SUPPORT=true\n";
+        file << "MOCA_INTERFACE=true\n";
+        file <<"WIFI_INTERFACE==wlan0\n";
+        file <<"MOCA_INTERFACE=eth0\n";
+        file <<"ETHERNET_INTERFACE=eth0\n";
+        file.close();
+
+        ON_CALL(wrapsImplMock, popen(::testing::_, ::testing::_))
+            .WillByDefault(::testing::Invoke(
+             [&](const char* command, const char* type) -> FILE* {
+                return __real_popen(command, type);
+            }));
+    }
+};
+
+class NetworkTest : public NetworkTestBase {
+protected:
+
+    Core::ProxyType<Plugin::Network> plugin;
+    Core::JSONRPC::Handler& handler;
+    Core::JSONRPC::Connection connection;
+    string response;
+
+    Core::JSONRPC::Message message;
+    ServiceMock service;
+
+    NetworkTest() : plugin(Core::ProxyType<Plugin::Network>::Create()),
+                    handler(*plugin),
+                    connection(1, 0)
+    {
+        IARM_EventHandler_t interfaceEnabled;
+        IARM_EventHandler_t interfaceConnection;
+        IARM_EventHandler_t interfaceIpaddress;
+        IARM_EventHandler_t defaultInterface;
+
+        EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call_with_IPCTimeout)
+            .Times(::testing::AnyNumber())
+            .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen, int timeout) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_isAvailable)));
+                return IARM_RESULT_SUCCESS;
+     });
+
+        ON_CALL(iarmBusImplMock, IARM_Bus_RegisterEventHandler(::testing::_, ::testing::_, ::testing::_))
+            .WillByDefault(::testing::Invoke(
+            [&](const char* ownerName, IARM_EventId_t eventId, IARM_EventHandler_t handler) {
+            if ((string(IARM_BUS_NM_SRV_MGR_NAME) == string(ownerName)) && (eventId == IARM_BUS_NETWORK_MANAGER_EVENT_INTERFACE_ENABLED_STATUS)) {
+                interfaceEnabled = handler;
+            }
+            if ((string(IARM_BUS_NM_SRV_MGR_NAME) == string(ownerName)) && (eventId == IARM_BUS_NETWORK_MANAGER_EVENT_INTERFACE_CONNECTION_STATUS)) {
+                interfaceConnection = handler;
+            }
+            if ((string(IARM_BUS_NM_SRV_MGR_NAME) == string(ownerName)) && (eventId == IARM_BUS_NETWORK_MANAGER_EVENT_INTERFACE_IPADDRESS)) {
+                interfaceIpaddress = handler;
+            }
+            if ((string(IARM_BUS_NM_SRV_MGR_NAME) == string(ownerName)) && (eventId == IARM_BUS_NETWORK_MANAGER_EVENT_DEFAULT_INTERFACE)) {
+                defaultInterface = handler;
+            }
+            return IARM_RESULT_SUCCESS;
+        }));
+
+        EXPECT_EQ(string(""), plugin->Initialize(&service));
+    }
+
+    virtual ~NetworkTest() override
+    {
+        Wraps::getInstance().impl = nullptr;
+        IarmBus::getInstance().impl = nullptr;
+    }
+};
+
+TEST_F(NetworkTest, RegisteredMethods)
+{
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("getStbIp")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("getInterfaces")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("isInterfaceEnabled")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("setInterfaceEnabled")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("getDefaultInterface")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("getIPSettings")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("isConnectedToInternet")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("getPublicIP")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("getSTBIPFamily")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("setConnectivityTestEndpoints")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("setDefaultInterface")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("setIPSettings")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("trace")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("traceNamedEndpoint")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("getNamedEndpoints")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("pingNamedEndpoint")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("ping")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("getQuirks")));
+}
+
+TEST_F(NetworkTest, getStbIp)
+{
+    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_getSTBip)));
+
+                auto param = static_cast<IARM_BUS_NetSrvMgr_Iface_EventData_t*>(arg);
+                memcpy(&param->activeIfaceIpaddr, "192.168.1.101", sizeof("192.168.1.101"));
+                EXPECT_EQ(string(param->activeIfaceIpaddr), string(_T("192.168.1.101")));
+
+                return IARM_RESULT_SUCCESS;
+           });
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getStbIp"), _T("{}"), response));
+    EXPECT_EQ(response, string("{\"ip\":\"192.168.1.101\",\"success\":true}"));
+}
+
+TEST_F(NetworkTest, getInterfaces)
+{
+    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_getInterfaceList)));
+                auto param = static_cast<IARM_BUS_NetSrvMgr_InterfaceList_t *>(arg);
+
+				param->size = 1;
+                memcpy(&param->interfaces[0].name, "eth0", sizeof("eth0"));
+                memcpy(&param->interfaces[0].mac, "AA:AA:AA:AA:AA:AA", sizeof("AA:AA:AA:AA:AA:AA"));
+                param->interfaces[0].flags = 69699;
+
+                return IARM_RESULT_SUCCESS;
+            });
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getInterfaces"), _T("{}"), response));
+	EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"interface\":\"ETHERNET\"")));
+	EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"macAddress\":\"AA:AA:AA:AA:AA:AA\"")));
+	EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"enabled\":true")));
+	EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"connected\":true")));
+	EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"success\":true")));
+}
+
+TEST_F(NetworkTest, isInterfaceEnabled)
+{
+    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_isInterfaceEnabled)));
+                auto param = static_cast<IARM_BUS_NetSrvMgr_Iface_EventData_t  *>(arg);
+
+                memcpy(&param->setInterface, "ETHERNET", sizeof("ETHERNET"));
+	            param->isInterfaceEnabled = true;
+
+                EXPECT_EQ(string(param->setInterface), string(_T("ETHERNET")));
+                EXPECT_EQ(param->isInterfaceEnabled, true);
+
+                return IARM_RESULT_SUCCESS;
+            });
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("isInterfaceEnabled"), _T("{\"interface\": \"ETHERNET\"}"), response));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"enabled\":true")));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"success\":true")));
+}
+
+TEST_F(NetworkTest, getDefaultInterface)
+{
+    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_getDefaultInterface)));
+                auto param = static_cast<IARM_BUS_NetSrvMgr_DefaultRoute_t *>(arg);
+                memcpy(&param->interface, "eth0", sizeof("eth0"));
+                memcpy(&param->gateway, "192.168.1.1", sizeof("192.168.1.1"));
+
+                return IARM_RESULT_SUCCESS;
+            });
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getDefaultInterface"), _T("{}"), response));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"interface\":\"ETHERNET\"")));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"success\":true")));
+}
+
+TEST_F(NetworkTest, getIPSettings)
+{
+    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_getIPSettings)));
+
+                auto param = static_cast<IARM_BUS_NetSrvMgr_Iface_Settings_t  *>(arg);
+	            memcpy(&param->interface, "ETHERNET", sizeof("ETHERNET"));
+                memcpy(&param->ipversion, "IPV4", sizeof("IPV4"));
+                param->autoconfig  = true;
+                memcpy(&param->ipaddress, "192.168.1.101", sizeof("192.168.1.101"));
+                memcpy(&param->netmask, "255.255.255.0", sizeof("255.255.255.0"));
+	            memcpy(&param->gateway, "192.168.1.1", sizeof("192.168.1.1"));
+                memcpy(&param->primarydns, "192.168.1.1", sizeof("192.168.1.1"));
+                memcpy(&param->secondarydns, "192.168.1.2", sizeof("192.168.1.2"));
+
+                EXPECT_EQ(string(param->interface), string(_T("ETHERNET")));
+                EXPECT_EQ(string(param->ipversion), string(_T("IPV4")));
+                EXPECT_EQ(string(param->ipaddress), string(_T("192.168.1.101")));
+                EXPECT_EQ(string(param->netmask), string(_T("255.255.255.0")));
+                EXPECT_EQ(string(param->gateway), string(_T("192.168.1.1")));
+                EXPECT_EQ(string(param->primarydns), string(_T("192.168.1.1")));
+                EXPECT_EQ(string(param->secondarydns), string(_T("192.168.1.2")));
+                EXPECT_EQ(param->autoconfig, true);
+
+                return IARM_RESULT_SUCCESS;
+            });
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getIPSettings"), _T("{\"interface\": \"ETHERNET\",\"ipversion\": \"IPV4\"}"), response));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"interface\":\"ETHERNET\"")));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"ipversion\":\"IPV4\"")));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"autoconfig\":true")));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"ipaddr\":\"192.168.1.101\"")));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"netmask\":\"255.255.255.0\"")));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"gateway\":\"192.168.1.1\"")));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"primarydns\":\"192.168.1.1\"")));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"secondarydns\":\"192.168.1.2\"")));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"success\":true")));
+}
+
+TEST_F(NetworkTest, isConnectedToInternet)
+{
+    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_isConnectedToInternet)));
+                *((bool*) arg) = true;
+
+                EXPECT_EQ(*((bool*) arg), true);
+
+                return IARM_RESULT_SUCCESS;
+            });
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("isConnectedToInternet"), _T("{}"), response));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"connectedToInternet\":true")));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"success\":true")));
+}
+
+TEST_F(NetworkTest, getPublicIP)
+{
+    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_getPublicIP)));
+                auto param = static_cast<IARM_BUS_NetSrvMgr_Iface_StunRequest_t   *>(arg);
+                memcpy(&param->public_ip, "69.136.49.95", sizeof("69.136.49.95"));
+
+                EXPECT_EQ(string(param->public_ip), string(_T("69.136.49.95")));
+
+                return IARM_RESULT_SUCCESS;
+            });
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getPublicIP"), _T("{\"iface\": \"WIFI\", \"ipv6\": false}"), response));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"public_ip\":\"69.136.49.95\"")));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"success\":true")));
+}
+
+TEST_F(NetworkTest, setInterfaceEnabled)
+{
+    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_setInterfaceEnabled)));
+
+                return IARM_RESULT_SUCCESS;
+            });
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("setInterfaceEnabled"), _T("{\"interface\": \"WIFI\", \"enabled\": true, \"persist\": true}"), response));
+    EXPECT_EQ(response, string("{\"success\":true}"));
+}
+
+TEST_F(NetworkTest, getSTBIPFamily)
+{
+
+    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_getIPSettings)));
+
+                auto param = static_cast<IARM_BUS_NetSrvMgr_Iface_Settings_t  *>(arg);
+                memcpy(&param->interface, "ETHERNET", sizeof("ETHERNET"));
+                memcpy(&param->ipversion, "IPV4", sizeof("IPV4"));
+                param->autoconfig  = true;
+                memcpy(&param->ipaddress, "192.168.1.101", sizeof("192.168.1.101"));
+                memcpy(&param->netmask, "255.255.255.0", sizeof("255.255.255.0"));
+                memcpy(&param->gateway, "192.168.1.1", sizeof("192.168.1.1"));
+                memcpy(&param->primarydns, "192.168.1.1", sizeof("192.168.1.1"));
+                memcpy(&param->secondarydns, "192.168.1.2", sizeof("192.168.1.2"));
+
+                EXPECT_EQ(string(param->interface), string(_T("ETHERNET")));
+                EXPECT_EQ(string(param->ipversion), string(_T("IPV4")));
+                EXPECT_EQ(string(param->ipaddress), string(_T("192.168.1.101")));
+                EXPECT_EQ(string(param->netmask), string(_T("255.255.255.0")));
+                EXPECT_EQ(string(param->gateway), string(_T("192.168.1.1")));
+                EXPECT_EQ(string(param->primarydns), string(_T("192.168.1.1")));
+                EXPECT_EQ(string(param->secondarydns), string(_T("192.168.1.2")));
+                EXPECT_EQ(param->autoconfig, true);
+
+                return IARM_RESULT_SUCCESS;
+            });
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getIPSettings"), _T("{\"interface\": \"ETHERNET\",\"ipversion\": \"IPV4\"}"), response));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getSTBIPFamily"), _T("{\"family\": \"AF_INET\"}"), response));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"ip\":\"192.168.1.101\"")));
+	EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"success\":true")));
+}
+
+TEST_F(NetworkTest, setConnectivityTestEndpoints)
+{
+    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_setConnectivityTestEndpoints)));
+
+                return IARM_RESULT_SUCCESS;
+            });
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("setConnectivityTestEndpoints"), _T("{\"endpoints\": [\"xfinity.com:8080\"]}"), response));
+    EXPECT_EQ(response, string("{\"success\":true}"));
+}
+
+TEST_F(NetworkTest, setDefaultInterface)
+{
+    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_setDefaultInterface)));
+
+                return IARM_RESULT_SUCCESS;
+            });
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("setDefaultInterface"), _T("{\"interface\": \"WIFI\", \"persist\": true}"), response));
+    EXPECT_EQ(response, string("{\"success\":true}"));
+}
+
+TEST_F(NetworkTest, setIPSettings)
+{
+    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_setIPSettings)));
+
+                auto param = static_cast<IARM_BUS_NetSrvMgr_Iface_Settings_t  *>(arg);
+                param->isSupported = true;
+                return IARM_RESULT_SUCCESS;
+            });
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("setIPSettings"), _T("{\"interface\": \"WIFI\", \"ipversion\": \"IPV4\",\"autoconfig\": true,\"ipaddr\": \"192.168.1.101\",\"netmask\": \"255.255.255.0\",\"gateway\": \"192.168.1.1\",\"primarydns\": \"192.168.1.1\",\"secondarydns\": \"192.168.1.2\"}"), response));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"supported\":true")));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"success\":true")));
+}
+
+TEST_F(NetworkTest, trace)
+{
+    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_getDefaultInterface)));
+
+                auto param = static_cast<IARM_BUS_NetSrvMgr_DefaultRoute_t *>(arg);
+                memcpy(&param->interface, "eth0", sizeof("eth0"));
+                memcpy(&param->gateway, "45.57.221.20", sizeof("45.57.221.20"));
+
+                return IARM_RESULT_SUCCESS;
+            });
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getDefaultInterface"), _T("{}"), response));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("trace"), _T("{\"endpoint\":\"45.57.221.20\", \"packets\":5}"), response));
+	EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"success\":true")));
+}
+
+TEST_F(NetworkTest, traceNamedEndpoint)
+{
+	EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_getDefaultInterface)));
+
+                auto param = static_cast<IARM_BUS_NetSrvMgr_DefaultRoute_t *>(arg);
+                memcpy(&param->interface, "eth0", sizeof("eth0"));
+				memcpy(&param->gateway, "45.57.221.20", sizeof("45.57.221.20"));
+
+                return IARM_RESULT_SUCCESS;
+            });
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getDefaultInterface"), _T("{}"), response));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("traceNamedEndpoint"), _T("{\"endpointName\": \"CMTS\", \"packets\": 5}"), response));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"success\":true")));
+}
+
+TEST_F(NetworkTest, getNamedEndpoints)
+{
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getNamedEndpoints"), _T("{}"), response));
+	EXPECT_EQ(response, string("{\"endpoints\":[\"CMTS\"],\"success\":true}"));
+}
+
+TEST_F(NetworkTest, pingNamedEndpoint)
+{
+	EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_getDefaultInterface)));
+
+                auto param = static_cast<IARM_BUS_NetSrvMgr_DefaultRoute_t *>(arg);
+                memcpy(&param->interface, "eth0", sizeof("eth0"));
+                memcpy(&param->gateway, "127.0.0.1", sizeof("127.0.0.1"));
+
+                return IARM_RESULT_SUCCESS;
+            });
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getDefaultInterface"), _T("{}"), response));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("pingNamedEndpoint"), _T("{\"endpointName\": \"CMTS\", \"packets\": 5, \"guid\": \"...\"}"), response));
+   	EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"target\":\"127.0.0.1\"")));
+	EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"success\":true")));
+	EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"packetsTransmitted\":5")));
+	EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"packetsReceived\":5")));
+	EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"packetLoss\":\" 0\"")));
+}
+
+TEST_F(NetworkTest, ping)
+{
+	EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_getDefaultInterface)));
+
+                auto param = static_cast<IARM_BUS_NetSrvMgr_DefaultRoute_t *>(arg);
+                memcpy(&param->interface, "eth0", sizeof("eth0"));
+                memcpy(&param->gateway, "192.168.1.1", sizeof("192.168.1.1"));
+
+                return IARM_RESULT_SUCCESS;
+            });
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getDefaultInterface"), _T("{}"), response));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("ping"), _T("{\"endpoint\": \"127.0.0.1\", \"packets\": 5, \"guid\": \"...\"}"), response));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"target\":\"127.0.0.1\"")));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"success\":true")));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"packetsTransmitted\":5")));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"packetsReceived\":5")));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"packetLoss\":\" 0\"")));
+}
+
+TEST_F(NetworkTest, getQuirks)
+{
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getQuirks"), _T("{}"), response));
+	EXPECT_EQ(response, string("{\"quirks\":[\"RDK-20093\"],\"success\":true}"));
+}


### PR DESCRIPTION
Reason for change: Implement unit testcases for network plugin part rdkservices Fix above issue:
Test Procedure: Run unit test cases for Rdkservices
Risks: High
Signed-off-by: Kumar Santhanam <Kumar_Santhanam@comcast.com>