### PR TITLE
RDKDEV-426: RDKCOM-3495 SecurityAgent: Enable visibility of Plugin_SecurityAgent …

### DIFF
--- a/SecurityAgent/CHANGELOG.md
+++ b/SecurityAgent/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.0.1] - 2022-20-12
+### Changed
+- Enable visibility of Plugin_SecurityAgent Module in Metrological Dashboard
+
 ## [1.0.0] - 2022-05-11
 ### Added
 - Add CHANGELOG

--- a/SecurityAgent/Module.h
+++ b/SecurityAgent/Module.h
@@ -17,16 +17,13 @@
  * limitations under the License.
  */
  
-#ifndef TIMESYNC_MODULE_H
-#define TIMESYNC_MODULE_H
+#pragma once
 
 #ifndef MODULE_NAME
-#define MODULE_NAME Plugin_TimeSync
+#define MODULE_NAME Plugin_SecurityAgent
 #endif
 
 #include <plugins/plugins.h>
 
 #undef EXTERNAL
 #define EXTERNAL
-
-#endif // TIMESYNC_MODULE_H


### PR DESCRIPTION
…Module in Metrological Dashboard

SecurityAgent plugin was not having an entry in the "Module" listed on Metrological dashboard. Even adding the different log categories for "Plugin_SecurityAgent" in "tracing.json" file were not generating the respective logs.
The issue was caused because the "Module.h" file for the plugin was having a wrong value defined for MODULE_NAME macro, instead of having "Plugin_SecurityAgent" it was assigned "Plugin_TimeSync". This commit defines MODULE_NAME with "Plugin_SecurityAgent" value so that "Plugin_SecurityAgent" logs are available in "Tracing" section of Metrological Dashboard and "Plugin_TimeSync" module is removed.

(cherry picked from commit a95016cb0752653cec45a2f05dbaff362ab476cb)