### PR TITLE
RDKDEV-460: Propagate autostart configuration for the DisplaySettings, HdcpProfile, HdmiCec and XCast rdkservices

### DIFF
--- a/DisplaySettings/CMakeLists.txt
+++ b/DisplaySettings/CMakeLists.txt
@@ -18,6 +18,7 @@
 set(PLUGIN_NAME DisplaySettings)
 set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
 
+set(PLUGIN_DISPLAYSETTINGS_AUTOSTART "false" CACHE STRING "Automatically start DisplaySettings plugin")
 set(PLUGIN_DISPLAYSETTINGS_STARTUPORDER "" CACHE STRING "To configure startup order of DisplaySettings plugin")
 
 find_package(${NAMESPACE}Plugins REQUIRED)

--- a/DisplaySettings/DisplaySettings.config
+++ b/DisplaySettings/DisplaySettings.config
@@ -1,4 +1,4 @@
-set (autostart false)
+set (autostart ${PLUGIN_DISPLAYSETTINGS_AUTOSTART})
 set (preconditions Platform)
 set (callsign "org.rdk.DisplaySettings")
 

--- a/HdcpProfile/CMakeLists.txt
+++ b/HdcpProfile/CMakeLists.txt
@@ -18,6 +18,7 @@
 set(PLUGIN_NAME HdcpProfile)
 set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
 
+set(PLUGIN_HDCPPROFILE_AUTOSTART "false" CACHE STRING "Automatically start HdcpProfile plugin")
 set(PLUGIN_HDCPPROFILE_STARTUPORDER "" CACHE STRING "To configure startup order of HdcpProfile plugin")
 
 find_package(${NAMESPACE}Plugins REQUIRED)

--- a/HdcpProfile/HdcpProfile.config
+++ b/HdcpProfile/HdcpProfile.config
@@ -1,4 +1,4 @@
-set (autostart false)
+set (autostart ${PLUGIN_HDCPPROFILE_AUTOSTART})
 set (preconditions Platform)
 set (callsign "org.rdk.HdcpProfile")
 

--- a/HdmiCec/CMakeLists.txt
+++ b/HdmiCec/CMakeLists.txt
@@ -18,6 +18,7 @@
 set(PLUGIN_NAME HdmiCec)
 set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
 
+set(PLUGIN_HDMICEC_AUTOSTART "false" CACHE STRING "Automatically start HdmiCec plugin")
 set(PLUGIN_HDMICEC_STARTUPORDER "" CACHE STRING "To configure startup order of HdmiCec plugin")
 
 find_package(${NAMESPACE}Plugins REQUIRED)

--- a/HdmiCec/HdmiCec.config
+++ b/HdmiCec/HdmiCec.config
@@ -1,4 +1,4 @@
-set (autostart false)
+set (autostart ${PLUGIN_HDMICEC_AUTOSTART})
 set (preconditions Platform)
 set (callsign "org.rdk.HdmiCec")
 

--- a/XCast/CMakeLists.txt
+++ b/XCast/CMakeLists.txt
@@ -18,6 +18,7 @@
 set(PLUGIN_NAME XCast)
 set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
 
+set(PLUGIN_XCAST_AUTOSTART "false" CACHE STRING "Automatically start XCast plugin")
 set(PLUGIN_XCAST_STARTUPORDER "" CACHE STRING "To configure startup order of XCast plugin")
 
 find_package(${NAMESPACE}Plugins REQUIRED)

--- a/XCast/XCast.config
+++ b/XCast/XCast.config
@@ -1,4 +1,4 @@
-set (autostart false)
+set (autostart ${PLUGIN_XCAST_AUTOSTART})
 set (preconditions Platform)
 set (callsign "org.rdk.Xcast")
 


### PR DESCRIPTION
Done like for the other plugins:
CMake variable PLUGIN_PluginName_AUTOSTART controls that for DisplaySettings, HdcpProfile, HdmiCec and XCast rdkservices