### PR TITLE
RDKTV-21475: [One time issue]: HDMI-AVR is not auto connected when we…

### DIFF
--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -817,6 +817,7 @@ namespace WPEFramework
                                                 /* Initiate a ping straight away */
                                                 HdmiCecSink::_instance->m_pollNextState = POLL_THREAD_STATE_PING;
                                                 HdmiCecSink::_instance->m_ThreadExitCV.notify_one();
+						LOGINFO("Notified the ThreadExit upon State change\n");
 					}
 			}
 			else
@@ -2701,7 +2702,7 @@ namespace WPEFramework
 				if ( _instance->m_ThreadExitCV.wait_for(lk, std::chrono::milliseconds(_instance->m_sleepTime)) == std::cv_status::timeout )
 					continue;
 				else
-					LOGINFO("Thread is going to Exit m_pollThreadExit %d\n", _instance->m_pollThreadExit );
+					LOGINFO("Thread is going to Exit m_pollThreadExit %d with sleeptime: %d\n", _instance->m_pollThreadExit,_instance->m_sleepTime);
 
 			}
         }


### PR DESCRIPTION
… update the build from 5.11p2s3 to 5.11p3s3

Reason for change: Adding debug prints to debug the issue if the issue is observed in thread exiting.
Test Procedure: Build and Verify.
Risks: Low
Signed-off-by: Aishwariya B <aishwariya.bhaskar@sky.uk>