### PR TITLE
RDKDEV-459: RDKCOM-3519 OMWAPPI-824 fix DisplaySettings core dump

### DIFF
--- a/DisplaySettings/CHANGELOG.md
+++ b/DisplaySettings/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+## [1.0.17] - 2023-01-19
+### Fixed
+- Fixed fix DisplaySettings core dump
+
 ## [1.0.16] - 2022-12-09
 ### Fixed
 - Fixed  Added support for HDRPLUS format support

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -79,7 +79,7 @@ using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 16
+#define API_VERSION_NUMBER_PATCH 17
 
 static bool isCecArcRoutingThreadEnabled = false;
 static bool isCecEnabled = false;

--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -259,7 +259,7 @@ namespace WPEFramework {
             int m_hdmiInAudioDevicePowerState;
             int m_currentArcRoutingState;
 
-            PluginHost::IShell* m_service;
+            PluginHost::IShell* m_service = nullptr;
 
         public:
             static DisplaySettings* _instance;


### PR DESCRIPTION
Without default null value, the plugin dumps on

ASSERT(m_service == nullptr);

in DisplaySettings::Initialize

(cherry picked from commit 5094d0ea0d5229debb04d20d69b7a804711d9a66)