### PR TITLE
SERXIONE-1281 : Fix deadlock in Maintenance Manager code

### DIFF
--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -292,6 +292,9 @@ namespace WPEFramework {
                 MaintenanceManager::_instance->onMaintenanceStatusChange(MAINTENANCE_ERROR);
                 m_statusMutex.unlock();
                 LOGINFO("Maintenance is exiting as device is not connected to internet.");
+                if (UNSOLICITED_MAINTENANCE == g_maintenance_type && !g_unsolicited_complete){
+                    g_unsolicited_complete = true;
+                }
                 return;
             }
 
@@ -631,6 +634,7 @@ namespace WPEFramework {
             MaintenanceManager::g_lastSuccessful_maint_time="";
             MaintenanceManager::g_task_status=0;
             MaintenanceManager::m_abort_flag=false;
+            MaintenanceManager::g_unsolicited_complete = false;
 
             /* we post just to tell that we are in idle at this moment */
             m_statusMutex.lock();
@@ -863,6 +867,9 @@ namespace WPEFramework {
                         LOGINFO("Thread joined successfully\n");
                     }
 
+                    if ( g_maintenance_type == UNSOLICITED_MAINTENANCE && !g_unsolicited_complete) {
+                        g_unsolicited_complete = true;
+                    }
                     MaintenanceManager::_instance->onMaintenanceStatusChange(notify_status);
                 }
                 else {
@@ -1203,7 +1210,7 @@ namespace WPEFramework {
                     /* only one maintenance at a time */
                     /* Lock so that m_notify_status will not be updated  further */
                     m_statusMutex.lock();
-                    if ( MAINTENANCE_STARTED != m_notify_status  ){
+                    if ( MAINTENANCE_STARTED != m_notify_status && g_unsolicited_complete ){
 
                         /*reset the status to 0*/
                         g_task_status=0;

--- a/MaintenanceManager/MaintenanceManager.h
+++ b/MaintenanceManager/MaintenanceManager.h
@@ -130,6 +130,7 @@ namespace WPEFramework {
                 bool m_abort_flag;
 
                 uint16_t g_task_status;
+                bool g_unsolicited_complete;
 
                 std::mutex  m_callMutex;
                 std::mutex  m_statusMutex;


### PR DESCRIPTION
Reason for change: If AS calls startMaintenance before we acquire internet access, the Unsolicited maintenance cycle launched from boot will be locked due to the same mutex used in the startMaintenance task.

Test Procedure: Verify that the maintenance tasks launch as expected

Risks: Low
Priority: P0