### PR TITLE
REFPLTV-1573: RDKServices: LoadFailed event is not triggerring with t…

### DIFF
--- a/WebKitBrowser/WebKitBrowser.cpp
+++ b/WebKitBrowser/WebKitBrowser.cpp
@@ -290,7 +290,7 @@ namespace Plugin {
 
     void WebKitBrowser::LoadFinished(const string& URL, int32_t code)
     {
-        string message(string("{ \"url\": \"") + URL + string("\", \"loaded\":true, \"httpstatus\":") + Core::NumberType<int32_t>(code).Text() + string(" }"));
+        string message(string("{ \"url\": \"") + URL + string("\", \"loaded\":true") + string(" }"));
         TRACE(Trace::Information, (_T("LoadFinished: %s"), message.c_str()));
         _service->Notify(message);
         Exchange::JWebBrowser::Event::LoadFinished(*this, URL, code);

--- a/WebKitBrowser/WebKitImplementation.cpp
+++ b/WebKitBrowser/WebKitImplementation.cpp
@@ -1962,8 +1962,6 @@ static GSourceFuncs _handlerIntervention =
         {
             _adminLock.Lock();
 
-            _URL = URL;
-
             std::list<Exchange::IWebBrowser::INotification*>::iterator index(_notificationClients.begin());
             {
                 while (index != _notificationClients.end()) {


### PR DESCRIPTION
…he URL which is failed to load by the browser

Reason for change: LoadFailed is displaying for valid url.

Test Procedure: LoadFailed event should trigger based on URL loaded by browser.

Risks: Low

Signed-off-by: srowth513 <Sravanthi_Rowthu@comcast.com>