### PR TITLE
Merge pull request #3494 from dautapankumardora/sprint/22Q4_19740_OSD_retry

### DIFF
--- a/HdmiCecSink/CHANGELOG.md
+++ b/HdmiCecSink/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
-## [1.0.8]
+## [1.0.8] 2022-12-21
 ### Fixed
 - Improve the CEC retry mechanism for OSDName on I2c cec bus busy.
  

--- a/HdmiCecSink/CHANGELOG.md
+++ b/HdmiCecSink/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
-## [1.0.3]
+## [1.0.8]
 ### Fixed
 - Improve the CEC retry mechanism for OSDName on I2c cec bus busy.
  

--- a/HdmiCecSink/CHANGELOG.md
+++ b/HdmiCecSink/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.0.3]
+### Fixed
+- Improve the CEC retry mechanism for OSDName on I2c cec bus busy.
+ 
 ## [1.0.7] - 2022-11-28
 ### Fixed
 - Treat warnings as errors for unit tests workflow

--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -148,7 +148,7 @@ static int32_t HdmiArcPortID = -1;
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 7
+#define API_VERSION_NUMBER_PATCH 8
 
 namespace WPEFramework
 {


### PR DESCRIPTION

RDKTV-19740: Modify the frequency of CEC messages sent from TV (cherry picked from commit 86bf25b99c294c64d4cb5844de1a5540fb5b8bd6)

Reason for change: Improve the CEC retry mechanism on I2c cec bus busy
Test Procedure: Refer the ticket for test procedure
Risks: Low
Priority: P1
Signed-off-by: bp-tdora114 [dautapankumar.dora@sky.uk](mailto:dautapankumar.dora@sky.uk)