### PR TITLE
RDKDEV-652: control initial state/setup of the XCast plugin via compilation flags

### DIFF
--- a/XCast/XCast.cpp
+++ b/XCast/XCast.cpp
@@ -89,9 +89,17 @@ SERVICE_REGISTRATION(XCast, API_VERSION_NUMBER_MAJOR, API_VERSION_NUMBER_MINOR, 
 static RtXcastConnector * _rtConnector  = RtXcastConnector::getInstance();
 static int locateCastObjectRetryCount = 0;
 bool XCast::isCastEnabled = false;
-bool XCast::m_xcastEnable= false;
+#ifdef XCAST_ENABLED_BY_DEFAULT
+bool XCast::m_xcastEnable = true;
+#else
+bool XCast::m_xcastEnable = false;
+#endif
 string XCast::m_friendlyName = "";
+#ifdef XCAST_ENABLED_BY_DEFAULT_IN_STANDBY
+bool XCast::m_standbyBehavior = true;
+#else
 bool XCast::m_standbyBehavior = false;
+#endif
 bool XCast::m_enableStatus = false;
 
 IARM_Bus_PWRMgr_PowerState_t XCast::m_powerState = IARM_BUS_PWRMGR_POWERSTATE_STANDBY;


### PR DESCRIPTION
no need to use XCast API to enable:
- setStandbyBehavior => default value could be set to true by -DXCAST_ENABLED_BY_DEFAULT
- setEnabled => default value could be set to true by -DXCAST_ENABLED_BY_DEFAULT_IN_STANDBY