### PR TITLE
RDKDEV-438: RDKCOM-3539 DisplayInfo: Include "tvhdrtypes" property on…

### DIFF
--- a/DisplayInfo/CHANGELOG.md
+++ b/DisplayInfo/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.0.3] - 2023-01-31
+### Changed
+- tvhdrtypes property included on DisplayInfo REST API calls
+
 ## [1.0.2] - 2022-12-09
 ### Changed
 - Syncup of changes from Metro version, Includes below changes:

--- a/DisplayInfo/DisplayInfo.cpp
+++ b/DisplayInfo/DisplayInfo.cpp
@@ -21,7 +21,7 @@
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 2
+#define API_VERSION_NUMBER_PATCH 3
 
 namespace WPEFramework {
 namespace {
@@ -237,7 +237,21 @@ namespace Plugin {
 
         Exchange::IHDRProperties::HDRType hdrType(Exchange::IHDRProperties::HDRType::HDR_OFF);
         if (_hdrProperties->HDRSetting(hdrType) == Core::ERROR_NONE) {
-            displayInfo.Hdrtype = static_cast<JsonData::DisplayInfo::DisplayinfoData::HdrtypeType>(hdrType);
+            displayInfo.Hdrtype = static_cast<JsonData::DisplayInfo::HdrtypesType>(hdrType);
+        }
+
+	Exchange::IHDRProperties::IHDRIterator* hdrIterator;
+        if (_hdrProperties->TVCapabilities(hdrIterator) == Core::ERROR_NONE) {
+            if (hdrIterator != nullptr) {
+                Exchange::IHDRProperties::HDRType tvHdr;
+                while (hdrIterator->Next(tvHdr)) {
+                    Core::JSON::EnumType<JsonData::DisplayInfo::HdrtypesType>& Element(displayInfo.Tvhdrtypes.Add());
+                    Element = static_cast<JsonData::DisplayInfo::HdrtypesType>(tvHdr);
+                }
+
+                displayInfo.Tvhdrtypes.Set(true);
+                hdrIterator->Release();
+            }
         }
     }
 


### PR DESCRIPTION
… DisplayInfo REST API call

The DisplayInfo.cpp file is modified to invoke TVCapabilities() which basically passes an iterator to get the HDR types supported by TV, these values are then updated against new DisplayInfo property 'tvhdrtypes'.

Signed-off-by: prajwal-tata
(cherry picked from commit ccc97ee0031649ae89f665f97fff0058e623b0ac)