### PR TITLE
TraceControl: Add module name to trace

### DIFF
--- a/TraceControl/TraceOutput.h
+++ b/TraceControl/TraceOutput.h
@@ -52,7 +52,7 @@ namespace Plugin {
                     syslog(LOG_NOTICE, "[%s]: %s\n", time.c_str(), information->Data());
                 } else {
                     string time(Core::Time::Now().ToRFC1123(true));
-                    syslog(LOG_NOTICE, "[%s]:[%s:%d] %s: %s\n", time.c_str(), Core::FileNameOnly(fileName), lineNumber, information->Category(), information->Data());
+                    syslog(LOG_NOTICE, "[%s]:[%s]:[%s:%d]: %s: %s\n", time.c_str(), information->Module(), Core::FileNameOnly(fileName), lineNumber, information->Category(), information->Data());
                 }
             } else
 #endif
@@ -62,7 +62,7 @@ namespace Plugin {
                     printf("[%s]: %s\n", time.c_str(), information->Data());
                 } else {
                     string time(Core::Time::Now().ToRFC1123(true));
-                    printf("[%s]:[%s:%d] %s: %s\n", time.c_str(), Core::FileNameOnly(fileName), lineNumber, information->Category(), information->Data());
+                    printf("[%s]:[%s]:[%s:%d] %s: %s\n", time.c_str(), information->Module(), Core::FileNameOnly(fileName), lineNumber, information->Category(), information->Data());
                 }
             }
         }


### PR DESCRIPTION
The current implementation of the TraceControl plugin won't output the origin of the trace.

With this commit, the resulting log message will have the form: 

`[<time>]:[<module-name>]:[<file-name:line-number>] <log-category>: <data>`

This would allow for easier handling of log messages in a scenario where multiple plugins have their tracing flag enabled at the same time.

This change is targeting only the non-abbreviated form of the logs, as the understanding is that adding the module name would make it "less abbreviated".

To capture syslog messages for a given module, use `journalctl |grep <module-name>`.