### PR TITLE
Skip (by default) coverage and Valgrind when invoke unit tests locall…

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -193,7 +193,7 @@ jobs:
         run: echo "TOOLCHAIN_FILE=${{github.workspace}}/rdkservices/Tests/clang.cmake" >> $GITHUB_ENV
 
       - name: Set gcc/with-coverage toolchain
-        if: ${{ matrix.compiler == 'gcc' && matrix.coverage == 'with-coverage' }}
+        if: ${{ matrix.compiler == 'gcc' && matrix.coverage == 'with-coverage' && !env.ACT }}
         run: echo "TOOLCHAIN_FILE=${{github.workspace}}/rdkservices/Tests/gcc-with-coverage.cmake" >> $GITHUB_ENV
 
       - name: Build rdkservices
@@ -301,6 +301,7 @@ jobs:
           RdkServicesTest
 
       - name: Run unit tests with valgrind
+        if: ${{ !env.ACT }}
         run: >
           PATH=${{github.workspace}}/install/usr/bin:${PATH}
           LD_LIBRARY_PATH=${{github.workspace}}/install/usr/lib:${{github.workspace}}/install/usr/lib/wpeframework/plugins:${LD_LIBRARY_PATH}
@@ -314,7 +315,7 @@ jobs:
           RdkServicesTest
 
       - name: Generate coverage
-        if: ${{ matrix.coverage == 'with-coverage' }}
+        if: ${{ matrix.coverage == 'with-coverage' && !env.ACT }}
         run: >
           lcov -c
           -o coverage.info


### PR DESCRIPTION
…y to provide a more rapid feedback for the developers making incremental code changes