### PR TITLE
LLAMA-9377: Llama- Automatic updates option not working as expected

### DIFF
--- a/MaintenanceManager/CHANGELOG.md
+++ b/MaintenanceManager/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.0.11] - 2023-01-18
+### Fixed
+- Allow to set OptOut value when maintenance is in progress
+
 ## [1.0.10] - 2022-12-08
 ### Fixed
 - Send MAINTENANCE_ERROR event from stopMaintenance()

--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -66,7 +66,7 @@ using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 10
+#define API_VERSION_NUMBER_PATCH 11
 #define SERVER_DETAILS  "127.0.0.1:9998"
 
 
@@ -1112,12 +1112,6 @@ namespace WPEFramework {
 	    int mode = 1;
 
             rdkvfwrfc = readRFC(TR181_RDKVFWUPGRADER);
-            /* check if maintenance is on progress or not */
-            /* if in progress and firmware rfc is false then restrict the same */
-            if ( (rdkvfwrfc == false) && (MAINTENANCE_STARTED == m_notify_status) ){
-                LOGERR("Maintenance is in Progress, Mode change not allowed");
-                returnResponse(true);
-	    }
             /* Label should have maintenance mode and softwareOptout field */
             if ( parameters.HasLabel("maintenanceMode") && parameters.HasLabel("optOut") ){
 
@@ -1131,6 +1125,9 @@ namespace WPEFramework {
 
                 std::lock_guard<std::mutex> guard(m_callMutex);
 
+                /* check if maintenance is on progress or not */
+                /* if in progress restrict the same */
+                if ( MAINTENANCE_STARTED != m_notify_status ){
 
                     LOGINFO("SetMaintenanceMode new_mode = %s\n",new_mode.c_str());
 
@@ -1145,6 +1142,9 @@ namespace WPEFramework {
                     }
                     g_currentMode = new_mode;
                     m_setting.setValue("background_flag", bg_flag);
+		}else {
+                     /*If firmware rfc is true and IARM bus component present allow to change maintenance mode*/
+	            if (rdkvfwrfc == true) {
 #if defined(USE_IARMBUS) || defined(USE_IARM_BUS)
 		    /* Sending IARM Event to application for mode change */
 		    (new_mode != BACKGROUND_MODE) ? mode = 1 : mode = 0;
@@ -1153,10 +1153,26 @@ namespace WPEFramework {
 	            ret_code = IARM_Bus_BroadcastEvent("RdkvFWupgrader", (IARM_EventId_t) 0, (void *)&mode, sizeof(mode));
 	            if (ret_code == IARM_RESULT_SUCCESS) {
                         LOGINFO("IARM_Bus_BroadcastEvent is success and value=%d\n", mode);
+                        g_currentMode = new_mode;
+                        /* remove any older one */
+                        m_setting.remove("background_flag");
+                        if ( BACKGROUND_MODE == new_mode ) {
+                            bg_flag = "true";
+                        }
+                        else {
+                            /* foreground */
+                            bg_flag = "false";
+                        }
+		        m_setting.setValue("background_flag", bg_flag);
 	            }else{
-                        LOGINFO("IARM_Bus_BroadcastEvent is fail and value=%d\n", mode);
+                        LOGINFO("IARM_Bus_BroadcastEvent is fail Mode change not allowed and value=%d\n", mode);
 	            }
 #endif /* defined(USE_IARMBUS) || defined(USE_IARM_BUS) */
+		    }else {
+                        LOGERR("Maintenance is in Progress, Mode change not allowed");
+		    }
+                    result =true;
+		}
 
                 /* OptOut changes here */
                 new_optout_state = parameters["optOut"].String();


### PR DESCRIPTION
Reason for change: optout option set is not happening during maintenance
                   is in progress. Now added changes to allow
                   optout option set during maintenance in in progress.

Test Procedure: 1> Trigger download is Llama tv.
                2> When download is in progress change the mode using
                   setMaintenanceMode with optout option set.
                3> Expected Result is maintenance mode will not change
                   but optout option should be set with new value.

Risks: High

Priority: P0

Signed-off-by: satya200 <satyasundar_sahu@comcast.com>