### PR TITLE
Cherry-pick changes from 22Q4 sprint

### DIFF
--- a/WebKitBrowser/CMakeLists.txt
+++ b/WebKitBrowser/CMakeLists.txt
@@ -48,6 +48,8 @@ option(PLUGIN_WEBKITBROWSER_ENABLE_JIT "Enable the use of JIT javascript optimal
 option(PLUGIN_WEBKITBROWSER_ENABLE_DFG "Enable the use of DFG javascript optimalization" ON)
 option(PLUGIN_APPS_ENABLE_JIT "Enable the use of JIT javascript optimalization" OFF)
 option(PLUGIN_APPS_ENABLE_DFG "Enable the use of DFG javascript optimalization" OFF)
+option(PLUGIN_WEBKITBROWSER_CLOUD_COOKIEJAR "Enable support for exporting/importing cookie jar" OFF)
+option(PLUGIN_WEBKITBROWSER_LOGGING_UTILS "Enable possibility to redirect stdout/err to specific systemd service" OFF)
 
 set(PLUGIN_WEBKITBROWSER_IMPLEMENTATION "${MODULE_NAME}Impl" CACHE STRING "Specify a library with a webkit implementation." )
 
@@ -135,6 +137,7 @@ set(PLUGIN_HTML_APP_WEBINSPECTOR_ADDRESS ":::10001" CACHE STRING "IP:Port for We
 set(PLUGIN_HTML_APP_LOCALSTORAGE_ENABLE "false" CACHE STRING "Enable LocalStorage of Html App")
 set(PLUGIN_HTML_APP_PERSISTENTPATHPOSTFIX "" CACHE STRING "Specify callsign persistent path postfix")
 set(PLUGIN_HTML_APP_MEMORYPRESSURE ${PLUGIN_WEBKITBROWSER_MEMORYPRESSURE} CACHE STRING "Html App Memory Pressure")
+set(PLUGIN_HTML_APP_COMPOSITOR "noaa" CACHE STRING "cairo compositor mode for Html App")
 
 set(PLUGIN_LIGHTNING_APP_AUTOSTART "false" CACHE STRING "Automatically start Lightning App plugin")
 set(PLUGIN_LIGHTNING_APP_STARTUPORDER "" CACHE STRING "To configure startup order of Lightning App plugin")
@@ -144,6 +147,7 @@ set(PLUGIN_LIGHTNING_APP_WEBINSPECTOR_ADDRESS ":::10002" CACHE STRING "IP:Port f
 set(PLUGIN_LIGHTNING_APP_LOCALSTORAGE_ENABLE "false" CACHE STRING "Enable LocalStorage of Lightning App")
 set(PLUGIN_LIGHTNING_APP_PERSISTENTPATHPOSTFIX "" CACHE STRING "Specify callsign persistent path postfix")
 set(PLUGIN_LIGHTNING_APP_MEMORYPRESSURE ${PLUGIN_WEBKITBROWSER_MEMORYPRESSURE} CACHE STRING "Lightning App Memory Pressure")
+set(PLUGIN_LIGHTNING_APP_COMPOSITOR "noaa" CACHE STRING "cairo compositor mode for Lightning App")
 
 set(PLUGIN_JSPP_AUTOSTART "false" CACHE STRING "Automatically start JSPP plugin")
 set(PLUGIN_JSPP_STARTUPORDER "" CACHE STRING "To configure startup order of JSPP plugin")
@@ -199,6 +203,23 @@ target_link_libraries(${PLUGIN_WEBKITBROWSER_IMPLEMENTATION}
         ${NAMESPACE}Definitions::${NAMESPACE}Definitions
         WPEBackend::WPEBackend
         WPEWebKit::WPEWebKit)
+
+if (PLUGIN_WEBKITBROWSER_CLOUD_COOKIEJAR)
+    find_package(ZLIB REQUIRED)
+    target_link_libraries(${PLUGIN_WEBKITBROWSER_IMPLEMENTATION}
+        PRIVATE
+        ZLIB::ZLIB)
+    target_compile_definitions(${PLUGIN_WEBKITBROWSER_IMPLEMENTATION}
+        PRIVATE
+        ENABLE_CLOUD_COOKIE_JAR=1)
+    target_sources(${PLUGIN_WEBKITBROWSER_IMPLEMENTATION} PRIVATE CookieJar.cpp)
+    include(CookieJarCrypto/CMakeLists.txt)
+endif()
+
+if (PLUGIN_WEBKITBROWSER_LOGGING_UTILS)
+    target_compile_definitions(${PLUGIN_WEBKITBROWSER_IMPLEMENTATION} PRIVATE ENABLE_LOGGING_UTILS)
+    target_sources(${PLUGIN_WEBKITBROWSER_IMPLEMENTATION} PRIVATE LoggingUtils.cpp)
+endif()
 
 if(WPE_WEBKIT_DEPRECATED_API)
     target_compile_definitions(${PLUGIN_WEBKITBROWSER_IMPLEMENTATION} PRIVATE WPE_WEBKIT_DEPRECATED_API)

--- a/WebKitBrowser/CookieJar.cpp
+++ b/WebKitBrowser/CookieJar.cpp
@@ -1,0 +1,286 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2020 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CookieJar.h"
+
+#include <sstream>
+#include <iterator>
+#include <algorithm>
+
+#include <glib.h>
+#include <zlib.h>
+
+#if defined(COOKIE_JAR_CRYPTO_IMPLEMENTATION)
+#include COOKIE_JAR_CRYPTO_IMPLEMENTATION
+#else
+#error "Please define COOKIE_JAR_CRYPTO_IMPLEMENTATION"
+#endif
+
+namespace WPEFramework {
+namespace Plugin {
+
+namespace {
+
+static std::string serialize(const std::vector<std::string>& cookies)
+{
+    std::ostringstream os;
+    std::copy(cookies.begin(), cookies.end(), std::ostream_iterator<std::string>(os, "\n"));
+    return os.str();
+}
+
+static void deserialize(const std::string& cookies, std::vector<std::string>& result)
+{
+    std::string cookie;
+    std::stringstream ss(cookies);
+    while(ss.good())
+    {
+        getline(ss, cookie, '\n');
+        if (!cookie.empty())
+            result.push_back(cookie);
+    }
+}
+
+static std::string toBase64(const std::vector<uint8_t>& in)
+{
+    gchar* encoded = g_base64_encode(in.data(), in.size());
+    std::string result;
+    if (encoded) {
+        result.assign(encoded);
+        g_free(encoded);
+    }
+    return result;
+}
+
+static std::vector<uint8_t> fromBase64(const std::string& str)
+{
+    gsize outlen;
+    guint8* decoded = g_base64_decode(str.c_str(), &outlen);
+    std::vector<uint8_t> result;
+    if (decoded) {
+        result.assign(decoded, decoded + outlen);
+        g_free(decoded);
+    }
+    return result;
+}
+
+static std::vector<uint8_t> compress(const std::string& str)
+{
+    std::vector<uint8_t> result;
+    size_t nbytes = str.size();
+    if (nbytes == 0)
+    {
+        result.resize(4, '\0');
+        return result;
+    }
+    const int compressionLevel = 1;
+    unsigned long len = nbytes + nbytes / 100 + 13;
+    int status;
+    do
+    {
+        result.resize(len + 4);
+        status = ::compress2((unsigned char*)result.data() + 4, &len,
+            (const unsigned char*)str.c_str(), nbytes, compressionLevel);
+        switch (status)
+        {
+        case Z_OK:
+            result.resize(len + 4);
+            result[0] = (nbytes & 0xff000000) >> 24;
+            result[1] = (nbytes & 0x00ff0000) >> 16;
+            result[2] = (nbytes & 0x0000ff00) >> 8;
+            result[3] = (nbytes & 0x000000ff);
+            break;
+        case Z_MEM_ERROR:
+            TRACE_GLOBAL(Trace::Error,(_T("Z_MEM_ERROR: Not enough memory")));
+            result.resize(0);
+            break;
+        case Z_BUF_ERROR:
+            len *= 2;
+            break;
+        }
+    }
+    while (status == Z_BUF_ERROR);
+    return result;
+}
+
+static std::string uncompress(const std::vector<uint8_t>& in)
+{
+    std::string result;
+    size_t nbytes = in.size();
+    if (nbytes <= 4)
+    {
+        if (nbytes < 4 || std::any_of(in.cbegin(), in.cend(), [](int v) {return v != 0;}))
+        {
+            TRACE_GLOBAL(Trace::Error,(_T("Input data is corrupted")));
+        }
+        return result;
+    }
+    const unsigned char* data = (const unsigned char*) in.data();
+    unsigned long expectedSize = (unsigned long)(
+        (data[0] << 24) | (data[1] << 16) |
+        (data[2] <<  8) | (data[3]));
+    unsigned long len = std::max(expectedSize, 1ul);
+    int status;
+    do
+    {
+        result.resize(len);
+        status = ::uncompress((unsigned char*)result.data(), &len, data + 4, nbytes - 4);
+        switch (status)
+        {
+        case Z_BUF_ERROR:
+            len *= 2;
+            break;
+        case Z_MEM_ERROR:
+            TRACE_GLOBAL(Trace::Error,(_T("Z_MEM_ERROR: Not enough memory")));
+            result.resize(0);
+            break;
+        case Z_DATA_ERROR:
+            TRACE_GLOBAL(Trace::Error,(_T("Z_DATA_ERROR: Input data is corrupted")));
+            result.resize(0);
+            break;
+        }
+    }
+    while (status == Z_BUF_ERROR);
+    return result;
+}
+
+// CRC-16 for compatability with rdkbrowser / rdkbrwoser2
+static uint32_t crc_checksum(const std::string& str)
+{
+    static const unsigned short crc_tbl[16] = {
+        0x0000, 0x1081, 0x2102, 0x3183,
+        0x4204, 0x5285, 0x6306, 0x7387,
+        0x8408, 0x9489, 0xa50a, 0xb58b,
+        0xc60c, 0xd68d, 0xe70e, 0xf78f
+    };
+    unsigned short crc = 0xffff;
+    unsigned char c = 0;
+    const unsigned char *p = (const unsigned char*) str.data();
+    size_t len = str.size();
+    while (len--)
+    {
+        c = *p++;
+        crc = ((crc >> 4) & 0x0fff) ^ crc_tbl[((crc ^ c) & 15)];
+        c >>= 4;
+        crc = ((crc >> 4) & 0x0fff) ^ crc_tbl[((crc ^ c) & 15)];
+    }
+    return ~crc & 0xffff;
+}
+
+} // namespace
+
+struct CookieJar::CookieJarPrivate
+{
+    CookieJarCrypto _cookieJarCrypto;
+
+    uint32_t Pack(const std::vector<std::string> &cookies, uint32_t& version, uint32_t& checksum, string& payload)
+    {
+        uint32_t rc;
+        std::string serialized;
+        std::vector<uint8_t> encrypted;
+
+        serialized = serialize(cookies);
+        checksum = crc_checksum(serialized);
+
+        rc = _cookieJarCrypto.Encrypt(compress(serialized), version, encrypted);
+
+        if (rc != Core::ERROR_NONE)
+        {
+            TRACE_GLOBAL(Trace::Error,(_T("Encryption failed, rc = %u"), rc));
+        }
+        else
+        {
+            payload = toBase64(encrypted);
+        }
+
+        return rc;
+    }
+
+    uint32_t Unpack(const uint32_t version, const uint32_t checksum, const string& payload, std::vector<std::string>& cookies)
+    {
+        uint32_t rc = Core::ERROR_GENERAL;
+        std::vector<uint8_t> decrypted;
+
+        rc = _cookieJarCrypto.Decrypt(fromBase64(payload), version, decrypted);
+
+        if (rc != Core::ERROR_NONE)
+        {
+            TRACE_GLOBAL(Trace::Error,(_T("Decryption failed, rc = %u"), rc));
+        }
+        else
+        {
+            std::string serialized;
+            int actualChecksum;
+
+            serialized = uncompress(decrypted);
+            actualChecksum = crc_checksum(serialized);
+            if (actualChecksum != checksum)
+            {
+                rc = Core::ERROR_GENERAL;
+                TRACE_GLOBAL(Trace::Error,(_T("Checksum does not match: actual=%d expected=%d"), actualChecksum, checksum));
+            }
+            else
+            {
+                deserialize(serialized, cookies);
+            }
+        }
+
+        return rc;
+    }
+};
+
+CookieJar::CookieJar()
+    : _priv(new CookieJarPrivate)
+{
+}
+
+CookieJar::~CookieJar() = default;
+
+uint32_t CookieJar::Pack(uint32_t& version, uint32_t& checksum, string& payload) const
+{
+    return _priv->Pack(_cookies, version, checksum, payload);
+}
+
+uint32_t CookieJar::Unpack(const uint32_t version, const uint32_t checksum, const string& payload)
+{
+    uint32_t rc;
+    std::vector<std::string> cookies;
+
+    rc = _priv->Unpack(version, checksum, payload, cookies);
+
+    if (rc == WPEFramework::Core::ERROR_NONE) {
+        _cookies = std::move(cookies);
+        _refreshed.SetState( false );
+    }
+
+    return rc;
+}
+
+void CookieJar::SetCookies(std::vector<std::string> && cookies)
+{
+    _cookies = std::move(cookies);
+    _refreshed.SetState( true );
+}
+
+std::vector<std::string> CookieJar::GetCookies() const
+{
+    return _cookies;
+}
+
+} // namespace Plugin
+} // namespace WPEFramework

--- a/WebKitBrowser/CookieJar.h
+++ b/WebKitBrowser/CookieJar.h
@@ -1,0 +1,58 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2020 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "Module.h"
+
+#include <string>
+#include <vector>
+#include <memory>
+
+namespace WPEFramework {
+namespace Plugin {
+
+class CookieJar
+{
+public:
+    CookieJar();
+    ~CookieJar();
+
+    bool IsStale() const { return _refreshed.GetState() == false; }
+    void MarkAsStale() { _refreshed.SetState( false ); }
+    bool WaitForRefresh(int timeout_ms) const { return _refreshed.WaitState(true, timeout_ms); }
+
+    // Get/Set cookies
+    void SetCookies(std::vector<std::string> &&);
+    std::vector<std::string> GetCookies() const;
+
+    // Pack/unack cookies for storing in the "cloud"
+    uint32_t Pack(uint32_t& version, uint32_t& checksum, string& payload) const;
+    uint32_t Unpack(const uint32_t version, const uint32_t checksum, const string& payload);
+
+private:
+    Core::StateTrigger<bool> _refreshed { false };
+    std::vector<std::string> _cookies;
+
+    struct CookieJarPrivate;
+    mutable std::unique_ptr<CookieJarPrivate> _priv;
+};
+
+} // namespace Plugin
+} // namespace WPEFramework

--- a/WebKitBrowser/CookieJarCrypto/CMakeLists.txt
+++ b/WebKitBrowser/CookieJarCrypto/CMakeLists.txt
@@ -1,0 +1,16 @@
+set(PLUGIN_WEBKITBROWSER_COOKIE_JAR_CRYPTO_IMPLEMENTATION "CookieJarCryptoExample.h" CACHE STRING "Implementation of cookie jar encryption/decryption routines." )
+set(PLUGIN_WEBKITBROWSER_COOKIE_JAR_CRYPTO_LIBS "" CACHE STRING "Additional linker options that are needed to build specified cookie jar crypto implementation.")
+
+target_include_directories(${PLUGIN_WEBKITBROWSER_IMPLEMENTATION}
+    PRIVATE
+        CookieJarCrypto)
+
+target_compile_definitions(${PLUGIN_WEBKITBROWSER_IMPLEMENTATION}
+    PRIVATE
+        COOKIE_JAR_CRYPTO_IMPLEMENTATION="${PLUGIN_WEBKITBROWSER_COOKIE_JAR_CRYPTO_IMPLEMENTATION}")
+
+if(PLUGIN_WEBKITBROWSER_COOKIE_JAR_CRYPTO_LIBS)
+    target_link_libraries(${PLUGIN_WEBKITBROWSER_IMPLEMENTATION}
+        PRIVATE
+            ${PLUGIN_WEBKITBROWSER_COOKIE_JAR_CRYPTO_LIBS})
+endif()

--- a/WebKitBrowser/CookieJarCrypto/CookieJarCryptoExample.h
+++ b/WebKitBrowser/CookieJarCrypto/CookieJarCryptoExample.h
@@ -1,0 +1,89 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2020 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "../Module.h"
+
+#include <cryptalgo/cryptalgo.h>
+
+namespace WPEFramework {
+namespace Plugin {
+
+// Following implementation is for demonstration purposes only, not intended for a production.
+struct CookieJarCrypto
+{
+    static constexpr uint32_t kDefaultVersion = 1;
+    static constexpr uint32_t kBlockSize = 16;
+    static constexpr uint32_t kKeyLen  = 32;
+    const uint8_t kIV[16] = { 0x0 };
+    const uint8_t kKey[kKeyLen] = { 0x0 };
+
+    // @brief Encrypt using AES 256 CBC cipher
+    // @param in Data to encrypt
+    // @param version Version of the key used for encryption
+    // @param out Encrypted data
+    uint32_t Encrypt(std::vector<uint8_t> in, unsigned int& version /* @out */, std::vector<uint8_t>& out /* @out */)
+    {
+        uint32_t rc;
+        size_t out_size = ((in.size() + kBlockSize - 1) / kBlockSize) * kBlockSize;
+
+        version = kDefaultVersion;
+        out.resize(out_size);
+        in.resize(out_size, out_size - in.size());         // Add PKCS padding
+
+        Crypto::AESEncryption encryptor(Crypto::AES_CBC);
+        encryptor.InitialVector(kIV);
+        rc = encryptor.Key(kKeyLen, kKey);
+        if (rc == Core::ERROR_NONE)
+        {
+            rc = encryptor.Encrypt(in.size(), in.data(), out.data());
+        }
+
+        return rc;
+    }
+
+    // @brief Decrypt using AES 256 CBC cipher
+    // @param in Data to decrypt
+    // @param version Version of the key used for encryption
+    // @param out Clear data
+    uint32_t Decrypt(std::vector<uint8_t> in, unsigned int version, std::vector<uint8_t>& out)
+    {
+        uint32_t rc = Core::ERROR_UNAVAILABLE;
+        if (version == kDefaultVersion)
+        {
+            size_t out_size = ((in.size() + kBlockSize - 1) / kBlockSize) * kBlockSize;
+            out.resize(out_size);
+
+            Crypto::AESDecryption decryptor(Crypto::AES_CBC);
+            decryptor.InitialVector(kIV);
+            rc = decryptor.Key(kKeyLen, kKey);
+            if (rc == Core::ERROR_NONE)
+            {
+                rc = decryptor.Decrypt(in.size(), in.data(), out.data());
+            }
+        }
+
+        return rc;
+    }
+
+};
+
+} // namespace Plugin
+} // namespace WPEFramework

--- a/WebKitBrowser/Extension/CMakeLists.txt
+++ b/WebKitBrowser/Extension/CMakeLists.txt
@@ -25,6 +25,7 @@ find_package(WPEWebKit REQUIRED)
 option(PLUGIN_SECURITYAGENT "Enable the Security Agent Features interface in javascript." OFF)
 option(PLUGIN_WEBKITBROWSER_AAMP_JSBINDINGS "Enable AAMP JS bindings." OFF)
 option(PLUGIN_WEBKITBROWSER_BADGER_BRIDGE "Enable $badger support." OFF)
+option(PLUGIN_WEBKITBROWSER_UPDATE_TZ_FROM_FILE "Update TimeZone from given file" OFF)
 
 add_library(${MODULE_NAME} SHARED
     main.cpp
@@ -51,6 +52,15 @@ endif()
 if(PLUGIN_WEBKITBROWSER_BADGER_BRIDGE)
     target_sources(${MODULE_NAME} PRIVATE BridgeObject.cpp)
     target_compile_definitions(${MODULE_NAME} PRIVATE ENABLE_BADGER_BRIDGE)
+endif()
+
+if(PLUGIN_WEBKITBROWSER_UPDATE_TZ_FROM_FILE)
+    target_sources(${MODULE_NAME} PRIVATE ../TimeZone/TimeZoneSupport.cpp)
+    target_compile_definitions(${MODULE_NAME} PRIVATE UPDATE_TZ_FROM_FILE)
+    target_include_directories(${MODULE_NAME} PRIVATE ../TimeZone)
+    if(TZ_FILE)
+        add_definitions(-DTZ_FILE="${TZ_FILE}")
+    endif()
 endif()
 
 set_target_properties(${MODULE_NAME} PROPERTIES

--- a/WebKitBrowser/Extension/main.cpp
+++ b/WebKitBrowser/Extension/main.cpp
@@ -45,6 +45,10 @@
 #include "AAMPJSBindings.h"
 #endif
 
+#if defined(UPDATE_TZ_FROM_FILE)
+#include "TimeZoneSupport.h"
+#endif
+
 using namespace WPEFramework;
 
 static Core::NodeId GetConnectionNode()
@@ -115,10 +119,17 @@ public:
               list->AddWhiteListToWebKit(extension);
             }
         }
+
+#if defined(UPDATE_TZ_FROM_FILE)
+        _tzSupport.Initialize();
+#endif
     }
 
     void Deinitialize()
     {
+#if defined(UPDATE_TZ_FROM_FILE)
+        _tzSupport.Deinitialize();
+#endif
         if (_comClient.IsValid() == true) {
             _comClient.Release();
         }
@@ -206,6 +217,10 @@ private:
 private:
     Core::ProxyType<RPC::InvokeServerType<2, 0, 4> > _engine;
     Core::ProxyType<RPC::CommunicatorClient> _comClient;
+
+#if defined(UPDATE_TZ_FROM_FILE)
+    TZ::TimeZoneSupport _tzSupport;
+#endif
 
     string _consoleLogPrefix;
     gboolean _logToSystemConsoleEnabled;

--- a/WebKitBrowser/HtmlApp.config
+++ b/WebKitBrowser/HtmlApp.config
@@ -1,6 +1,6 @@
 set(autostart ${PLUGIN_HTML_APP_AUTOSTART})
 
-set(preconditions Graphics Internet)
+set(preconditions Graphics)
 
 if(PLUGIN_HTML_APP_STARTUPORDER)
 set (startuporder ${PLUGIN_HTML_APP_STARTUPORDER})
@@ -34,7 +34,7 @@ map()
         kv(extensiondir ${PLUGIN_WEBKITBROWSER_EXTENSION_DIRECTORY})
     endif()
     kv(transparent ${PLUGIN_WEBKITBROWSER_TRANSPARENT})
-    kv(compositor "noaa")
+    kv(compositor ${PLUGIN_HTML_APP_COMPOSITOR})
     kv(inspector ${PLUGIN_HTML_APP_WEBINSPECTOR_ADDRESS})
     kv(fps true)
     kv(cursor false)

--- a/WebKitBrowser/InjectedBundle/CMakeLists.txt
+++ b/WebKitBrowser/InjectedBundle/CMakeLists.txt
@@ -26,6 +26,7 @@ option(PLUGIN_AMAZON_HYBRID "Enable the Amazon Player interface (Hawaii) in the 
 option(PLUGIN_SECURITYAGENT "Enable the Security Agent Features interface in javascript." OFF)
 option(PLUGIN_WEBKITBROWSER_AAMP_JSBINDINGS "Enable AAMP JS bindings." OFF)
 option(PLUGIN_WEBKITBROWSER_BADGER_BRIDGE "Enable $badger support." OFF)
+option(PLUGIN_WEBKITBROWSER_UPDATE_TZ_FROM_FILE "Update TimeZone from given file" OFF)
 
 add_library(${MODULE_NAME} SHARED
     main.cpp
@@ -62,6 +63,15 @@ endif()
 if(PLUGIN_WEBKITBROWSER_BADGER_BRIDGE)
     target_sources(${MODULE_NAME} PRIVATE BridgeObject.cpp)
     target_compile_definitions(${MODULE_NAME} PRIVATE ENABLE_BADGER_BRIDGE)
+endif()
+
+if(PLUGIN_WEBKITBROWSER_UPDATE_TZ_FROM_FILE)
+    target_sources(${MODULE_NAME} PRIVATE ../TimeZone/TimeZoneSupport.cpp)
+    target_compile_definitions(${MODULE_NAME} PRIVATE UPDATE_TZ_FROM_FILE)
+    target_include_directories(${MODULE_NAME} PRIVATE ../TimeZone)
+    if(TZ_FILE)
+        add_definitions(-DTZ_FILE="${TZ_FILE}")
+    endif()
 endif()
 
 set_target_properties(${MODULE_NAME} PROPERTIES

--- a/WebKitBrowser/InjectedBundle/main.cpp
+++ b/WebKitBrowser/InjectedBundle/main.cpp
@@ -46,6 +46,10 @@
 #include "AAMPJSBindings.h"
 #endif
 
+#if defined(UPDATE_TZ_FROM_FILE)
+#include "TimeZoneSupport.h"
+#endif
+
 using namespace WPEFramework;
 using JavaScript::ClassDefinition;
 
@@ -107,10 +111,17 @@ public:
             Trace::TraceUnit::Instance().Open(_comClient->ConnectionId());
         }
         _whiteListedOriginDomainPairs = WhiteListedOriginDomainsList::RequestFromWPEFramework();
+
+#if defined(UPDATE_TZ_FROM_FILE)
+        _tzSupport.Initialize();
+#endif
     }
 
     void Deinitialize()
     {
+#if defined(UPDATE_TZ_FROM_FILE)
+        _tzSupport.Deinitialize();
+#endif
         if (_comClient.IsValid() == true) {
             _comClient.Release();
         }
@@ -128,6 +139,10 @@ public:
 private:
     Core::ProxyType<RPC::InvokeServerType<2, 0, 4> > _engine;
     Core::ProxyType<RPC::CommunicatorClient> _comClient;
+
+#if defined(UPDATE_TZ_FROM_FILE)
+    TZ::TimeZoneSupport _tzSupport;
+#endif
 
     // White list for CORS.
     std::unique_ptr<WhiteListedOriginDomainsList> _whiteListedOriginDomainPairs;

--- a/WebKitBrowser/JSPP.config
+++ b/WebKitBrowser/JSPP.config
@@ -125,6 +125,7 @@ map()
             kv(value "/opt/QT/home")
         end()
 
+    kv(loggingtarget "sky-jspp.service")
 end()
 ans(configuration)
 

--- a/WebKitBrowser/LightningApp.config
+++ b/WebKitBrowser/LightningApp.config
@@ -1,6 +1,6 @@
 set(autostart ${PLUGIN_LIGHTNING_APP_AUTOSTART})
 
-set(preconditions Graphics Internet)
+set(preconditions Graphics)
 
 if(PLUGIN_LIGHTNING_APP_STARTUPORDER)
 set (startuporder ${PLUGIN_LIGHTNING_APP_STARTUPORDER})
@@ -34,7 +34,7 @@ map()
         kv(extensiondir ${PLUGIN_WEBKITBROWSER_EXTENSION_DIRECTORY})
     endif()
     kv(transparent ${PLUGIN_WEBKITBROWSER_TRANSPARENT})
-    kv(compositor "noaa")
+    kv(compositor ${PLUGIN_LIGHTNING_APP_COMPOSITOR})
     kv(inspector ${PLUGIN_LIGHTNING_APP_WEBINSPECTOR_ADDRESS})
     kv(fps true)
     kv(cursor false)

--- a/WebKitBrowser/LoggingUtils.cpp
+++ b/WebKitBrowser/LoggingUtils.cpp
@@ -1,0 +1,132 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stddef.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include <syslog.h>
+#include <signal.h>
+#include <glib.h>
+
+#include "Module.h"
+
+namespace WPEFramework {
+namespace Plugin {
+
+bool RedirectAllLogsToService(const string& target_service)
+{
+  if (target_service.empty()) {
+    fprintf(stderr, "RedirectLog: Invalid argument. Logs target service expected\n");
+    return false;
+  }
+  const string kServiceExt = ".service";
+  if (target_service.size() <= kServiceExt.size() ||
+      target_service.substr(target_service.size() - kServiceExt.size(), kServiceExt.size()) != kServiceExt) {
+    fprintf(stderr, "RedirectLog: Invalid serivce name: *.service format expected\n");
+    return false;
+  }
+
+  const string targetServiceName = target_service.substr(0, target_service.size() - kServiceExt.size());
+  const string kSystemdCgroupTargetTasksFilePath = "/sys/fs/cgroup/systemd/system.slice/" + target_service + "/tasks";
+  if (!g_file_test(kSystemdCgroupTargetTasksFilePath.c_str(), G_FILE_TEST_EXISTS)) {
+    fprintf(stderr, "RedirectLog: %s unit cgroup doesn't exist\n", target_service.c_str());
+    return false;
+  }
+
+  // Add all threads of current process to target systemd cgroup
+  WPEFramework::Core::Directory taskDir("/proc/self/task");
+  while (taskDir.Next() == true) {
+    if (taskDir.Name() == "." || taskDir.Name() == "..")
+      continue;
+    FILE* f = fopen(kSystemdCgroupTargetTasksFilePath.c_str(), "a");
+    if (f) {
+      fprintf(f, "%s", taskDir.Name().c_str());
+      fclose(f);
+    } else {
+      fprintf(stderr, "RedirectLog: cannot move %s thread to '%s': %s\n",
+              taskDir.Name().c_str(), kSystemdCgroupTargetTasksFilePath.c_str(), strerror(errno));
+    }
+  }
+
+  // Redirect stdout / stderr
+  sockaddr_un sa;
+  memset (&sa, 0, sizeof (sa));
+  sa.sun_family = AF_UNIX;
+  g_strlcpy (sa.sun_path, "/run/systemd/journal/stdout", sizeof(sa.sun_path));
+
+  int fd = -1;
+  fd = socket(AF_UNIX, SOCK_STREAM, 0);
+  if (fd < 0) {
+    perror("RedirectLog: socket() failed");
+    return false;
+  }
+
+  int r = connect(fd, (const sockaddr*)&sa, sizeof(sa));
+  if (r < 0) {
+    perror("RedirectLog: couldn't connect");
+    close(fd);
+    return false;
+  }
+
+  shutdown(fd, SHUT_RD);
+
+  int value = (8*1024*1024);
+  setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &value, sizeof(value));
+
+  char* header = g_strdup_printf("%s\n%s\n%i\n%i\n0\n0\n0\n", targetServiceName.c_str(), target_service.c_str(), (LOG_DAEMON|LOG_INFO), 1);
+  char *p = header;
+  size_t nbytes = strlen(header);
+
+  do {
+    ssize_t k;
+    k = write(fd, p, nbytes);
+    if (k < 0) {
+      if (errno == EINTR)
+        continue;
+      perror("RedirectLog: write() failed");
+      break;
+    }
+    p += k;
+    nbytes -= k;
+  }
+  while (nbytes > 0);
+  g_free(header);
+
+  if (nbytes != 0) {
+    perror("RedirectLog: write() not completed");
+    close(fd);
+    return false;
+  }
+
+#ifdef SIGPIPE
+  signal (SIGPIPE, SIG_IGN);
+#endif
+
+  dup3(fd, STDOUT_FILENO, 0);
+  dup3(fd, STDERR_FILENO, 0);
+
+  close(fd);
+  return true;
+}
+
+}
+}

--- a/WebKitBrowser/LoggingUtils.h
+++ b/WebKitBrowser/LoggingUtils.h
@@ -1,0 +1,30 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <core/Portability.h>
+
+namespace WPEFramework {
+namespace Plugin {
+
+bool RedirectAllLogsToService(const string& target_service);
+
+}
+}

--- a/WebKitBrowser/TimeZone/TimeZoneSupport.cpp
+++ b/WebKitBrowser/TimeZone/TimeZoneSupport.cpp
@@ -1,0 +1,109 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2020 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+#include <syslog.h>
+
+#include "TimeZoneSupport.h"
+
+#ifdef TZ_FILE
+const char *kTimeZoneFile = TZ_FILE;
+#else
+const char *kTimeZoneFile = "/opt/persistent/timeZoneDST";
+#endif
+
+namespace WPEFramework {
+
+namespace TZ {
+
+    void trim(std::string &str) {
+        if (str.empty())
+            return;
+
+        gchar *tmp = g_strdup(str.c_str());
+        str = std::string(g_strstrip(tmp));
+        g_free(tmp);
+    }
+
+    void TimeZoneSupport::HandleTimeZoneFileUpdate(GFileMonitor *monitor, GFile *file, GFile *other, GFileMonitorEvent evtype, gpointer user_data) {
+        if (evtype == G_FILE_MONITOR_EVENT_CHANGES_DONE_HINT) {
+            TimeZoneSupport *tzSupport = (TimeZoneSupport*)user_data;
+            gchar *content = nullptr;
+            gsize length = 0;
+
+            auto result = g_file_load_contents(file, nullptr, &content, &length, nullptr, nullptr);
+            if(result && content && length > 0) {
+                std::string timeZone(content);
+                trim(timeZone);
+
+                if (timeZone != tzSupport->_previousTimeZone) {
+                    tzSupport->_previousTimeZone = timeZone;
+                    timeZone = ":" + timeZone;
+                    SYSLOG(Trace::Information, (_T("TimeZone is updated to \"%s\" from \"%s\" file"), timeZone.c_str(), tzSupport->_tzFile.c_str()));
+                    Core::SystemInfo::SetEnvironment(_T("TZ"), _T(timeZone), true);
+                    tzset();
+                }
+
+                g_free(content);
+            }
+        }
+    }
+
+    TimeZoneSupport::TimeZoneSupport()
+        : _timeZoneFileMonitor(nullptr)
+        , _timeZoneFileMonitorId(0)
+        , _previousTimeZone()
+        , _tzFile(kTimeZoneFile)
+    {
+        trim(_tzFile);
+    }
+
+    void TimeZoneSupport::Initialize()
+    {
+        if(_tzFile.empty()) {
+            SYSLOG(Trace::Warning, (_T("Invalid file input for TZ update")));
+            return;
+        }
+
+        Core::SystemInfo::GetEnvironment(std::string(_T("TZ")), _previousTimeZone);
+        trim(_previousTimeZone);
+
+        GFile *file = g_file_new_for_path(_tzFile.c_str());
+        if(g_file_query_exists(file, nullptr))
+            HandleTimeZoneFileUpdate(nullptr, file, nullptr, G_FILE_MONITOR_EVENT_CHANGES_DONE_HINT, this);
+
+        _timeZoneFileMonitor = g_file_monitor_file(file, G_FILE_MONITOR_NONE, nullptr, nullptr);
+        _timeZoneFileMonitorId = g_signal_connect(_timeZoneFileMonitor, "changed", reinterpret_cast<GCallback>(HandleTimeZoneFileUpdate), this);
+        SYSLOG(Trace::Information, (_T("Installed file monitor for \"%s\""), _tzFile.c_str()));
+
+        g_object_unref(file);
+    }
+
+    void TimeZoneSupport::Deinitialize()
+    {
+        if (_timeZoneFileMonitor) {
+            if (_timeZoneFileMonitorId > 0)
+                g_signal_handler_disconnect(_timeZoneFileMonitor, _timeZoneFileMonitorId);
+
+            g_object_unref(_timeZoneFileMonitor);
+            _timeZoneFileMonitor = nullptr;
+            _timeZoneFileMonitorId = 0;
+        }
+    }
+}
+}

--- a/WebKitBrowser/TimeZone/TimeZoneSupport.h
+++ b/WebKitBrowser/TimeZone/TimeZoneSupport.h
@@ -1,0 +1,46 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2020 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+#ifndef __TIMEZONESUPPORTH
+#define __TIMEZONESUPPORTH
+
+#include "Module.h"
+#include <gio/gio.h>
+
+namespace WPEFramework {
+namespace TZ {
+    class TimeZoneSupport {
+    public:
+        TimeZoneSupport();
+        void Initialize();
+        void Deinitialize();
+    
+    private:
+        static void HandleTimeZoneFileUpdate(GFileMonitor *monitor, GFile *file, GFile *other, GFileMonitorEvent evtype, gpointer user_data);
+
+    private:
+        GFileMonitor *_timeZoneFileMonitor;
+        gulong _timeZoneFileMonitorId;
+        std::string _previousTimeZone;
+        std::string _tzFile;
+    };
+}
+}
+
+#endif // __TIMEZONESUPPORTH

--- a/WebKitBrowser/WebKitBrowser.cpp
+++ b/WebKitBrowser/WebKitBrowser.cpp
@@ -114,6 +114,17 @@ namespace Plugin {
         } else {
             RegisterAll();
             Exchange::JWebBrowser::Register(*this, _browser);
+
+            _cookieJar = _browser->QueryInterface<Exchange::IBrowserCookieJar>();
+            if (_cookieJar) {
+                _cookieJar->Register(&_notification);
+                Exchange::JBrowserCookieJar::Register(*this, _cookieJar);
+            }
+
+            _browserScripting = _browser->QueryInterface<Exchange::IBrowserScripting>();
+            if (_browserScripting) {
+                Exchange::JBrowserScripting::Register(*this, _browserScripting);
+            }
         }
 
         return message;
@@ -135,6 +146,15 @@ namespace Plugin {
         _memory->Release();
         _application->Release();
         Exchange::JWebBrowser::Unregister(*this);
+        if (_browserScripting) {
+            Exchange::JBrowserScripting::Unregister(*this);
+            _browserScripting->Release();
+        }
+        if (_cookieJar) {
+            Exchange::JBrowserCookieJar::Unregister(*this);
+            _cookieJar->Unregister(&_notification);
+            _cookieJar->Release();
+        }
         UnregisterAll();
 
         PluginHost::IStateControl* stateControl(_browser->QueryInterface<PluginHost::IStateControl>());
@@ -312,6 +332,11 @@ namespace Plugin {
     {
         TRACE(Trace::Information, (_T("BridgeQuery: %s"), message.c_str()));
         event_bridgequery(message);
+    }
+
+    void WebKitBrowser::CookieJarChanged()
+    {
+        Exchange::JBrowserCookieJar::Event::CookieJarChanged(*this);
     }
 
     void WebKitBrowser::StateChange(const PluginHost::IStateControl::state state)

--- a/WebKitBrowser/WebKitBrowserJsonRpc.cpp
+++ b/WebKitBrowser/WebKitBrowserJsonRpc.cpp
@@ -30,6 +30,7 @@ namespace Plugin {
     using namespace JsonData::Browser;
     using namespace JsonData::WebBrowser;
     using namespace JsonData::StateControl;
+    using namespace JsonData::BrowserCookieJar;
     using namespace WPEFramework::Exchange;
 
     // Registration
@@ -40,6 +41,7 @@ namespace Plugin {
         Property<Core::JSON::EnumType<StateType>>(_T("state"), &WebKitBrowser::get_state, &WebKitBrowser::set_state, this); /* StateControl */
         Property<Core::JSON::ArrayType<Core::JSON::String>>(_T("languages"), &WebKitBrowser::get_languages, &WebKitBrowser::set_languages, this);
         Property<Core::JSON::ArrayType<JsonData::WebKitBrowser::HeadersData>>(_T("headers"), &WebKitBrowser::get_headers, &WebKitBrowser::set_headers, this);
+        Property<CookieJarParamsData>(_T("cookiejar"), &WebKitBrowser::get_cookiejar, &WebKitBrowser::set_cookiejar, this);
         Register<DeleteParamsData,void>(_T("delete"), &WebKitBrowser::endpoint_delete, this);
     }
 
@@ -48,6 +50,7 @@ namespace Plugin {
         Unregister(_T("state"));
         Unregister(_T("headers"));
         Unregister(_T("languages"));
+        Unregister(_T("cookiejar"));
         Unregister(_T("delete"));
     }
 
@@ -167,6 +170,45 @@ namespace Plugin {
         }
 
         return result;
+    }
+
+    // Property: cookiejar
+    // Return codes:
+    //  - ERROR_NONE: Success
+    uint32_t WebKitBrowser::get_cookiejar(CookieJarParamsData& response) const
+    {
+        if (_cookieJar == nullptr)
+            return Core::ERROR_UNAVAILABLE;
+
+        uint32_t version = 0;
+        uint32_t checksum = 0;
+        string payload;
+
+        uint32_t result =
+            static_cast<const IBrowserCookieJar*>(_cookieJar)->CookieJar(version, checksum, payload);
+
+        if (result == Core::ERROR_NONE) {
+            response.Version = version;
+            response.Checksum = checksum;
+            response.Payload = payload;
+        }
+
+        return result;
+    }
+
+    // Property: cookiejar
+    // Return codes:
+    //  - ERROR_NONE: Success
+    uint32_t WebKitBrowser::set_cookiejar(const CookieJarParamsData& param)
+    {
+        if (_cookieJar == nullptr)
+            return Core::ERROR_UNAVAILABLE;
+
+        uint32_t version = param.Version.Value();
+        uint32_t checksum = param.Checksum.Value();
+        const string& payload = param.Payload.Value();
+
+        return _cookieJar->CookieJar(version, checksum, payload);
     }
 
     // Event: statechange - Signals a state change of the service


### PR DESCRIPTION
- RDK-36951: Support use of paths without further modifications

Reason for change: Backward compatibiliy with already deployed systems
Test Procedure: Verify plugin configuration is correctly set Risks: Small

Signed-off-by: Filipe Norte <filipe.norte@sky.uk>

- RDK-36108: Add JSPP support

- [WebKitBrowserPlugin] Add API to execute JS in web page context

- And initial support for cloud cookie jar

- WebKitBrowser: Fix cookie crypto jar linkage

Signed-off-by: Ievgen Mutavchi <Ievgen_Mutavchi@comcast.com>

- RDK-36108: Set JSPP environment variables

- Implement SetCookies and RefreshCookieJar APIs for WebKit browser plugin.

- Use GLib WebKitCookieManager APIs (...get/set_cookie_jar)

RDK-38159: TimeZone update

Reason for change: Update TZ from file (updated by external component) Test Procedure: None
Priority: P1
Risks: None

Signed-off-by: Vivek.A <vivek_arumugam@comcast.com>

Move impl to separate file

Rearrange TZ support files to be used by Extension

Address review comments
* Remove UtilsStrings.h dependency
* Dereference GFile & GFileMonitor instances

Add WebKit User Content Filter support for WebKit plugin

Add "contentfilter" config for WebKitBrowser plugin that is used as JSON with user contetn filter

Only GLIB based WebKit API supports this feature

Redirect logs to another systemd service.

With rdkbrowser2 all browser logs were part of a parent service. Webkit browser plugin prints logs as wpeframework service.

This change adds possibility to redirect all webkit browser plugin logs (stdout and stderr) to another systemd service to preserve any logging monitors and file watchers still working.

RDK-38353: Enable MSAA Cairo compositor by default

Reason for change: Make cairo compositor configurable for Html & Lightning callsigns
Test Procedure: Refer ticket
Priority: P1
Risks: None

Signed-off-by: Vivek.A <vivek_arumugam@comcast.com>

RDK-38406: Startupscreen launch failed with webkitbrowserplugin backend

Reason for change: On startup screen launch the "Internet" precondition is not met for HtmlApp callsign. This precondition is not required for HtmlApp & LightningApp callsigns as it might be possible for launching locally hosted pages with those callsigns
Test Procedure: Verify startupscreen is loaded with webkitbrowserplugin Priority: P1
Risks: None

Signed-off-by: Vivek.A <vivek_arumugam@comcast.com>

[WebKitBrowser] initialize UserAgent string

[WebKitBrowsr] fix handling of canceled loads

XIONE-10935: Failing to launch Crackle app

Reason for change: Crackle app fails when FileSystem API
 is present. With https://bugs.webkit.org/show_bug.cgi?id=202796
 the DirectoryUpload feature was enabled for WPE port. Disabling
 it to keep the behavior same as wpe-2.22 and there are no use
 cases with that
Test Procedure: None
Priority: P1
Risks: None

Signed-off-by: Vivek.A <vivek_arumugam@comcast.com>

DELIA-58272 : Log error code in webkitbrowser plugin when URL fails to load

Reason for change: Log error code in webkitbrowser plugin when URL fails to load Test Procedure: Specified in ticket
Risks: NA

Signed-off-by: Simi Mathew <simim@tataelxsi.co.in>