### PR TITLE
LLAMA-9377: Llama- Automatic updates option not working as expected

### DIFF
--- a/MaintenanceManager/CHANGELOG.md
+++ b/MaintenanceManager/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.0.13] - 2023-01-30
+### Fixed
+- Allow to set OptOut value when maintenance is in progress
+
 ## [1.0.12] - 2023-01-18
 ### Fixed
 - Fixed deadlock in Maintenance Manager code


### PR DESCRIPTION
Reason for change: optout option set is not happening during maintenance is in progress. Now added changes to allow
optout option set during maintenance in in progress.

Test Procedure: 1> Trigger download is Llama tv.
2> When download is in progress change the mode using setMaintenanceMode with optout option set.
3> Expected Result is maintenance mode will not change but optout option should be set with new value.

Risks: High

Priority: P0

Signed-off-by: satya200 <satyasundar_sahu@comcast.com>