### PR TITLE
 DELIA-60044: Thread Handling for HdmiCec, HdmiCec_2 and HdmiCecSource

### DIFF
--- a/HdmiCec/HdmiCec.cpp
+++ b/HdmiCec/HdmiCec.cpp
@@ -528,13 +528,33 @@ namespace WPEFramework
 
                 m_updateThreadExit = true;
                 //Trigger codition to exit poll loop
-                pthread_cond_signal(&(_instance->m_condSigUpdate));
+                pthread_mutex_lock(&(_instance->m_lockUpdate)); //Join mutex lock to wait until thread is in its wait condition
+                pthread_cond_signal(&(_instance->m_condSigUpdate))
+                pthread_mutex_unlock(&(_instance->m_lockUpdate));;
+                try{
+                    if (m_UpdateThread.get().joinable()) {//Join thread to make sure it's deleted before moving on.
+                        m_UpdateThread.get().join();
+                    }
+                }
+                catch (const std::system_error& e) {
+                    LOGERR("exception in joining threadUpdateCheck %s", e.what());
+	            }
                 LOGWARN("Deleted update Thread %p", smConnection );
 
 
                 m_pollThreadExit = true;
                 //Trigger codition to exit poll loop
+                pthread_mutex_lock(&(_instance->m_lock)); //Join mutex lock to wait until thread is in its wait condition
                 pthread_cond_signal(&(_instance->m_condSig));
+                pthread_mutex_unlock(&(_instance->m_lock));
+                try{
+                    if (m_pollThread.get().joinable()) {//Join thread to make sure it's deleted before moving on.
+                        m_pollThread.get().join();
+                    }
+                }
+                catch (const std::system_error& e) {
+                    LOGERR("exception in joining threadRun %s", e.what());
+	            }
                 LOGWARN("Deleted Thread %p", smConnection );
                 //Clear cec device cache.
                 removeAllCecDevices();

--- a/HdmiCec/HdmiCec.cpp
+++ b/HdmiCec/HdmiCec.cpp
@@ -531,14 +531,9 @@ namespace WPEFramework
                 pthread_mutex_lock(&(_instance->m_lockUpdate)); //Join mutex lock to wait until thread is in its wait condition
                 pthread_cond_signal(&(_instance->m_condSigUpdate));
                 pthread_mutex_unlock(&(_instance->m_lockUpdate));
-                try{
-                    if (m_UpdateThread.get().joinable()) {//Join thread to make sure it's deleted before moving on.
-                        m_UpdateThread.get().join();
-                    }
+                if (m_UpdateThread.get().joinable()) {//Join thread to make sure it's deleted before moving on.
+                    m_UpdateThread.get().join();
                 }
-                catch (const std::system_error& e) {
-                    LOGERR("exception in joining threadUpdateCheck %s", e.what());
-	            }
                 LOGWARN("Deleted update Thread %p", smConnection );
 
 
@@ -547,14 +542,9 @@ namespace WPEFramework
                 pthread_mutex_lock(&(_instance->m_lock)); //Join mutex lock to wait until thread is in its wait condition
                 pthread_cond_signal(&(_instance->m_condSig));
                 pthread_mutex_unlock(&(_instance->m_lock));
-                try{
-                    if (m_pollThread.get().joinable()) {//Join thread to make sure it's deleted before moving on.
-                        m_pollThread.get().join();
-                    }
+                if (m_pollThread.get().joinable()) {//Join thread to make sure it's deleted before moving on.
+                    m_pollThread.get().join();
                 }
-                catch (const std::system_error& e) {
-                    LOGERR("exception in joining threadRun %s", e.what());
-	            }
                 LOGWARN("Deleted Thread %p", smConnection );
                 //Clear cec device cache.
                 removeAllCecDevices();

--- a/HdmiCec/HdmiCec.cpp
+++ b/HdmiCec/HdmiCec.cpp
@@ -529,8 +529,8 @@ namespace WPEFramework
                 m_updateThreadExit = true;
                 //Trigger codition to exit poll loop
                 pthread_mutex_lock(&(_instance->m_lockUpdate)); //Join mutex lock to wait until thread is in its wait condition
-                pthread_cond_signal(&(_instance->m_condSigUpdate))
-                pthread_mutex_unlock(&(_instance->m_lockUpdate));;
+                pthread_cond_signal(&(_instance->m_condSigUpdate));
+                pthread_mutex_unlock(&(_instance->m_lockUpdate));
                 try{
                     if (m_UpdateThread.get().joinable()) {//Join thread to make sure it's deleted before moving on.
                         m_UpdateThread.get().join();

--- a/HdmiCecSource/HdmiCecSource.cpp
+++ b/HdmiCecSource/HdmiCecSource.cpp
@@ -1254,14 +1254,9 @@ namespace WPEFramework
                 pthread_mutex_lock(&(_instance->m_lockUpdate)); //Join mutex lock to wait until thread is in its wait condition
                 pthread_cond_signal(&(_instance->m_condSigUpdate));
                 pthread_mutex_unlock(&(_instance->m_lockUpdate));
-                try{
-                    if (m_UpdateThread.get().joinable()) {//Join thread to make sure it's deleted before moving on.
-                        m_UpdateThread.get().join();
-                    }
+                if (m_UpdateThread.get().joinable()) {//Join thread to make sure it's deleted before moving on.
+                    m_UpdateThread.get().join();
                 }
-                catch (const std::system_error& e) {
-                    LOGERR("exception in joining threadUpdateCheck %s", e.what());
-	            }
                 LOGWARN("Deleted update Thread %p", smConnection );
 
                 m_pollThreadExit = true;
@@ -1269,14 +1264,9 @@ namespace WPEFramework
                 pthread_mutex_lock(&(_instance->m_lock)); //Join mutex lock to wait until thread is in its wait condition
                 pthread_cond_signal(&(_instance->m_condSig));
                 pthread_mutex_unlock(&(_instance->m_lock));
-                try{
-                    if (m_pollThread.get().joinable()) {//Join thread to make sure it's deleted before moving on.
-                        m_pollThread.get().join();
-                    }
+                if (m_pollThread.get().joinable()) {//Join thread to make sure it's deleted before moving on.
+                    m_pollThread.get().join();
                 }
-                catch (const std::system_error& e) {
-                    LOGERR("exception in joining threadRun %s", e.what());
-	            }
                 LOGWARN("Deleted Thread %p", smConnection );
                 //Clear cec device cache.
                 removeAllCecDevices();

--- a/HdmiCecSource/HdmiCecSource.cpp
+++ b/HdmiCecSource/HdmiCecSource.cpp
@@ -1252,8 +1252,8 @@ namespace WPEFramework
                 m_updateThreadExit = true;
                 //Trigger codition to exit poll loop
                 pthread_mutex_lock(&(_instance->m_lockUpdate)); //Join mutex lock to wait until thread is in its wait condition
-                pthread_cond_signal(&(_instance->m_condSigUpdate))
-                pthread_mutex_unlock(&(_instance->m_lockUpdate));;
+                pthread_cond_signal(&(_instance->m_condSigUpdate));
+                pthread_mutex_unlock(&(_instance->m_lockUpdate));
                 try{
                     if (m_UpdateThread.get().joinable()) {//Join thread to make sure it's deleted before moving on.
                         m_UpdateThread.get().join();

--- a/HdmiCecSource/HdmiCecSource.cpp
+++ b/HdmiCecSource/HdmiCecSource.cpp
@@ -1251,12 +1251,32 @@ namespace WPEFramework
 
                 m_updateThreadExit = true;
                 //Trigger codition to exit poll loop
-                pthread_cond_signal(&(_instance->m_condSigUpdate));
+                pthread_mutex_lock(&(_instance->m_lockUpdate)); //Join mutex lock to wait until thread is in its wait condition
+                pthread_cond_signal(&(_instance->m_condSigUpdate))
+                pthread_mutex_unlock(&(_instance->m_lockUpdate));;
+                try{
+                    if (m_UpdateThread.get().joinable()) {//Join thread to make sure it's deleted before moving on.
+                        m_UpdateThread.get().join();
+                    }
+                }
+                catch (const std::system_error& e) {
+                    LOGERR("exception in joining threadUpdateCheck %s", e.what());
+	            }
                 LOGWARN("Deleted update Thread %p", smConnection );
 
                 m_pollThreadExit = true;
                 //Trigger codition to exit poll loop
+                pthread_mutex_lock(&(_instance->m_lock)); //Join mutex lock to wait until thread is in its wait condition
                 pthread_cond_signal(&(_instance->m_condSig));
+                pthread_mutex_unlock(&(_instance->m_lock));
+                try{
+                    if (m_pollThread.get().joinable()) {//Join thread to make sure it's deleted before moving on.
+                        m_pollThread.get().join();
+                    }
+                }
+                catch (const std::system_error& e) {
+                    LOGERR("exception in joining threadRun %s", e.what());
+	            }
                 LOGWARN("Deleted Thread %p", smConnection );
                 //Clear cec device cache.
                 removeAllCecDevices();

--- a/HdmiCec_2/HdmiCec_2.cpp
+++ b/HdmiCec_2/HdmiCec_2.cpp
@@ -1254,14 +1254,9 @@ namespace WPEFramework
                 pthread_mutex_lock(&(_instance->m_lockUpdate)); //Join mutex lock to wait until thread is in its wait condition
                 pthread_cond_signal(&(_instance->m_condSigUpdate));
                 pthread_mutex_unlock(&(_instance->m_lockUpdate));
-                try{
-                    if (m_UpdateThread.get().joinable()) {//Join thread to make sure it's deleted before moving on.
-                        m_UpdateThread.get().join();
-                    }
+                if (m_UpdateThread.get().joinable()) {//Join thread to make sure it's deleted before moving on.
+                    m_UpdateThread.get().join();
                 }
-                catch (const std::system_error& e) {
-                    LOGERR("exception in joining threadUpdateCheck %s", e.what());
-	            }
                 LOGWARN("Deleted update Thread %p", smConnection );
 
                 m_pollThreadExit = true;
@@ -1269,14 +1264,9 @@ namespace WPEFramework
                 pthread_mutex_lock(&(_instance->m_lock)); //Join mutex lock to wait until thread is in its wait condition
                 pthread_cond_signal(&(_instance->m_condSig));
                 pthread_mutex_unlock(&(_instance->m_lock));
-                try{
-                    if (m_pollThread.get().joinable()) {//Join thread to make sure it's deleted before moving on.
-                        m_pollThread.get().join();
-                    }
+                if (m_pollThread.get().joinable()) {//Join thread to make sure it's deleted before moving on.
+                    m_pollThread.get().join();
                 }
-                catch (const std::system_error& e) {
-                    LOGERR("exception in joining threadRun %s", e.what());
-	            }
                 LOGWARN("Deleted Thread %p", smConnection );
                 //Clear cec device cache.
                 removeAllCecDevices();

--- a/HdmiCec_2/HdmiCec_2.cpp
+++ b/HdmiCec_2/HdmiCec_2.cpp
@@ -1252,8 +1252,8 @@ namespace WPEFramework
                 m_updateThreadExit = true;
                 //Trigger codition to exit poll loop
                 pthread_mutex_lock(&(_instance->m_lockUpdate)); //Join mutex lock to wait until thread is in its wait condition
-                pthread_cond_signal(&(_instance->m_condSigUpdate))
-                pthread_mutex_unlock(&(_instance->m_lockUpdate));;
+                pthread_cond_signal(&(_instance->m_condSigUpdate));
+                pthread_mutex_unlock(&(_instance->m_lockUpdate));
                 try{
                     if (m_UpdateThread.get().joinable()) {//Join thread to make sure it's deleted before moving on.
                         m_UpdateThread.get().join();

--- a/HdmiCec_2/HdmiCec_2.cpp
+++ b/HdmiCec_2/HdmiCec_2.cpp
@@ -1251,12 +1251,32 @@ namespace WPEFramework
 
                 m_updateThreadExit = true;
                 //Trigger codition to exit poll loop
-                pthread_cond_signal(&(_instance->m_condSigUpdate));
+                pthread_mutex_lock(&(_instance->m_lockUpdate)); //Join mutex lock to wait until thread is in its wait condition
+                pthread_cond_signal(&(_instance->m_condSigUpdate))
+                pthread_mutex_unlock(&(_instance->m_lockUpdate));;
+                try{
+                    if (m_UpdateThread.get().joinable()) {//Join thread to make sure it's deleted before moving on.
+                        m_UpdateThread.get().join();
+                    }
+                }
+                catch (const std::system_error& e) {
+                    LOGERR("exception in joining threadUpdateCheck %s", e.what());
+	            }
                 LOGWARN("Deleted update Thread %p", smConnection );
 
                 m_pollThreadExit = true;
                 //Trigger codition to exit poll loop
+                pthread_mutex_lock(&(_instance->m_lock)); //Join mutex lock to wait until thread is in its wait condition
                 pthread_cond_signal(&(_instance->m_condSig));
+                pthread_mutex_unlock(&(_instance->m_lock));
+                try{
+                    if (m_pollThread.get().joinable()) {//Join thread to make sure it's deleted before moving on.
+                        m_pollThread.get().join();
+                    }
+                }
+                catch (const std::system_error& e) {
+                    LOGERR("exception in joining threadRun %s", e.what());
+	            }
                 LOGWARN("Deleted Thread %p", smConnection );
                 //Clear cec device cache.
                 removeAllCecDevices();


### PR DESCRIPTION
[DELIA-60044](https://ccp.sys.comcast.net/browse/DELIA-60044): Thread Handling for HDMICECs

Reason for change:
Updating HdmiCec, HdmiCec_2 and HdmiCecSource
So that threads exit properly when closing down HDMICEC
Not long after initialization
Test Procedure: None
Risks: Low

Signed-off-by: Hayden Gfeller <Hayden_Gfeller@comcast.com>
