### PR TITLE
RDKDEV-459: fix DisplaySettings core dump

### DIFF
--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -258,7 +258,7 @@ namespace WPEFramework {
             int m_hdmiInAudioDevicePowerState;
             int m_currentArcRoutingState;
 
-            PluginHost::IShell* m_service;
+            PluginHost::IShell* m_service = nullptr;
 
         public:
             static DisplaySettings* _instance;


### PR DESCRIPTION
Without default null value, the plugin dumps on

ASSERT(m_service == nullptr);

in DisplaySettings::Initialize