### PR TITLE
DELIA-59295 :avoid invalid time zone set using setTimeZoneDST

### DIFF
--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -2227,6 +2227,7 @@ namespace WPEFramework {
         uint32_t SystemServices::setTimeZoneDST(const JsonObject& parameters,
                 JsonObject& response)
 	{
+		LOGERR("Entered to setTimeZoneDST");
 		bool resp = false;
 		if (parameters.HasLabel("timeZone")) {
 			std::string dir = dirnameOf(TZ_FILE);

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -2234,10 +2234,15 @@ namespace WPEFramework {
 			std::string timeZone = "";
 			try {
 				timeZone = parameters["timeZone"].String();
+				int pos = timeZone.find("/");
 				if (timeZone.empty() || (timeZone == "null")) {
 					LOGERR("Empty timeZone received.");
-				} else {
-					int pos = timeZone.find("/");
+				}
+				else if( (pos == string::npos) ||  ( (pos != string::npos) &&  (pos+1 == timeZone.length())  )   )
+				{
+					LOGERR("Invalid timeZone  Only Country received : %s . \n", timeZone.c_str());
+				}
+				else {
 					std::string path =ZONEINFO_DIR;
 					path += "/";
 					std::string country = timeZone.substr(0,pos);


### PR DESCRIPTION
Reason for change: To avoid invalid time zone set using setTimeZoneDST
Test Procedure: Invalid timeZone(Ex :UTC-5) not accepted
Risks: Low
Priority: P1