### PR TITLE
XIONE-11185, RDKTV-21162, RDKTV-21171: Fix locking issues in MM

### DIFF
--- a/MaintenanceManager/CHANGELOG.md
+++ b/MaintenanceManager/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.0.11] - 2023-01-10
+### Fixed
+- Fixed locking issues in iarmEventHandler
+
 ## [1.0.10] - 2022-12-08
 ### Fixed
 - Send MAINTENANCE_ERROR event from stopMaintenance()

--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -66,7 +66,7 @@ using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 10
+#define API_VERSION_NUMBER_PATCH 11
 #define SERVER_DETAILS  "127.0.0.1:9998"
 
 
@@ -822,6 +822,7 @@ namespace WPEFramework {
                 }
                 else{
                     LOGINFO("Ignoring/Unknown Maintenance Status!!");
+                    m_statusMutex.unlock();
                     return;
                 }
 


### PR DESCRIPTION
Reason for change: Lock inside iarmEventhandler in Maintenenace manager is not released properly while handling unknown events

Test Procedure: Refert ticket
Risks: Low
Priority: P0