### PR TITLE
Rdkservices FrontPanel plugin memory not released properly

### DIFF
--- a/FrontPanel/FrontPanel.cpp
+++ b/FrontPanel/FrontPanel.cpp
@@ -208,6 +208,7 @@ namespace WPEFramework
 
         void FrontPanel::Deinitialize(PluginHost::IShell* /* service */)
         {
+	    CFrontPanel::instance()->Deinitialize();
             FrontPanel::_instance = nullptr;
 
             {

--- a/FrontPanel/FrontPanel.cpp
+++ b/FrontPanel/FrontPanel.cpp
@@ -208,7 +208,6 @@ namespace WPEFramework
 
         void FrontPanel::Deinitialize(PluginHost::IShell* /* service */)
         {
-	    CFrontPanel::instance()->Deinitialize();
             FrontPanel::_instance = nullptr;
 
             {

--- a/helpers/frontpanel.cpp
+++ b/helpers/frontpanel.cpp
@@ -190,6 +190,19 @@ namespace WPEFramework
             return s_instance;
         }
 
+	void CFrontPanel::Deinitialize()
+	{
+	    if(s_instance){
+		if(mFrontPanelHelper)
+		{
+			delete mFrontPanelHelper;
+			mFrontPanelHelper = nullptr;
+		}
+		delete s_instance;
+		s_instance = nullptr;
+	    }
+	}
+
         bool CFrontPanel::start()
         {
             LOGWARN("Front panel start");

--- a/helpers/frontpanel.h
+++ b/helpers/frontpanel.h
@@ -99,6 +99,7 @@ namespace WPEFramework
         {
         public:
             static CFrontPanel* instance();
+	    void Deinitialize();
             bool start();
             bool stop();
             std::string getLastError();
@@ -142,11 +143,15 @@ namespace WPEFramework
 
             std::string lastError_;
             FrontPanelHelper* mFrontPanelHelper;
+	    ~CFrontPanel(){}
         };
-
+	
         class FrontPanelHelper
         {
-            void setRemoteLedState(bool state);
+	    private: 
+            		void setRemoteLedState(bool state);
+	    public:
+			virtual ~FrontPanelHelper() = default;
         };
 
     } // namespace Plugin


### PR DESCRIPTION
[DELIA-59064](https://ccp.sys.comcast.net/browse/DELIA-59064): Rdkservices FrontPanel plugin memory not released properly

Reason for change:

Fixing memory leak discovered by valgrind log in frontpanel.cpp (helper)
present
Test Procedure: None
Risks: Low


Signed-off-by:Hayden Gfeller <Hayden_Gfeller@comcast.com>