### PR TITLE
RDKDEV-426: SecurityAgent: Enable visibility of Plugin_SecurityAgent Module in Metrological Dashboard

### DIFF
--- a/SecurityAgent/Module.h
+++ b/SecurityAgent/Module.h
@@ -17,16 +17,13 @@
  * limitations under the License.
  */
  
-#ifndef TIMESYNC_MODULE_H
-#define TIMESYNC_MODULE_H
+#pragma once
 
 #ifndef MODULE_NAME
-#define MODULE_NAME Plugin_TimeSync
+#define MODULE_NAME Plugin_SecurityAgent
 #endif
 
 #include <plugins/plugins.h>
 
 #undef EXTERNAL
 #define EXTERNAL
-
-#endif // TIMESYNC_MODULE_H


### PR DESCRIPTION
This Pull request is to enable Plugin_SecurityAgent option in "**Tracing -> Modules**" in ML Dashboard.  
The issue arised because the plugin was available as "**Plugin_TimeSync**" in ML dashboard instead of "**Plugin_SecurityAgent**"

The **Plugin_SecurityAgent** module can now be seen listed in ML dashboard replacing "Plugin_TimeSync:

![Screenshot (92)](https://user-images.githubusercontent.com/119570354/205003065-fa018672-5fef-44f2-81a6-03f831d2e655.png)

**Testing:** Tried to enable "**Trace::Information**" log from dashboard and also by modifying "tracing.json" file for **Plugin_SecurityAgent** and in both the cases was successfully able to generate logs.