### PR TITLE
DELIA-59295 : Avoid invalid time zone set using setTimeZoneDST

### DIFF
--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -2232,34 +2232,51 @@ namespace WPEFramework {
 			std::string timeZone = "";
 			try {
 				timeZone = parameters["timeZone"].String();
+				int pos = timeZone.find("/");
 				if (timeZone.empty() || (timeZone == "null")) {
 					LOGERR("Empty timeZone received.");
-				} else {
-					if (!dirExists(dir)) {
-						std::string command = "mkdir -p " + dir + " \0";
-						Utils::cRunScript(command.c_str());
-					} else {
-						//Do nothing//
-					}
-					std::string oldTimeZoneDST = getTimeZoneDSTHelper();
-
-					FILE *f = fopen(TZ_FILE, "w");
-					if (f) {
-						if (timeZone.size() != fwrite(timeZone.c_str(), 1, timeZone.size(), f))
-							LOGERR("Failed to write %s", TZ_FILE);
-
-						fflush(f);
-						fsync(fileno(f));
-						fclose(f);
-						if (SystemServices::_instance)
-							SystemServices::_instance->onTimeZoneDSTChanged(oldTimeZoneDST,timeZone);
-						resp = true;
-					} else {
-						LOGERR("Unable to open %s file.\n", TZ_FILE);
-						populateResponseWithError(SysSrv_FileAccessFailed, response);
-						resp = false;
-					}
 				}
+				else if( (pos == string::npos) ||  ( (pos != string::npos) &&  (pos+1 == timeZone.length())  )   )
+				{
+					LOGERR("Invalid timezone format received : %s . Timezone should be in Olson format  Ex : America/New_York .  \n", timeZone.c_str());
+				}
+				else {
+					std::string path =ZONEINFO_DIR;
+					path += "/";
+					std::string country = timeZone.substr(0,pos);
+					std::string city = path+timeZone;
+					if( dirExists(path+country)  && Utils::fileExists(city.c_str()) ) 
+					{
+						if (!dirExists(dir)) {
+							std::string command = "mkdir -p " + dir + " \0";
+							Utils::cRunScript(command.c_str());
+						} else {
+							//Do nothing//
+						}
+						std::string oldTimeZoneDST = getTimeZoneDSTHelper();
+
+						FILE *f = fopen(TZ_FILE, "w");
+						if (f) {
+							if (timeZone.size() != fwrite(timeZone.c_str(), 1, timeZone.size(), f))
+								LOGERR("Failed to write %s", TZ_FILE);
+
+							fflush(f);
+							fsync(fileno(f));
+							fclose(f);
+							if (SystemServices::_instance)
+								SystemServices::_instance->onTimeZoneDSTChanged(oldTimeZoneDST,timeZone);
+							resp = true;
+						} else {
+							LOGERR("Unable to open %s file.\n", TZ_FILE);
+							populateResponseWithError(SysSrv_FileAccessFailed, response);
+							resp = false;
+						}
+						else{
+							LOGERR("Invalid timeZone  %s received. Timezone not supported in TZ Database. \n", timeZone.c_str());
+							populateResponseWithError(SysSrv_FileNotPresent, response);
+							resp = false;
+						}
+					}
 			} catch (...) {
 				LOGERR("catch block : parameters[\"timeZone\"]...");
 			}

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -2232,7 +2232,7 @@ namespace WPEFramework {
 			std::string timeZone = "";
 			try {
 				timeZone = parameters["timeZone"].String();
-				int pos = timeZone.find("/");
+				size_t pos = timeZone.find("/");
 				if (timeZone.empty() || (timeZone == "null")) {
 					LOGERR("Empty timeZone received.");
 				}
@@ -2271,12 +2271,13 @@ namespace WPEFramework {
 							populateResponseWithError(SysSrv_FileAccessFailed, response);
 							resp = false;
 						}
-						else{
-							LOGERR("Invalid timeZone  %s received. Timezone not supported in TZ Database. \n", timeZone.c_str());
-							populateResponseWithError(SysSrv_FileNotPresent, response);
-							resp = false;
-						}
 					}
+					else{
+						LOGERR("Invalid timeZone  %s received. Timezone not supported in TZ Database. \n", timeZone.c_str());
+						populateResponseWithError(SysSrv_FileNotPresent, response);
+						resp = false;
+					}
+				}
 			} catch (...) {
 				LOGERR("catch block : parameters[\"timeZone\"]...");
 			}


### PR DESCRIPTION
Reason for change: To avoid invalid time zone set using setTimeZoneDST
Test Procedure: Invalid timeZone(Ex :UTC-5) not accepted
Risks: Low
Priority: P1