### PR TITLE
XIONE-11314: Wpeframework log is flooding with "Information: BridgeQuery"

### DIFF
--- a/WebKitBrowser/WebKitBrowser.cpp
+++ b/WebKitBrowser/WebKitBrowser.cpp
@@ -330,7 +330,6 @@ namespace Plugin {
 
     void WebKitBrowser::BridgeQuery(const string& message)
     {
-        TRACE(Trace::Information, (_T("BridgeQuery: %s"), message.c_str()));
         event_bridgequery(message);
     }
 


### PR DESCRIPTION
Reason for change: Remove logging of BridgeQuery
Signed-off-by: Vivek.A <vivek_arumugam@comcast.com>