### PR TITLE
RDK-38157 : Add MediaEngineRMF plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -344,6 +344,10 @@ if(PLUGIN_UNIFIEDCASMANAGEMENT)
     add_subdirectory(UnifiedCASManagement)
 endif()
 
+if(PLUGIN_MEDIAENGINERMF)
+    add_subdirectory(MediaEngineRMF)
+endif()
+
 if(WPEFRAMEWORK_CREATE_IPKG_TARGETS)
     set(CPACK_GENERATOR "DEB")
     set(CPACK_DEB_COMPONENT_INSTALL ON)

--- a/MediaEngineRMF/CHANGELOG.md
+++ b/MediaEngineRMF/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this RDK Service will be documented in this file.
+
+* Each RDK Service has a CHANGELOG file that contains all changes done so far. When version is updated, add a entry in the CHANGELOG.md at the top with user friendly information on what was changed with the new version. Please don't mention JIRA tickets in CHANGELOG. 
+
+* Please Add entry in the CHANGELOG for each version change and indicate the type of change with these labels:
+    * **Added** for new features.
+    * **Changed** for changes in existing functionality.
+    * **Deprecated** for soon-to-be removed features.
+    * **Removed** for now removed features.
+    * **Fixed** for any bug fixes.
+    * **Security** in case of vulnerabilities.
+
+* Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
+
+* For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+
+## [1.0.0] - 2023-01-10
+### Added
+- Added support for video playback via RDK mediaframework (RMF). It's in early stages and capabilities are limited to channel change ability and little else.

--- a/MediaEngineRMF/CMakeLists.txt
+++ b/MediaEngineRMF/CMakeLists.txt
@@ -1,0 +1,64 @@
+# If not stated otherwise in this file or this component's license file the
+# following copyright and licenses apply:
+#
+# Copyright 2022 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set(PLUGIN_NAME MediaEngineRMF)
+set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
+
+set(PLUGIN_MediaEngineRMF_STARTUPORDER "" CACHE STRING "To configure startup order of MediaEngineRMF plugin")
+
+find_package(${NAMESPACE}Plugins REQUIRED)
+
+add_library(${MODULE_NAME} SHARED
+        MediaEngineRMF.cpp
+        Module.cpp)
+
+set_target_properties(${MODULE_NAME} PROPERTIES
+        CXX_STANDARD 11
+        CXX_STANDARD_REQUIRED YES)
+target_compile_options(${MODULE_NAME} PRIVATE -Wno-error)
+
+target_compile_definitions(${MODULE_NAME} PRIVATE MODULE_NAME=Plugin_${PLUGIN_NAME})
+
+list(APPEND CMAKE_MODULE_PATH
+        "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")
+
+find_package(IARMBus)
+if (IARMBus_FOUND)
+    target_include_directories(${MODULE_NAME} PRIVATE ${IARMBUS_INCLUDE_DIRS})
+    target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins ${IARMBUS_LIBRARIES})
+else (IARMBus_FOUND)
+    message ("Module IARMBus required.")
+    target_include_directories(${MODULE_NAME} PRIVATE ${IARMBUS_INCLUDE_DIRS})
+    target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins ${IARMBUS_LIBRARIES})
+endif(IARMBus_FOUND)
+
+find_package(LMPLAYER REQUIRED)
+if (LMPLAYER_FOUND)
+    add_definitions(-DLMPLAYER_FOUND)
+    target_include_directories(${MODULE_NAME} PRIVATE ${LMPLAYER_INCLUDE_DIRS})
+    target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins ${LMPLAYER_LIBRARIES})
+
+else(LMPLAYER_FOUND)
+    message ("Module libmediaplayer required.")
+endif(LMPLAYER_FOUND)
+
+target_include_directories(${MODULE_NAME} PRIVATE ../helpers)
+
+install(TARGETS ${MODULE_NAME}
+        DESTINATION lib/${STORAGE_DIRECTORY}/plugins)
+
+write_config(${PLUGIN_NAME})

--- a/MediaEngineRMF/MediaEngineRMF.config
+++ b/MediaEngineRMF/MediaEngineRMF.config
@@ -1,0 +1,3 @@
+set (autostart false)
+set (preconditions Platform)
+set (callsign org.rdk.MediaEngineRMF)

--- a/MediaEngineRMF/MediaEngineRMF.cpp
+++ b/MediaEngineRMF/MediaEngineRMF.cpp
@@ -1,0 +1,416 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2022 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+
+#include <algorithm>
+#include <regex>
+#include "libmediaplayer.h"
+#include "MediaEngineRMF.h"
+
+#include "UtilsCStr.h"
+#include "UtilsJsonRpc.h"
+#include "UtilsIarm.h"
+
+const string WPEFramework::Plugin::MediaEngineRMF::SERVICE_NAME = "org.rdk.MediaEngineRMF";
+const string WPEFramework::Plugin::MediaEngineRMF::METHOD_PLAY = "play";
+const string WPEFramework::Plugin::MediaEngineRMF::METHOD_STOP = "stop";
+const string WPEFramework::Plugin::MediaEngineRMF::METHOD_MUTE = "mute";
+const string WPEFramework::Plugin::MediaEngineRMF::METHOD_SET_VIDEO_RECTANGLE = "setVideoRectangle";
+const string WPEFramework::Plugin::MediaEngineRMF::METHOD_SET_VOLUME = "setVolume";
+const string WPEFramework::Plugin::MediaEngineRMF::METHOD_INITIALIZE = "initialize";
+const string WPEFramework::Plugin::MediaEngineRMF::METHOD_DEINITIALIZE = "deinitialize";
+const string WPEFramework::Plugin::MediaEngineRMF::EVT_ON_STATUS = "onStatusChanged";
+const string WPEFramework::Plugin::MediaEngineRMF::EVT_ON_WARNING = "onWarning";
+const string WPEFramework::Plugin::MediaEngineRMF::EVT_ON_ERROR = "onError";
+
+#define API_VERSION_NUMBER_MAJOR 1
+#define API_VERSION_NUMBER_MINOR 0
+#define API_VERSION_NUMBER_PATCH 0
+
+using namespace std;
+using namespace libmediaplayer;
+
+struct kv_pair
+{
+    const char * key;
+    const char * value;
+};
+
+static kv_pair environment_variables[] = { //TODO: AXG1v4-specific settings. Move this to somewhere platform-specific.
+    {"RMF_OSAL_THREAD_INFO_CALL_PORT", "54128"},
+    {"DtcpSrmFilePath", "/opt/persistent/dtcp.srm"},
+    {"GST_REGISTRY_FORK", "no"},
+    {"GST_REGISTRY", "/opt/.gstreamer/registry.bin"},
+    {"PFC_ROOT", "/"},
+    {"VL_ECM_RPC_IF_NAME", "eth2:0"},
+    {"VL_DOCSIS_DHCP_IF_NAME", "eth2"},
+    {"VL_DOCSIS_WAN_IF_NAME", "eth2"},
+    {"VL_PLATFORM_NAME", "BCM_NEXUS_LINUX_74XX"},
+    {"PERM_NVRAM_DIR", "/opt/persistent"},
+    {"DYN_NVRAM_DIR", "/opt/persistent"},
+    {"brcm_directfb_mode", "n"},
+    {"brcm_multiprocess_server", "refsw_server"},
+    {"brcm_multiprocess_mode", "y"},
+    {"dtcp_create_session_wait", "y"}
+};
+
+static void set_env_variables()
+{
+    int list_size = sizeof(environment_variables) / sizeof(kv_pair);
+    for (int i = 0; i < list_size; i++)
+    {
+        setenv(environment_variables[i].key, environment_variables[i].value, 1);
+    }
+}
+
+namespace WPEFramework {
+
+    namespace {
+
+        static Plugin::Metadata<Plugin::MediaEngineRMF> metadata(
+            // Version (Major, Minor, Patch)
+            API_VERSION_NUMBER_MAJOR, API_VERSION_NUMBER_MINOR, API_VERSION_NUMBER_PATCH,
+            // Preconditions
+            {},
+            // Terminations
+            {},
+            // Controls
+            {}
+        );
+    }
+    
+    namespace Plugin {
+
+        SERVICE_REGISTRATION(MediaEngineRMF, API_VERSION_NUMBER_MAJOR, API_VERSION_NUMBER_MINOR, API_VERSION_NUMBER_PATCH);
+
+        MediaEngineRMF* MediaEngineRMF::_instance = nullptr;
+
+        static void event_callback(notification_payload * payload, void * data)
+        {
+            (void) data;
+            if(nullptr != MediaEngineRMF::_instance)
+            {
+                MediaEngineRMF::_instance->onEvent(payload);
+            }
+        }
+
+        static void error_callback(notification_payload * payload, void * data)
+        {
+            (void) data;
+            if(nullptr != MediaEngineRMF::_instance)
+            {
+                MediaEngineRMF::_instance->onError(payload);
+            }   
+        }
+
+
+        MediaEngineRMF::MediaEngineRMF()
+            : PluginHost::JSONRPC(), m_player_state(player_state::UNINITIALIZED)
+        {
+            LOGINFO("ctor");
+
+            MediaEngineRMF::_instance = this;
+            Register(METHOD_PLAY, &MediaEngineRMF::play, this);
+            Register(METHOD_STOP, &MediaEngineRMF::stop, this);
+            Register(METHOD_INITIALIZE, &MediaEngineRMF::initialize_player, this);
+            Register(METHOD_DEINITIALIZE, &MediaEngineRMF::deinitialize_player, this);
+            Register(METHOD_SET_VOLUME, &MediaEngineRMF::setVolume, this);
+            Register(METHOD_SET_VIDEO_RECTANGLE, &MediaEngineRMF::setVideoRectangle, this);
+            Register(METHOD_MUTE, &MediaEngineRMF::mute, this);
+
+
+        }
+
+        MediaEngineRMF::~MediaEngineRMF()
+        {
+            //LOGINFO("dtor");
+            Unregister(METHOD_PLAY);
+            Unregister(METHOD_STOP);
+            Unregister(METHOD_INITIALIZE);
+            Unregister(METHOD_DEINITIALIZE);
+            Unregister(METHOD_SET_VOLUME);
+            Unregister(METHOD_SET_VIDEO_RECTANGLE);
+            Unregister(METHOD_MUTE);
+        }
+
+        const string MediaEngineRMF::Initialize(PluginHost::IShell* /* service */)
+        {
+            return "";
+        }
+
+        void MediaEngineRMF::Deinitialize(PluginHost::IShell* /* service */)
+        {
+            MediaEngineRMF::_instance = nullptr;
+        }
+
+        string MediaEngineRMF::Information() const
+        {
+            return(string("{\"service\": \"") + SERVICE_NAME + string("\"}"));
+        }
+
+        // Registered methods begin
+        //parameters: {"source_type" : "qam"}
+        uint32_t MediaEngineRMF::initialize_player(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+
+            bool success  = false;
+            returnIfStringParamNotFound(parameters, "source_type");
+            const std::string & type = parameters["source_type"].String();
+            if("qam" == type)
+            {
+                if(player_state::PLATFORM_INITIALIZED <= m_player_state)
+                {
+                    LOGINFO("QAM is already initialized.");
+                    success = true;
+                }
+                else
+                {
+                    LOGINFO("Initializing QAM support.");
+                    set_env_variables();
+                    if(0 != mediaplayer::initialize(QAM, true, true))
+                    {
+                        LOGERR("Could not initialize QAM support");
+                    }
+                    else
+                    {
+                        m_player_state = player_state::PLATFORM_INITIALIZED;
+                        success = true;
+                    }
+                }
+            }
+            else
+            {
+                LOGERR("Unsupported source type: %s", type.c_str());
+            }
+            returnResponse(success);
+        }
+
+        //parameters: {"source_type" : "qam"}
+        uint32_t MediaEngineRMF::deinitialize_player(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+
+            bool success  = false;
+            if(player_state::PLATFORM_INITIALIZED != m_player_state)
+            {
+                LOGERR("Wrong state. Cannot deinitialize.");
+            }
+            else
+            {
+                returnIfStringParamNotFound(parameters, "source_type");
+                const std::string & type = parameters["source_type"].String();
+                if("qam" == type)
+                {
+                    LOGINFO("De-initializing QAM support.");
+                    if(0 != mediaplayer::deinitialize(QAM))
+                    {
+                        LOGERR("Could not deinitialize QAM support");
+                    }
+                    else
+                    {
+                        m_player_state = player_state::UNINITIALIZED;
+                        success = true;
+                    }
+                }
+            }
+            returnResponse(success);
+        }
+
+        //parameters: {"source_type" : "qam", "identifier" : "ocap://0x123a"} 
+        uint32_t MediaEngineRMF::play(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool success  = false;
+            returnIfStringParamNotFound(parameters, "source_type");
+            returnIfStringParamNotFound(parameters, "identifier");
+
+            if(player_state::PLATFORM_INITIALIZED != m_player_state)
+            {
+                LOGERR("Platform not initialized");
+            }
+            else
+            {
+                const std::string source_type = parameters["source_type"].String();
+                const std::string identifier = parameters["identifier"].String();
+                if("qam" == source_type)
+                {
+                    //Process for qam mediaplayer.
+                    if(std::string::npos != identifier.find("ocap://0x"))
+                    {
+                        m_player = std::unique_ptr <mediaplayer> (mediaplayer::createMediaPlayer(QAM, identifier));
+                        if(nullptr == m_player)
+                        {
+                            LOGERR("Media player creation failed.");
+                        }
+                        else
+                        {
+                            m_player_state = player_state::INSTANTIATED;
+                            LOGINFO("Successfully created media player.");
+                            m_player->registerEventCallbacks(event_callback, error_callback, nullptr);
+                            m_player->setVideoRectangle(m_video_rectangle.x, m_video_rectangle.y, m_video_rectangle.width, m_video_rectangle.height);
+
+                            if(0 != m_player->play())
+                            {
+                                LOGERR("Play failed.");
+                            }
+                            else
+                            {
+                                success = true;
+                                m_player_state = player_state::PLAYING;
+                                LOGINFO("Play call returned successfully");
+                            }
+                        }
+                    }
+                    else
+                    {
+                        LOGERR("Identifier is not an OCAP locator.");
+                    }
+                }
+                else
+                {
+                    LOGERR("Unsupported source type.");
+                }
+            }
+            returnResponse(success);
+        }
+
+        //parameters: {}
+        uint32_t MediaEngineRMF::stop(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool success  = false;
+            if(player_state::PLAYING != m_player_state)
+            {
+                LOGERR("Player is not currently playing.");
+            }
+            else
+            {
+                m_player->registerEventCallbacks(nullptr, nullptr, nullptr);
+                if(0 != m_player->stop())
+                {
+                    LOGERR("Stop failed.");
+                }
+                m_player_state = player_state::PLATFORM_INITIALIZED;
+                m_player.reset();
+                success  = true;
+            }
+            returnResponse(success);
+        }
+
+        //parameters: {"mute" : true}
+        uint32_t MediaEngineRMF::mute(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool success  = false;
+            returnIfBooleanParamNotFound(parameters, "mute");
+            bool mute = parameters["mute"].Boolean();
+
+            if(player_state::INSTANTIATED > m_player_state)
+            {
+                LOGERR("Cannot mute before creating player.");
+            }
+            else
+            {
+                m_player->mute(mute);
+                success  = true;
+            }
+            returnResponse(success);
+        }
+        //parameters: {"volume" : 0.5}
+        uint32_t MediaEngineRMF::setVolume(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            bool success  = false;
+            returnIfNumberParamNotFound(parameters, "volume");
+            
+            float volume = static_cast <float> (parameters["volume"].Float());
+
+            if(player_state::INSTANTIATED > m_player_state)
+            {
+                LOGERR("Cannot set volume before creating player.");
+            }
+            else
+            {
+                m_player->setVolume(volume);
+                success  = true;
+            }
+            returnResponse(success);
+        }
+
+        //parameters: {"video_rectangle" : {"x" : 0, "y": 0, "width" : 1080, "height" : 720}}
+        uint32_t MediaEngineRMF::setVideoRectangle(const JsonObject& parameters, JsonObject& response)
+        {
+            const char * object_label = "video_rectangle";
+            LOGINFOMETHOD();
+            bool success  = false;
+
+            if(!parameters.HasLabel(object_label) || parameters[object_label].Content() != WPEFramework::Core::JSON::Variant::type::OBJECT)
+            {
+                LOGERR("No argument '%s' or it has incorrect type", object_label);
+                returnResponse(false);
+            }
+            JsonObject rect = parameters[object_label].Object();
+
+            returnIfNumberParamNotFound(rect, "x");
+            returnIfNumberParamNotFound(rect, "y");
+            returnIfNumberParamNotFound(rect, "width");
+            returnIfNumberParamNotFound(rect, "height");
+            
+            m_video_rectangle.x = rect["x"].Number();
+            m_video_rectangle.y = rect["x"].Number();
+            m_video_rectangle.width = rect["width"].Number();
+            m_video_rectangle.height = rect["height"].Number();
+
+            if(player_state::INSTANTIATED > m_player_state)
+            {
+                LOGERR("Player not created. Caching video rectangle parameters.");
+            }
+            else
+            {
+                m_player->setVideoRectangle(m_video_rectangle.x, m_video_rectangle.y, m_video_rectangle.width, m_video_rectangle.height);
+            }
+
+            success  = true;
+            returnResponse(success);
+        }
+
+        void MediaEngineRMF::onEvent(notification_payload * payload)
+        {
+            JsonObject params;
+            params["title"] = payload->m_title;
+            params["source"] = payload->m_source;
+            params["code"] = payload->m_code;
+            params["message"] = payload->m_message;
+            sendNotify(EVT_ON_STATUS.c_str(), params);
+        }
+
+        void MediaEngineRMF::onError(notification_payload * payload)
+        {
+            JsonObject params;
+            params["title"] = payload->m_title;
+            params["source"] = payload->m_source;
+            params["code"] = payload->m_code;
+            params["message"] = payload->m_message;
+            sendNotify(EVT_ON_ERROR.c_str(), params);
+        }
+
+        // Internal methods end
+    } // namespace Plugin
+} // namespace WPEFramework

--- a/MediaEngineRMF/MediaEngineRMF.h
+++ b/MediaEngineRMF/MediaEngineRMF.h
@@ -1,0 +1,102 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2022 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+#pragma once
+
+#include <memory>
+#include "Module.h"
+
+namespace libmediaplayer //Forward declaration.
+{
+    class mediaplayer;
+}
+namespace WPEFramework {
+    namespace Plugin {
+        class MediaEngineRMF : public PluginHost::IPlugin, public PluginHost::JSONRPC {
+        public:
+
+            enum class player_state {
+                UNINITIALIZED=0,
+                PLATFORM_INITIALIZED=1,
+                INSTANTIATED=2,
+                PAUSED=3,
+                PLAYING=4,
+            };
+
+            struct video_rectangle
+            {
+                unsigned int x;
+                unsigned int y;
+                unsigned int width;
+                unsigned int height;
+                video_rectangle(): x(0), y(0), width(1080), height(720){} //Safe defaults
+            };
+
+            MediaEngineRMF();
+            virtual ~MediaEngineRMF();
+            virtual const string Initialize(PluginHost::IShell* service) override;
+            virtual void Deinitialize(PluginHost::IShell* service) override;
+            virtual string Information() const override;
+            void onError(libmediaplayer::notification_payload * payload);
+            void onEvent(libmediaplayer::notification_payload * payload);
+
+            BEGIN_INTERFACE_MAP(MODULE_NAME)
+            INTERFACE_ENTRY(PluginHost::IPlugin)
+            INTERFACE_ENTRY(PluginHost::IDispatcher)
+            END_INTERFACE_MAP
+
+        public/*members*/:
+            static MediaEngineRMF* _instance;
+
+        public /*constants*/:
+            static const string SERVICE_NAME;
+            static const string METHOD_PLAY;
+            static const string METHOD_STOP;
+            static const string METHOD_MUTE;
+            static const string METHOD_SET_VOLUME;
+            static const string METHOD_SET_VIDEO_RECTANGLE;
+
+            static const string METHOD_INITIALIZE;
+            static const string METHOD_DEINITIALIZE;
+            static const string EVT_ON_STATUS;
+            static const string EVT_ON_ERROR;
+            static const string EVT_ON_WARNING;
+
+
+        private/*registered methods*/:
+            //methods
+            uint32_t initialize_player(const JsonObject& parameters, JsonObject& response);
+            uint32_t deinitialize_player(const JsonObject& parameters, JsonObject& response);
+            uint32_t play(const JsonObject& parameters, JsonObject& response);
+            uint32_t stop(const JsonObject& parameters, JsonObject& response);
+            uint32_t mute(const JsonObject& parameters, JsonObject& response);
+            uint32_t setVolume(const JsonObject& parameters, JsonObject& response);
+            uint32_t setVideoRectangle(const JsonObject& parameters, JsonObject& response);
+
+        private/*internal methods*/:
+            MediaEngineRMF(const MediaEngineRMF&) = delete;
+            MediaEngineRMF& operator=(const MediaEngineRMF&) = delete;
+
+        private/*members*/:
+            player_state m_player_state;
+            std::unique_ptr <libmediaplayer::mediaplayer> m_player;
+            video_rectangle m_video_rectangle;
+        };
+    } // namespace Plugin
+} // namespace WPEFramework

--- a/MediaEngineRMF/MediaEngineRMF.json
+++ b/MediaEngineRMF/MediaEngineRMF.json
@@ -1,0 +1,237 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rdkcentral/rdkservices/main/Tools/json_generator/schemas/interface.schema.json",
+    "jsonrpc": "2.0",
+    "info": {
+      "title": "MediaEngineRMF API",
+      "class": "MediaEngineRMF",
+      "description": "The `MediaEngineRMF` plugin allows you to play QAM video using Thunder"
+    },
+    "common": {
+        "$ref": "../common/common.json"
+    },
+    "definitions": {
+        "source_type": {
+            "summary": "The type of source by RMF pipeline",
+            "type": "string",
+            "example": "qam"
+        },
+        "video_rectangle": {
+            "summary": "Video rectangle dimensions",
+            "type": "object",
+            "properties": {
+                "x" : {
+                    "summary": "x axis offset in pixels",
+                    "type": "number",
+                    "example": 0
+                },
+                "y" : {
+                    "summary": "y axis offset in pixels",
+                    "type": "number",
+                    "example": 0
+                },
+                "width" : {
+                    "summary": "width in pixels",
+                    "type": "number",
+                    "example": 0
+                },
+                "length" : {
+                    "summary": "length in pixels",
+                    "type": "number",
+                    "example": 0
+                }
+            }
+        }
+    },
+    "methods": {
+        "initialize":{
+            "summary": "Performs one-time initialization necessary to use the specified source_type",
+            "params": {
+                "type": "object",
+                "properties": {
+                    "source_type": {
+                        "$ref": "#/definitions/source_type"
+                    }
+                },
+                "required": [
+                    "source_type"
+                ]
+            },
+            "result": {
+                "$ref": "#/common/result"
+            }
+        },
+        "deinitialize":{
+            "summary": "Performs final clean-up related to specified source_type",
+            "params": {
+                "type": "object",
+                "properties": {
+                    "source_type": {
+                        "$ref": "#/definitions/source_type"
+                    }
+                },
+                "required": [
+                    "source_type"
+                ]
+            },
+            "result": {
+                "$ref": "#/common/result"
+            }
+        },
+        "play":{
+            "summary": "Play specified QAM service",
+            "params": {
+                "type": "object",
+                "properties": {
+                    "source_type": {
+                        "$ref": "#/definitions/source_type"
+                    },
+                    "identifier" : {
+                        "summary": "A string that uniquely identifies the QAM/RMF service to play",
+                        "type": "string",
+                        "example": "ocap://0x3f0d"
+                    }
+                },
+                "required": [
+                    "source_type",
+                    "identifier"
+                ]
+            },
+            "result": {
+                "$ref": "#/common/result"
+            }
+        },
+        "stop":{
+            "summary": "Stops playback of the current service.",
+            "params": {
+            },
+            "result": {
+                "$ref": "#/common/result"
+            }
+        },
+        "mute":{
+            "summary": "Mute/unmute audio",
+            "params": {
+                "type": "object",
+                "properties": {
+                    "mute" : {
+                        "summary": "Use true to mute, false to unmute",
+                        "type": "boolean",
+                        "example": true
+                    }
+                },
+                "required": [
+                    "mute"
+                ]
+            },
+            "result": {
+                "$ref": "#/common/result"
+            }
+        },
+        "setVolume":{
+            "summary": "Set audio volume",
+            "params": {
+                "type": "object",
+                "properties": {
+                    "volume" : {
+                        "summary": "Audio level to set",
+                        "type": "number",
+                        "example": 0.5
+                    }
+                },
+                "required": [
+                    "volume"
+                ]
+            },
+            "result": {
+                "$ref": "#/common/result"
+            }
+        },
+        "setVideoRectangle":{
+            "summary": "Set video rectangle",
+            "params": {
+                "type": "object",
+                "properties": {
+                    "video_rectangle" : {
+                        "$ref": "#/definitions/video_rectangle"
+                    }
+                },
+                "required": [
+                    "video_rectangle"
+                ]
+            },
+            "result": {
+                "$ref": "#/common/result"
+            }
+        }
+    },
+    "events": {
+        "onStatusChanged": {
+            "summary": "Triggered when there is a change in the status of the underlying RMF plugin. Used to notify events.",
+            "params": {
+                "type": "object",
+                "properties": {
+                    "source": {
+                        "summary": "Indicates the origin of the event",
+                        "type": "string",
+                        "example": "mpsink"
+                    },
+                    "code": {
+                        "summary": "Integer code mapped to the event. Depends on the source of the event.",
+                        "type": "number",
+                        "example": "0"
+                    },
+                    "title": {
+                        "summary": "Title indicating nature of the event.",
+                        "type": "string",
+                        "example": "report first video frame"
+                    },
+                    "message": {
+                        "summary": "Optional details or context related to the event",
+                        "type": "string",
+                        "example": ""
+                    }
+                },
+                "required": [
+                    "source",
+                    "code",
+                    "title",
+                    "message"
+                ]
+            },
+            "onError": {
+                "summary": "Triggered to notify any errors.",
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "source": {
+                            "summary": "Indicates the origin of the error",
+                            "type": "string",
+                            "example": "qam"
+                        },
+                        "code": {
+                            "summary": "Error code. Depends on the source of the error.",
+                            "type": "number",
+                            "example": "-1"
+                        },
+                        "title": {
+                            "summary": "Title indicating nature of the error.",
+                            "type": "string",
+                            "example": "warning"
+                        },
+                        "message": {
+                            "summary": "Optional details or context related to the error",
+                            "type": "string",
+                            "example": "BUFFER_UNDERFLOW"
+                        }
+                    },
+                    "required": [
+                        "source",
+                        "code",
+                        "title",
+                        "message"
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/MediaEngineRMF/MediaEngineRMFPlugin.json
+++ b/MediaEngineRMF/MediaEngineRMFPlugin.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rdkcentral/rdkservices/main/Tools/json_generator/schemas/plugin.schema.json",
+    "info": {
+      "title": "MediaEngineRMF Plugin",
+      "callsign": "org.rdk.MediaEngineRMF",
+      "class":"MediaEngineRMF",
+      "locator": "libWPEFrameworkMediaEngineRMF.so",
+      "description": "The `MediaEngineRMF` plugin allows you to play QAM video using Thunder"
+    },
+    "interface": {
+      "$ref": "MediaEngineRMF.json#"
+    }
+  }

--- a/MediaEngineRMF/Module.cpp
+++ b/MediaEngineRMF/Module.cpp
@@ -1,0 +1,22 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2022 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+#include "Module.h"
+
+MODULE_NAME_DECLARATION(BUILD_REFERENCE)

--- a/MediaEngineRMF/Module.h
+++ b/MediaEngineRMF/Module.h
@@ -1,0 +1,29 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2022 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+#pragma once
+#ifndef MODULE_NAME
+#define MODULE_NAME Plugin_MediaEngineRMF
+#endif
+
+#include <plugins/plugins.h>
+#include <tracing/tracing.h>
+
+#undef EXTERNAL
+#define EXTERNAL

--- a/cmake/FindLMPLAYER.cmake
+++ b/cmake/FindLMPLAYER.cmake
@@ -1,0 +1,47 @@
+# If not stated otherwise in this file or this component's license file the
+# following copyright and licenses apply:
+#
+# Copyright 2020 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# - Try to find Audio Capture Mgr
+# Once done this will define
+#  LMPLAYER_FOUND - System has audiocapturemgr
+#  LMPLAYER_INCLUDE_DIRS - The audiocapturemgr include directories
+#  LMPLAYER_LIBRARIES - The libraries needed to use audiocapturemgr
+#  LMPLAYER_FLAGS - The flags needed to use audiocapturemgr
+#
+
+find_package(PkgConfig)
+
+find_library(LMPLAYER_LIBRARIES NAMES mediaplayer)
+find_path(LMPLAYER_INCLUDE_DIRS NAMES libmediaplayer.h)
+#find_library(LMPLAYER_LIBRARIES NAMES ds)
+#find_path(LMPLAYER_INCLUDE_DIRS NAMES dsTypes.h PATH_SUFFIXES rdk/ds-hal)
+message(STATUS "LMPLAYER_LIBRARIES is ${LMPLAYER_LIBRARIES}")
+message(STATUS "LMPLAYER_INCLUDE_DIRS is ${LMPLAYER_INCLUDE_DIRS}")
+
+set(LMPLAYER_LIBRARIES ${LMPLAYER_LIBRARIES} CACHE PATH "Path to libmediaplayer library")
+set(LMPLAYER_INCLUDE_DIRS ${LMPLAYER_INCLUDE_DIRS} )
+set(LMPLAYER_INCLUDE_DIRS ${LMPLAYER_INCLUDE_DIRS} CACHE PATH "Path to libmediaplayer include")
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(LMPLAYER DEFAULT_MSG LMPLAYER_INCLUDE_DIRS LMPLAYER_LIBRARIES)
+
+mark_as_advanced(
+    LMPLAYER_FOUND
+    LMPLAYER_INCLUDE_DIRS
+    LMPLAYER_LIBRARIES
+    LMPLAYER_LIBRARY_DIRS
+    LMPLAYER_FLAGS)


### PR DESCRIPTION
Reason for change: support for UVE-QAM playback.
Test Procedure: see ticket
Risks: low
Priority: P2
Signed-off-by: csojan <chaithents@tataelxsi.co.in>

RDK-38157 : JSON interface spec for MediaEngineRMF

Also fixed redundant calls to initialize mediaplayer

Reason for change: support for UVE-QAM playback.
Test Procedure: see ticket
Risks: low
Priority: P2
Signed-off-by: csojan <chaithents@tataelxsi.co.in>