### PR TITLE
RDKTV-21748: Removing OSD name Updated to FA on Feature Abort

### DIFF
--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -436,7 +436,7 @@ namespace WPEFramework
 					
 					case GIVE_OSD_NAME :
 			 		{
-			 			HdmiCecSink::_instance->deviceList[header.from.toInt()].update(OSDName("FA"));
+			 			HdmiCecSink::_instance->deviceList[header.from.toInt()].update(OSDName(""));
 			 		}
 						break;
 
@@ -1842,7 +1842,7 @@ namespace WPEFramework
 	
 		void HdmiCecSink::sendMenuLanguage()
 		{
-			Language lang = "NA";
+			Language lang = "";
 			if(!HdmiCecSink::_instance)
 				return;
 
@@ -2470,7 +2470,7 @@ namespace WPEFramework
 
 					case CECDeviceParams::REQUEST_OSD_NAME :	
 					{
-						_instance->deviceList[logicalAddress].update(OSDName("NA"));
+						_instance->deviceList[logicalAddress].update(OSDName(""));
 					}
 						break;
 

--- a/HdmiCecSink/HdmiCecSink.h
+++ b/HdmiCecSink/HdmiCecSink.h
@@ -139,7 +139,7 @@ namespace WPEFramework {
 			std::chrono::system_clock::time_point m_lastPowerUpdateTime;
 			
 			CECDeviceParams() 
-			: m_deviceType(0), m_logicalAddress(0),m_physicalAddr(0x0f,0x0f,0x0f,0x0f),m_cecVersion(0),m_vendorID(0,0,0),m_osdName("NA"),m_powerStatus(0),m_currentLanguage("NA")
+			: m_deviceType(0), m_logicalAddress(0),m_physicalAddr(0x0f,0x0f,0x0f,0x0f),m_cecVersion(0),m_vendorID(0,0,0),m_osdName(""),m_powerStatus(0),m_currentLanguage("")
 			{
 				m_isDevicePresent = false;
 				m_isActiveSource = false;
@@ -160,9 +160,9 @@ namespace WPEFramework {
 				m_physicalAddr = PhysicalAddress(0x0f,0x0f,0x0f,0x0f);
 				m_cecVersion = 0;
 				m_vendorID = VendorID(0,0,0);
-				m_osdName = "NA";
+				m_osdName = "";
 				m_powerStatus = 0;
- 				m_currentLanguage = "NA";
+ 				m_currentLanguage = "";
 				m_isDevicePresent = false;
 				m_isActiveSource = false;
 				m_isPAUpdated = false;


### PR DESCRIPTION
Reason for change: OSD name is set as "NA" by default and set to "FA" when Feature Abort command is received. Changing this values to empty string ""
Test Procedure: Steps mentioned in ticket
Risks: Low
Signed-off-by: Dhivya Ilangovan <dhivya.dilangovan@sky.uk>