### PR TITLE
DELIA-59417 Thunder plugin failing when building for g-unit tests for rdkservices

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   unit-tests:
     name: Build and run unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Set up cache

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   BUILD_TYPE: Debug
-  THUNDER_REF: "a87b48eca1e76c3e6f03d689e6302b1fb090b52c"
+  THUNDER_REF: "R2-v1.12"
   INTERFACES_REF: "f61d710cc51628819d0fd80b8cc65e55eeec12b4"
 
 jobs:


### PR DESCRIPTION
Thunder failing when building for g-unit tests for rdkservices because of Ubuntu version change in Github workflow form October onwards they choosing Ubuntu 22.04 as ubuntu latest so because of that default tool version also changed this leads to the build error