### PR TITLE
RDKTV-20951: IP Address value is not shown in device settings 

### DIFF
--- a/Network/CHANGELOG.md
+++ b/Network/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.0.6] - 2022-12-13
+### Fixed
+- Fixed empty IP Address value being returned.
+
 ## [1.0.5] - 2022-12-13
 ### Added
 - Added Network plugin unitTest cases.

--- a/Network/Network.cpp
+++ b/Network/Network.cpp
@@ -34,7 +34,7 @@ using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 5
+#define API_VERSION_NUMBER_PATCH 6
 
 /* Netsrvmgr Based Macros & Structures */
 #define IARM_BUS_NM_SRV_MGR_NAME "NET_SRV_MGR"
@@ -496,8 +496,11 @@ typedef struct _IARM_BUS_NetSrvMgr_Iface_EventData_t {
                 {
                     response["ip"] = string(param.activeIfaceIpaddr, MAX_IP_ADDRESS_LEN - 1);
                     m_stbIpCache = string(param.activeIfaceIpaddr, MAX_IP_ADDRESS_LEN - 1);
-                    m_useStbIPCache = true;
                     result = true;
+                    if (!m_stbIpCache.empty())
+                    {
+                        m_useStbIPCache = true;
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
Reason for change: Fix stale empty IP address being stored in cache Test Procedure: Build and verify.
Risks: High
Signed-off-by:Zameerun Rasheed M S <zexpen@gmail.com>

Co-authored-by: Karunakaran A <48997923+karuna2git@users.noreply.github.com>