### PR TITLE
RDKTV-21578, RDKTV-21788: No Audio in LG soundbar

### DIFF
--- a/DisplaySettings/CHANGELOG.md
+++ b/DisplaySettings/CHANGELOG.md
@@ -15,6 +15,11 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+## [1.0.17] - 2023-02-03
+### Fixed
+- Fixed Blocked sending events to Displaysettings when panel power state is STANDBY
+- Fixed Parallel execution of event handlers
+
 ## [1.0.16] - 2022-12-09
 ### Fixed
 - Fixed  Added support for HDRPLUS format support

--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -236,8 +236,7 @@ namespace WPEFramework {
             std::mutex m_callMutex;
             std::mutex m_SadMutex;
 	    std::thread m_arcRoutingThread;
-	    std::mutex m_arcRoutingStateMutex;
-	    std::mutex m_ArcDisableMutex;
+	    std::mutex m_AudioDeviceStatesUpdateMutex;
 	    bool m_cecArcRoutingThreadRun; 
 	    std::condition_variable arcRoutingCV;
 	    bool m_hdmiInAudioDeviceConnected;
@@ -245,6 +244,7 @@ namespace WPEFramework {
             bool m_arcPendingSADRequest;   
             bool m_isPwrMgr2RFCEnabled;
 	    bool m_hdmiCecAudioDeviceDetected;
+	    bool m_systemAudioMode_Power_RequestedAndReceived;
 	    dsAudioARCTypes_t m_hdmiInAudioDeviceType;
 	    JsonObject m_audioOutputPortConfig;
             JsonObject getAudioOutputPortConfig() { return m_audioOutputPortConfig; }

--- a/HdmiCecSink/CHANGELOG.md
+++ b/HdmiCecSink/CHANGELOG.md
@@ -16,6 +16,12 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+
+## [1.0.8] - 2023-02-03
+### Fixed
+- Fixed Blocked sending events to Displaysettings when panel power state is STANDBY
+- Fixed Parallel execution of event handlers
+
 ## [1.0.7] - 2022-11-28
 ### Fixed
 - Treat warnings as errors for unit tests workflow

--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -79,6 +79,10 @@
 #define SAD_FMT_CODE_AC3 2
 #define SAD_FMT_CODE_ENHANCED_AC3 10
 
+#define SYSTEM_AUDIO_MODE_ON 0x01
+#define SYSTEM_AUDIO_MODE_OFF 0x00
+#define AUDIO_DEVICE_POWERSTATE_OFF 1
+
 enum {
 	DEVICE_POWER_STATE_ON = 0,
 	DEVICE_POWER_STATE_OFF = 1
@@ -148,7 +152,7 @@ static int32_t HdmiArcPortID = -1;
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 7
+#define API_VERSION_NUMBER_PATCH 8
 
 namespace WPEFramework
 {
@@ -996,7 +1000,7 @@ namespace WPEFramework
                  return;
             }
 
-	    if ( (msg.status.toInt() == 0x00) && (m_currentArcRoutingState == ARC_STATE_ARC_INITIATED))
+	    if ( (msg.status.toInt() == SYSTEM_AUDIO_MODE_OFF) && (m_currentArcRoutingState == ARC_STATE_ARC_INITIATED))
             {
 		/* ie system audio mode off -> amplifier goign to standby but still ARC is in initiated state,stop ARC and 
 		 bring the ARC state machine to terminated state*/
@@ -1006,7 +1010,18 @@ namespace WPEFramework
             }
 
             params["audioMode"] = msg.status.toString().c_str();
-            sendNotify(eventString[HDMICECSINK_EVENT_SYSTEM_AUDIO_MODE], params);
+	    if (msg.status.toInt() == SYSTEM_AUDIO_MODE_ON) {
+		LOGINFO("panel power state is %s", powerState ? "Off" : "On");
+	        if (powerState == DEVICE_POWER_STATE_ON ) {
+		    LOGINFO("Notifying system audio mode ON event");
+                    sendNotify(eventString[HDMICECSINK_EVENT_SYSTEM_AUDIO_MODE], params);
+		} else {
+		    LOGINFO("Not notifying system audio mode ON event");
+		}
+	    } else {
+		    LOGINFO("Notifying system audio Mode OFF event");
+		    sendNotify(eventString[HDMICECSINK_EVENT_SYSTEM_AUDIO_MODE], params);
+	    }
          }
          void HdmiCecSink::Process_ReportAudioStatus_msg(const ReportAudioStatus msg)
          {
@@ -1132,11 +1147,18 @@ namespace WPEFramework
         {
             JsonObject params;
             params["powerStatus"] = JsonValue(powerStatus);
-            LOGINFO("Notify DS!!! logicalAddress = %d , Audio device power status = %d \n", logicalAddress, powerStatus);
-	    /* update audio device power status request flag only if Audio device is ON or in STANDBY not in other states */
-	    if((powerStatus == 0) || (powerStatus == 1))
-	        m_audioDevicePowerStatusRequested = false;
-            sendNotify(eventString[HDMICECSINK_EVENT_AUDIO_DEVICE_POWER_STATUS], params);
+	    LOGINFO("Panle power state is %s", powerState ? "Off" : "On");
+	    if (powerStatus != AUDIO_DEVICE_POWERSTATE_OFF) {
+	        if (powerState == DEVICE_POWER_STATE_ON ) {
+                    LOGINFO("Notify DS!!! logicalAddress = %d , Audio device power status = %d \n", logicalAddress, powerStatus);
+                    sendNotify(eventString[HDMICECSINK_EVENT_AUDIO_DEVICE_POWER_STATUS], params);
+		} else {
+		    LOGINFO("Not notifying audio device power state to DS");
+		}
+	    } else {
+                    LOGINFO("Notify DS!!! logicalAddress = %d , Audio device power status = %d \n", logicalAddress, powerStatus);
+                    sendNotify(eventString[HDMICECSINK_EVENT_AUDIO_DEVICE_POWER_STATUS], params);
+	    }
         }
 
         void HdmiCecSink::SendStandbyMsgEvent(const int logicalAddress)
@@ -3037,6 +3059,8 @@ namespace WPEFramework
             {
                m_arcStartStopTimer.stop();
             }
+	    if (powerState == DEVICE_POWER_STATE_ON ) {
+		LOGINFO("Notifying Arc Initiation event as power state is %s", powerState ? "Off" : "On");
 		{
             	  std::lock_guard<std::mutex> lock(_instance->m_arcRoutingStateMutex);
 	          _instance->m_currentArcRoutingState = ARC_STATE_ARC_INITIATED;
@@ -3045,7 +3069,9 @@ namespace WPEFramework
                   LOGINFO("Got : ARC_INITIATED  and notify Device setting");
                   params["status"] = string("success");
                   sendNotify(eventString[HDMICECSINK_EVENT_ARC_INITIATION_EVENT], params); 
-	  
+	    } else {
+		LOGINFO("Not notifying Arc Initiation event as power state is %s", powerState ? "Off" : "On");
+	    }
 
        }
        void HdmiCecSink::Process_TerminateArc()


### PR DESCRIPTION
Reason for change: Fix the audio mute issue in LG sound bar after panel standby wakeup Test Procedure: Check audio is routed to LG SB after standby wakeup Risks: Low

Signed-off-by: shashank.kumar@sky.uk <shashank.kumar@sky.uk>