### PR TITLE
RDKDEV-481: ONEMPERS-287 XCast: retry reconnection till success

### DIFF
--- a/XCast/XCast.cpp
+++ b/XCast/XCast.cpp
@@ -741,7 +741,10 @@ void XCast::onLocateCastTimer()
     int status = _rtConnector->connectToRemoteService();
     if(status != 0)
     {
-        locateCastObjectRetryCount++;
+        if(locateCastObjectRetryCount < 4)
+        {
+            locateCastObjectRetryCount++;
+        }
         if(locateCastObjectRetryCount == 1)
         {
             LOGINFO("Retry after 5 sec...");


### PR DESCRIPTION
The commit changes XCast plugin reconnection behavior. The previous implementation retries connection to the remote server up to 4 times, with the increasing interval before retries. There is no reason to stop retrying as plugin without this connection is useless, so right now it repeats the fourth retry (60 seconds timeout) till success.