### PR TITLE
RDKTV-20951: IP Address value is not shown in device settings

### DIFF
--- a/Network/Network.cpp
+++ b/Network/Network.cpp
@@ -496,8 +496,11 @@ typedef struct _IARM_BUS_NetSrvMgr_Iface_EventData_t {
                 {
                     response["ip"] = string(param.activeIfaceIpaddr, MAX_IP_ADDRESS_LEN - 1);
                     m_stbIpCache = string(param.activeIfaceIpaddr, MAX_IP_ADDRESS_LEN - 1);
-                    m_useStbIPCache = true;
                     result = true;
+                    if (!m_stbIpCache.empty())
+                    {
+                        m_useStbIPCache = true;
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
Reason for change: Fix stale empty IP address being stored in cache Test Procedure: Build and verify.
Risks: High
Signed-off-by:Zameerun Rasheed M S <zmamoo711@cable.comcast.com>