### PR TITLE
RDKDEV-464  rdkservice: XCast: explicit linking with cjson

### DIFF
--- a/XCast/CMakeLists.txt
+++ b/XCast/CMakeLists.txt
@@ -41,7 +41,7 @@ target_include_directories(${MODULE_NAME} PRIVATE ${IARMBUS_INCLUDE_DIRS} ../hel
 target_include_directories(${MODULE_NAME} PRIVATE ${RFC_INCLUDE_DIRS} ../helpers)
 target_include_directories(${MODULE_NAME} PRIVATE $ENV{PKG_CONFIG_SYSROOT_DIR}/usr/include/pxcore)
 
-target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins rtRemote rtCore ${RFC_LIBRARIES} ${IARMBUS_LIBRARIES})
+target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins rtRemote rtCore cjson ${RFC_LIBRARIES} ${IARMBUS_LIBRARIES})
 
 
 install(TARGETS ${MODULE_NAME}


### PR DESCRIPTION
In the following configuration with XCast:

RFC_ENABLED not defined while compilation :  dependency to librfcapi.so is not present in linked library: libWPEFrameworkXCast.so 

If we build libWPEFrameworkXCast.so we would like to have explicit dependency to cjson.

That is probably not an issue when linked with RFC_ENABLED (librfcapi.so depends on cjson) 

