### PR TITLE
DELIA-60084 : Fix SecurityAgent access to /jsonrpc

### DIFF
--- a/SecurityAgent/SecurityContext.cpp
+++ b/SecurityAgent/SecurityContext.cpp
@@ -79,7 +79,7 @@ namespace Plugin {
         string method = "";
 
         if ((request.Path.find(_servicePrefix, 0) != 0) || (_servicePrefix.length() > request.Path.length())) {
-            return ((_accessControlList != nullptr) && (_accessControlList->Allowed(_context.URL.Value(),"","")));
+            return (_accessControlList != nullptr);
         }
 
         Core::TextSegmentIterator index(Core::TextFragment(request.Path, _servicePrefix.length(), static_cast<uint32_t>(request.Path.length() - _servicePrefix.length())), false, '/');


### PR DESCRIPTION
Reason for change: access relies on the "default" value in ACL, regardless of the permissions specified for the callsign/method. Test Procedure: create token for ACL role with "default":"blocked", make curl request to /jsonrpc and callsign allowed for the role.
Risks: None
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>