### PR TITLE
XIONE-11185, RDKTV-21162, RDKTV-21171: Fix locking issues in MM

### DIFF
--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -822,6 +822,7 @@ namespace WPEFramework {
                 }
                 else{
                     LOGINFO("Ignoring/Unknown Maintenance Status!!");
+                    m_statusMutex.unlock();
                     return;
                 }
 


### PR DESCRIPTION
Reason for change: Lock inside iarmEventhandler in Maintenenace manager is not released properly while handling unknown events

Test Procedure: Refert ticket
Risks: Low
Priority: P0