### PR TITLE
XIONE-9937: CEC bus busy write failures

### DIFF
--- a/HdmiCec/CHANGELOG.md
+++ b/HdmiCec/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.0.4] - 2022-12-09
+### Fixed
+- Self ping removed
+
 ## [1.0.3] - 2022-11-22
 ### Fixed
 - RAII thread midifications

--- a/HdmiCec/HdmiCec.cpp
+++ b/HdmiCec/HdmiCec.cpp
@@ -57,7 +57,7 @@
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 3
+#define API_VERSION_NUMBER_PATCH 4
 
 enum {
 	HDMICEC_EVENT_DEVICE_ADDED=0,
@@ -854,6 +854,10 @@ namespace WPEFramework
 	bool HdmiCec::pingDeviceUpdateList (int idev)
 	{
 		bool isConnected = false;
+		//self ping is not required
+		if ((unsigned int)idev == logicalAddress){
+			return isConnected;
+		}
 		if(!HdmiCec::_instance)
 		{
 			LOGERR("HdmiCec::_instance not existing");

--- a/HdmiCec_2/CHANGELOG.md
+++ b/HdmiCec_2/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.0.5] - 2022-12-09
+### Fixed
+- Self ping removed
+
 ## [1.0.4] - 2022-11-22
 ### Fixed
 - RAII thread midifications

--- a/HdmiCec_2/HdmiCec_2.cpp
+++ b/HdmiCec_2/HdmiCec_2.cpp
@@ -57,7 +57,7 @@
 #define HDMICEC_EVENT_ON_STANDBY_MSG_RECEIVED "standbyMessageReceived"
 #define DEV_TYPE_TUNER 1
 #define HDMI_HOT_PLUG_EVENT_CONNECTED 0
-#define ABORT_REASON_ID 4
+#define ABORT_REASON_ID 5
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
@@ -1424,6 +1424,10 @@ namespace WPEFramework
 	bool HdmiCec_2::pingDeviceUpdateList (int idev)
 	{
 		bool isConnected = false;
+		//self ping is not required
+		if (idev == logicalAddress.toInt()){
+		        return isConnected;
+		}
 		if(!HdmiCec_2::_instance)
 		{
 			LOGERR("HdmiCec_2::_instance not existing");


### PR DESCRIPTION
Reason for change:
CEC bus busy write failures
Self ping removed
Test Procedure: None
Risks: Low

Change-Id: I290b608f843f44f9fc93984b2e20830303116f04 Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>