### PR TITLE
Updated the yml to pull Thunder R2 from specific REV

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   BUILD_TYPE: Debug
-  THUNDER_REF: "R2-v1.12"
+  THUNDER_REF: "a87b48eca1e76c3e6f03d689e6302b1fb090b52c"
   INTERFACES_REF: "f61d710cc51628819d0fd80b8cc65e55eeec12b4"
 
 jobs:


### PR DESCRIPTION
Thunder updated to address visibility of ```class Netlink::Parameters``` to public and this change is to verify the unit test frame work compilation.


Signed-off-by: Karunakaran A <karunakaran_amirthalingam@cable.comcast.com>