### PR TITLE
XIONE-9937: CEC bus busy write failures

### DIFF
--- a/HdmiCec/HdmiCec.cpp
+++ b/HdmiCec/HdmiCec.cpp
@@ -854,6 +854,10 @@ namespace WPEFramework
 	bool HdmiCec::pingDeviceUpdateList (int idev)
 	{
 		bool isConnected = false;
+		//self ping is not required
+		if ((unsigned int)idev == logicalAddress){
+			return isConnected;
+		}
 		if(!HdmiCec::_instance)
 		{
 			LOGERR("HdmiCec::_instance not existing");

--- a/HdmiCecSource/HdmiCecSource.cpp
+++ b/HdmiCecSource/HdmiCecSource.cpp
@@ -1424,6 +1424,10 @@ namespace WPEFramework
 	bool HdmiCecSource::pingDeviceUpdateList (int idev)
 	{
 		bool isConnected = false;
+		//self ping is not required
+		if (idev == logicalAddress.toInt()){
+		        return isConnected;
+		}
 		if(!HdmiCecSource::_instance)
 		{
 			LOGERR("HdmiCecSource::_instance not existing");

--- a/HdmiCec_2/HdmiCec_2.cpp
+++ b/HdmiCec_2/HdmiCec_2.cpp
@@ -1424,6 +1424,10 @@ namespace WPEFramework
 	bool HdmiCec_2::pingDeviceUpdateList (int idev)
 	{
 		bool isConnected = false;
+		//self ping is not required
+		if (idev == logicalAddress.toInt()){
+		        return isConnected;
+		}
 		if(!HdmiCec_2::_instance)
 		{
 			LOGERR("HdmiCec_2::_instance not existing");


### PR DESCRIPTION
Reason for change:
CEC bus busy write failures
Self ping removed
Test Procedure: None
Risks: Low

Change-Id: I290b608f843f44f9fc93984b2e20830303116f04 Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>