### PR TITLE
DELIA-57717: Fix for WPEFramework crash with callstack std::execute_n…

### DIFF
--- a/WifiManager/WifiManager.cpp
+++ b/WifiManager/WifiManager.cpp
@@ -116,6 +116,7 @@ namespace WPEFramework
         void WifiManager::Deinitialize(PluginHost::IShell* service)
         {
             wifiScan.Deinitialize(service);
+            wifiSignalThreshold.stopSignalThresholdThread();
 
             instance = nullptr;
         }

--- a/WifiManager/impl/WifiManagerSignalThreshold.cpp
+++ b/WifiManager/impl/WifiManagerSignalThreshold.cpp
@@ -98,7 +98,12 @@ WifiManagerSignalThreshold::WifiManagerSignalThreshold():
 {
 }
 
+
 WifiManagerSignalThreshold::~WifiManagerSignalThreshold()
+{
+}
+
+void WifiManagerSignalThreshold::stopSignalThresholdThread()
 {
     stopThread();
 }
@@ -186,7 +191,6 @@ void WifiManagerSignalThreshold::loop(int interval)
         if (running)
         {
             getSignalData(signalStrength, strength);
-
 
             if (strength != lastStrength)
             {

--- a/WifiManager/impl/WifiManagerSignalThreshold.h
+++ b/WifiManager/impl/WifiManagerSignalThreshold.h
@@ -48,6 +48,7 @@ namespace WPEFramework {
             uint32_t setSignalThresholdChangeEnabled(const JsonObject& parameters, JsonObject& response);
             void setSignalThresholdChangeEnabled(bool enable);
             uint32_t isSignalThresholdChangeEnabled(const JsonObject& parameters, JsonObject& response) const;
+            void stopSignalThresholdThread();
 
         private:
             void setSignalThresholdChangeEnabled(bool enabled, int interval);


### PR DESCRIPTION
…… (#3575)

* DELIA-57717: Fix for WPEFramework crash with callstack std::execute_native_thread_routine

Reason for change: Thread stop is not happening when wifiManager get deactivated Fix above issue: Calling thread stop before deactivated Test Procedure:
Risks:
Priority: P0
Signed-off-by: Kumar Santhanam <Kumar_Santhanam@comcast.com>

* Update WifiManagerInterface.h

* Update WifiManager.h

Co-authored-by: Karunakaran A <48997923+karuna2git@users.noreply.github.com>
(cherry picked from commit 9628b92658fa23b67188df043ab16509f8e08629)