### PR TITLE
XIONE-9937: CEC bus busy write failures

### DIFF
--- a/HdmiCec/HdmiCec.cpp
+++ b/HdmiCec/HdmiCec.cpp
@@ -854,6 +854,10 @@ namespace WPEFramework
 	bool HdmiCec::pingDeviceUpdateList (int idev)
 	{
 		bool isConnected = false;
+		//self ping is not required
+		if ((unsigned int)idev == logicalAddress){
+			return isConnected;
+		}
 		if(!HdmiCec::_instance)
 		{
 			LOGERR("HdmiCec::_instance not existing");

--- a/HdmiCec_2/HdmiCec_2.cpp
+++ b/HdmiCec_2/HdmiCec_2.cpp
@@ -1424,6 +1424,10 @@ namespace WPEFramework
 	bool HdmiCec_2::pingDeviceUpdateList (int idev)
 	{
 		bool isConnected = false;
+		//self ping is not required
+		if (idev == logicalAddress.toInt()){
+		        return isConnected;
+		}
 		if(!HdmiCec_2::_instance)
 		{
 			LOGERR("HdmiCec_2::_instance not existing");


### PR DESCRIPTION
Reason for change:
CEC bus busy write failures
Self ping removed
Test Procedure: None
Risks: Low

Change-Id: Id65780406f002f9c31bd348b79e2a5f08f6b2a54 Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>