### PR TITLE
LLama-9018: SystemAudioPlayer Plugin is in Deactivated state after CDL

### DIFF
--- a/SystemAudioPlayer/SystemAudioPlayer.cpp
+++ b/SystemAudioPlayer/SystemAudioPlayer.cpp
@@ -57,7 +57,7 @@ namespace Plugin {
 
         _service->Register(&_notification);
 
-        _sap = _service->Root<Exchange::ISystemAudioPlayer>(_connectionId, 5000, _T("SystemAudioPlayerImplementation"));
+        _sap = _service->Root<Exchange::ISystemAudioPlayer>(_connectionId, 8000, _T("SystemAudioPlayerImplementation"));
 
         std::string message;
         if(_sap != nullptr) {


### PR DESCRIPTION
Reason for change: To increase timeout when initializing SystemAudioPlayer plugin
Test Procedure: after CDL check SAP gets activated 
Risks: Low

Signed-off-by: vdinak240 <Vishnu_Dinakaran@comcast.com>