### PR TITLE
RDK-37908: Unit tests for voice, control, and RAM plugins

### DIFF
--- a/ControlService/CMakeLists.txt
+++ b/ControlService/CMakeLists.txt
@@ -22,11 +22,15 @@ find_package(${NAMESPACE}Plugins REQUIRED)
 
 set(PLUGIN_CONTROLSERVICE_STARTUPORDER "" CACHE STRING "To configure startup order of ControlService plugin")
 
+if (NOT RDK_SERVICES_TEST)
 add_subdirectory(test)
+endif ()
 
 add_library(${MODULE_NAME} SHARED
         ControlService.cpp
         Module.cpp)
+
+set_source_files_properties(ControlService.cpp PROPERTIES COMPILE_FLAGS "-fexceptions")
 
 set_target_properties(${MODULE_NAME} PROPERTIES
         CXX_STANDARD 11

--- a/ControlService/ControlService.cpp
+++ b/ControlService/ControlService.cpp
@@ -244,7 +244,7 @@ namespace WPEFramework {
                 }
 
                 if (len != sizeof(IARM_Bus_IRMgr_EventData_t)) {
-                    LOGERR("ERROR - Got IARM_BUS_IRMGR_EVENT_IRKEY event with bad data length: %u, should be: %u!!",
+                    LOGERR("ERROR - Got IARM_BUS_IRMGR_EVENT_IRKEY event with bad data length: %zu, should be: %zu!!",
                            len, sizeof(IARM_Bus_IRMgr_EventData_t));
                 }
                 // We only care about the SETUP key - don't clutter the log with other irMgr keypress events
@@ -286,7 +286,7 @@ namespace WPEFramework {
 
                     if (len != sizeof(ctrlm_rcu_iarm_event_key_ghost_t))
                     {
-                        LOGERR("ERROR - Got CTRLM_RCU_IARM_EVENT_KEY_GHOST event with bad data length: %u, should be: %u!!\n",
+                        LOGERR("ERROR - Got CTRLM_RCU_IARM_EVENT_KEY_GHOST event with bad data length: %zu, should be: %zu!!\n",
                                len, sizeof(ctrlm_rcu_iarm_event_key_ghost_t));
                     }
 
@@ -328,7 +328,7 @@ namespace WPEFramework {
                 LOGINFO("Got a controlMgr battery milestone event!");
                 if (len != sizeof(ctrlm_rcu_iarm_event_battery_t))
                 {
-                    LOGERR("ERROR - Got CTRLM_RCU_IARM_EVENT_BATTERY_MILESTONE event with bad data length: %u, should be: %u!!\n",
+                    LOGERR("ERROR - Got CTRLM_RCU_IARM_EVENT_BATTERY_MILESTONE event with bad data length: %zu, should be: %zu!!\n",
                            len, sizeof(ctrlm_rcu_iarm_event_battery_t));
                     return;
                 }
@@ -366,7 +366,7 @@ namespace WPEFramework {
                 LOGINFO("Got a controlMgr remote reboot event!");
                 if (len != sizeof(ctrlm_rcu_iarm_event_remote_reboot_t))
                 {
-                    LOGERR("ERROR - Got CTRLM_RCU_IARM_EVENT_REMOTE_REBOOT event with bad data length: %u, should be: %u!!\n",
+                    LOGERR("ERROR - Got CTRLM_RCU_IARM_EVENT_REMOTE_REBOOT event with bad data length: %zu, should be: %zu!!\n",
                            len, sizeof(ctrlm_rcu_iarm_event_remote_reboot_t));
                     return;
                 }
@@ -409,7 +409,7 @@ namespace WPEFramework {
                 // Allow for variable size event, dictated by this event type
                 if (len < sizeof(ctrlm_rcu_iarm_event_reverse_cmd_t))
                 {
-                    LOGERR("ERROR - Got CTRLM_RCU_IARM_EVENT_RCU_REVERSE_CMD_END event with bad data length: %u, should be: %u!!\n",
+                    LOGERR("ERROR - Got CTRLM_RCU_IARM_EVENT_RCU_REVERSE_CMD_END event with bad data length: %zu, should be: %zu!!\n",
                            len, sizeof(ctrlm_rcu_iarm_event_reverse_cmd_t));
                     return;
                 }
@@ -475,7 +475,7 @@ namespace WPEFramework {
 
                    if (len != sizeof(ctrlm_rcu_iarm_event_control_t))
                    {
-                       LOGERR("ERROR - Got CTRLM_RCU_IARM_EVENT_CONTROL event with bad data length: %u, should be: %u!!\n",
+                       LOGERR("ERROR - Got CTRLM_RCU_IARM_EVENT_CONTROL event with bad data length: %zu, should be: %zu!!\n",
                               len, sizeof(ctrlm_rcu_iarm_event_control_t));
                    }
 
@@ -1228,7 +1228,7 @@ namespace WPEFramework {
             }
 
             keypressInfo["remoteId"]           = JsonValue((int)lastKeyInfo.controller_id);
-            keypressInfo["timestamp"]          = JsonValue((long long)lastKeyInfo.timestamp);   // This timestamp is already in milliseconds
+            keypressInfo["timestamp"]          = JsonValue((int64_t)lastKeyInfo.timestamp);   // This timestamp is already in milliseconds
             keypressInfo["sourceName"]         = std::string(lastKeyInfo.source_name);
 
             if (lastKeyInfo.source_type == IARM_BUS_IRMGR_KEYSRC_RF)
@@ -1936,7 +1936,7 @@ namespace WPEFramework {
                     strncpy(strRemoteType, pairMetrics.last_screenbind_remote_type, CTRLM_MAIN_SOURCE_NAME_MAX_LENGTH);
                     strRemoteType[CTRLM_MAIN_SOURCE_NAME_MAX_LENGTH - 1] = '\0';
                     stbData["stbLastScreenBindErrorRemoteType"] = std::string(strRemoteType);
-                    stbData["stbLastScreenBindErrorTimestamp"]  = JsonValue((long long)(pairMetrics.last_screenbind_error_timestamp * 1000LL));
+                    stbData["stbLastScreenBindErrorTimestamp"]  = JsonValue((int64_t)(pairMetrics.last_screenbind_error_timestamp * 1000LL));
 
                     stbData["stbNumOtherBindFailures"]          = JsonValue((int)pairMetrics.num_non_screenbind_failures);
                     stbData["stbLastOtherBindErrorCode"]        = JsonValue((int)pairMetrics.last_non_screenbind_error_code);
@@ -1944,7 +1944,7 @@ namespace WPEFramework {
                     strRemoteType[CTRLM_MAIN_SOURCE_NAME_MAX_LENGTH - 1] = '\0';
                     stbData["stbLastOtherBindErrorRemoteType"]  = std::string(strRemoteType);
                     stbData["stbLastOtherBindErrorBindType"]    = JsonValue((int)pairMetrics.last_non_screenbind_error_binding_type);
-                    stbData["stbLastOtherBindErrorTimestamp"]   = JsonValue((long long)(pairMetrics.last_non_screenbind_error_timestamp * 1000LL));
+                    stbData["stbLastOtherBindErrorTimestamp"]   = JsonValue((int64_t)(pairMetrics.last_non_screenbind_error_timestamp * 1000LL));
                 }
             }
 
@@ -2015,12 +2015,12 @@ namespace WPEFramework {
             remoteInfo["remoteModel"]               = std::string(getRemoteModel(ctrlStatus.status.type));
             remoteInfo["remoteModelVersion"]        = std::string(getRemoteModelVersion(ctrlStatus.status.type));
             remoteInfo["howRemoteIsPaired"]         = std::string(getPairingType(ctrlStatus.status.binding_type));
-            remoteInfo["pairingTimestamp"]          = JsonValue((long long)(ctrlStatus.status.time_binding * 1000LL));
+            remoteInfo["pairingTimestamp"]          = JsonValue((int64_t)(ctrlStatus.status.time_binding * 1000LL));
             remoteInfo["batteryLevelLoaded"]        = JsonValue(std::to_string(ctrlStatus.status.battery_voltage_loaded));  // TODO: Fix problem with FP parameters
             remoteInfo["batteryLevelUnloaded"]      = JsonValue(std::to_string(ctrlStatus.status.battery_voltage_unloaded));  // TODO: Fix problem with FP parameters
             remoteInfo["batteryLevelPercentage"]    = JsonValue((int)ctrlStatus.status.battery_level_percent);
             remoteInfo["batteryLastEvent"]          = JsonValue((int)ctrlStatus.status.battery_event);
-            remoteInfo["batteryLastEventTimestamp"] = JsonValue((long long)(ctrlStatus.status.time_battery_update * 1000LL));
+            remoteInfo["batteryLastEventTimestamp"] = JsonValue((int64_t)(ctrlStatus.status.time_battery_update * 1000LL));
 
             remoteInfo["numVoiceCommandsPreviousDay"]        = JsonValue((int)ctrlStatus.status.voice_cmd_count_yesterday);
             remoteInfo["numVoiceCommandsCurrentDay"]         = JsonValue((int)ctrlStatus.status.voice_cmd_count_today);
@@ -2037,7 +2037,7 @@ namespace WPEFramework {
             remoteInfo["numVoiceCmdsHighLossCurrentDay"]  = JsonValue((int)ctrlStatus.status.utterances_exceeding_packet_loss_threshold_today);
 
             remoteInfo["lastRebootErrorCode"]   = JsonValue((int)ctrlStatus.status.reboot_reason);
-            remoteInfo["lastRebootTimestamp"]   = JsonValue((long long)(ctrlStatus.status.reboot_timestamp * 1000LL));
+            remoteInfo["lastRebootTimestamp"]   = JsonValue((int64_t)(ctrlStatus.status.reboot_timestamp * 1000LL));
 
             remoteInfo["versionInfoSw"]     = std::string(ctrlStatus.status.version_software);
             remoteInfo["versionInfoHw"]     = std::string(ctrlStatus.status.version_hardware);
@@ -2049,7 +2049,7 @@ namespace WPEFramework {
             remoteInfo["programmedAvrIRCode"]   = std::string(ctrlStatus.status.ir_db_code_avr);
 
             remoteInfo["bHasRemoteBeenUpdated"] = JsonValue((bool)ctrlStatus.status.firmware_updated);
-            remoteInfo["lastCommandTimeDate"]   = JsonValue((long long)(ctrlStatus.status.time_last_key * 1000LL));
+            remoteInfo["lastCommandTimeDate"]   = JsonValue((int64_t)(ctrlStatus.status.time_last_key * 1000LL));
             remoteInfo["rf4ceRemoteSocMfr"]     = std::string(ctrlStatus.status.chipset);
             remoteInfo["remoteMfr"]             = std::string(ctrlStatus.status.manufacturer);
 
@@ -2062,22 +2062,22 @@ namespace WPEFramework {
             remoteInfo["bHasBattery"]                       = JsonValue((bool)ctrlStatus.status.has_battery);
             if((bool)ctrlStatus.status.has_battery)
             {
-                remoteInfo["batteryChangedTimestamp"]           = JsonValue((long long)(ctrlStatus.status.time_battery_changed * 1000LL));
+                remoteInfo["batteryChangedTimestamp"]           = JsonValue((int64_t)(ctrlStatus.status.time_battery_changed * 1000LL));
                 remoteInfo["batteryChangedActualPercentage"]    = JsonValue((int)ctrlStatus.status.battery_changed_actual_percentage);
                 remoteInfo["batteryChangedUnloadedVoltage"]     = JsonValue(std::to_string(ctrlStatus.status.battery_changed_unloaded_voltage));
-                remoteInfo["battery75PercentTimestamp"]         = JsonValue((long long)(ctrlStatus.status.time_battery_75_percent * 1000LL));
+                remoteInfo["battery75PercentTimestamp"]         = JsonValue((int64_t)(ctrlStatus.status.time_battery_75_percent * 1000LL));
                 remoteInfo["battery75PercentActualPercentage"]  = JsonValue((int)ctrlStatus.status.battery_75_percent_actual_percentage);
                 remoteInfo["battery75PercentUnloadedVoltage"]   = JsonValue(std::to_string(ctrlStatus.status.battery_75_percent_unloaded_voltage));
-                remoteInfo["battery50PercentTimestamp"]         = JsonValue((long long)(ctrlStatus.status.time_battery_50_percent * 1000LL));
+                remoteInfo["battery50PercentTimestamp"]         = JsonValue((int64_t)(ctrlStatus.status.time_battery_50_percent * 1000LL));
                 remoteInfo["battery50PercentActualPercentage"]  = JsonValue((int)ctrlStatus.status.battery_50_percent_actual_percentage);
                 remoteInfo["battery50PercentUnloadedVoltage"]   = JsonValue(std::to_string(ctrlStatus.status.battery_50_percent_unloaded_voltage));
-                remoteInfo["battery25PercentTimestamp"]         = JsonValue((long long)(ctrlStatus.status.time_battery_25_percent * 1000LL));
+                remoteInfo["battery25PercentTimestamp"]         = JsonValue((int64_t)(ctrlStatus.status.time_battery_25_percent * 1000LL));
                 remoteInfo["battery25PercentActualPercentage"]  = JsonValue((int)ctrlStatus.status.battery_25_percent_actual_percentage);
                 remoteInfo["battery25PercentUnloadedVoltage"]   = JsonValue(std::to_string(ctrlStatus.status.battery_25_percent_unloaded_voltage));
-                remoteInfo["battery5PercentTimestamp"]          = JsonValue((long long)(ctrlStatus.status.time_battery_5_percent * 1000LL));
+                remoteInfo["battery5PercentTimestamp"]          = JsonValue((int64_t)(ctrlStatus.status.time_battery_5_percent * 1000LL));
                 remoteInfo["battery5PercentActualPercentage"]   = JsonValue((int)ctrlStatus.status.battery_5_percent_actual_percentage);
                 remoteInfo["battery5PercentUnloadedVoltage"]    = JsonValue(std::to_string(ctrlStatus.status.battery_5_percent_unloaded_voltage));
-                remoteInfo["battery0PercentTimestamp"]          = JsonValue((long long)(ctrlStatus.status.time_battery_0_percent * 1000LL));
+                remoteInfo["battery0PercentTimestamp"]          = JsonValue((int64_t)(ctrlStatus.status.time_battery_0_percent * 1000LL));
                 remoteInfo["battery0PercentActualPercentage"]   = JsonValue((int)ctrlStatus.status.battery_0_percent_actual_percentage);
                 remoteInfo["battery0PercentUnloadedVoltage"]    = JsonValue(std::to_string(ctrlStatus.status.battery_0_percent_unloaded_voltage));
                 remoteInfo["batteryVoltageLargeJumpCounter"]    = JsonValue((int)ctrlStatus.status.battery_voltage_large_jump_counter);
@@ -2087,7 +2087,7 @@ namespace WPEFramework {
             remoteInfo["bHasDSP"]                        = JsonValue((bool)ctrlStatus.status.has_dsp);
             if((bool)ctrlStatus.status.has_dsp)
             {
-                remoteInfo["averageTimeInPrivacyMode"]       = JsonValue((long long)ctrlStatus.status.average_time_in_privacy_mode);
+                remoteInfo["averageTimeInPrivacyMode"]       = JsonValue((int64_t)ctrlStatus.status.average_time_in_privacy_mode);
                 remoteInfo["bInPrivacyMode"]                 = JsonValue((bool)ctrlStatus.status.in_privacy_mode);
                 remoteInfo["averageSNR"]                     = JsonValue((int)ctrlStatus.status.average_snr);
                 remoteInfo["averageKeywordConfidence"]       = JsonValue((int)ctrlStatus.status.average_keyword_confidence);
@@ -2095,9 +2095,9 @@ namespace WPEFramework {
                 remoteInfo["totalNumberOfSpeakersWorking"]   = JsonValue((int)ctrlStatus.status.total_number_of_speakers_working);
                 remoteInfo["endOfSpeechInitialTimeoutCount"] = JsonValue((int)ctrlStatus.status.end_of_speech_initial_timeout_count);
                 remoteInfo["endOfSpeechTimeoutCount"]        = JsonValue((int)ctrlStatus.status.end_of_speech_timeout_count);
-                remoteInfo["uptimeStartTime"]                = JsonValue((long long)ctrlStatus.status.time_uptime_start * 1000LL);
-                remoteInfo["uptimeInSeconds"]                = JsonValue((long long)ctrlStatus.status.uptime_seconds);
-                remoteInfo["privacyTimeInSeconds"]           = JsonValue((long long)ctrlStatus.status.privacy_time_seconds);
+                remoteInfo["uptimeStartTime"]                = JsonValue((int64_t)(ctrlStatus.status.time_uptime_start * 1000LL));
+                remoteInfo["uptimeInSeconds"]                = JsonValue((int64_t)ctrlStatus.status.uptime_seconds);
+                remoteInfo["privacyTimeInSeconds"]           = JsonValue((int64_t)ctrlStatus.status.privacy_time_seconds);
                 remoteInfo["versionDSPBuildId"]              = std::string(ctrlStatus.status.version_dsp_build_id);
             }
 

--- a/RemoteActionMapping/CMakeLists.txt
+++ b/RemoteActionMapping/CMakeLists.txt
@@ -22,12 +22,16 @@ set(PLUGIN_REMOTEACTIONMAPPING_STARTUPORDER "" CACHE STRING "To configure startu
 
 find_package(${NAMESPACE}Plugins REQUIRED)
 
+if (NOT RDK_SERVICES_TEST)
 add_subdirectory(test)
+endif ()
 
 add_library(${MODULE_NAME} SHARED
         RemoteActionMapping.cpp
         RamHelper.cpp
         Module.cpp)
+
+    set_source_files_properties(RemoteActionMapping.cpp PROPERTIES COMPILE_FLAGS "-fexceptions")
 
 set_target_properties(${MODULE_NAME} PROPERTIES
         CXX_STANDARD 11

--- a/RemoteActionMapping/RamHelper.cpp
+++ b/RemoteActionMapping/RamHelper.cpp
@@ -571,43 +571,43 @@ namespace WPEFramework {
                     rfDesc = (unsigned char*)rfDescriptor_IRPowerToggle;
                     rfDescLength = sizeof(rfDescriptor_IRPowerToggle);
                     flags |= MSO_RIB_IRRFDB_RFRELEASED_BIT;
-                    LOGWARN("IR Power Toggle RF Descriptor included, size: %d.", rfDescLength);
+                    LOGWARN("IR Power Toggle RF Descriptor included, size: %zu.", rfDescLength);
                     break;
                 case MSO_RFKEY_PWR_OFF:
                     rfDesc = (unsigned char*)rfDescriptor_DiscretePwrOff;
                     rfDescLength = sizeof(rfDescriptor_DiscretePwrOff);
                     flags |= MSO_RIB_IRRFDB_RFRELEASED_BIT;
-                    LOGWARN("Discrete Power Off RF Descriptor included, size: %d.", rfDescLength);
+                    LOGWARN("Discrete Power Off RF Descriptor included, size: %zu.", rfDescLength);
                     break;
                 case MSO_RFKEY_PWR_ON:
                     rfDesc = (unsigned char*)rfDescriptor_DiscretePwrOn;
                     rfDescLength = sizeof(rfDescriptor_DiscretePwrOn);
                     flags |= MSO_RIB_IRRFDB_RFRELEASED_BIT;
-                    LOGWARN("Discrete Power On RF Descriptor included, size: %d.", rfDescLength);
+                    LOGWARN("Discrete Power On RF Descriptor included, size: %zu.", rfDescLength);
                     break;
                 case MSO_RFKEY_VOL_PLUS:
                     rfDesc = (unsigned char*)rfDescriptor_VolumeUp;
                     rfDescLength = sizeof(rfDescriptor_VolumeUp);
                     flags |= MSO_RIB_IRRFDB_RFRELEASED_BIT;
-                    LOGWARN("Volume Up RF Descriptor included, size: %d.", rfDescLength);
+                    LOGWARN("Volume Up RF Descriptor included, size: %zu.", rfDescLength);
                     break;
                 case MSO_RFKEY_VOL_MINUS:
                     rfDesc = (unsigned char*)rfDescriptor_VolumeDown;
                     rfDescLength = sizeof(rfDescriptor_VolumeDown);
                     flags |= MSO_RIB_IRRFDB_RFRELEASED_BIT;
-                    LOGWARN("Volume Down RF Descriptor included, size: %d.", rfDescLength);
+                    LOGWARN("Volume Down RF Descriptor included, size: %zu.", rfDescLength);
                     break;
                 case MSO_RFKEY_MUTE:
                     rfDesc = (unsigned char*)rfDescriptor_Mute;
                     rfDescLength = sizeof(rfDescriptor_Mute);
                     flags |= MSO_RIB_IRRFDB_RFRELEASED_BIT;
-                    LOGWARN("Mute RF Descriptor included, size: %d.", rfDescLength);
+                    LOGWARN("Mute RF Descriptor included, size: %zu.", rfDescLength);
                     break;
                 case MSO_RFKEY_INPUT_SELECT:
                     rfDesc = (unsigned char*)rfDescriptor_Input;
                     rfDescLength = sizeof(rfDescriptor_Input);
                     flags |= MSO_RIB_IRRFDB_RFRELEASED_BIT;
-                    LOGWARN("Input RF Descriptor included, size: %d.", rfDescLength);
+                    LOGWARN("Input RF Descriptor included, size: %zu.", rfDescLength);
                     break;
                 default:
                     LOGWARN("No RF Descriptor included for RF Key 0x%02X.", (unsigned)actionMap.rfKeyCode);
@@ -618,7 +618,7 @@ namespace WPEFramework {
             total = 1 + rfDescLength + 2 + dataSize;
             if (total > CTRLM_RCU_MAX_RIB_ATTRIBUTE_SIZE)
             {
-                LOGERR("LOGIC ERROR - IR-RF DB entry length is %u, for RF Key 0x%02X, exceeds size limits!!",
+                LOGERR("LOGIC ERROR - IR-RF DB entry length is %zu, for RF Key 0x%02X, exceeds size limits!!",
                        total, (unsigned)actionMap.rfKeyCode);
                 return false;
             }
@@ -638,7 +638,7 @@ namespace WPEFramework {
             bytePtr++;
             memcpy(bytePtr, data, dataSize);
 
-            LOGWARN("SET ribRequest data - total: %d, dataSize: %d, data: 0x%02X, 0x%02X, 0x%02X, 0x%02X - 0x%02X, 0x%02X, 0x%02X, 0x%02X - "
+            LOGWARN("SET ribRequest data - total: %zu, dataSize: %d, data: 0x%02X, 0x%02X, 0x%02X, 0x%02X - 0x%02X, 0x%02X, 0x%02X, 0x%02X - "
                     "0x%02X, 0x%02X, 0x%02X, 0x%02X - 0x%02X, 0x%02X, 0x%02X, 0x%02X - 0x%02X, 0x%02X, 0x%02X, 0x%02X.\n",
                     total, dataSize,
                     (unsigned char)ribRequest.data[0], (unsigned char)ribRequest.data[1], (unsigned char)ribRequest.data[2], (unsigned char)ribRequest.data[3],
@@ -1036,7 +1036,7 @@ namespace WPEFramework {
 
             if ((deviceID < 1) || (irData.size() <= 1))
             {
-                LOGERR("ERROR - Bad arguments - deviceID: %d, data size: %d!! Cannot set device power IRRFDB entry!",
+                LOGERR("ERROR - Bad arguments - deviceID: %d, data size: %zu!! Cannot set device power IRRFDB entry!",
                        deviceID, irData.size());
                 return false;
             }
@@ -1082,21 +1082,21 @@ namespace WPEFramework {
                     rfDesc = (unsigned char*)rfDescriptor_IRPowerToggle;
                     rfDescLength = sizeof(rfDescriptor_IRPowerToggle);
                     flags |= MSO_RIB_IRRFDB_RFRELEASED_BIT;
-                    LOGWARN("IR Power Toggle RF Descriptor included, size: %d.", rfDescLength);
+                    LOGWARN("IR Power Toggle RF Descriptor included, size: %zu.", rfDescLength);
                     break;
                 case XRC_RFKEY_TV_PWR_OFF:
                 case XRC_RFKEY_AVR_PWR_OFF:
                     rfDesc = (unsigned char*)rfDescriptor_DiscretePwrOff;
                     rfDescLength = sizeof(rfDescriptor_DiscretePwrOff);
                     flags |= MSO_RIB_IRRFDB_RFRELEASED_BIT;
-                    LOGWARN("Discrete Power Off RF Descriptor included, size: %d.", rfDescLength);
+                    LOGWARN("Discrete Power Off RF Descriptor included, size: %zu.", rfDescLength);
                     break;
                 case XRC_RFKEY_TV_PWR_ON:
                 case XRC_RFKEY_AVR_PWR_ON:
                     rfDesc = (unsigned char*)rfDescriptor_DiscretePwrOn;
                     rfDescLength = sizeof(rfDescriptor_DiscretePwrOn);
                     flags |= MSO_RIB_IRRFDB_RFRELEASED_BIT;
-                    LOGWARN("Discrete Power On RF Descriptor included, size: %d.", rfDescLength);
+                    LOGWARN("Discrete Power On RF Descriptor included, size: %zu.", rfDescLength);
                     break;
                 default:
                     LOGERR("LOGIC ERROR - Invalid separate power RF Key 0x%02X.", (unsigned)rfKeyCode);
@@ -1124,7 +1124,7 @@ namespace WPEFramework {
             total = 1 + rfDescLength + 2 + dataSize;
             if (total > CTRLM_RCU_MAX_RIB_ATTRIBUTE_SIZE)
             {
-                LOGERR("LOGIC ERROR - IR-RF DB entry length is %u, for RF Key 0x%02X, exceeds size limits!!",
+                LOGERR("LOGIC ERROR - IR-RF DB entry length is %zu, for RF Key 0x%02X, exceeds size limits!!",
                        total, (unsigned)rfKeyCode);
                 return false;
             }

--- a/RemoteActionMapping/RemoteActionMapping.cpp
+++ b/RemoteActionMapping/RemoteActionMapping.cpp
@@ -721,7 +721,7 @@ namespace WPEFramework {
                                 actionMap.tvIRData.push_back((unsigned char)(byteval & 0xFF));
                             }
                             keysPresent.tv.setKey(actionMap.rfKeyCode);
-                            LOGWARN("keyActionMap[%d]: tvIRKeyCode size: %d.", i, actionMap.tvIRData.size());
+                            LOGWARN("keyActionMap[%d]: tvIRKeyCode size: %zu.", i, actionMap.tvIRData.size());
                             if (actionMap.tvIRData.size() > 12)
                             {
                                 LOGWARN("tvIRKeyCode bytes - 0x%02X, 0x%02X, 0x%02X, 0x%02X, 0x%02X, 0x%02X, 0x%02X, 0x%02X, 0x%02X, 0x%02X, 0x%02X, 0x%02X",
@@ -783,7 +783,7 @@ namespace WPEFramework {
                                 actionMap.avrIRData.push_back((unsigned char)(byteval & 0xFF));
                             }
                             keysPresent.avr.setKey(actionMap.rfKeyCode);
-                            LOGWARN("keyActionMap[%d]: avrIRKeyCode size: %d.", i, actionMap.avrIRData.size());
+                            LOGWARN("keyActionMap[%d]: avrIRKeyCode size: %zu.", i, actionMap.avrIRData.size());
                             if (actionMap.avrIRData.size() > 12)
                             {
                                 LOGWARN("avrIRKeyCode bytes - 0x%02X, 0x%02X, 0x%02X, 0x%02X, 0x%02X, 0x%02X, 0x%02X, 0x%02X, 0x%02X, 0x%02X, 0x%02X, 0x%02X",
@@ -808,7 +808,7 @@ namespace WPEFramework {
                 LOGWARN("localMaps is finished, size: %d", (int)localMaps.size());
                 if (numMaps != (int)localMaps.size())
                 {
-                    LOGERR("ERROR - maps conversion failure - input numMaps: %d, output localMaps size: %d!",
+                    LOGERR("ERROR - maps conversion failure - input numMaps: %d, output localMaps size: %zu!",
                            numMaps, localMaps.size());
                     response["status_code"] = (int)STATUS_INVALID_ARGUMENT;
                     returnResponse(false);
@@ -2142,7 +2142,7 @@ namespace WPEFramework {
             if (done)
             {
                 stopRIBLoadTimer();
-                LOGWARN("Sending onIRCodeLoad event - numKeys is %d.", rfKeyCodes.size());
+                LOGWARN("Sending onIRCodeLoad event - numKeys is %zu.", rfKeyCodes.size());
                 m_irdbLoadState = IRDB_LOAD_STATE_NONE;
                 onIRCodeLoad(deviceID, rfKeyCodes, IRCODE_LOAD_STATUS_OK);
                 m_lastSetRemoteID = -1;
@@ -2241,7 +2241,7 @@ namespace WPEFramework {
                         status = IRCODE_LOAD_STATUS_REFUSED;
                     }
 
-                    LOGWARN("TIMEOUT: IRRF Database LoadState(%d) - sending onIRCodeLoad event - numKeys: %d, status: %d.",
+                    LOGWARN("TIMEOUT: IRRF Database LoadState(%d) - sending onIRCodeLoad event - numKeys: %zu, status: %d.",
                             m_irdbLoadState, rfKeyCodes.size(), status);
 
                     m_irdbLoadState = IRDB_LOAD_STATE_NONE;

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -76,6 +76,9 @@ include_directories(../LocationSync
         ../FrontPanel
         ../OCIContainer
         ../HdmiCecSink
+        ../VoiceControl
+        ../ControlService
+        ../RemoteActionMapping
         )
 link_directories(../LocationSync
         ../PersistentStore
@@ -106,6 +109,9 @@ link_directories(../LocationSync
         ../FrontPanel
         ../OCIContainer
         ../HdmiCecSink
+        ../VoiceControl
+        ../ControlService
+        ../RemoteActionMapping
         )
 
 target_link_libraries(${PROJECT_NAME}
@@ -140,6 +146,9 @@ target_link_libraries(${PROJECT_NAME}
         ${NAMESPACE}FrontPanel
         ${NAMESPACE}OCIContainer
         ${NAMESPACE}HdmiCecSink
+        ${NAMESPACE}VoiceControl
+        ${NAMESPACE}ControlService
+        ${NAMESPACE}RemoteActionMapping
         )
 
 target_include_directories(${PROJECT_NAME}

--- a/Tests/mocks/Ctrlm.h
+++ b/Tests/mocks/Ctrlm.h
@@ -1,0 +1,1087 @@
+/*
+ * If not stated otherwise in this file or this component's license file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2014 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+#ifndef _CTRLM_H_
+#define _CTRLM_H_
+
+#include "libIARM.h"
+#include "libIBusDaemon.h"
+#include "ctrlm_ipc_key_codes.h"
+
+#define CTRLM_MAIN_IARM_BUS_NAME                                 "Ctrlm"                                ///< Control Manager's IARM Bus Name
+#define CTRLM_MAIN_IARM_BUS_API_REVISION                         (16)                                   ///< Revision of the Control Manager Main IARM API
+
+#define CTRLM_MAIN_IARM_CALL_STATUS_GET                          "Main_StatusGet"                       ///< Retrieves Control Manager's Status information
+#define CTRLM_MAIN_IARM_CALL_NETWORK_STATUS_GET                  "Main_NetworkStatusGet"                ///< Retrieves the network's Status information
+#define CTRLM_MAIN_IARM_CALL_IR_REMOTE_USAGE_GET                 "Main_IrRemoteUsageGet"                ///< Retrieves the ir remote usage info
+#define CTRLM_MAIN_IARM_CALL_LAST_KEY_INFO_GET                   "Main_LastKeyInfoGet"                  ///< Retrieves the last key info
+#define CTRLM_MAIN_IARM_CALL_CONTROL_SERVICE_SET_VALUES          "Main_ControlService_SetValues"        ///< IARM Call to set control service values
+#define CTRLM_MAIN_IARM_CALL_CONTROL_SERVICE_GET_VALUES          "Main_ControlService_GetValues"        ///< IARM Call to get control service values
+#define CTRLM_MAIN_IARM_CALL_CONTROL_SERVICE_CAN_FIND_MY_REMOTE  "Main_ControlService_CanFindMyRemote"  ///< IARM Call to get control service find my remote
+#define CTRLM_MAIN_IARM_CALL_CONTROL_SERVICE_START_PAIRING_MODE  "Main_ControlService_StartPairingMode" ///< IARM Call to set control service start pairing mode
+#define CTRLM_MAIN_IARM_CALL_CONTROL_SERVICE_END_PAIRING_MODE    "Main_ControlService_EndPairingMode"   ///< IARM Call to set control service end pairing mode
+#define CTRLM_MAIN_IARM_CALL_PAIRING_METRICS_GET                 "Main_PairingMetricsGet"               ///< Retrieves the stb's pairing metrics
+#define CTRLM_MAIN_IARM_CALL_CHIP_STATUS_GET                     "Main_ChipStatusGet"                   ///< get Chip status
+
+#define CTRLM_MAIN_NETWORK_ID_INVALID                          (0xFF) ///< An invalid network identifier
+#define CTRLM_MAIN_CONTROLLER_ID_INVALID                       (0xFF) ///< An invalid controller identifier
+
+#define CTRLM_MAIN_CONTROLLER_ID_ALL                           (0xFE) ///< Indicates that the command applies to all networks
+
+#define CTRLM_MAIN_CONTROLLER_ID_LAST_USED                     (0xFD) ///< An last used controller identifier
+
+#define CTRLM_MAIN_VERSION_LENGTH                                (20) ///< Maximum length of the version string
+#define CTRLM_MAIN_MAX_NETWORKS                                   (4) ///< Maximum number of networks
+#define CTRLM_MAIN_MAX_BOUND_CONTROLLERS                          (9) ///< Maximum number of bound controllers
+#define CTRLM_MAIN_MAX_CHIPSET_LENGTH                            (16) ///< Maximum length of chipset name string (including null termination)
+#define CTRLM_MAIN_COMMIT_ID_MAX_LENGTH                          (48) ///< Maximum length of commit ID string (including null termination)
+#define CTRLM_MAIN_RECEIVER_ID_MAX_LENGTH                        (40) ///< Maximum length of receiver ID string (including null termination)
+#define CTRLM_MAIN_DEVICE_ID_MAX_LENGTH                          (24) ///< Maximum length of device ID string (including null termination)
+#define CTRLM_MAIN_SOURCE_NAME_MAX_LENGTH                        (20) ///< Maximum length of source name string (including null termination)
+
+// Bitmask defines for setting the available value in ctrlm_main_iarm_call_control_service_settings_t
+#define CTRLM_MAIN_CONTROL_SERVICE_SETTINGS_ASB_ENABLED                 (0x01) ///< Setting to enable/disable asb
+#define CTRLM_MAIN_CONTROL_SERVICE_SETTINGS_OPEN_CHIME_ENABLED          (0x02) ///< Setting to enable/disable open chime
+#define CTRLM_MAIN_CONTROL_SERVICE_SETTINGS_CLOSE_CHIME_ENABLED         (0x04) ///< Setting to enable/disable close chime
+#define CTRLM_MAIN_CONTROL_SERVICE_SETTINGS_PRIVACY_CHIME_ENABLED       (0x08) ///< Setting to enable/disable privacy chime
+#define CTRLM_MAIN_CONTROL_SERVICE_SETTINGS_CONVERSATIONAL_MODE         (0x10) ///< Setting for conversational mode (0-6)
+#define CTRLM_MAIN_CONTROL_SERVICE_SETTINGS_SET_CHIME_VOLUME            (0x20) ///< Setting to set the chime volume
+#define CTRLM_MAIN_CONTROL_SERVICE_SETTINGS_SET_IR_COMMAND_REPEATS      (0x40) ///< Setting to set the ir command repeats
+
+#define CTRLM_MIN_CONVERSATIONAL_MODE (0)
+#define CTRLM_MAX_CONVERSATIONAL_MODE (6)
+#define CTRLM_MIN_IR_COMMAND_REPEATS  (1)
+#define CTRLM_MAX_IR_COMMAND_REPEATS  (10)
+
+#define CTRLM_MAX_PARAM_STR_LEN           (64)
+
+typedef enum {
+   CTRLM_IARM_CALL_RESULT_SUCCESS                 = 0, ///< The requested operation was completed successfully.
+   CTRLM_IARM_CALL_RESULT_ERROR                   = 1, ///< An error occurred during the requested operation.
+   CTRLM_IARM_CALL_RESULT_ERROR_READ_ONLY         = 2, ///< An error occurred trying to write to a read-only entity.
+   CTRLM_IARM_CALL_RESULT_ERROR_INVALID_PARAMETER = 3, ///< An input parameter is invalid.
+   CTRLM_IARM_CALL_RESULT_ERROR_API_REVISION      = 4, ///< The API revision is invalid or no longer supported
+   CTRLM_IARM_CALL_RESULT_ERROR_NOT_SUPPORTED     = 5, ///< The requested operation is not supported
+   CTRLM_IARM_CALL_RESULT_INVALID                 = 6, ///< Invalid call result value
+} ctrlm_iarm_call_result_t;
+
+/// @brief Control Manager Events
+/// @details The events enumeration defines a value for each event that can be generated by Control Manager.
+typedef enum {
+   CTRLM_MAIN_IARM_EVENT_BINDING_BUTTON             =  0, ///< Generated when a state change of the binding button status occurs
+   CTRLM_MAIN_IARM_EVENT_BINDING_LINE_OF_SIGHT      =  1, ///< Generated when a state change of the line of sight status occurs
+   CTRLM_MAIN_IARM_EVENT_AUTOBIND_LINE_OF_SIGHT     =  2, ///< Generated when a state change of the autobind line of sight status occurs
+   CTRLM_MAIN_IARM_EVENT_CONTROLLER_UNBIND          =  3, ///< Generated when a controller binding is removed
+   CTRLM_RCU_IARM_EVENT_KEY_PRESS                   =  4, ///< Generated each time a key event occurs (down, repeat, up)
+   CTRLM_RCU_IARM_EVENT_VALIDATION_BEGIN            =  5, ///< Generated at the beginning of a validation attempt
+   CTRLM_RCU_IARM_EVENT_VALIDATION_KEY_PRESS        =  6, ///< Generated when the user enters a validation code digit/letter
+   CTRLM_RCU_IARM_EVENT_VALIDATION_END              =  7, ///< Generated at the end of a validation attempt
+   CTRLM_RCU_IARM_EVENT_CONFIGURATION_COMPLETE      =  8, ///< Generated upon completion of controller configuration
+   CTRLM_RCU_IARM_EVENT_FUNCTION                    =  9, ///< Generated when a function is performed on a controller
+   CTRLM_RCU_IARM_EVENT_KEY_GHOST                   = 10, ///< Generated when a ghost code is received from a controller
+   CTRLM_RCU_IARM_EVENT_RIB_ACCESS_CONTROLLER       = 11, ///< Generated when a controller accesses a RIB entry
+   CTRLM_VOICE_IARM_EVENT_SESSION_BEGIN             = 12, ///< Voice session began
+   CTRLM_VOICE_IARM_EVENT_SESSION_END               = 13, ///< Voice session ended
+   CTRLM_VOICE_IARM_EVENT_SESSION_RESULT            = 14, ///< Result of a voice session
+   CTRLM_VOICE_IARM_EVENT_SESSION_STATS             = 15, ///< Statistics from a voice session
+   CTRLM_VOICE_IARM_EVENT_SESSION_ABORT             = 16, ///< Voice session was aborted (denied)
+   CTRLM_VOICE_IARM_EVENT_SESSION_SHORT             = 17, ///< Voice session did not meet minimum duration
+   CTRLM_VOICE_IARM_EVENT_MEDIA_SERVICE             = 18, ///< Voice session results in media service event
+   CTRLM_DEVICE_UPDATE_IARM_EVENT_READY_TO_DOWNLOAD = 19, ///< Indicates that a device has an update available
+   CTRLM_DEVICE_UPDATE_IARM_EVENT_DOWNLOAD_STATUS   = 20, ///< Provides status of a download that is in progress
+   CTRLM_DEVICE_UPDATE_IARM_EVENT_LOAD_BEGIN        = 21, ///< Indicates that a device has started to load an image
+   CTRLM_DEVICE_UPDATE_IARM_EVENT_LOAD_END          = 22, ///< Indicates that a device has completed an image load
+   CTRLM_RCU_IARM_EVENT_BATTERY_MILESTONE           = 23, ///< Indicates that a battery milestone event occured
+   CTRLM_RCU_IARM_EVENT_REMOTE_REBOOT               = 24, ///< Indicates that a remote reboot event occured
+   CTRLM_RCU_IARM_EVENT_RCU_REVERSE_CMD_BEGIN       = 25, ///< Indicates that a RCU Reverse Command started
+   CTRLM_RCU_IARM_EVENT_RCU_REVERSE_CMD_END         = 26, ///< Indicates that a RCU Reverse Command ended 
+   CTRLM_RCU_IARM_EVENT_CONTROL                     = 27, ///< Generated when a control event is received from a controller
+   CTRLM_VOICE_IARM_EVENT_JSON_SESSION_BEGIN        = 28, ///< Generated on voice session begin, payload is JSON for consumption by Thunder Plugin
+   CTRLM_VOICE_IARM_EVENT_JSON_STREAM_BEGIN         = 29, ///< Generated on voice stream begin, payload is JSON for consumption by Thunder Plugin
+   CTRLM_VOICE_IARM_EVENT_JSON_KEYWORD_VERIFICATION = 30, ///< Generated on voice keyword verification, payload is JSON for consumption by Thunder Plugin
+   CTRLM_VOICE_IARM_EVENT_JSON_SERVER_MESSAGE       = 31, ///< Generated on voice server message, payload is JSON for consumption by Thunder Plugin
+   CTRLM_VOICE_IARM_EVENT_JSON_STREAM_END           = 32, ///< Generated on voice stream end, payload is JSON for consumption by Thunder Plugin
+   CTRLM_VOICE_IARM_EVENT_JSON_SESSION_END          = 33, ///< Generated on voice session end, payload is JSON for consumption by Thunder Plugin
+   CTRLM_RCU_IARM_EVENT_RCU_STATUS                  = 34, ///< Generated when someting changes in the BLE remote
+   CTRLM_RCU_IARM_EVENT_RF4CE_PAIRING_WINDOW_TIMEOUT = 35, ///< Indicates that a battery milestone event occured
+   CTRLM_MAIN_IARM_EVENT_MAX                        = 36  ///< Placeholder for the last event (used in registration)
+} ctrlm_main_iarm_event_t;
+
+/// @brief Remote Control Key Status
+/// @details The status of the key.
+typedef enum {
+   CTRLM_KEY_STATUS_DOWN    = 0, ///< Key down
+   CTRLM_KEY_STATUS_UP      = 1, ///< Key up
+   CTRLM_KEY_STATUS_REPEAT  = 2, ///< Key repeat
+   CTRLM_KEY_STATUS_INVALID = 3, ///< Invalid key status
+} ctrlm_key_status_t;
+
+/// @brief Data Access Type
+/// @details The type of permission for access to data in Control Manager.
+typedef enum {
+   CTRLM_ACCESS_TYPE_READ    = 0, ///< Read access
+   CTRLM_ACCESS_TYPE_WRITE   = 1, ///< Write access
+   CTRLM_ACCESS_TYPE_INVALID = 2  ///< Invalid access type
+} ctrlm_access_type_t;
+
+/// @brief Network Type
+/// @details The Control Manager network type.
+typedef enum {
+   CTRLM_NETWORK_TYPE_RF4CE        = 0,   ///< RF4CE Network
+   CTRLM_NETWORK_TYPE_BLUETOOTH_LE = 1,   ///< Bluetooth Low Energy Network
+   CTRLM_NETWORK_TYPE_IP           = 2,   ///< IP Network
+   CTRLM_NETWORK_TYPE_DSP          = 3,   ///< DSP Network
+   CTRLM_NETWORK_TYPE_INVALID      = 255  ///< Invalid Network
+} ctrlm_network_type_t;
+
+/// @brief Pairing Restrictions
+/// @details The Control Manager network type.
+typedef enum {
+   CTRLM_PAIRING_RESTRICT_NONE                = 0,   ///< No restrictions on pairing
+   CTRLM_PAIRING_RESTRICT_TO_VOICE_REMOTES    = 1,   ///< Only pair voice remotes
+   CTRLM_PAIRING_RESTRICT_TO_VOICE_ASSISTANTS = 2,   ///< Only pair voice assistants
+   CTRLM_PAIRING_RESTRICT_MAX                 = 3    ///< Maximum restriction value
+} ctrlm_pairing_restrict_by_remote_t;
+
+/// @brief Pairing Restrictions
+/// @details The Control Manager network type.
+typedef enum {
+   CTRLM_PAIRING_MODE_BUTTON_BUTTON_BIND    = 0,   ///< Button Button binding
+   CTRLM_PAIRING_MODE_SCREEN_BIND           = 1,   ///< Screen binding
+   CTRLM_PAIRING_MODE_ONE_TOUCH_AUTO_BIND   = 2,   ///< One Touch Auto binding
+   CTRLM_PAIRING_MODE_MAX                   = 3,   ///< Maximum pairing mode value
+} ctrlm_pairing_modes_t;
+
+/// @brief Pairing Restrictions
+/// @details The Control Manager network type.
+typedef enum
+{
+   CTRLM_BIND_STATUS_SUCCESS,
+   CTRLM_BIND_STATUS_NO_DISCOVERY_REQUEST,
+   CTRLM_BIND_STATUS_NO_PAIRING_REQUEST,
+   CTRLM_BIND_STATUS_HAL_FAILURE,
+   CTRLM_BIND_STATUS_CTRLM_BLACKOUT,
+   CTRLM_BIND_STATUS_ASB_FAILURE,
+   CTRLM_BIND_STATUS_STD_KEY_EXCHANGE_FAILURE,
+   CTRLM_BIND_STATUS_PING_FAILURE,
+   CTRLM_BIND_STATUS_VALILDATION_FAILURE,
+   CTRLM_BIND_STATUS_RIB_UPDATE_FAILURE,
+   CTRLM_BIND_STATUS_BIND_WINDOW_TIMEOUT,
+   CTRLM_BIND_STATUS_UNKNOWN_FAILURE,
+} ctrlm_bind_status_t;
+
+/// @brief chime volume settings
+/// @details The Control Manager network type.
+typedef enum
+{
+   CTRLM_CHIME_VOLUME_LOW,
+   CTRLM_CHIME_VOLUME_MEDIUM,
+   CTRLM_CHIME_VOLUME_HIGH,
+   CTRLM_CHIME_VOLUME_INVALID,
+} ctrlm_chime_volume_t;
+
+/// @brief Network Id Type
+/// @details During initialization, of the HAL network, Control Manager will assign a unique id to the network.  It must be used in all
+/// subsequent communication with the Control Manager.
+typedef unsigned char ctrlm_network_id_t;
+/// @brief Controller Id Type
+/// @details When a controller is paired, the Control Manager will assign an id (typically 48/64 bit MAC address) to the controller.
+typedef unsigned char ctrlm_controller_id_t;
+
+/// @}
+/// @addtogroup CTRLM_IPC_MAIN_STRUCTS
+/// @{
+/// @brief Structure definitions
+/// @details The Control Manager provides structures that are used in IARM calls and events.
+
+/// @brief Network Structure
+/// @details The information for a network.
+typedef struct {
+   ctrlm_network_id_t   id;   ///< identifier of the network
+   ctrlm_network_type_t type; ///< Type of network
+} ctrlm_network_t;
+
+/// @brief Control Manager Status Structure
+/// @details The Control Manager Status structure is used in the CTRLM_MAIN_IARM_CALL_STATUS_GET call. See the @link CTRLM_IPC_MAIN_CALLS Calls@endlink section for more details on invoking this call.
+typedef struct {
+   unsigned char            api_revision;                                       ///< Revision of this API
+   ctrlm_iarm_call_result_t result;                                             ///< OUT - The result of the operation.
+   unsigned char            network_qty;                                        ///< OUT - Number of networks connected to Control Manager
+   ctrlm_network_t          networks[CTRLM_MAIN_MAX_NETWORKS];                  ///< OUT - List of networks
+   char                     ctrlm_version[CTRLM_MAIN_VERSION_LENGTH];           ///< OUT - Software version of Control Manager
+   char                     ctrlm_commit_id[CTRLM_MAIN_COMMIT_ID_MAX_LENGTH];   ///< OUT - Last commit ID of Control Manager
+   char                     stb_device_id[CTRLM_MAIN_DEVICE_ID_MAX_LENGTH];     ///< OUT - Device ID obtained from the Set-Top Box
+   char                     stb_receiver_id[CTRLM_MAIN_RECEIVER_ID_MAX_LENGTH]; ///< OUT - Receiver ID obtained from the Set-Top Box
+} ctrlm_main_iarm_call_status_t;
+
+/// @brief RF Channel Structure
+/// @details The diagnostics information for an RF channel.
+typedef struct {
+   unsigned char number;  ///< RF channel number (15, 20 or 25 for RF4CE)
+   unsigned char quality; ///< Quality indicator for this channel
+} ctrlm_rf_channel_t;
+
+/// @brief RF4CE Network Status Structure
+/// @details The RF4CE Network Status structure provided detailed information about the network.
+typedef struct {
+   char                  version_hal[CTRLM_MAIN_VERSION_LENGTH];        ///< Software version of the HAL driver
+   unsigned char         controller_qty;                                ///< Number of controllers bound to the target device
+   ctrlm_controller_id_t controllers[CTRLM_MAIN_MAX_BOUND_CONTROLLERS]; ///< List of controllers bound to the target device
+   unsigned short        pan_id;                                        ///< PAN Identifier
+   ctrlm_rf_channel_t    rf_channel_active;                             ///< Current RF channel on which the target is operating
+   unsigned long long    ieee_address;                                  ///< The 64-bit IEEE Address of the target device
+   unsigned short        short_address;                                 ///< Short address (if applicable)
+   char                  chipset[CTRLM_MAIN_MAX_CHIPSET_LENGTH];        ///< Chipset of the target
+} ctrlm_network_status_rf4ce_t;
+
+/// @brief Network Status Structure
+/// @details The Network Status structure is used in the CTRLM_MAIN_IARM_CALL_NETWORK_STATUS_GET call. See the @link CTRLM_IPC_MAIN_CALLS Calls@endlink section for more details on invoking this call.
+typedef struct {
+   unsigned char            api_revision; ///< Revision of this API
+   ctrlm_iarm_call_result_t result;       ///< OUT - Result of the operation
+   ctrlm_network_id_t       network_id;   ///< IN - identifier of network
+   union {
+      ctrlm_network_status_rf4ce_t rf4ce; ///< OUT - RF4CE network status
+   } status;                              ///< OUT - Union of network status types
+} ctrlm_main_iarm_call_network_status_t;
+
+/// @brief Control Manager IR Remote Usage Structure
+/// @details The Control Manager Status structure is used in the CTRLM_MAIN_IARM_CALL_IR_REMOTE_USAGE_GET call. See the @link CTRLM_IPC_MAIN_CALLS Calls@endlink section for more details on invoking this call.
+typedef struct {
+   unsigned char            api_revision;             ///< Revision of this API
+   ctrlm_iarm_call_result_t result;                   ///< OUT - The result of the operation.
+   unsigned long            today;                    ///< OUT - The current day
+   unsigned char            has_ir_xr2_yesterday;     ///< OUT - Boolean value indicating XR2 in IR mode was used the previous day
+   unsigned char            has_ir_xr5_yesterday;     ///< OUT - Boolean value indicating XR5 in IR mode was used the previous day
+   unsigned char            has_ir_xr11_yesterday;    ///< OUT - Boolean value indicating XR11 in IR mode was used the previous day
+   unsigned char            has_ir_xr15_yesterday;    ///< OUT - Boolean value indicating XR15 in IR mode was used the previous day
+   unsigned char            has_ir_xr2_today;         ///< OUT - Boolean value indicating XR2 in IR mode was used the current day
+   unsigned char            has_ir_xr5_today;         ///< OUT - Boolean value indicating XR5 in IR mode was used the current day
+   unsigned char            has_ir_xr11_today;        ///< OUT - Boolean value indicating XR11 in IR mode was used the current day
+   unsigned char            has_ir_xr15_today;        ///< OUT - Boolean value indicating XR15 in IR mode was used the current day
+   unsigned char            has_ir_remote_yesterday;  ///< OUT - Boolean value indicating remote in IR mode was used the previous day
+   unsigned char            has_ir_remote_today;      ///< OUT - Boolean value indicating remote in IR mode was used the current day
+} ctrlm_main_iarm_call_ir_remote_usage_t;
+
+/// @brief Control Manager Last Key Info Structure
+/// @details The Control Manager Status structure is used in the CTRLM_MAIN_IARM_CALL_LAST_KEY_INFO_GET call. See the @link CTRLM_IPC_MAIN_CALLS Calls@endlink section for more details on invoking this call.
+typedef struct {
+   unsigned char            api_revision;                                       ///< Revision of this API
+   ctrlm_network_id_t       network_id;                                         ///< IN - identifier of network on which the controller is bound
+   ctrlm_iarm_call_result_t result;                                             ///< OUT - The result of the operation.
+   int                      controller_id;                                      ///< OUT - The controller id of the last key press.
+   unsigned char            source_type;                                        ///< OUT - The source type of the last key press.
+   unsigned long            source_key_code;                                    ///< OUT - The keycode of the last key press.
+   long long                timestamp;                                          ///< OUT - The timestamp of the last key press.
+   unsigned char            is_screen_bind_mode;                                ///< OUT - Indicates if the last key press is from a remote is in screen bind mode.
+   unsigned char            remote_keypad_config;                               ///< OUT - The remote keypad configuration (Has Setup/NumberKeys).
+   char                     source_name[CTRLM_MAIN_SOURCE_NAME_MAX_LENGTH];     ///< OUT - The source name of the last key press.
+} ctrlm_main_iarm_call_last_key_info_t;
+
+/// @brief Control Manager Control Service Settings Structure
+/// @details The Control Manager Status structure is used in the CTRLM_MAIN_IARM_CALL_CONTROL_SERVICE_SET_VALUES call. See the @link CTRLM_IPC_MAIN_CALLS Calls@endlink section for more details on invoking this call.
+typedef struct {
+   unsigned char                api_revision;                                   ///< The revision of this API.
+   ctrlm_iarm_call_result_t     result;                                         ///< Result of the IARM call
+   unsigned long                available;                                      ///< Bitmask indicating the settings that are available in this event
+   unsigned char                asb_supported;                                  ///< Read only Boolean value to indicate asb supported enable (non-zero) or not supported (zero) asb
+   unsigned char                asb_enabled;                                    ///< Boolean value to enable (non-zero) or disable (zero) asb
+   unsigned char                open_chime_enabled;                             ///< Boolean value to enable (non-zero) or disable (zero) open chime
+   unsigned char                close_chime_enabled;                            ///< Boolean value to enable (non-zero) or disable (zero) close chime
+   unsigned char                privacy_chime_enabled;                          ///< Boolean value to enable (non-zero) or disable (zero) privacy chime
+   unsigned char                conversational_mode;                            ///< Boolean value to set conversational mode (0-6)
+   ctrlm_chime_volume_t         chime_volume;                                   ///< The chime volume
+   unsigned char                ir_command_repeats;                             ///< The ir command repeats (1 - 10)
+} ctrlm_main_iarm_call_control_service_settings_t;
+
+/// @brief Control Manager Control Service Can Find My Remote Structure
+/// @details The Control Manager Status structure is used in the CTRLM_MAIN_IARM_CALL_CONTROL_SERVICE_CAN_FIND_MY_REMOTE call. See the @link CTRLM_IPC_MAIN_CALLS Calls@endlink section for more details on invoking this call.
+typedef struct {
+   unsigned char                api_revision;                                   ///< The revision of this API.
+   ctrlm_iarm_call_result_t     result;                                         ///< Result of the IARM call
+   unsigned char                is_supported;                                   ///< Read only Boolean value to indicate if findMyRemote is supported enable (non-zero) or not supported (zero)
+   ctrlm_network_type_t         network_type;                                   ///< [in]  Type of network on which the controller is bound
+} ctrlm_main_iarm_call_control_service_can_find_my_remote_t;
+
+/// @brief Control Manager Control Service Pairing Mode Structure
+/// @details The Control Manager Status structure is used in the CTRLM_MAIN_IARM_CALL_CONTROL_SERVICE_START_PAIRING_MODE call. See the @link CTRLM_IPC_MAIN_CALLS Calls@endlink section for more details on invoking this call.
+
+typedef struct {
+   unsigned char                api_revision;                                   ///< The revision of this API.
+   ctrlm_iarm_call_result_t     result;                                         ///< Result of the IARM call
+   ctrlm_network_id_t           network_id;                                     ///< Identifier of network or CTRLM_MAIN_NETWORK_ID_ALL for all networks
+   unsigned char                pairing_mode;                                   ///< Indicates the pairing mode
+   unsigned char                restrict_by_remote;                             ///< Indicates the remote bucket (no restrictions, only voice remotes, only voice assistants)
+   unsigned int                 bind_status;                                    ///< OUT - The bind status of the pairing session
+} ctrlm_main_iarm_call_control_service_pairing_mode_t;
+
+/// @brief Control Manager Pairing Metrics Structure
+/// @details The Control Manager Status structure is used in the CTRLM_MAIN_IARM_CALL_PAIRING_METRICS_GET call. See the @link CTRLM_IPC_MAIN_CALLS Calls@endlink section for more details on invoking this call.
+typedef struct {
+   unsigned char            api_revision;                                                       ///< Revision of this API
+   ctrlm_iarm_call_result_t result;                                                             ///< OUT - The result of the operation.
+   unsigned long            num_screenbind_failures;                                            ///< OUT - The total number of screenbind failures on this stb
+   unsigned long            last_screenbind_error_timestamp;                                    ///< OUT - Timestamp of the last screenbind error
+   ctrlm_bind_status_t      last_screenbind_error_code;                                         ///< OUT - The last screenbind error code
+   char                     last_screenbind_remote_type[CTRLM_MAIN_SOURCE_NAME_MAX_LENGTH];     ///< OUT - The last screenbind error remote type
+   unsigned long            num_non_screenbind_failures;                                        ///< OUT - The total number of screenbind failures on this stb
+   unsigned long            last_non_screenbind_error_timestamp;                                ///< OUT - Timestamp of the last screenbind error
+   ctrlm_bind_status_t      last_non_screenbind_error_code;                                     ///< OUT - The last screenbind error code
+   unsigned char            last_non_screenbind_error_binding_type;                             ///< OUT - The last screenbind error binding type
+   char                     last_non_screenbind_remote_type[CTRLM_MAIN_SOURCE_NAME_MAX_LENGTH]; ///< OUT - The last screenbind error remote type
+} ctrlm_main_iarm_call_pairing_metrics_t;
+
+/// @brief Chip Status Structure
+/// @details The Chip Status structure is used in the CTRLM_MAIN_IARM_CALL_CHIP_STATUS_GET call. See the @link CTRLM_IPC_MAIN_CALLS Calls@endlink section for more details on invoking this call.
+typedef struct {
+   unsigned char            api_revision;   ///< Revision of this API
+   ctrlm_iarm_call_result_t result;         ///< OUT - Result of the operation
+   ctrlm_network_id_t       network_id;     ///< IN - identifier of network
+   unsigned char            chip_connected; ///< OUT - 1 - chip connected, 0 - chip disconnected
+} ctrlm_main_iarm_call_chip_status_t;
+
+#define CTRLM_VOICE_IARM_CALL_STATUS               "Voice_Status"             ///< IARM Call to get status
+#define CTRLM_VOICE_IARM_CALL_CONFIGURE_VOICE      "Voice_ConfigureVoice"     ///< IARM Call to set up voice with JSON payload
+#define CTRLM_VOICE_IARM_CALL_SET_VOICE_INIT       "Voice_SetVoiceInit"       ///< IARM Call to set application data with JSON payload in the voice server init message
+#define CTRLM_VOICE_IARM_CALL_SEND_VOICE_MESSAGE   "Voice_SendVoiceMessage"   ///< IARM Call to send JSON payload to voice server
+#define CTRLM_VOICE_IARM_CALL_SESSION_TYPES        "Voice_SessionTypes"       ///< IARM Call to get voice session request types
+#define CTRLM_VOICE_IARM_CALL_SESSION_REQUEST      "Voice_SessionRequest"     ///< IARM Call to request a voice session
+#define CTRLM_VOICE_IARM_CALL_SESSION_TERMINATE    "Voice_SessionTerminate"   ///< IARM Call to terminate a voice session
+
+#define CTRLM_VOICE_IARM_CALL_RESULT_LEN_MAX       (2048) ///< IARM Call result length
+
+#define CTRLM_VOICE_IARM_BUS_API_REVISION             (9) ///< Revision of the Voice IARM API
+// APIs for Thunder Plugin
+
+// IARM Call JSON
+// This structure is used for the following calls:
+//   CTRLM_VOICE_IARM_CALL_CONFIGURE_VOICE
+//   CTRLM_VOICE_IARM_CALL_SET_VOICE_INIT
+//   CTRLM_VOICE_IARM_CALL_SEND_VOICE_MESSAGE
+//
+// The payload MUST be a NULL terminated JSON String.
+typedef struct {
+   unsigned char  api_revision;
+   char           result[CTRLM_VOICE_IARM_CALL_RESULT_LEN_MAX];
+   char           payload[];
+} ctrlm_voice_iarm_call_json_t;
+
+// IARM Event JSON
+// This structure is used for the following calls:
+//   CTRLM_VOICE_IARM_EVENT_SESSION_BEGIN_JSON 
+//   CTRLM_VOICE_IARM_EVENT_STREAM_BEGIN_JSON  
+//   CTRLM_VOICE_IARM_EVENT_SERVER_MESSAGE_JSON
+//   CTRLM_VOICE_IARM_EVENT_STREAM_END_JSON    
+//   CTRLM_VOICE_IARM_EVENT_SESSION_END_JSON   
+//
+// The payload MUST be a NULL terminated JSON String.
+typedef struct {
+   unsigned char  api_revision;
+   char           payload[];
+} ctrlm_voice_iarm_event_json_t;
+
+typedef enum {
+   CTRLM_KEY_CODE_OK               = 0x00,
+   CTRLM_KEY_CODE_UP_ARROW         = 0x01,
+   CTRLM_KEY_CODE_DOWN_ARROW       = 0x02,
+   CTRLM_KEY_CODE_LEFT_ARROW       = 0x03,
+   CTRLM_KEY_CODE_RIGHT_ARROW      = 0x04,
+   CTRLM_KEY_CODE_MENU             = 0x09,
+   CTRLM_KEY_CODE_DVR              = 0x0B,
+   CTRLM_KEY_CODE_FAV              = 0x0C,
+   CTRLM_KEY_CODE_EXIT             = 0x0D,
+   CTRLM_KEY_CODE_HOME             = 0x10,
+   CTRLM_KEY_CODE_DIGIT_0          = 0x20,
+   CTRLM_KEY_CODE_DIGIT_1          = 0x21,
+   CTRLM_KEY_CODE_DIGIT_2          = 0x22,
+   CTRLM_KEY_CODE_DIGIT_3          = 0x23,
+   CTRLM_KEY_CODE_DIGIT_4          = 0x24,
+   CTRLM_KEY_CODE_DIGIT_5          = 0x25,
+   CTRLM_KEY_CODE_DIGIT_6          = 0x26,
+   CTRLM_KEY_CODE_DIGIT_7          = 0x27,
+   CTRLM_KEY_CODE_DIGIT_8          = 0x28,
+   CTRLM_KEY_CODE_DIGIT_9          = 0x29,
+   CTRLM_KEY_CODE_PERIOD           = 0x2A,
+   CTRLM_KEY_CODE_RETURN           = 0x2B,
+   CTRLM_KEY_CODE_CH_UP            = 0x30,
+   CTRLM_KEY_CODE_CH_DOWN          = 0x31,
+   CTRLM_KEY_CODE_LAST             = 0x32,
+   CTRLM_KEY_CODE_LANG             = 0x33,
+   CTRLM_KEY_CODE_INPUT_SELECT     = 0x34,
+   CTRLM_KEY_CODE_INFO             = 0x35,
+   CTRLM_KEY_CODE_HELP             = 0x36,
+   CTRLM_KEY_CODE_PAGE_UP          = 0x37,
+   CTRLM_KEY_CODE_PAGE_DOWN        = 0x38,
+   CTRLM_KEY_CODE_MOTION           = 0x3B,
+   CTRLM_KEY_CODE_SEARCH           = 0x3C,
+   CTRLM_KEY_CODE_LIVE             = 0x3D,
+   CTRLM_KEY_CODE_HD_ZOOM          = 0x3E,
+   CTRLM_KEY_CODE_SHARE            = 0x3F,
+   CTRLM_KEY_CODE_TV_POWER         = 0x40,
+   CTRLM_KEY_CODE_VOL_UP           = 0x41,
+   CTRLM_KEY_CODE_VOL_DOWN         = 0x42,
+   CTRLM_KEY_CODE_MUTE             = 0x43,
+   CTRLM_KEY_CODE_PLAY             = 0x44,
+   CTRLM_KEY_CODE_STOP             = 0x45,
+   CTRLM_KEY_CODE_PAUSE            = 0x46,
+   CTRLM_KEY_CODE_RECORD           = 0x47,
+   CTRLM_KEY_CODE_REWIND           = 0x48,
+   CTRLM_KEY_CODE_FAST_FORWARD     = 0x49,
+   CTRLM_KEY_CODE_30_SEC_SKIP      = 0x4B,
+   CTRLM_KEY_CODE_REPLAY           = 0x4C,
+   CTRLM_KEY_CODE_TV_POWER_ON      = 0x4D,
+   CTRLM_KEY_CODE_TV_POWER_OFF     = 0x4E,
+   CTRLM_KEY_CODE_SWAP             = 0x51,
+   CTRLM_KEY_CODE_ON_DEMAND        = 0x52,
+   CTRLM_KEY_CODE_GUIDE            = 0x53,
+   CTRLM_KEY_CODE_PUSH_TO_TALK     = 0x57,
+   CTRLM_KEY_CODE_PIP_ON_OFF       = 0x58,
+   CTRLM_KEY_CODE_PIP_MOVE         = 0x59,
+   CTRLM_KEY_CODE_PIP_CH_UP        = 0x5A,
+   CTRLM_KEY_CODE_PIP_CH_DOWN      = 0x5B,
+   CTRLM_KEY_CODE_LOCK             = 0x5C,
+   CTRLM_KEY_CODE_DAY_PLUS         = 0x5D,
+   CTRLM_KEY_CODE_DAY_MINUS        = 0x5E,
+   CTRLM_KEY_CODE_PLAY_PAUSE       = 0x61,
+   CTRLM_KEY_CODE_STOP_VIDEO       = 0x64,
+   CTRLM_KEY_CODE_MUTE_MIC         = 0x65,
+   CTRLM_KEY_CODE_AVR_POWER_TOGGLE = 0x68,
+   CTRLM_KEY_CODE_AVR_POWER_OFF    = 0x69,
+   CTRLM_KEY_CODE_AVR_POWER_ON     = 0x6A,
+   CTRLM_KEY_CODE_POWER_TOGGLE     = 0x6B,
+   CTRLM_KEY_CODE_POWER_OFF        = 0x6C,
+   CTRLM_KEY_CODE_POWER_ON         = 0x6D,
+   CTRLM_KEY_CODE_OCAP_B           = 0x71,
+   CTRLM_KEY_CODE_OCAP_C           = 0x72,
+   CTRLM_KEY_CODE_OCAP_D           = 0x73,
+   CTRLM_KEY_CODE_OCAP_A           = 0x74,
+   CTRLM_KEY_CODE_CC               = 0x90,
+   CTRLM_KEY_CODE_PROFILE          = 0xA0,
+   CTRLM_KEY_CODE_CALL             = 0xA1,
+   CTRLM_KEY_CODE_HOLD             = 0xA2,
+   CTRLM_KEY_CODE_END              = 0xA3,
+   CTRLM_KEY_CODE_VIEWS            = 0xA4,
+   CTRLM_KEY_CODE_SELF_VIEW        = 0xA5,
+   CTRLM_KEY_CODE_ZOOM_IN          = 0xA6,
+   CTRLM_KEY_CODE_ZOOM_OUT         = 0xA7,
+   CTRLM_KEY_CODE_BACKSPACE        = 0xA8,
+   CTRLM_KEY_CODE_LOCK_UNLOCK      = 0xA9,
+   CTRLM_KEY_CODE_CAPS             = 0xAA,
+   CTRLM_KEY_CODE_ALT              = 0xAB,
+   CTRLM_KEY_CODE_SPACE            = 0xAC,
+   CTRLM_KEY_CODE_WWW_DOT          = 0xAD,
+   CTRLM_KEY_CODE_DOT_COM          = 0xAE,
+   CTRLM_KEY_CODE_UPPER_A          = 0xB0,
+   CTRLM_KEY_CODE_UPPER_B          = 0xB1,
+   CTRLM_KEY_CODE_UPPER_C          = 0xB2,
+   CTRLM_KEY_CODE_UPPER_D          = 0xB3,
+   CTRLM_KEY_CODE_UPPER_E          = 0xB4,
+   CTRLM_KEY_CODE_UPPER_F          = 0xB5,
+   CTRLM_KEY_CODE_UPPER_G          = 0xB6,
+   CTRLM_KEY_CODE_UPPER_H          = 0xB7,
+   CTRLM_KEY_CODE_UPPER_I          = 0xB8,
+   CTRLM_KEY_CODE_UPPER_J          = 0xB9,
+   CTRLM_KEY_CODE_UPPER_K          = 0xBA,
+   CTRLM_KEY_CODE_UPPER_L          = 0xBB,
+   CTRLM_KEY_CODE_UPPER_M          = 0xBC,
+   CTRLM_KEY_CODE_UPPER_N          = 0xBD,
+   CTRLM_KEY_CODE_UPPER_O          = 0xBE,
+   CTRLM_KEY_CODE_UPPER_P          = 0xBF,
+   CTRLM_KEY_CODE_UPPER_Q          = 0xC0,
+   CTRLM_KEY_CODE_UPPER_R          = 0xC1,
+   CTRLM_KEY_CODE_UPPER_S          = 0xC2,
+   CTRLM_KEY_CODE_UPPER_T          = 0xC3,
+   CTRLM_KEY_CODE_UPPER_U          = 0xC4,
+   CTRLM_KEY_CODE_UPPER_V          = 0xC5,
+   CTRLM_KEY_CODE_UPPER_W          = 0xC6,
+   CTRLM_KEY_CODE_UPPER_X          = 0xC7,
+   CTRLM_KEY_CODE_UPPER_Y          = 0xC8,
+   CTRLM_KEY_CODE_UPPER_Z          = 0xC9,
+   CTRLM_KEY_CODE_LOWER_A          = 0xCA,
+   CTRLM_KEY_CODE_LOWER_B          = 0xCB,
+   CTRLM_KEY_CODE_LOWER_C          = 0xCC,
+   CTRLM_KEY_CODE_LOWER_D          = 0xCD,
+   CTRLM_KEY_CODE_LOWER_E          = 0xCE,
+   CTRLM_KEY_CODE_LOWER_F          = 0xCF,
+   CTRLM_KEY_CODE_LOWER_G          = 0xD0,
+   CTRLM_KEY_CODE_LOWER_H          = 0xD1,
+   CTRLM_KEY_CODE_LOWER_I          = 0xD2,
+   CTRLM_KEY_CODE_LOWER_J          = 0xD3,
+   CTRLM_KEY_CODE_LOWER_K          = 0xD4,
+   CTRLM_KEY_CODE_LOWER_L          = 0xD5,
+   CTRLM_KEY_CODE_LOWER_M          = 0xD6,
+   CTRLM_KEY_CODE_LOWER_N          = 0xD7,
+   CTRLM_KEY_CODE_LOWER_O          = 0xD8,
+   CTRLM_KEY_CODE_LOWER_P          = 0xD9,
+   CTRLM_KEY_CODE_LOWER_Q          = 0xDA,
+   CTRLM_KEY_CODE_LOWER_R          = 0xDB,
+   CTRLM_KEY_CODE_LOWER_S          = 0xDC,
+   CTRLM_KEY_CODE_LOWER_T          = 0xDD,
+   CTRLM_KEY_CODE_LOWER_U          = 0xDE,
+   CTRLM_KEY_CODE_LOWER_V          = 0xDF,
+   CTRLM_KEY_CODE_LOWER_W          = 0xE0,
+   CTRLM_KEY_CODE_LOWER_X          = 0xE1,
+   CTRLM_KEY_CODE_LOWER_Y          = 0xE2,
+   CTRLM_KEY_CODE_LOWER_Z          = 0xE3,
+   CTRLM_KEY_CODE_QUESTION         = 0xE4,
+   CTRLM_KEY_CODE_EXCLAMATION      = 0xE5,
+   CTRLM_KEY_CODE_POUND            = 0xE6,
+   CTRLM_KEY_CODE_DOLLAR           = 0xE7,
+   CTRLM_KEY_CODE_PERCENT          = 0xE8,
+   CTRLM_KEY_CODE_AMPERSAND        = 0xE9,
+   CTRLM_KEY_CODE_ASTERISK         = 0xEA,
+   CTRLM_KEY_CODE_LEFT_PAREN       = 0xEB,
+   CTRLM_KEY_CODE_RIGHT_PAREN      = 0xEC,
+   CTRLM_KEY_CODE_PLUS             = 0xED,
+   CTRLM_KEY_CODE_MINUS            = 0xEE,
+   CTRLM_KEY_CODE_EQUAL            = 0xEF,
+   CTRLM_KEY_CODE_FORWARD_SLASH    = 0xF0,
+   CTRLM_KEY_CODE_UNDERSCORE       = 0xF1,
+   CTRLM_KEY_CODE_DOUBLE_QUOTE     = 0xF2,
+   CTRLM_KEY_CODE_COLON            = 0xF3,
+   CTRLM_KEY_CODE_SEMICOLON        = 0xF4,
+   CTRLM_KEY_CODE_COMMERCIAL_AT    = 0xF5,
+   CTRLM_KEY_CODE_APOSTROPHE       = 0xF6,
+   CTRLM_KEY_CODE_COMMA            = 0xF7,
+   CTRLM_KEY_CODE_INVALID          = 0xFF
+} ctrlm_key_code_t;
+
+#define CTRLM_RCU_IARM_CALL_CONTROLLER_STATUS            "Rcu_ControllerStatus"     ///< IARM Call to get controller information
+#define CTRLM_RCU_IARM_CALL_RIB_REQUEST_GET              "Rcu_RibRequestGet"        ///< IARM Call to retrieves an attribute from the controller's RIB
+#define CTRLM_RCU_IARM_CALL_RIB_REQUEST_SET              "Rcu_RibRequestSet"        ///< IARM Call to set an attribute in the controller's RIB
+#define CTRLM_RCU_IARM_CALL_REVERSE_CMD                  "Rcu_ReverseCmd"           ///< IARM Call to Trigger Remote Controller Action
+
+#define CTRLM_RCU_IARM_BUS_API_REVISION                  (13)    ///< Revision of the RCU IARM API
+#define CTRLM_RCU_VALIDATION_KEY_QTY                      (3)    ///< Number of validation keys used in internal validation
+#define CTRLM_RCU_VERSION_LENGTH                         (18)    ///< Maximum length of the version string
+#define CTRLM_RCU_BUILD_ID_LENGTH                        (93)    ///< Maximum length of the build id string
+#define CTRLM_RCU_DSP_BUILD_ID_LENGTH                    (93)    ///< Maximum length of the dsp build id string
+#define CTRLM_RCU_MAX_USER_STRING_LENGTH                  (9)    ///< Maximum length of remote user string (including null termination)
+#define CTRLM_RCU_MAX_IR_DB_CODE_LENGTH                   (7)    ///< Maximum length of an IR DB code string (including null termination)
+#define CTRLM_RCU_MAX_MANUFACTURER_LENGTH                (16)    ///< Maximum length of manufacturer name string (including null termination)
+#define CTRLM_RCU_MAX_CHIPSET_LENGTH                     (16)    ///< Maximum length of chipset name string (including null termination)
+#define CTRLM_RCU_CALL_RCU_REVERSE_CMD_PARAMS_MAX        (10)    ///< Maximum number of parameters for CTRLM_RCU_IARM_CALL_REVERSE_CMD call
+#define CTRLM_RCU_MAX_EVENT_SOURCE_LENGTH                (10)    ///< Maximum length of the event source (including null termination)
+#define CTRLM_RCU_MAX_EVENT_TYPE_LENGTH                  (20)    ///< Maximum length of the event type (including null termination)
+#define CTRLM_RCU_MAX_EVENT_DATA_LENGTH                  (50)    ///< Maximum length of the event data (including null termination)
+
+#define CTRLM_RCU_MAX_RIB_ATTRIBUTE_SIZE                 (92)    ///< Maximum size of a RIB attribute (in bytes)
+#define CTRLM_RCU_RIB_ATTR_LEN_CONTROLLER_IRDB_STATUS    (15)    ///< RIB Attribute Length - Controller IRDB Status
+#define CTRLM_RCU_RIB_ATTR_LEN_TARGET_IRDB_STATUS        (13)    ///< RIB Attribute Length - Target IRDB Status
+
+/// @brief RCU Binding Validation Results
+/// @details The process of binding a remote control will terminate with one of the results in this enumeration.
+typedef enum {
+   CTRLM_RCU_VALIDATION_RESULT_SUCCESS          =  0, ///< The validation completed successfully.
+   CTRLM_RCU_VALIDATION_RESULT_PENDING          =  1, ///< The validation is still pending.
+   CTRLM_RCU_VALIDATION_RESULT_TIMEOUT          =  2, ///< The validation has exceeded the timeout period.
+   CTRLM_RCU_VALIDATION_RESULT_COLLISION        =  3, ///< The validation resulted in a collision (key was received from a different remote than the one being validated).
+   CTRLM_RCU_VALIDATION_RESULT_FAILURE          =  4, ///< The validation did not complete successfully (communication failures).
+   CTRLM_RCU_VALIDATION_RESULT_ABORT            =  5, ///< The validation was aborted (infinity key from remote being validated).
+   CTRLM_RCU_VALIDATION_RESULT_FULL_ABORT       =  6, ///< The validation was fully aborted (exit key from remote being validated).
+   CTRLM_RCU_VALIDATION_RESULT_FAILED           =  7, ///< The validation has failed (ie. did not put in correct code, etc).
+   CTRLM_RCU_VALIDATION_RESULT_BIND_TABLE_FULL  =  8, ///< The validation has failed due to lack of space in the binding table.
+   CTRLM_RCU_VALIDATION_RESULT_IN_PROGRESS      =  9, ///< The validation has failed because another validation is in progress.
+   CTRLM_RCU_VALIDATION_RESULT_CTRLM_RESTART    = 10, ///< The validation has failed because of restarting controlMgr.
+   CTRLM_RCU_VALIDATION_RESULT_MAX              = 11  ///< Maximum validation result value
+} ctrlm_rcu_validation_result_t;
+
+/// @brief RCU Configuration Results
+/// @details The process of configuring a remote control will terminate with one of the results in this enumeration.
+typedef enum {
+   CTRLM_RCU_CONFIGURATION_RESULT_SUCCESS = 0, ///< The configuration completed successfully.
+   CTRLM_RCU_CONFIGURATION_RESULT_PENDING = 1, ///< The configuration is still pending.
+   CTRLM_RCU_CONFIGURATION_RESULT_TIMEOUT = 2, ///< The configuration has exceeded the timeout period.
+   CTRLM_RCU_CONFIGURATION_RESULT_FAILURE = 4, ///< The configuration did not complete successfully.
+   CTRLM_RCU_CONFIGURATION_RESULT_MAX     = 5  ///< Maximum validation result value
+} ctrlm_rcu_configuration_result_t;
+
+/// @brief RCU RIB Attribute Id's
+/// @details The attribute identifier of all supported RIB entries.
+typedef enum {
+   CTRLM_RCU_RIB_ATTR_ID_PERIPHERAL_ID             = 0x00, ///< RIB Attribute - Peripheral Id
+   CTRLM_RCU_RIB_ATTR_ID_RF_STATISTICS             = 0x01, ///< RIB Attribute - RF Statistics
+   CTRLM_RCU_RIB_ATTR_ID_VERSIONING                = 0x02, ///< RIB Attribute - Versioning
+   CTRLM_RCU_RIB_ATTR_ID_BATTERY_STATUS            = 0x03, ///< RIB Attribute - Battery Status
+   CTRLM_RCU_RIB_ATTR_ID_SHORT_RF_RETRY_PERIOD     = 0x04, ///< RIB Attribute - Short RF Retry Period
+   CTRLM_RCU_RIB_ATTR_ID_TARGET_ID_DATA            = 0x05, ///< RIB Attribute - Target ID Data
+   CTRLM_RCU_RIB_ATTR_ID_POLLING_METHODS           = 0x08, ///< RIB Attribute - Polling Methods
+   CTRLM_RCU_RIB_ATTR_ID_POLLING_CONFIGURATION     = 0x09, ///< RIB Attribute - Polling Configuration
+   CTRLM_RCU_RIB_ATTR_ID_PRIVACY                   = 0x0B, ///< RIB Attribute - Privacy
+   CTRLM_RCU_RIB_ATTR_ID_CONTROLLER_CAPABILITIES   = 0x0C, ///< RIB Attribute - Controller Capabilities
+   CTRLM_RCU_RIB_ATTR_ID_RESPONSE_TIME             = 0x0D, ///< RIB Attribute - Response Time
+   CTRLM_RCU_RIB_ATTR_ID_VOICE_COMMAND_STATUS      = 0x10, ///< RIB Attribute - Voice Command Status
+   CTRLM_RCU_RIB_ATTR_ID_VOICE_COMMAND_LENGTH      = 0x11, ///< RIB Attribute - Voice Command Length
+   CTRLM_RCU_RIB_ATTR_ID_MAXIMUM_UTTERANCE_LENGTH  = 0x12, ///< RIB Attribute - Maximum Utterance Length
+   CTRLM_RCU_RIB_ATTR_ID_VOICE_COMMAND_ENCRYPTION  = 0x13, ///< RIB Attribute - Voice Command Encryption
+   CTRLM_RCU_RIB_ATTR_ID_MAX_VOICE_DATA_RETRY      = 0x14, ///< RIB Attribute - Voice Data Retry
+   CTRLM_RCU_RIB_ATTR_ID_MAX_VOICE_CSMA_BACKOFF    = 0x15, ///< RIB Attribute - Maximum Voice CSMA Backoff
+   CTRLM_RCU_RIB_ATTR_ID_MIN_VOICE_DATA_BACKOFF    = 0x16, ///< RIB Attribute - Minimum Voice Data Backoff
+   CTRLM_RCU_RIB_ATTR_ID_VOICE_CTRL_AUDIO_PROFILES = 0x17, ///< RIB Attribute - Voice Controller Audio Profiles
+   CTRLM_RCU_RIB_ATTR_ID_VOICE_TARG_AUDIO_PROFILES = 0x18, ///< RIB Attribute - Voice Target Audio Profiles
+   CTRLM_RCU_RIB_ATTR_ID_VOICE_STATISTICS          = 0x19, ///< RIB Attribute - Voice Statistics
+   CTRLM_RCU_RIB_ATTR_ID_RIB_ENTRIES_UPDATED       = 0x1A, ///< RIB Attribute - Entries Updated
+   CTRLM_RCU_RIB_ATTR_ID_RIB_UPDATE_CHECK_INTERVAL = 0x1B, ///< RIB Attribute - Update Check Interval
+   CTRLM_RCU_RIB_ATTR_ID_VOICE_SESSION_STATISTICS  = 0x1C, ///< RIB Attribute - Voice Session Statistics
+   CTRLM_RCU_RIB_ATTR_ID_OPUS_ENCODING_PARAMS      = 0x1D, ///< RIB Attribute - OPUS Encoding Params
+   CTRLM_RCU_RIB_ATTR_ID_VOICE_SESSION_QOS         = 0x1E, ///< RIB Attribute - Voice Session QOS
+   CTRLM_RCU_RIB_ATTR_ID_UPDATE_VERSIONING         = 0x31, ///< RIB Attribute - Update Versioning
+   CTRLM_RCU_RIB_ATTR_ID_PRODUCT_NAME              = 0x32, ///< RIB Attribute - Product Name
+   CTRLM_RCU_RIB_ATTR_ID_DOWNLOAD_RATE             = 0x33, ///< RIB Attribute - Download Rate
+   CTRLM_RCU_RIB_ATTR_ID_UPDATE_POLLING_PERIOD     = 0x34, ///< RIB Attribute - Update Polling Period
+   CTRLM_RCU_RIB_ATTR_ID_DATA_REQUEST_WAIT_TIME    = 0x35, ///< RIB Attribute - Data Request Wait Time
+   CTRLM_RCU_RIB_ATTR_ID_IR_RF_DATABASE_STATUS     = 0xDA, ///< RIB Attribute - IR RF Database Status
+   CTRLM_RCU_RIB_ATTR_ID_IR_RF_DATABASE            = 0xDB, ///< RIB Attribute - IR RF Database
+   CTRLM_RCU_RIB_ATTR_ID_VALIDATION_CONFIGURATION  = 0xDC, ///< RIB Attribute - Validation Configuration
+   CTRLM_RCU_RIB_ATTR_ID_CONTROLLER_IRDB_STATUS    = 0xDD, ///< RIB Attribute - Controller IRDB Status
+   CTRLM_RCU_RIB_ATTR_ID_TARGET_IRDB_STATUS        = 0xDE, ///< RIB Attribute - Target IRDB Status
+   CTRLM_RCU_RIB_ATTR_ID_FAR_FIELD_CONFIGURATION   = 0xE0, ///< RIB Attribute - Far Field Configuration
+   CTRLM_RCU_RIB_ATTR_ID_FAR_FIELD_METRICS         = 0xE1, ///< RIB Attribute - Far Field Metrics
+   CTRLM_RCU_RIB_ATTR_ID_DSP_CONFIGURATION         = 0xE2, ///< RIB Attribute - DSP Configuration
+   CTRLM_RCU_RIB_ATTR_ID_DSP_METRICS               = 0xE3, ///< RIB Attribute - DSP Metrics
+   CTRLM_RCU_RIB_ATTR_ID_MFG_TEST                  = 0xFB, ///< RIB Attribute - MFG Test
+   CTRLM_RCU_RIB_ATTR_ID_MEMORY_DUMP               = 0xFE, ///< RIB Attribute - Memory Dump
+   CTRLM_RCU_RIB_ATTR_ID_GENERAL_PURPOSE           = 0xFF, ///< RIB Attribute - General Purpose
+} ctrlm_rcu_rib_attr_id_t;
+
+/// @brief RCU Binding Type
+/// @details The type of binding that can be performed between a controller and target.
+typedef enum {
+   CTRLM_RCU_BINDING_TYPE_INTERACTIVE = 0, ///< User initiated binding method
+   CTRLM_RCU_BINDING_TYPE_AUTOMATIC   = 1, ///< Automatic binding method
+   CTRLM_RCU_BINDING_TYPE_BUTTON      = 2, ///< Button binding method
+   CTRLM_RCU_BINDING_TYPE_SCREEN_BIND = 3, ///< Screen bind method
+   CTRLM_RCU_BINDING_TYPE_INVALID     = 4  ///< Invalid binding type
+} ctrlm_rcu_binding_type_t;
+
+/// @brief RCU Validation Type
+/// @details The type of validation that can be performed between a controller and target.
+typedef enum {
+   CTRLM_RCU_VALIDATION_TYPE_APPLICATION   = 0, ///< Application based validation
+   CTRLM_RCU_VALIDATION_TYPE_INTERNAL      = 1, ///< Control Manager based validation
+   CTRLM_RCU_VALIDATION_TYPE_AUTOMATIC     = 2, ///< Autobinding validation
+   CTRLM_RCU_VALIDATION_TYPE_BUTTON        = 3, ///< Button based validation
+   CTRLM_RCU_VALIDATION_TYPE_PRECOMMISSION = 4, ///< Precommissioned controller
+   CTRLM_RCU_VALIDATION_TYPE_SCREEN_BIND   = 5, ///< Screen bind based validation
+   CTRLM_RCU_VALIDATION_TYPE_INVALID       = 6  ///< Invalid validation type
+} ctrlm_rcu_validation_type_t;
+
+/// @brief RCU Binding Security Type
+/// @details The type of binding security used between the controller and target.
+typedef enum {
+   CTRLM_RCU_BINDING_SECURITY_TYPE_NORMAL   = 0, ///< Normal Security
+   CTRLM_RCU_BINDING_SECURITY_TYPE_ADVANCED = 1  ///< Advanced Security
+} ctrlm_rcu_binding_security_type_t;
+
+/// @brief RCU Ghost Codes
+/// @details The enumeration of ghost codes that can be produced by the controller. XRC spec 11.2.10.1
+typedef enum {
+   CTRLM_RCU_GHOST_CODE_VOLUME_UNITY_GAIN = 0, ///< Volume unity gain (vol +/- or mute pressed)
+   CTRLM_RCU_GHOST_CODE_POWER_OFF         = 1, ///< Power off pressed
+   CTRLM_RCU_GHOST_CODE_POWER_ON          = 2, ///< Power on pressed
+   CTRLM_RCU_GHOST_CODE_IR_POWER_TOGGLE   = 3, ///< Power toggled
+   CTRLM_RCU_GHOST_CODE_IR_POWER_OFF      = 4, ///< Power off pressed
+   CTRLM_RCU_GHOST_CODE_IR_POWER_ON       = 5, ///< Power on pressed
+   CTRLM_RCU_GHOST_CODE_VOLUME_UP         = 6, ///< Volume up pressed
+   CTRLM_RCU_GHOST_CODE_VOLUME_DOWN       = 7, ///< Volume down pressed
+   CTRLM_RCU_GHOST_CODE_MUTE              = 8, ///< Mute pressed
+   CTRLM_RCU_GHOST_CODE_INPUT             = 9, ///< TV input pressed
+   CTRLM_RCU_GHOST_CODE_FIND_MY_REMOTE    = 10,///< User pressed any button in Find My Remote mode
+   CTRLM_RCU_GHOST_CODE_INVALID           = 11 ///< Invalid ghost code
+} ctrlm_rcu_ghost_code_t;
+
+/// @brief RCU Functions
+/// @details The enumeration of functions that can be produced by the controller.
+typedef enum {
+   CTRLM_RCU_FUNCTION_SETUP                  =  0, ///< <setup> Setup key held for 3 seconds
+   CTRLM_RCU_FUNCTION_BACKLIGHT              =  1, ///< <setup><92X> Backlight time where X is on time in seconds
+   CTRLM_RCU_FUNCTION_POLL_FIRMWARE          =  2, ///< <setup><964> Poll for a firmware update
+   CTRLM_RCU_FUNCTION_POLL_AUDIO_DATA        =  3, ///< <setup><965> Poll for an audio data update
+   CTRLM_RCU_FUNCTION_RESET_SOFT             =  4, ///< <setup><980> Soft Reset on the controller
+   CTRLM_RCU_FUNCTION_RESET_FACTORY          =  5, ///< <setup><981> Factory Reset on the controller (mode is changed to clip discovery)
+   CTRLM_RCU_FUNCTION_BLINK_SOFTWARE_VERSION =  6, ///< <setup><983> Software version
+   CTRLM_RCU_FUNCTION_BLINK_AVR_CODE         =  7, ///< <setup><985> AVR Code
+   CTRLM_RCU_FUNCTION_RESET_IR               =  8, ///< <setup><986> Reset IR only
+   CTRLM_RCU_FUNCTION_RESET_RF               =  9, ///< <setup><987> RF Reset on the controller  (mode is changed to clip discovery)
+   CTRLM_RCU_FUNCTION_BLINK_TV_CODE          = 10, ///< <setup><990> Blink the TV code on the LED's
+   CTRLM_RCU_FUNCTION_IR_DB_TV_SEARCH        = 11, ///< <setup><991> Library Search for TV's
+   CTRLM_RCU_FUNCTION_IR_DB_AVR_SEARCH       = 12, ///< <setup><992> Library Search for AVR's
+   CTRLM_RCU_FUNCTION_KEY_REMAPPING          = 13, ///< <setup><994> Key remapping
+   CTRLM_RCU_FUNCTION_BLINK_IR_DB_VERSION    = 14, ///< <setup><995> IR DB version
+   CTRLM_RCU_FUNCTION_BLINK_BATTERY_LEVEL    = 15, ///< <setup><999> Blink the battery level
+   CTRLM_RCU_FUNCTION_DISCOVERY              = 16, ///< <setup><XFINITY> Discovery Request
+   CTRLM_RCU_FUNCTION_MODE_IR_CLIP           = 17, ///< <setup><A> Clip mode
+   CTRLM_RCU_FUNCTION_MODE_IR_MOTOROLA       = 18, ///< <setup><B> Motorola
+   CTRLM_RCU_FUNCTION_MODE_IR_CISCO          = 19, ///< <setup><C> Cisco Mode
+   CTRLM_RCU_FUNCTION_MODE_CLIP_DISCOVERY    = 20, ///< <setup><D> Clip Discovery mode
+   CTRLM_RCU_FUNCTION_IR_DB_TV_SELECT        = 21, ///< <setup><1####> TV code select
+   CTRLM_RCU_FUNCTION_IR_DB_AVR_SELECT       = 22, ///< <setup><3####> AVR code select
+   CTRLM_RCU_FUNCTION_INVALID_KEY_COMBO      = 23, ///< Invalid key combo (key combo for XR16, not XR11 or XR15)
+   CTRLM_RCU_FUNCTION_INVALID                = 24  ///< Invalid function
+} ctrlm_rcu_function_t;
+
+/// @brief RCU Controller Type
+/// @details The type of controller.
+typedef enum {
+   CTRLM_RCU_CONTROLLER_TYPE_XR2     = 0,
+   CTRLM_RCU_CONTROLLER_TYPE_XR5     = 1,
+   CTRLM_RCU_CONTROLLER_TYPE_XR11    = 2,
+   CTRLM_RCU_CONTROLLER_TYPE_XR15    = 3,
+   CTRLM_RCU_CONTROLLER_TYPE_XR15V2  = 4,
+   CTRLM_RCU_CONTROLLER_TYPE_XR16    = 5,
+   CTRLM_RCU_CONTROLLER_TYPE_XR18    = 6,
+   CTRLM_RCU_CONTROLLER_TYPE_XR19    = 7,
+   CTRLM_RCU_CONTROLLER_TYPE_XRA     = 8,
+   CTRLM_RCU_CONTROLLER_TYPE_UNKNOWN = 9,
+   CTRLM_RCU_CONTROLLER_TYPE_INVALID = 10
+} ctrlm_rcu_controller_type_t;
+
+/// @brief RCU IR DB Type
+/// @details The type of IR DB in the controller.
+typedef enum {
+   CTRLM_RCU_IR_DB_TYPE_UEI     = 0,
+   CTRLM_RCU_IR_DB_TYPE_REMOTEC = 1,
+   CTRLM_RCU_IR_DB_TYPE_INVALID = 2
+} ctrlm_rcu_ir_db_type_t;
+
+/// @brief RCU IR DB State
+/// @details The state of IR DB in the controller.
+typedef enum {
+   CTRLM_RCU_IR_DB_STATE_NO_CODES       = 0,
+   CTRLM_RCU_IR_DB_STATE_TV_CODE        = 1,
+   CTRLM_RCU_IR_DB_STATE_AVR_CODE       = 2,
+   CTRLM_RCU_IR_DB_STATE_TV_AVR_CODES   = 3,
+   CTRLM_RCU_IR_DB_STATE_IR_RF_DB_CODES = 4,
+   CTRLM_RCU_IR_DB_STATE_INVALID        = 5
+} ctrlm_rcu_ir_db_state_t;
+
+
+/// @brief RCU Battery Event
+/// @details The events associate with the battery in the controller.
+typedef enum {
+   CTRLM_RCU_BATTERY_EVENT_NONE         = 0,
+   CTRLM_RCU_BATTERY_EVENT_REPLACED     = 1,
+   CTRLM_RCU_BATTERY_EVENT_CHARGING     = 2,
+   CTRLM_RCU_BATTERY_EVENT_PENDING_DOOM = 3,
+   CTRLM_RCU_BATTERY_EVENT_75_PERCENT   = 4,
+   CTRLM_RCU_BATTERY_EVENT_50_PERCENT   = 5,
+   CTRLM_RCU_BATTERY_EVENT_25_PERCENT   = 6,
+   CTRLM_RCU_BATTERY_EVENT_0_PERCENT    = 7, 
+   CTRLM_RCU_BATTERY_EVENT_INVALID      = 8,
+} ctrlm_rcu_battery_event_t;
+
+/// @brief RCU Reverse Command Type
+/// @details An enumeration of the reverse command types.
+typedef enum {
+   CTRLM_RCU_REVERSE_CMD_FIND_MY_REMOTE = 0,
+   CTRLM_RCU_REVERSE_CMD_REBOOT         = 1,
+} ctrlm_rcu_reverse_cmd_t;
+
+/// @brief RCU Reverse Command Event
+/// @details The events associate with the Action performed on the controller.
+typedef enum {
+   CTRLM_RCU_REVERSE_CMD_SUCCESS                = 0,
+   CTRLM_RCU_REVERSE_CMD_FAILURE                = 1,
+   CTRLM_RCU_REVERSE_CMD_CONTROLLER_NOT_CAPABLE = 2,
+   CTRLM_RCU_REVERSE_CMD_CONTROLLER_NOT_FOUND   = 3,
+   CTRLM_RCU_REVERSE_CMD_CONTROLLER_FOUND       = 4,
+   CTRLM_RCU_REVERSE_CMD_USER_INTERACTION       = 5,
+   CTRLM_RCU_REVERSE_CMD_DISABLED               = 6,
+   CTRLM_RCU_REVERSE_CMD_INVALID                = 7,
+} ctrlm_rcu_reverse_cmd_result_t;
+
+typedef enum {
+   CTRLM_RCU_FMR_ALERT_FLAGS_ID = 1,           // combination of flags defined in ctrlm_rcu_find_my_remote_alert_flag_t
+   CTRLM_FIND_RCU_FMR_ALERT_DURATION_ID = 2,   // unsigned integer alert duration in msec
+} ctrlm_rcu_find_my_remote_parameter_id_t;
+
+/// @brief RCU Alert flags
+typedef enum {
+  CTRLM_RCU_ALERT_AUDIBLE = 0x01,
+  CTRLM_RCU_ALERT_VISUAL  = 0x02
+} ctrlm_rcu_alert_flags_t;
+
+typedef enum {
+   CONTROLLER_REBOOT_POWER_ON      = 0,
+   CONTROLLER_REBOOT_EXTERNAL      = 1,
+   CONTROLLER_REBOOT_WATCHDOG      = 2,
+   CONTROLLER_REBOOT_CLOCK_LOSS    = 3,
+   CONTROLLER_REBOOT_BROWN_OUT     = 4,
+   CONTROLLER_REBOOT_OTHER         = 5,
+   CONTROLLER_REBOOT_ASSERT_NUMBER = 6
+} controller_reboot_reason_t;
+
+/// @brief Controller Status Structure
+/// @details This structure contains a controller's diagnostic information.
+typedef struct {
+   unsigned long long                ieee_address;                                          ///< The 64-bit IEEE Address
+   unsigned short                    short_address;                                         ///< Short address (if applicable)
+   unsigned long                     time_binding;                                          ///< Time that the controller was bound (number of seconds since the Epoch, 1970-01-01 00:00:00 +0000 (UTC))
+   ctrlm_rcu_binding_type_t          binding_type;                                          ///< Type of binding that was performed
+   ctrlm_rcu_validation_type_t       validation_type;                                       ///< Type of validation that was performed
+   ctrlm_rcu_binding_security_type_t security_type;                                         ///< Security type for the binding
+   unsigned long                     command_count;                                         ///< Amount of commands received from this controller
+   ctrlm_key_code_t                  last_key_code;                                         ///< Last key code received
+   ctrlm_key_status_t                last_key_status;                                       ///< Key status of last key code
+   unsigned char                     link_quality_percent;                                  ///< Link quality percentage (0-100)
+   unsigned char                     link_quality;                                          ///< Link quality indicator
+   char                              manufacturer[CTRLM_RCU_MAX_MANUFACTURER_LENGTH];       ///< Manufacturer of the controller
+   char                              chipset[CTRLM_RCU_MAX_CHIPSET_LENGTH];                 ///< Chipset of the controller
+   char                              version_software[CTRLM_RCU_VERSION_LENGTH];            ///< Software version of controller
+   char                              version_dsp[CTRLM_RCU_VERSION_LENGTH];                 ///< DSP version of controller
+   char                              version_keyword_model[CTRLM_RCU_VERSION_LENGTH];       ///< Keyword model version of controller
+   char                              version_arm[CTRLM_RCU_VERSION_LENGTH];                 ///< ARM version of controller
+   char                              version_hardware[CTRLM_RCU_VERSION_LENGTH];            ///< Hardware version of controller
+   char                              version_irdb[CTRLM_RCU_VERSION_LENGTH];                ///< IR database version (if available)
+   char                              version_build_id[CTRLM_RCU_BUILD_ID_LENGTH];           ///< Build ID of software on controller
+   char                              version_dsp_build_id[CTRLM_RCU_DSP_BUILD_ID_LENGTH];   ///< DSP Build ID of software on controller
+   char                              version_bootloader[CTRLM_RCU_VERSION_LENGTH];          ///< Bootloader
+   char                              version_golden[CTRLM_RCU_VERSION_LENGTH];              ///< Golden Software version
+   char                              version_audio_data[CTRLM_RCU_VERSION_LENGTH];          ///< Audio Data version (if available)
+   unsigned char                     firmware_updated;                                      ///< Boolean value indicating that the controller's firmware has been updated (1) or not (0)
+   unsigned char                     has_battery;                                           ///< Boolean value indicating that the controller has a battery (1) or not (0)
+   unsigned char                     battery_level_percent;                                 ///< Battery Level percentage (0-100)
+   float                             battery_voltage_loaded;                                ///< Battery Voltage under load
+   float                             battery_voltage_unloaded;                              ///< Battery Voltage not under load
+   unsigned long                     time_last_key;                                         ///< Time of last key code received (number of seconds since the Epoch, 1970-01-01 00:00:00 +0000 (UTC))
+   unsigned long                     time_battery_update;                                   ///< Time of battery update (number of seconds since the Epoch, 1970-01-01 00:00:00 +0000 (UTC))
+   unsigned long                     time_battery_changed;                                  ///< Time of battery changed (number of seconds since the Epoch, 1970-01-01 00:00:00 +0000 (UTC))
+   unsigned char                     battery_changed_actual_percentage;                     ///< Actual percentage of the batteries when the were "changed"
+   float                             battery_changed_unloaded_voltage;                      ///< Actual voltage of the batteries when the were "changed"
+   unsigned long                     time_battery_75_percent;                               ///< Time of battery at 75% (number of seconds since the Epoch, 1970-01-01 00:00:00 +0000 (UTC))
+   unsigned char                     battery_75_percent_actual_percentage;                  ///< Actual percentage of the batteries when they hit 75% or below
+   float                             battery_75_percent_unloaded_voltage;                   ///< Actual voltage of the batteries when they hit 75% or below
+   unsigned long                     time_battery_50_percent;                               ///< Time of battery at 50% (number of seconds since the Epoch, 1970-01-01 00:00:00 +0000 (UTC))
+   unsigned char                     battery_50_percent_actual_percentage;                  ///< Actual percentage of the batteries when they hit 50% or below
+   float                             battery_50_percent_unloaded_voltage;                   ///< Actual voltage of the batteries when they hit 50% or below
+   unsigned long                     time_battery_25_percent;                               ///< Time of battery at 25% (number of seconds since the Epoch, 1970-01-01 00:00:00 +0000 (UTC))
+   unsigned char                     battery_25_percent_actual_percentage;                  ///< Actual percentage of the batteries when they hit 25% or below
+   float                             battery_25_percent_unloaded_voltage;                   ///< Actual voltage of the batteries when they hit 25% or below
+   unsigned long                     time_battery_5_percent;                                ///< Time of battery at 5% (number of seconds since the Epoch, 1970-01-01 00:00:00 +0000 (UTC))
+   unsigned char                     battery_5_percent_actual_percentage;                   ///< Actual percentage of the batteries when they hit 5% or below
+   float                             battery_5_percent_unloaded_voltage;                    ///< Actual voltage of the batteries when they hit 5% or below
+   unsigned long                     time_battery_0_percent;                                ///< Time of battery at 0% (number of seconds since the Epoch, 1970-01-01 00:00:00 +0000 (UTC))
+   unsigned char                     battery_0_percent_actual_percentage;                   ///< Actual percentage of the batteries when they hit 0% or below
+   float                             battery_0_percent_unloaded_voltage;                    ///< Actual voltage of the batteries when they hit 0% or below
+   ctrlm_rcu_battery_event_t         battery_event;                                         ///< Last battery event
+   unsigned long                     time_battery_event;                                    ///< Time of the last battery event (number of seconds since the Epoch, 1970-01-01 00:00:00 +0000 (UTC))
+   char                              type[CTRLM_RCU_MAX_USER_STRING_LENGTH];                ///< Remote control's type string
+   ctrlm_rcu_ir_db_type_t            ir_db_type;                                            ///< Type of IR Database in the controller
+   ctrlm_rcu_ir_db_state_t           ir_db_state;                                           ///< State of IR Database in the controller
+   char                              ir_db_code_tv[CTRLM_RCU_MAX_IR_DB_CODE_LENGTH];        ///< Current TV Code programmed in the controller
+   char                              ir_db_code_avr[CTRLM_RCU_MAX_IR_DB_CODE_LENGTH];       ///< Current AVR Code programmed in the controller
+   unsigned long                     voice_cmd_count_today;                                 ///< Number of normal voice commands received today
+   unsigned long                     voice_cmd_count_yesterday;                             ///< Number of normal voice commands received yesterday
+   unsigned long                     voice_cmd_short_today;                                 ///< Number of short voice commands received today
+   unsigned long                     voice_cmd_short_yesterday;                             ///< Number of short voice commands received yesterday
+   unsigned long                     voice_packets_sent_today;                              ///< Number of voice packets sent today
+   unsigned long                     voice_packets_sent_yesterday;                          ///< Number of voice packets sent yesterday
+   unsigned long                     voice_packets_lost_today;                              ///< Number of voice packets lost today
+   unsigned long                     voice_packets_lost_yesterday;                          ///< Number of voice packets lost yesterday
+   float                             voice_packet_loss_average_today;                       ///< The average packet loss for today (sent-received)/sent
+   float                             voice_packet_loss_average_yesterday;                   ///< The average packet loss for yesterday (sent-received)/sent
+   unsigned long                     utterances_exceeding_packet_loss_threshold_today;      ///< Number utterances exceeding the packet loss threshold today
+   unsigned long                     utterances_exceeding_packet_loss_threshold_yesterday;  ///< Number utterances exceeding the packet loss threshold yesterday
+   unsigned char                     checkin_for_device_update;                             ///< Boolean value indicating that the controller has checked in in the last x hours for device update
+   unsigned char                     ir_db_code_download_supported;                         ///< Boolean value indicating that the controller supports irdb code download
+   unsigned char                     has_dsp;                                               ///< Boolean value indicating that the controller has a dsp chip (1) or not (0)
+   unsigned long                     average_time_in_privacy_mode;                          ///< Average time in privacy mode
+   unsigned char                     in_privacy_mode;                                       ///< Boolean value indicating whether the controller is currently in privacy mode
+   unsigned char                     average_snr;                                           ///< Average signal to noise ratio
+   unsigned char                     average_keyword_confidence;                            ///< Average keyword confidence
+   unsigned char                     total_number_of_mics_working;                          ///< Total number of mics that are working
+   unsigned char                     total_number_of_speakers_working;                      ///< Total number of speakers that are working
+   unsigned int                      end_of_speech_initial_timeout_count;                   ///< End of speech initial timeout count
+   unsigned int                      end_of_speech_timeout_count;                           ///< End of speech timeout count
+   unsigned long                     time_uptime_start;                                     ///< The time uptime started counting
+   unsigned long                     uptime_seconds;                                        ///< The uptime of the remote in seconds
+   unsigned long                     privacy_time_seconds;                                  ///< Total amount of time remote is in privacy mode
+   unsigned char                     reboot_reason;                                         ///< The last remote reboot reason
+   unsigned char                     reboot_voltage;                                        ///< The last remote reboot voltage
+   unsigned int                      reboot_assert_number;                                  ///< The last remote assert_number 
+   unsigned long                     reboot_timestamp;                                      ///< Time of the last remote reboot
+   unsigned long                     time_last_heartbeat;                                   ///< The time of the last heartbeat
+   char                              irdb_entry_id_name_tv[CTRLM_MAX_PARAM_STR_LEN];        ///< The TV irdb code name
+   char                              irdb_entry_id_name_avr[CTRLM_MAX_PARAM_STR_LEN];       ///< The AVR irdb code name
+   unsigned char                     battery_voltage_large_jump_counter;                    ///< The large jump counter for battery voltage
+   unsigned char                     battery_voltage_large_decline_detected;                ///< The large decline detected flag for battery voltage
+} ctrlm_controller_status_t;
+
+/// @brief Structure of Remote Controls's Controller Status IARM call
+/// @details This structure provides information about a controller.
+typedef struct {
+   unsigned char             api_revision;  ///< Revision of this API
+   ctrlm_iarm_call_result_t  result;        ///< Result of the IARM call
+   ctrlm_network_id_t        network_id;    ///< IN The identifier of network on which the controller is bound
+   ctrlm_controller_id_t     controller_id; ///< IN
+   ctrlm_controller_status_t status;        ///< Status of the controller
+} ctrlm_rcu_iarm_call_controller_status_t;
+
+/// @brief Structure of Remote Controls's RIB Request get and set IARM calls
+/// @details This structure provides information about a controller's RIB entry.
+typedef struct {
+   unsigned char            api_revision;                           ///< Revision of this API
+   ctrlm_iarm_call_result_t result;                                 ///< Result of the IARM call
+   ctrlm_network_id_t       network_id;                             ///< IN - identifier of network on which the controller is bound
+   ctrlm_controller_id_t    controller_id;                          ///< IN - identifier of the controller
+   ctrlm_rcu_rib_attr_id_t  attribute_id;                           ///< RIB attribute identifier
+   unsigned char            attribute_index;                        ///< RIB attribute index
+   unsigned char            length;                                 ///< RIB data length
+   char                     data[CTRLM_RCU_MAX_RIB_ATTRIBUTE_SIZE]; ///< RIB entry's data
+} ctrlm_rcu_iarm_call_rib_request_t;
+
+/// @brief Structure of Remote Control's Key Press IARM event
+/// @details This event notifies listeners that a key event has occurred.
+typedef struct {
+   unsigned char            api_revision;                                      ///< Revision of this API
+   ctrlm_network_id_t       network_id;                                        ///< identifier of network on which the controller is bound
+   ctrlm_network_type_t     network_type;                                      ///< type of network on which the controller is bound
+   ctrlm_controller_id_t    controller_id;                                     ///< identifier of the controller on which the key was pressed
+   ctrlm_key_status_t       key_status;                                        ///< status of the key press (down, repeat, up)
+   ctrlm_key_code_t         key_code;                                          ///< received key code
+   ctrlm_rcu_binding_type_t binding_type;                                      ///< Type of binding that was performed
+   char                     controller_type[CTRLM_RCU_MAX_USER_STRING_LENGTH]; ///< Remote control's type string
+} ctrlm_rcu_iarm_event_key_press_t;
+
+/// @brief Structure of Remote Control's Validation Begin IARM event
+/// @details This event notifies listeners that a validation attempt has begun.
+typedef struct {
+   unsigned char               api_revision;                                      ///< Revision of this API
+   ctrlm_network_id_t          network_id;                                        ///< identifier of network on which the controller is bound
+   ctrlm_network_type_t        network_type;                                      ///< type of network on which the controller is bound
+   ctrlm_controller_id_t       controller_id;                                     ///< identifier of the controller on which the validation is being performed
+   ctrlm_rcu_binding_type_t    binding_type;                                      ///< Type of binding that is being performed
+   ctrlm_rcu_validation_type_t validation_type;                                   ///< Type of validation that is being performed
+   ctrlm_key_code_t            validation_keys[CTRLM_RCU_VALIDATION_KEY_QTY];     ///< Validation keys to be displayed for internal validation
+   char                        controller_type[CTRLM_RCU_MAX_USER_STRING_LENGTH]; ///< Remote control's type string
+} ctrlm_rcu_iarm_event_validation_begin_t;
+
+/// @brief Structure of Remote Control's Validation End IARM event
+/// @details This event notifies listeners that a validation attempt has completed.
+typedef struct {
+   unsigned char                 api_revision;                                      ///< Revision of this API
+   ctrlm_network_id_t            network_id;                                        ///< identifier of network on which the controller is bound
+   ctrlm_network_type_t          network_type;                                      ///< type of network on which the controller is bound
+   ctrlm_controller_id_t         controller_id;                                     ///< identifier of the controller on which the validation was performed
+   ctrlm_rcu_binding_type_t      binding_type;                                      ///< Type of binding that was performed
+   ctrlm_rcu_validation_type_t   validation_type;                                   ///< Type of validation that was performed
+   ctrlm_rcu_validation_result_t result;                                            ///< Result of the validation attempt
+   char                          controller_type[CTRLM_RCU_MAX_USER_STRING_LENGTH]; ///< Remote control's type string
+} ctrlm_rcu_iarm_event_validation_end_t;
+
+/// @brief Structure of Remote Control's Configuration Complete IARM event
+/// @details This event notifies listeners that a validation attempt has completed.
+typedef struct {
+   unsigned char                    api_revision;                                      ///< Revision of this API
+   ctrlm_network_id_t               network_id;                                        ///< identifier of network on which the controller is bound
+   ctrlm_network_type_t             network_type;                                      ///< type of network on which the controller is bound
+   ctrlm_controller_id_t            controller_id;                                     ///< identifier of the controller on which the validation was performed
+   ctrlm_rcu_configuration_result_t result;                                            ///< Result of the configuration attempt
+   ctrlm_rcu_binding_type_t         binding_type;                                      ///< Type of binding that was performed
+   char                             controller_type[CTRLM_RCU_MAX_USER_STRING_LENGTH]; ///< Remote control's type string
+   ctrlm_controller_status_t        status;                                            ///< Remote control's status
+} ctrlm_rcu_iarm_event_configuration_complete_t;
+
+/// @brief Structure of Remote Control's Ghost Key IARM event
+/// @details This event notifies listeners that a ghost code event has occurred.
+typedef struct {
+   unsigned char          api_revision;          ///< Revision of this API
+   ctrlm_network_id_t     network_id;            ///< Identifier of network on which the controller is bound
+   ctrlm_network_type_t   network_type;          ///< Type of network on which the controller is bound
+   ctrlm_controller_id_t  controller_id;         ///< Identifier of the controller on which the key was pressed
+   ctrlm_rcu_ghost_code_t ghost_code;            ///< Ghost code
+   unsigned char          remote_keypad_config;  /// The remote keypad configuration (Has Setup/NumberKeys).
+} ctrlm_rcu_iarm_event_key_ghost_t;
+
+/// @brief Structure of Remote Control's Ghost Key IARM event
+/// @details This event notifies listeners that a ghost code event has occurred.
+typedef struct {
+   unsigned char          api_revision;                                    ///< Revision of this API
+   int                    controller_id;                                   ///< Identifier of the controller on which the key was pressed
+   char                   event_source[CTRLM_RCU_MAX_EVENT_SOURCE_LENGTH]; ///< The key source
+   char                   event_type[CTRLM_RCU_MAX_EVENT_TYPE_LENGTH];     ///< The control type
+   char                   event_data[CTRLM_RCU_MAX_EVENT_DATA_LENGTH];     ///< The data
+   int                    event_value;                                     ///< The value
+   int                    spare_value;                                     ///< A spare value (sfm needs this extra one)
+} ctrlm_rcu_iarm_event_control_t;
+
+/// @brief Structure of Remote Control's RIB Entry Access IARM event
+/// @details The RIB Entry Access Event uses this structure. See the @link CTRLM_IPC_RCU_EVENTS Events@endlink section for more details on registering to receive this event.
+typedef struct {
+   unsigned char           api_revision;  ///< Revision of this API
+   ctrlm_network_id_t      network_id;    ///< Identifier of network on which the controller is bound
+   ctrlm_network_type_t    network_type;  ///< Type of network on which the controller is bound
+   ctrlm_controller_id_t   controller_id; ///< Identifier of the controller
+   ctrlm_rcu_rib_attr_id_t identifier;    ///< RIB attribute identifier
+   unsigned char           index;         ///< RIB attribute index
+   ctrlm_access_type_t     access_type;   ///< RIB access type (read/write)
+} ctrlm_rcu_iarm_event_rib_entry_access_t;
+
+/// @brief Structure of Remote Control's remote reboot IARM event
+/// @details This event notifies listeners that a remote rebooot event has occurred.
+typedef struct {
+   unsigned char              api_revision;  ///< Revision of this API
+   ctrlm_network_id_t         network_id;    ///< Identifier of network on which the controller is bound
+   ctrlm_network_type_t       network_type;  ///< Type of network on which the controller is bound
+   ctrlm_controller_id_t      controller_id; ///< Identifier of the controller
+   unsigned char              voltage;       ///< Voltage when reboot reason is CONTROLLER_REBOOT_ASSERT_NUMBER
+   controller_reboot_reason_t reason;        ///< Remote reboot reason
+   unsigned long              timestamp;     ///< Reboot timestamp
+   unsigned int               assert_number; ///< Assert Number when reboot reason is CONTROLLER_REBOOT_ASSERT_NUMBER
+} ctrlm_rcu_iarm_event_remote_reboot_t;
+
+/// @brief Structure of Remote Control's Battery IARM event
+/// @details This event notifies listeners that a DSP event has occurred.
+typedef struct {
+   unsigned char              api_revision;  ///< Revision of this API
+   ctrlm_network_id_t         network_id;    ///< Identifier of network on which the controller is bound
+   ctrlm_network_type_t       network_type;  ///< Type of network on which the controller is bound
+   ctrlm_controller_id_t      controller_id; ///< Identifier of the controller
+   ctrlm_rcu_battery_event_t  battery_event; ///< Battery event
+   unsigned char              percent;       ///< Battery percentage
+} ctrlm_rcu_iarm_event_battery_t;
+
+typedef struct {
+   unsigned char  param_id; ///< parameter id
+   unsigned long  size;     ///< parameter size, in bytes
+} ctrlm_rcu_reverse_cmd_param_descriptor_t;
+
+typedef struct {
+   unsigned char            api_revision;     ///< [in]  Revision of this API
+   ctrlm_iarm_call_result_t result;           ///< [out] Result of the IARM call
+   ctrlm_network_type_t     network_type;     ///< [in]  Type of network on which the controller is bound
+   ctrlm_controller_id_t    controller_id;    ///< [in]  Identifier of the controller. controller ID, CTRLM_MAIN_CONTROLLER_ID_ALL or CTRLM_MAIN_CONTROLLER_ID_LAST_USED
+   ctrlm_rcu_reverse_cmd_t  cmd;              ///< [in]  command ID
+   ctrlm_rcu_reverse_cmd_result_t cmd_result; ///< [out] Reverse Command result
+   unsigned long            total_size;       ///< [in]  ctrlm_main_iarm_call_rcu_reverse_cmd_t + data size
+   unsigned char            num_params;       ///< [in]  number of parameters
+   ctrlm_rcu_reverse_cmd_param_descriptor_t params_desc[CTRLM_RCU_CALL_RCU_REVERSE_CMD_PARAMS_MAX];   ///< command parameter descriptor
+   unsigned char            param_data[1];    ///< parameters data
+} ctrlm_main_iarm_call_rcu_reverse_cmd_t;
+
+typedef struct {
+   unsigned char                  api_revision;     ///< Revision of this API
+   ctrlm_network_id_t             network_id;       ///< Identifier of network on which the controller is bound
+   ctrlm_network_type_t           network_type;     ///< Type of network on which the controller is bound
+   ctrlm_controller_id_t          controller_id;    ///< Identifier of the controller on which the key was pressed
+   ctrlm_rcu_reverse_cmd_t        action;           ///< Reverse Command that was performed on the controller
+   ctrlm_rcu_reverse_cmd_result_t result;           ///< Reverse Command result
+   int                            result_data_size; ///< Result Data Size
+   unsigned char                  result_data[1];   ///< Result Data buffer
+} ctrlm_rcu_iarm_event_reverse_cmd_t;
+#endif

--- a/Tests/mocks/Iarm.h
+++ b/Tests/mocks/Iarm.h
@@ -899,3 +899,196 @@ typedef struct _IARM_Bus_CECMgr_Status_Updated_Param_t
 #define IARM_BUS_DSMGR_API_dsHdmiInGetNumberOfInputs    "dsHdmiInGetNumberOfInputs"
 #define IARM_BUS_DSMGR_API_dsHdmiInGetStatus            "dsHdmiInGetStatus"
 #define IARM_BUS_DSMGR_API_dsGetHDMIARCPortId  "dsGetHDMIARCPortId"
+/* irMgr */
+#define IARM_BUS_IRMGR_NAME 						"IRMgr" /*!< IR Manager IARM -bus name */
+
+/*! Events published from IR Mananger */
+typedef enum _IRMgr_EventId_t {
+    IARM_BUS_IRMGR_EVENT_IRKEY,    /*!< Key Event  */
+    IARM_BUS_IRMGR_EVENT_CONTROL,
+    IARM_BUS_IRMGR_EVENT_MAX,      /*!< Maximum event id*/
+} IARM_Bus_IRMgr_EventId_t;
+
+/*! Possible IR Manager Key Source */
+typedef enum _IRMgr_KeySrc_t {
+	IARM_BUS_IRMGR_KEYSRC_FP,	/*!< Key Source FP */
+	IARM_BUS_IRMGR_KEYSRC_IR,	/*!< Key Source IR */
+	IARM_BUS_IRMGR_KEYSRC_RF,	/*!< Key Source RF */
+} IARM_Bus_IRMgr_KeySrc_t;
+
+/*! Key Event Data */
+typedef struct _IRMgr_EventData_t {
+    union {
+        struct _IRKEY_DATA{
+            /* Declare Event Data structure for IRMGR_EVENT_DUMMY0 */
+            int keyType;                    /*!< Key type (UP/DOWN/REPEAT) */
+            int keyCode;                    /*!< Key code */
+            int keyTag;                     /*!< key tag (identifies which remote) */
+            int keyOwner;                   /*!< key owner (normal or pairing op) */
+            int isFP;                       /*!< Key Source -- Remote/FP - TBD - Need to be removed after changing MPEOS*/
+            IARM_Bus_IRMgr_KeySrc_t keySrc; /*!< Key Source -- FP,IR,Remote */
+            unsigned int keySourceId;
+        } irkey, fpkey;
+    } data;
+}IARM_Bus_IRMgr_EventData_t;
+
+/*
+ * Declare RPC API names and their arguments
+ */
+#define IARM_BUS_IRMGR_API_SetRepeatInterval 		"SetRepeatInterval" /*!< Set the repeat key event interval*/
+
+/*! Declare Argument Data structure for SetRepeatInterval */
+typedef struct _IARM_Bus_IRMgr_SetRepeatInterval_Param_t {
+    unsigned int timeout;           /*!< Repeat key interval timeout*/
+} IARM_Bus_IRMgr_SetRepeatInterval_Param_t;
+
+#define IARM_BUS_IRMGR_API_GetRepeatInterval 		"GetRepeatInterval" /*!< Retrives the current repeat interval*/
+
+/*! Declare Argument Data structure for GetRepeatInterval */
+typedef struct _IARM_Bus_IRMgr_GetRepeatInterval_Param_t {
+	unsigned int timeout;          /*!< Repeat key interval timeout value retrived*/
+} IARM_Bus_IRMgr_GetRepeatInterval_Param_t;
+
+/* comcastIrKeyCodes */
+#define DELAY_REPEAT_MASK       0x00000001
+#define LANGUAGE_MASK           0x00000010
+#define MISSED_KEY_TIMEOUT_MASK 0x00000100
+#define REPEAT_KEY_ENABLED_MASK 0x00001000
+#define REPEAT_FREQUENCY_MASK   0x00010000
+#define REPORT_MODIFIERS_MASK   0x00100000
+#define NUM_OF_DEVICES_MASK     0x01000000
+
+
+#define KET_KEYDOWN 		0x00008000UL
+#define KET_KEYUP   		0x00008100UL
+#define KET_KEYREPEAT		0x00008200UL
+
+//Numeric keys (common in Remote and Key Board)
+//Combination of Key + device type (HID_DEVICES) is unique.
+#define KED_DIGIT0		    0x00000030UL
+#define KED_DIGIT1		    0x00000031UL
+#define KED_DIGIT2		    0x00000032UL
+#define KED_DIGIT3		    0x00000033UL
+#define KED_DIGIT4		    0x00000034UL
+#define KED_DIGIT5		    0x00000035UL
+#define KED_DIGIT6		    0x00000036UL
+#define KED_DIGIT7		    0x00000037UL
+#define KED_DIGIT8		    0x00000038UL
+#define KED_DIGIT9		    0x00000039UL
+#define KED_PERIOD		    0x00000040UL
+
+#define KED_DISCRETE_POWER_ON       0x00000050UL
+#define KED_DISCRETE_POWER_STANDBY  0x00000051UL
+
+#define KED_SEARCH          0x000000CFUL
+#define KED_SETUP           0x00000052UL
+
+#define KED_CLOSED_CAPTIONING       0x00000060UL
+#define KED_LANGUAGE                0x00000061UL
+#define KED_VOICE_GUIDANCE          0x00000062UL
+#define KED_HEARTBEAT               0x00000063UL
+#define KED_PUSH_TO_TALK            0x00000064UL
+#define KED_DESCRIPTIVE_AUDIO       0x00000065UL
+#define KED_VOLUME_OPTIMIZE         0x00000066UL
+#define KED_XR2V3                   0x00000067UL
+#define KED_XR5V2                   0x00000068UL
+#define KED_XR11V1                  0x00000069UL
+#define KED_XR11V2                  0x0000006AUL
+#define KED_XR13                    0x0000006BUL
+#define KED_XR11_NOTIFY             0x0000006CUL
+
+#define KED_XR15V1_NOTIFY           0x00000070UL
+#define KED_XR15V1_SELECT           0x00000071UL
+#define KED_XR15V1_PUSH_TO_TALK     0x00000072UL
+
+#define KED_SCREEN_BIND_NOTIFY      0x00000073UL
+
+#define KED_XR16V1_NOTIFY           0x00000074UL
+#define KED_XR16V1_SELECT           0x00000075UL
+#define KED_XR16V1_PUSH_TO_TALK     0x00000076UL
+
+#define KED_RF_POWER        0x0000007FUL
+#define KED_POWER           0x00000080UL
+#define KED_FP_POWER        KED_POWER
+#define KED_ARROWUP         0x00000081UL
+#define KED_ARROWDOWN       0x00000082UL
+#define KED_ARROWLEFT       0x00000083UL
+#define KED_ARROWRIGHT      0x00000084UL
+#define KED_SELECT          0x00000085UL
+#define KED_ENTER           0x00000086UL
+#define KED_EXIT            0x00000087UL
+#define KED_CHANNELUP       0x00000088UL
+#define KED_CHANNELDOWN     0x00000089UL
+#define KED_VOLUMEUP        0x0000008AUL
+#define KED_VOLUMEDOWN      0x0000008BUL
+#define KED_MUTE            0x0000008CUL
+#define KED_GUIDE           0x0000008DUL
+#define KED_VIEWINGGUIDE    KED_GUIDE
+#define KED_INFO            0x0000008EUL
+#define KED_SETTINGS        0x0000008FUL
+#define KED_PAGEUP          0x00000090UL
+#define KED_PAGEDOWN        0x00000091UL
+#define KED_KEYA            0x00000092UL
+#define KED_KEYB            0x00000093UL
+#define KED_KEYC            0x00000094UL
+#define KED_KEYD            0x0000009FUL
+#define KED_KEY_RED_CIRCLE      KED_KEYC //Host2.1 Sec 7.2
+#define KED_KEY_GREEN_DIAMOND   KED_KEYD //Host2.1 Sec 7.2
+#define KED_KEY_BLUE_SQUARE     KED_KEYB //Host2.1 Sec 7.2
+#define KED_KEY_YELLOW_TRIANGLE KED_KEYA //Host2.1 Sec 7.2
+#define KED_LAST            0x00000095UL
+#define KED_FAVORITE        0x00000096UL
+#define KED_REWIND          0x00000097UL
+#define KED_FASTFORWARD     0x00000098UL
+#define KED_PLAY            0x00000099UL
+#define KED_STOP            0x0000009AUL
+#define KED_PAUSE           0x0000009BUL
+#define KED_RECORD          0x0000009CUL
+#define KED_BYPASS          0x0000009DUL
+#define KED_TVVCR           0x0000009EUL
+
+#define KED_REPLAY               0x000000A0UL
+#define KED_HELP                 0x000000A1UL
+#define KED_RECALL_FAVORITE_0    0x000000A2UL
+#define KED_CLEAR                0x000000A3UL
+#define KED_DELETE               0x000000A4UL
+#define KED_START                0x000000A5UL
+#define KED_POUND                0x000000A6UL
+#define KED_FRONTPANEL1          0x000000A7UL
+#define KED_FRONTPANEL2          0x000000A8UL
+#define KED_OK                   0x000000A9UL
+#define KED_STAR                 0x000000AAUL
+#define KED_PROGRAM              0x000000ABUL
+
+#define KED_TVPOWER                0x000000C1UL	// Alt remote
+#define KED_PREVIOUS               0x000000C3UL	// Alt remote
+#define KED_NEXT                   0x000000C4UL	// Alt remote
+#define KED_MENU                   0x000000C0UL	// Alt remote
+#define KED_INPUTKEY               0x000000D0UL	//
+#define KED_LIVE                   0x000000D1UL	//
+#define KED_MYDVR                  0x000000D2UL	//
+#define KED_ONDEMAND               0x000000D3UL	//
+#define KED_STB_MENU               0x000000D4UL    //
+#define KED_AUDIO                  0x000000D5UL    //
+#define KED_FACTORY                0x000000D6UL    //
+#define KED_RFENABLE               0x000000D7UL    //
+#define KED_LIST                   0x000000D8UL
+#define KED_RF_PAIR_GHOST          0x000000EFUL	// Ghost code to implement auto pairing in RF remotes
+#define KED_WPS                    0x000000F0UL    // Key to initiate WiFi WPS pairing
+#define KED_DEEPSLEEP_WAKEUP       0x000000F1UL    // Key to initiate deepsleep wakeup
+#define KED_NEW_BATTERIES_INSERTED 0x000000F2UL // Signals a battery set was replaced
+#define KED_GRACEFUL_SHUTDOWN      0x000000F3UL // Signals an external power supply device is shutting down
+#define KED_UNDEFINEDKEY           0x000000FEUL	// Use for keys not defined here.  Pass raw code as well.
+
+
+#define KED_BACK            0x100000FEUL
+#define KED_DISPLAY_SWAP    0x300000FEUL
+#define KED_PINP_MOVE       0x400000FEUL
+#define KED_PINP_TOGGLE     0x500000FEUL
+#define KED_PINP_CHDOWN     0x600000FEUL
+#define KED_PINP_CHUP       0x700000FEUL
+#define KED_DMC_ACTIVATE    0x800000FEUL
+#define KED_DMC_DEACTIVATE  0x900000FEUL
+#define KED_DMC_QUERY       0xA00000FEUL
+#define KED_OTR_START       0xB00000FEUL
+#define KED_OTR_STOP        0xC00000FEUL

--- a/Tests/tests/test_ControlService.cpp
+++ b/Tests/tests/test_ControlService.cpp
@@ -1,0 +1,1031 @@
+/**
+ * If not stated otherwise in this file or this component's LICENSE
+ * file the following copyright and licenses apply:
+ *
+ * Copyright 2022 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+#include "gtest/gtest.h"
+#include "FactoriesImplementation.h"
+#include "ControlService.h"
+
+#include "IarmBusMock.h"
+#include "ServiceMock.h"
+
+using namespace WPEFramework;
+using ::testing::NiceMock;
+using ::testing::_;
+using ::testing::Invoke;
+using ::testing::Test;
+using ::testing::StrEq;
+using ::testing::Gt;
+using ::testing::AssertionResult;
+using ::testing::AssertionSuccess;
+using ::testing::AssertionFailure;
+
+class ControlServiceTest : public Test {
+protected:
+    Core::ProxyType<Plugin::ControlService> plugin_;
+    Core::JSONRPC::Handler&                 handler_;
+    Core::JSONRPC::Connection               connection_;
+    string                                  response_;
+    NiceMock<IarmBusImplMock>               iarmBusImplMock_;
+
+    ControlServiceTest()
+        : plugin_(Core::ProxyType<Plugin::ControlService>::Create())
+        , handler_(*plugin_)
+        , connection_(1, 0)
+    {
+        IarmBus::getInstance().impl = &iarmBusImplMock_;
+    }
+
+    virtual ~ControlServiceTest() override
+    {
+        IarmBus::getInstance().impl = nullptr;
+    }
+};
+
+static AssertionResult isValidCtrlmRcuIarmEvent(IARM_EventId_t ctrlmRcuIarmEventId)
+{
+    switch (ctrlmRcuIarmEventId) {
+        case CTRLM_RCU_IARM_EVENT_KEY_GHOST:
+        case CTRLM_RCU_IARM_EVENT_VALIDATION_BEGIN:
+        case CTRLM_RCU_IARM_EVENT_VALIDATION_KEY_PRESS:
+        case CTRLM_RCU_IARM_EVENT_VALIDATION_END:
+        case CTRLM_RCU_IARM_EVENT_CONFIGURATION_COMPLETE:
+        case CTRLM_RCU_IARM_EVENT_BATTERY_MILESTONE:
+        case CTRLM_RCU_IARM_EVENT_REMOTE_REBOOT:
+        case CTRLM_RCU_IARM_EVENT_RCU_REVERSE_CMD_END:
+        case CTRLM_RCU_IARM_EVENT_CONTROL:
+            return AssertionSuccess();
+        default:
+            return AssertionFailure();
+    }
+}
+
+class ControlServiceInitializedEventTest : public ControlServiceTest {
+protected:
+    IARM_EventHandler_t               controlEventHandler_;
+    NiceMock<ServiceMock>             service_;
+    NiceMock<FactoriesImplementation> factoriesImplementation_;
+    Core::JSONRPC::Message            message_;
+    PluginHost::IDispatcher*          dispatcher_;
+
+    ControlServiceInitializedEventTest() :
+        ControlServiceTest()
+    {
+        EXPECT_CALL(iarmBusImplMock_, IARM_Bus_RegisterEventHandler(StrEq(IARM_BUS_IRMGR_NAME),IARM_BUS_IRMGR_EVENT_IRKEY, _))
+            .WillOnce(Invoke(
+                [&](const char* ownerName, IARM_EventId_t eventId, IARM_EventHandler_t handler) {
+                    controlEventHandler_ = handler;
+                    return IARM_RESULT_SUCCESS;
+                }));
+        EXPECT_CALL(iarmBusImplMock_, IARM_Bus_RegisterEventHandler(StrEq(CTRLM_MAIN_IARM_BUS_NAME), _, _))
+            .WillRepeatedly(Invoke(
+                [&](const char* ownerName, IARM_EventId_t eventId, IARM_EventHandler_t handler) {
+                    EXPECT_TRUE(isValidCtrlmRcuIarmEvent(eventId));
+                    controlEventHandler_ = handler;
+                    return IARM_RESULT_SUCCESS;
+                }));
+
+        EXPECT_EQ(string(""), plugin_->Initialize(nullptr));
+        PluginHost::IFactories::Assign(&factoriesImplementation_);
+        dispatcher_ = static_cast<PluginHost::IDispatcher*>(plugin_->QueryInterface(PluginHost::IDispatcher::ID));
+        dispatcher_->Activate(&service_);
+    }
+
+    virtual ~ControlServiceInitializedEventTest() override
+    {
+        plugin_->Deinitialize(nullptr);
+        dispatcher_->Deactivate();
+        dispatcher_->Release();
+        PluginHost::IFactories::Assign(nullptr);
+    }
+};
+
+TEST_F(ControlServiceTest, RegisteredMethods)
+{
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Exists(_T("getQuirks")));
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Exists(_T("getAllRemoteData")));
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Exists(_T("getSingleRemoteData")));
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Exists(_T("getLastKeypressSource")));
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Exists(_T("getLastPairedRemoteData")));
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Exists(_T("setValues")));
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Exists(_T("getValues")));
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Exists(_T("startPairingMode")));
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Exists(_T("endPairingMode")));
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Exists(_T("canFindMyRemote")));
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Exists(_T("findLastUsedRemote")));
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Exists(_T("checkRf4ceChipConnectivity")));
+}
+
+TEST_F(ControlServiceTest, getQuirks)
+{
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Invoke(connection_, _T("getQuirks"), _T("{}"), response_));
+    EXPECT_EQ(response_, "{\"quirks\":[\"DELIA-43686\",\"RDK-28767\",\"RDK-31263\",\"RDK-32347\"],\"success\":true}");
+}
+
+TEST_F(ControlServiceTest, getAllRemoteData)
+{
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_MAIN_IARM_CALL_STATUS_GET), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_main_iarm_call_status_t*>(arg);
+                memset(param, 0, sizeof(ctrlm_main_iarm_call_status_t));
+
+                param->network_qty      = CTRLM_MAIN_MAX_NETWORKS;
+                param->networks[0].id   = 1;
+                param->networks[0].type = CTRLM_NETWORK_TYPE_RF4CE;
+                return IARM_RESULT_SUCCESS;
+            }));
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_MAIN_IARM_CALL_NETWORK_STATUS_GET), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_main_iarm_call_network_status_t*>(arg);
+                memset(param, 0, sizeof(ctrlm_main_iarm_call_network_status_t));
+
+                sprintf(param->status.rf4ce.version_hal,  "%s", "GPv2.6.3.514598");
+                sprintf(param->status.rf4ce.chipset,      "%s", "GP502KXBG");
+
+                param->status.rf4ce.ieee_address             = (uint64_t) 0x00155F00205E1789;
+                param->status.rf4ce.controller_qty           = 1;
+                param->status.rf4ce.pan_id                   = 25684;
+                param->status.rf4ce.rf_channel_active.number = 25;
+                param->status.rf4ce.short_address            = 64253;
+                return IARM_RESULT_SUCCESS;
+            }));
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_MAIN_IARM_CALL_PAIRING_METRICS_GET), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_main_iarm_call_pairing_metrics_t*>(arg);
+                memset(param, 0, sizeof(ctrlm_main_iarm_call_pairing_metrics_t));
+
+                sprintf(param->last_non_screenbind_remote_type, "%s", "...");
+                sprintf(param->last_screenbind_remote_type,     "%s", "...");
+
+                param->num_screenbind_failures                = 1;
+                param->last_screenbind_error_timestamp        = 1589356931;
+                param->last_screenbind_error_code             = CTRLM_BIND_STATUS_NO_DISCOVERY_REQUEST;
+                param->num_non_screenbind_failures            = 3;
+                param->last_non_screenbind_error_timestamp    = 1589359161;
+                param->last_non_screenbind_error_code         = CTRLM_BIND_STATUS_NO_PAIRING_REQUEST;
+                param->last_non_screenbind_error_binding_type = 2;
+                return IARM_RESULT_SUCCESS;
+            }));
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_MAIN_IARM_CALL_IR_REMOTE_USAGE_GET), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_main_iarm_call_ir_remote_usage_t*>(arg);
+                memset(param, 0, sizeof(ctrlm_main_iarm_call_ir_remote_usage_t));
+
+                param->result = CTRLM_IARM_CALL_RESULT_SUCCESS;
+                return IARM_RESULT_SUCCESS;
+            }));
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_RCU_IARM_CALL_CONTROLLER_STATUS), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_rcu_iarm_call_controller_status_t*>(arg);
+                memset(param, 0, sizeof(ctrlm_rcu_iarm_call_controller_status_t));
+
+                sprintf(param->status.type,                   "%s", "XR15-2");
+                sprintf(param->status.ir_db_code_tv,          "%s", "12371");
+                sprintf(param->status.ir_db_code_avr,         "%s", "31360");
+                sprintf(param->status.manufacturer,           "%s", "RS");
+                sprintf(param->status.chipset,                "%s", "QORVO");
+                sprintf(param->status.version_software,       "%s", "2.0.1.2");
+                sprintf(param->status.version_hardware,       "%s", "2.3.1.0");
+                sprintf(param->status.version_irdb,           "%s", "4.3.2.0");
+                sprintf(param->status.irdb_entry_id_name_tv,  "%s", "...");
+                sprintf(param->status.irdb_entry_id_name_avr, "%s", "...");
+
+                param->controller_id                                               = 1;
+                param->status.ieee_address                                         = (uint64_t) 0x00155F011C7F7359;
+                param->status.short_address                                        = 0;
+                param->status.time_binding                                         = 1538782229;
+                param->status.binding_type                                         = CTRLM_RCU_BINDING_TYPE_SCREEN_BIND;
+                param->status.validation_type                                      = CTRLM_RCU_VALIDATION_TYPE_SCREEN_BIND;
+                param->status.security_type                                        = CTRLM_RCU_BINDING_SECURITY_TYPE_NORMAL;
+                param->status.command_count                                        = 0;
+                param->status.last_key_code                                        = CTRLM_KEY_CODE_OK;
+                param->status.last_key_status                                      = CTRLM_KEY_STATUS_UP;
+                param->status.link_quality_percent                                 = 0;
+                param->status.link_quality                                         = 0;
+                param->status.firmware_updated                                     = 1;
+                param->status.has_battery                                          = 0;
+                param->status.battery_level_percent                                = 60;
+                param->status.battery_voltage_loaded                               = 2.61908;
+                param->status.battery_voltage_unloaded                             = 0.0;
+                param->status.time_last_key                                        = 1580263335;
+                param->status.time_battery_update                                  = 1602879639;
+                param->status.time_battery_changed                                 = 1641294389;
+                param->status.battery_changed_actual_percentage                    = 64;
+                param->status.battery_changed_unloaded_voltage                     = 2.729412;
+                param->status.time_battery_75_percent                              = 1641294389;
+                param->status.battery_75_percent_actual_percentage                 = 64;
+                param->status.battery_75_percent_unloaded_voltage                  = 2.729412;
+                param->status.time_battery_50_percent                              = 0;
+                param->status.battery_50_percent_actual_percentage                 = 0;
+                param->status.battery_50_percent_unloaded_voltage                  = 0;
+                param->status.time_battery_25_percent                              = 0;
+                param->status.battery_25_percent_actual_percentage                 = 0;
+                param->status.battery_25_percent_unloaded_voltage                  = 0;
+                param->status.time_battery_5_percent                               = 0;
+                param->status.battery_5_percent_actual_percentage                  = 0;
+                param->status.battery_5_percent_unloaded_voltage                   = 0;
+                param->status.time_battery_0_percent                               = 0;
+                param->status.battery_0_percent_actual_percentage                  = 0;
+                param->status.battery_0_percent_unloaded_voltage                   = 0;
+                param->status.battery_event                                        = CTRLM_RCU_BATTERY_EVENT_NONE;
+                param->status.time_battery_event                                   = 0;
+                param->status.ir_db_type                                           = CTRLM_RCU_IR_DB_TYPE_UEI;
+                param->status.ir_db_state                                          = CTRLM_RCU_IR_DB_STATE_TV_AVR_CODES;
+                param->status.voice_cmd_count_today                                = 0;
+                param->status.voice_cmd_count_yesterday                            = 0;
+                param->status.voice_cmd_short_today                                = 0;
+                param->status.voice_cmd_short_yesterday                            = 0;
+                param->status.voice_packets_sent_today                             = 0;
+                param->status.voice_packets_sent_yesterday                         = 0;
+                param->status.voice_packets_lost_today                             = 0;
+                param->status.voice_packets_lost_yesterday                         = 0;
+                param->status.voice_packet_loss_average_today                      = 0;
+                param->status.voice_packet_loss_average_yesterday                  = 0;
+                param->status.utterances_exceeding_packet_loss_threshold_today     = 0;
+                param->status.utterances_exceeding_packet_loss_threshold_yesterday = 0;
+                param->status.checkin_for_device_update                            = 1;
+                param->status.ir_db_code_download_supported                        = 1;
+                param->status.has_dsp                                              = 0;
+                param->status.average_time_in_privacy_mode                         = 0;
+                param->status.in_privacy_mode                                      = 0;
+                param->status.average_snr                                          = 0;
+                param->status.average_keyword_confidence                           = 0;
+                param->status.total_number_of_mics_working                         = 0;
+                param->status.total_number_of_speakers_working                     = 0;
+                param->status.end_of_speech_initial_timeout_count                  = 0;
+                param->status.end_of_speech_timeout_count                          = 0;
+                param->status.time_uptime_start                                    = 1641460244;
+                param->status.uptime_seconds                                       = 0;
+                param->status.privacy_time_seconds                                 = 0;
+                param->status.reboot_reason                                        = 0;
+                param->status.reboot_voltage                                       = 0;
+                param->status.reboot_assert_number                                 = 0;
+                param->status.reboot_timestamp                                     = 12342;
+                param->status.time_last_heartbeat                                  = 0;
+                param->status.battery_voltage_large_jump_counter                   = 0;
+                param->status.battery_voltage_large_decline_detected               = 0;
+                return IARM_RESULT_SUCCESS;
+            }));
+
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Invoke(connection_, _T("getAllRemoteData"), _T("{}"), response_));
+    EXPECT_EQ(response_, "{\"stbRf4ceMACAddress\":\"0x00155F00205E1789\","
+                         "\"stbRf4ceSocMfr\":\"GP502KXBG\","
+                         "\"stbHALVersion\":\"GPv2.6.3.514598\","
+                         "\"stbRf4ceShortAddress\":64253,"
+                         "\"stbPanId\":25684,"
+                         "\"stbActiveChannel\":25,"
+                         "\"stbNumPairedRemotes\":1,"
+                         "\"stbNumScreenBindFailures\":1,"
+                         "\"stbLastScreenBindErrorCode\":1,"
+                         "\"stbLastScreenBindErrorRemoteType\":\"...\","
+                         "\"stbLastScreenBindErrorTimestamp\":1589356931000,"
+                         "\"stbNumOtherBindFailures\":3,"
+                         "\"stbLastOtherBindErrorCode\":2,"
+                         "\"stbLastOtherBindErrorRemoteType\":\"...\","
+                         "\"stbLastOtherBindErrorBindType\":2,"
+                         "\"stbLastOtherBindErrorTimestamp\":1589359161000,"
+                         "\"bHasIrRemotePreviousDay\":false,"
+                         "\"bHasIrRemoteCurrentDay\":false,"
+                         "\"remoteData\":[{\"remoteId\":1,"
+                         "\"remoteMACAddress\":\"0x00155F011C7F7359\","
+                         "\"remoteModel\":\"XR15\","
+                         "\"remoteModelVersion\":\"v2\","
+                         "\"howRemoteIsPaired\":\"screen-bind\","
+                         "\"pairingTimestamp\":1538782229000,"
+                         "\"batteryLevelLoaded\":\"2.619080\","
+                         "\"batteryLevelUnloaded\":\"0.000000\","
+                         "\"batteryLevelPercentage\":60,"
+                         "\"batteryLastEvent\":0,"
+                         "\"batteryLastEventTimestamp\":1602879639000,"
+                         "\"numVoiceCommandsPreviousDay\":0,"
+                         "\"numVoiceCommandsCurrentDay\":0,"
+                         "\"numVoiceShortUtterancesPreviousDay\":0,"
+                         "\"numVoiceShortUtterancesCurrentDay\":0,"
+                         "\"numVoicePacketsSentPreviousDay\":0,"
+                         "\"numVoicePacketsSentCurrentDay\":0,"
+                         "\"numVoicePacketsLostPreviousDay\":0,"
+                         "\"numVoicePacketsLostCurrentDay\":0,"
+                         "\"aveVoicePacketLossPreviousDay\":\"0.000000\","
+                         "\"aveVoicePacketLossCurrentDay\":\"0.000000\","
+                         "\"numVoiceCmdsHighLossPreviousDay\":0,"
+                         "\"numVoiceCmdsHighLossCurrentDay\":0,"
+                         "\"lastRebootErrorCode\":0,"
+                         "\"lastRebootTimestamp\":12342000,"
+                         "\"versionInfoSw\":\"2.0.1.2\","
+                         "\"versionInfoHw\":\"2.3.1.0\","
+                         "\"versionInfoIrdb\":\"4.3.2.0\","
+                         "\"irdbType\":0,\"irdbState\":3,"
+                         "\"programmedTvIRCode\":\"12371\","
+                         "\"programmedAvrIRCode\":\"31360\","
+                         "\"bHasRemoteBeenUpdated\":true,"
+                         "\"lastCommandTimeDate\":1580263335000,"
+                         "\"rf4ceRemoteSocMfr\":\"QORVO\","
+                         "\"remoteMfr\":\"RS\","
+                         "\"signalStrengthPercentage\":0,"
+                         "\"linkQuality\":0,\"bHasCheckedIn\":true,"
+                         "\"bIrdbDownloadSupported\":true,"
+                         "\"securityType\":0,\"bHasBattery\":false,"
+                         "\"bHasDSP\":false}],"
+                         "\"status_code\":0,\"success\":true}");
+}
+
+TEST_F(ControlServiceTest, getSingleRemoteData)
+{
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_MAIN_IARM_CALL_STATUS_GET), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_main_iarm_call_status_t*>(arg);
+                memset(param, 0, sizeof(ctrlm_main_iarm_call_status_t));
+
+                param->network_qty      = CTRLM_MAIN_MAX_NETWORKS;
+                param->networks[0].id   = 1;
+                param->networks[0].type = CTRLM_NETWORK_TYPE_RF4CE;
+                return IARM_RESULT_SUCCESS;
+            }));
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_MAIN_IARM_CALL_NETWORK_STATUS_GET), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_main_iarm_call_network_status_t*>(arg);
+                memset(param, 0, sizeof(ctrlm_main_iarm_call_network_status_t));
+
+                param->status.rf4ce.controller_qty = 1;
+                return IARM_RESULT_SUCCESS;
+            }));
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_RCU_IARM_CALL_CONTROLLER_STATUS), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_rcu_iarm_call_controller_status_t*>(arg);
+                memset(param, 0, sizeof(ctrlm_rcu_iarm_call_controller_status_t));
+
+                sprintf(param->status.type,                   "%s", "XR15-2");
+                sprintf(param->status.ir_db_code_tv,          "%s", "12371");
+                sprintf(param->status.ir_db_code_avr,         "%s", "31360");
+                sprintf(param->status.manufacturer,           "%s", "RS");
+                sprintf(param->status.chipset,                "%s", "QORVO");
+                sprintf(param->status.version_software,       "%s", "2.0.1.2");
+                sprintf(param->status.version_hardware,       "%s", "2.3.1.0");
+                sprintf(param->status.version_irdb,           "%s", "4.3.2.0");
+                sprintf(param->status.irdb_entry_id_name_tv,  "%s", "...");
+                sprintf(param->status.irdb_entry_id_name_avr, "%s", "...");
+
+                param->controller_id                                               = 1;
+                param->status.ieee_address                                         = (uint64_t) 0x00155F011C7F7359;
+                param->status.short_address                                        = 0;
+                param->status.time_binding                                         = 1538782229;
+                param->status.binding_type                                         = CTRLM_RCU_BINDING_TYPE_SCREEN_BIND;
+                param->status.validation_type                                      = CTRLM_RCU_VALIDATION_TYPE_SCREEN_BIND;
+                param->status.security_type                                        = CTRLM_RCU_BINDING_SECURITY_TYPE_NORMAL;
+                param->status.command_count                                        = 0;
+                param->status.last_key_code                                        = CTRLM_KEY_CODE_OK;
+                param->status.last_key_status                                      = CTRLM_KEY_STATUS_UP;
+                param->status.link_quality_percent                                 = 0;
+                param->status.link_quality                                         = 0;
+                param->status.firmware_updated                                     = 1;
+                param->status.has_battery                                          = 0;
+                param->status.battery_level_percent                                = 60;
+                param->status.battery_voltage_loaded                               = 2.61908;
+                param->status.battery_voltage_unloaded                             = 0.0;
+                param->status.time_last_key                                        = 1580263335;
+                param->status.time_battery_update                                  = 1602879639;
+                param->status.time_battery_changed                                 = 1641294389;
+                param->status.battery_changed_actual_percentage                    = 64;
+                param->status.battery_changed_unloaded_voltage                     = 2.729412;
+                param->status.time_battery_75_percent                              = 1641294389;
+                param->status.battery_75_percent_actual_percentage                 = 64;
+                param->status.battery_75_percent_unloaded_voltage                  = 2.729412;
+                param->status.time_battery_50_percent                              = 0;
+                param->status.battery_50_percent_actual_percentage                 = 0;
+                param->status.battery_50_percent_unloaded_voltage                  = 0;
+                param->status.time_battery_25_percent                              = 0;
+                param->status.battery_25_percent_actual_percentage                 = 0;
+                param->status.battery_25_percent_unloaded_voltage                  = 0;
+                param->status.time_battery_5_percent                               = 0;
+                param->status.battery_5_percent_actual_percentage                  = 0;
+                param->status.battery_5_percent_unloaded_voltage                   = 0;
+                param->status.time_battery_0_percent                               = 0;
+                param->status.battery_0_percent_actual_percentage                  = 0;
+                param->status.battery_0_percent_unloaded_voltage                   = 0;
+                param->status.battery_event                                        = CTRLM_RCU_BATTERY_EVENT_NONE;
+                param->status.time_battery_event                                   = 0;
+                param->status.ir_db_type                                           = CTRLM_RCU_IR_DB_TYPE_UEI;
+                param->status.ir_db_state                                          = CTRLM_RCU_IR_DB_STATE_TV_AVR_CODES;
+                param->status.voice_cmd_count_today                                = 0;
+                param->status.voice_cmd_count_yesterday                            = 0;
+                param->status.voice_cmd_short_today                                = 0;
+                param->status.voice_cmd_short_yesterday                            = 0;
+                param->status.voice_packets_sent_today                             = 0;
+                param->status.voice_packets_sent_yesterday                         = 0;
+                param->status.voice_packets_lost_today                             = 0;
+                param->status.voice_packets_lost_yesterday                         = 0;
+                param->status.voice_packet_loss_average_today                      = 0;
+                param->status.voice_packet_loss_average_yesterday                  = 0;
+                param->status.utterances_exceeding_packet_loss_threshold_today     = 0;
+                param->status.utterances_exceeding_packet_loss_threshold_yesterday = 0;
+                param->status.checkin_for_device_update                            = 1;
+                param->status.ir_db_code_download_supported                        = 1;
+                param->status.has_dsp                                              = 0;
+                param->status.average_time_in_privacy_mode                         = 0;
+                param->status.in_privacy_mode                                      = 0;
+                param->status.average_snr                                          = 0;
+                param->status.average_keyword_confidence                           = 0;
+                param->status.total_number_of_mics_working                         = 0;
+                param->status.total_number_of_speakers_working                     = 0;
+                param->status.end_of_speech_initial_timeout_count                  = 0;
+                param->status.end_of_speech_timeout_count                          = 0;
+                param->status.time_uptime_start                                    = 1641460244;
+                param->status.uptime_seconds                                       = 0;
+                param->status.privacy_time_seconds                                 = 0;
+                param->status.reboot_reason                                        = 0;
+                param->status.reboot_voltage                                       = 0;
+                param->status.reboot_assert_number                                 = 0;
+                param->status.reboot_timestamp                                     = 12342;
+                param->status.time_last_heartbeat                                  = 0;
+                param->status.battery_voltage_large_jump_counter                   = 0;
+                param->status.battery_voltage_large_decline_detected               = 0;
+                return IARM_RESULT_SUCCESS;
+            }));
+
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Invoke(connection_, _T("getSingleRemoteData"), "{\"remoteId\":1}", response_));
+    EXPECT_EQ(response_, "{\"remoteData\":{\"remoteId\":1,"
+                         "\"remoteMACAddress\":\"0x00155F011C7F7359\","
+                         "\"remoteModel\":\"XR15\","
+                         "\"remoteModelVersion\":\"v2\","
+                         "\"howRemoteIsPaired\":\"screen-bind\","
+                         "\"pairingTimestamp\":1538782229000,"
+                         "\"batteryLevelLoaded\":\"2.619080\","
+                         "\"batteryLevelUnloaded\":\"0.000000\","
+                         "\"batteryLevelPercentage\":60,"
+                         "\"batteryLastEvent\":0,"
+                         "\"batteryLastEventTimestamp\":1602879639000,"
+                         "\"numVoiceCommandsPreviousDay\":0,"
+                         "\"numVoiceCommandsCurrentDay\":0,"
+                         "\"numVoiceShortUtterancesPreviousDay\":0,"
+                         "\"numVoiceShortUtterancesCurrentDay\":0,"
+                         "\"numVoicePacketsSentPreviousDay\":0,"
+                         "\"numVoicePacketsSentCurrentDay\":0,"
+                         "\"numVoicePacketsLostPreviousDay\":0,"
+                         "\"numVoicePacketsLostCurrentDay\":0,"
+                         "\"aveVoicePacketLossPreviousDay\":\"0.000000\","
+                         "\"aveVoicePacketLossCurrentDay\":\"0.000000\","
+                         "\"numVoiceCmdsHighLossPreviousDay\":0,"
+                         "\"numVoiceCmdsHighLossCurrentDay\":0,"
+                         "\"lastRebootErrorCode\":0,"
+                         "\"lastRebootTimestamp\":12342000,"
+                         "\"versionInfoSw\":\"2.0.1.2\","
+                         "\"versionInfoHw\":\"2.3.1.0\","
+                         "\"versionInfoIrdb\":\"4.3.2.0\","
+                         "\"irdbType\":0,\"irdbState\":3,"
+                         "\"programmedTvIRCode\":\"12371\","
+                         "\"programmedAvrIRCode\":\"31360\","
+                         "\"bHasRemoteBeenUpdated\":true,"
+                         "\"lastCommandTimeDate\":1580263335000,"
+                         "\"rf4ceRemoteSocMfr\":\"QORVO\","
+                         "\"remoteMfr\":\"RS\","
+                         "\"signalStrengthPercentage\":0,"
+                         "\"linkQuality\":0,\"bHasCheckedIn\":true,"
+                         "\"bIrdbDownloadSupported\":true,"
+                         "\"securityType\":0,\"bHasBattery\":false,"
+                         "\"bHasDSP\":false},"
+                         "\"status_code\":0,\"success\":true}");
+}
+
+TEST_F(ControlServiceTest, getLastKeypressSource)
+{
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_MAIN_IARM_CALL_LAST_KEY_INFO_GET), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_main_iarm_call_last_key_info_t*>(arg);
+                memset(param, 0, sizeof(ctrlm_main_iarm_call_last_key_info_t));
+
+                sprintf(param->source_name, "%s", "XR15-10");
+
+                param->result               = CTRLM_IARM_CALL_RESULT_SUCCESS;
+                param->controller_id        = 1;
+                param->source_type          = IARM_BUS_IRMGR_KEYSRC_RF;
+                param->source_key_code      = 133;
+                param->timestamp            = 1598470622000;
+                param->is_screen_bind_mode  = 1;
+                param->remote_keypad_config = 1;
+
+                return IARM_RESULT_SUCCESS;
+            }));
+
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Invoke(connection_, _T("getLastKeypressSource"), _T("{}"), response_));
+    EXPECT_EQ(response_, "{\"remoteId\":1,\"timestamp\":1598470622000,"
+                         "\"sourceName\":\"XR15-10\",\"sourceType\":\"RF\","
+                         "\"sourceKeyCode\":133,\"bIsScreenBindMode\":true,"
+                         "\"remoteKeypadConfig\":1,\"status_code\":0,"
+                         "\"success\":true}");
+}
+
+TEST_F(ControlServiceTest, getLastPairedRemoteData)
+{
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME),StrEq(CTRLM_MAIN_IARM_CALL_STATUS_GET), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_main_iarm_call_status_t*>(arg);
+                memset(param, 0, sizeof(ctrlm_main_iarm_call_status_t));
+
+                param->network_qty      = CTRLM_MAIN_MAX_NETWORKS;
+                param->networks[0].id   = 1;
+                param->networks[0].type = CTRLM_NETWORK_TYPE_RF4CE;
+                return IARM_RESULT_SUCCESS;
+            }));
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_MAIN_IARM_CALL_NETWORK_STATUS_GET), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_main_iarm_call_network_status_t*>(arg);
+                memset(param, 0, sizeof(ctrlm_main_iarm_call_network_status_t));
+
+                param->status.rf4ce.controller_qty = 1;
+                return IARM_RESULT_SUCCESS;
+            }));
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_RCU_IARM_CALL_CONTROLLER_STATUS), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_rcu_iarm_call_controller_status_t*>(arg);
+                memset(param, 0, sizeof(ctrlm_rcu_iarm_call_controller_status_t));
+
+                sprintf(param->status.type,                   "%s", "XR15-2");
+                sprintf(param->status.ir_db_code_tv,          "%s", "12371");
+                sprintf(param->status.ir_db_code_avr,         "%s", "31360");
+                sprintf(param->status.manufacturer,           "%s", "RS");
+                sprintf(param->status.chipset,                "%s", "QORVO");
+                sprintf(param->status.version_software,       "%s", "2.0.1.2");
+                sprintf(param->status.version_hardware,       "%s", "2.3.1.0");
+                sprintf(param->status.version_irdb,           "%s", "4.3.2.0");
+                sprintf(param->status.irdb_entry_id_name_tv,  "%s", "...");
+                sprintf(param->status.irdb_entry_id_name_avr, "%s", "...");
+
+                param->controller_id                                               = 1;
+                param->status.ieee_address                                         = (uint64_t) 0x00155F011C7F7359;
+                param->status.short_address                                        = 0;
+                param->status.time_binding                                         = 1538782229;
+                param->status.binding_type                                         = CTRLM_RCU_BINDING_TYPE_SCREEN_BIND;
+                param->status.validation_type                                      = CTRLM_RCU_VALIDATION_TYPE_SCREEN_BIND;
+                param->status.security_type                                        = CTRLM_RCU_BINDING_SECURITY_TYPE_NORMAL;
+                param->status.command_count                                        = 0;
+                param->status.last_key_code                                        = CTRLM_KEY_CODE_OK;
+                param->status.last_key_status                                      = CTRLM_KEY_STATUS_UP;
+                param->status.link_quality_percent                                 = 0;
+                param->status.link_quality                                         = 0;
+                param->status.firmware_updated                                     = 1;
+                param->status.has_battery                                          = 0;
+                param->status.battery_level_percent                                = 60;
+                param->status.battery_voltage_loaded                               = 2.61908;
+                param->status.battery_voltage_unloaded                             = 0.0;
+                param->status.time_last_key                                        = 1580263335;
+                param->status.time_battery_update                                  = 1602879639;
+                param->status.time_battery_changed                                 = 1641294389;
+                param->status.battery_changed_actual_percentage                    = 64;
+                param->status.battery_changed_unloaded_voltage                     = 2.729412;
+                param->status.time_battery_75_percent                              = 1641294389;
+                param->status.battery_75_percent_actual_percentage                 = 64;
+                param->status.battery_75_percent_unloaded_voltage                  = 2.729412;
+                param->status.time_battery_50_percent                              = 0;
+                param->status.battery_50_percent_actual_percentage                 = 0;
+                param->status.battery_50_percent_unloaded_voltage                  = 0;
+                param->status.time_battery_25_percent                              = 0;
+                param->status.battery_25_percent_actual_percentage                 = 0;
+                param->status.battery_25_percent_unloaded_voltage                  = 0;
+                param->status.time_battery_5_percent                               = 0;
+                param->status.battery_5_percent_actual_percentage                  = 0;
+                param->status.battery_5_percent_unloaded_voltage                   = 0;
+                param->status.time_battery_0_percent                               = 0;
+                param->status.battery_0_percent_actual_percentage                  = 0;
+                param->status.battery_0_percent_unloaded_voltage                   = 0;
+                param->status.battery_event                                        = CTRLM_RCU_BATTERY_EVENT_NONE;
+                param->status.time_battery_event                                   = 0;
+                param->status.ir_db_type                                           = CTRLM_RCU_IR_DB_TYPE_UEI;
+                param->status.ir_db_state                                          = CTRLM_RCU_IR_DB_STATE_TV_AVR_CODES;
+                param->status.voice_cmd_count_today                                = 0;
+                param->status.voice_cmd_count_yesterday                            = 0;
+                param->status.voice_cmd_short_today                                = 0;
+                param->status.voice_cmd_short_yesterday                            = 0;
+                param->status.voice_packets_sent_today                             = 0;
+                param->status.voice_packets_sent_yesterday                         = 0;
+                param->status.voice_packets_lost_today                             = 0;
+                param->status.voice_packets_lost_yesterday                         = 0;
+                param->status.voice_packet_loss_average_today                      = 0;
+                param->status.voice_packet_loss_average_yesterday                  = 0;
+                param->status.utterances_exceeding_packet_loss_threshold_today     = 0;
+                param->status.utterances_exceeding_packet_loss_threshold_yesterday = 0;
+                param->status.checkin_for_device_update                            = 1;
+                param->status.ir_db_code_download_supported                        = 1;
+                param->status.has_dsp                                              = 0;
+                param->status.average_time_in_privacy_mode                         = 0;
+                param->status.in_privacy_mode                                      = 0;
+                param->status.average_snr                                          = 0;
+                param->status.average_keyword_confidence                           = 0;
+                param->status.total_number_of_mics_working                         = 0;
+                param->status.total_number_of_speakers_working                     = 0;
+                param->status.end_of_speech_initial_timeout_count                  = 0;
+                param->status.end_of_speech_timeout_count                          = 0;
+                param->status.time_uptime_start                                    = 1641460244;
+                param->status.uptime_seconds                                       = 0;
+                param->status.privacy_time_seconds                                 = 0;
+                param->status.reboot_reason                                        = 0;
+                param->status.reboot_voltage                                       = 0;
+                param->status.reboot_assert_number                                 = 0;
+                param->status.reboot_timestamp                                     = 12342;
+                param->status.time_last_heartbeat                                  = 0;
+                param->status.battery_voltage_large_jump_counter                   = 0;
+                param->status.battery_voltage_large_decline_detected               = 0;
+                return IARM_RESULT_SUCCESS;
+            }));
+
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Invoke(connection_, _T("getLastPairedRemoteData"), _T("{}"), response_));
+    EXPECT_EQ(response_, "{\"remoteData\":{\"remoteId\":1,"
+                         "\"remoteMACAddress\":\"0x00155F011C7F7359\","
+                         "\"remoteModel\":\"XR15\","
+                         "\"remoteModelVersion\":\"v2\","
+                         "\"howRemoteIsPaired\":\"screen-bind\","
+                         "\"pairingTimestamp\":1538782229000,"
+                         "\"batteryLevelLoaded\":\"2.619080\","
+                         "\"batteryLevelUnloaded\":\"0.000000\","
+                         "\"batteryLevelPercentage\":60,"
+                         "\"batteryLastEvent\":0,"
+                         "\"batteryLastEventTimestamp\":1602879639000,"
+                         "\"numVoiceCommandsPreviousDay\":0,"
+                         "\"numVoiceCommandsCurrentDay\":0,"
+                         "\"numVoiceShortUtterancesPreviousDay\":0,"
+                         "\"numVoiceShortUtterancesCurrentDay\":0,"
+                         "\"numVoicePacketsSentPreviousDay\":0,"
+                         "\"numVoicePacketsSentCurrentDay\":0,"
+                         "\"numVoicePacketsLostPreviousDay\":0,"
+                         "\"numVoicePacketsLostCurrentDay\":0,"
+                         "\"aveVoicePacketLossPreviousDay\":\"0.000000\","
+                         "\"aveVoicePacketLossCurrentDay\":\"0.000000\","
+                         "\"numVoiceCmdsHighLossPreviousDay\":0,"
+                         "\"numVoiceCmdsHighLossCurrentDay\":0,"
+                         "\"lastRebootErrorCode\":0,"
+                         "\"lastRebootTimestamp\":12342000,"
+                         "\"versionInfoSw\":\"2.0.1.2\","
+                         "\"versionInfoHw\":\"2.3.1.0\","
+                         "\"versionInfoIrdb\":\"4.3.2.0\","
+                         "\"irdbType\":0,\"irdbState\":3,"
+                         "\"programmedTvIRCode\":\"12371\","
+                         "\"programmedAvrIRCode\":\"31360\","
+                         "\"bHasRemoteBeenUpdated\":true,"
+                         "\"lastCommandTimeDate\":1580263335000,"
+                         "\"rf4ceRemoteSocMfr\":\"QORVO\","
+                         "\"remoteMfr\":\"RS\","
+                         "\"signalStrengthPercentage\":0,"
+                         "\"linkQuality\":0,\"bHasCheckedIn\":true,"
+                         "\"bIrdbDownloadSupported\":true,"
+                         "\"securityType\":0,\"bHasBattery\":false,"
+                         "\"bHasDSP\":false},"
+                         "\"status_code\":0,\"success\":true}");
+}
+
+TEST_F(ControlServiceTest, setValues)
+{
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_MAIN_IARM_CALL_CONTROL_SERVICE_SET_VALUES), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_main_iarm_call_control_service_settings_t*>(arg);
+                EXPECT_FALSE(param->asb_enabled);
+                EXPECT_FALSE(param->open_chime_enabled);
+                EXPECT_TRUE(param->close_chime_enabled);
+                EXPECT_TRUE(param->privacy_chime_enabled);
+                EXPECT_EQ(param->conversational_mode, 6);
+                EXPECT_EQ(param->chime_volume, 1);
+                EXPECT_EQ(param->ir_command_repeats, 3);
+                EXPECT_THAT(param->available, Gt(0));
+                param->result = CTRLM_IARM_CALL_RESULT_SUCCESS;
+                return IARM_RESULT_SUCCESS;
+            }));
+
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Invoke(connection_,
+                                _T("setValues"),
+                                _T("{\"enableASB\":false,\"enableOpenChime\":false,"
+                                "\"enableCloseChime\":true,\"enablePrivacyChime\":true,"
+                                "\"conversationalMode\":6,\"chimeVolume\":1,"
+                                "\"irCommandRepeats\":3}"),
+                                response_));
+    EXPECT_EQ(response_, "{\"status_code\":0,\"success\":true}");
+}
+
+TEST_F(ControlServiceTest, getValues)
+{
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_MAIN_IARM_CALL_CONTROL_SERVICE_GET_VALUES), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_main_iarm_call_control_service_settings_t*>(arg);
+                memset(param, 0, sizeof(ctrlm_main_iarm_call_control_service_settings_t));
+
+                param->result                = CTRLM_IARM_CALL_RESULT_SUCCESS;
+                param->available             = 0;
+                param->asb_supported         = 1;
+                param->asb_enabled           = 0;
+                param->open_chime_enabled    = 0;
+                param->close_chime_enabled   = 1;
+                param->privacy_chime_enabled = 1;
+                param->conversational_mode   = 6;
+                param->chime_volume          = CTRLM_CHIME_VOLUME_MEDIUM;
+                param->ir_command_repeats    = 3;
+
+                return IARM_RESULT_SUCCESS;
+            }));
+
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Invoke(connection_, _T("getValues"), _T("{}"), response_));
+    EXPECT_EQ(response_, "{\"supportsASB\":true,\"enableASB\":false,"
+                         "\"enableOpenChime\":false,\"enableCloseChime\":true,"
+                         "\"enablePrivacyChime\":true,\"conversationalMode\":6,"
+                         "\"chimeVolume\":1,\"irCommandRepeats\":3,"
+                         "\"status_code\":0,\"success\":true}");
+}
+
+TEST_F(ControlServiceTest, startPairingMode)
+{
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_MAIN_IARM_CALL_STATUS_GET), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_main_iarm_call_status_t*>(arg);
+                memset(param, 0, sizeof(ctrlm_main_iarm_call_status_t));
+
+                param->network_qty      = CTRLM_MAIN_MAX_NETWORKS;
+                param->networks[0].id   = 1;
+                param->networks[0].type = CTRLM_NETWORK_TYPE_RF4CE;
+                return IARM_RESULT_SUCCESS;
+            }));
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_MAIN_IARM_CALL_CONTROL_SERVICE_START_PAIRING_MODE), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_main_iarm_call_control_service_pairing_mode_t*>(arg);
+                memset(param, 0, sizeof(ctrlm_main_iarm_call_control_service_pairing_mode_t));
+                param->result = CTRLM_IARM_CALL_RESULT_SUCCESS;
+                return IARM_RESULT_SUCCESS;
+            }));
+
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Invoke(connection_, _T("startPairingMode"), "{\"pairingMode\":0,\"restrictPairing\":0}", response_));
+    EXPECT_EQ(response_, "{\"status_code\":0,\"success\":true}");
+}
+
+TEST_F(ControlServiceTest, endPairingMode)
+{
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_MAIN_IARM_CALL_STATUS_GET), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_main_iarm_call_status_t*>(arg);
+                memset(param, 0, sizeof(ctrlm_main_iarm_call_status_t));
+
+                param->network_qty      = CTRLM_MAIN_MAX_NETWORKS;
+                param->networks[0].id   = 1;
+                param->networks[0].type = CTRLM_NETWORK_TYPE_RF4CE;
+                return IARM_RESULT_SUCCESS;
+            }));
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_MAIN_IARM_CALL_CONTROL_SERVICE_END_PAIRING_MODE), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_main_iarm_call_control_service_pairing_mode_t*>(arg);
+                memset(param, 0, sizeof(ctrlm_main_iarm_call_control_service_pairing_mode_t));
+                param->result      = CTRLM_IARM_CALL_RESULT_SUCCESS;
+                param->bind_status = 1;
+                return IARM_RESULT_SUCCESS;
+            }));
+
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Invoke(connection_, _T("endPairingMode"), _T("{}"), response_));
+    EXPECT_EQ(response_, "{\"bindStatus\":1,\"status_code\":0,\"success\":true}");
+}
+
+TEST_F(ControlServiceTest, canFindMyRemote)
+{
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_MAIN_IARM_CALL_CONTROL_SERVICE_CAN_FIND_MY_REMOTE), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_main_iarm_call_control_service_can_find_my_remote_t*>(arg);
+                memset(param, 0, sizeof(ctrlm_main_iarm_call_control_service_can_find_my_remote_t));
+                param->result       = CTRLM_IARM_CALL_RESULT_SUCCESS;
+                param->is_supported = 1;
+                return IARM_RESULT_SUCCESS;
+            }));
+
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Invoke(connection_, _T("canFindMyRemote"), _T("{}"), response_));
+    EXPECT_EQ(response_, "{\"result\":true,\"success\":true}");
+}
+
+TEST_F(ControlServiceTest, findLastUsedRemote)
+{
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_RCU_IARM_CALL_REVERSE_CMD), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_main_iarm_call_rcu_reverse_cmd_t*>(arg);
+                memset(param, 0, sizeof(ctrlm_main_iarm_call_rcu_reverse_cmd_t));
+                param->result     = CTRLM_IARM_CALL_RESULT_SUCCESS;
+                param->cmd_result = CTRLM_RCU_REVERSE_CMD_SUCCESS;
+                return IARM_RESULT_SUCCESS;
+            }));
+
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Invoke(connection_, _T("findLastUsedRemote"), "{\"timeOutPeriod\":20}", response_));
+    EXPECT_EQ(response_, "{\"status_code\":0,\"success\":true}");
+}
+
+TEST_F(ControlServiceTest, checkRf4ceChipConnectivity)
+{
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_MAIN_IARM_CALL_STATUS_GET), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_main_iarm_call_status_t*>(arg);
+                memset(param, 0, sizeof(ctrlm_main_iarm_call_status_t));
+
+                param->network_qty      = CTRLM_MAIN_MAX_NETWORKS;
+                param->networks[0].id   = 1;
+                param->networks[0].type = CTRLM_NETWORK_TYPE_RF4CE;
+                return IARM_RESULT_SUCCESS;
+            }));
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_MAIN_IARM_CALL_CHIP_STATUS_GET), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_main_iarm_call_chip_status_t*>(arg);
+                memset(param, 0, sizeof(ctrlm_main_iarm_call_chip_status_t));
+                param->result         = CTRLM_IARM_CALL_RESULT_SUCCESS;
+                param->chip_connected = 1;
+                return IARM_RESULT_SUCCESS;
+            }));
+
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Invoke(connection_, _T("checkRf4ceChipConnectivity"), _T("{}"), response_));
+    EXPECT_EQ(response_, "{\"rf4ceChipConnected\":1,\"success\":true}");
+}
+
+TEST_F(ControlServiceInitializedEventTest, onControl)
+{
+    EXPECT_CALL(service_, Submit(_, _))
+        .WillOnce(Invoke(
+            [&](const uint32_t, const Core::ProxyType<Core::JSON::IElement>& json) {
+                string text;
+                EXPECT_TRUE(json->ToString(text));
+                EXPECT_EQ(text, string(_T("{\"jsonrpc\":\"2.0\","
+                                          "\"method\":\"org.rdk.ControlService.onControl\","
+                                          "\"params\":{\"remoteId\":-1,\"eventValue\":82,"
+                                          "\"eventSource\":\"IR\",\"eventType\":\"SETUP\","
+                                          "\"eventData\":\"\"}}")));
+                return Core::ERROR_NONE;
+            }));
+
+    IARM_Bus_IRMgr_EventData_t eventData = {0};
+    eventData.data.irkey.keyType         = KET_KEYDOWN;
+    eventData.data.irkey.keyCode         = KED_SETUP;
+    eventData.data.irkey.keySrc          = IARM_BUS_IRMGR_KEYSRC_IR;
+    eventData.data.irkey.keySourceId     = 1;
+
+    handler_.Subscribe(0, _T("onControl"), _T("org.rdk.ControlService"), message_);
+    controlEventHandler_(IARM_BUS_IRMGR_NAME, IARM_BUS_IRMGR_EVENT_IRKEY, &eventData, sizeof(IARM_Bus_IRMgr_EventData_t));
+    handler_.Unsubscribe(0, _T("onControl"), _T("org.rdk.ControlService"), message_);
+}
+
+TEST_F(ControlServiceInitializedEventTest, onXRConfigurationComplete)
+{
+    EXPECT_CALL(service_, Submit(_, _))
+        .Times(1)
+        .WillOnce(Invoke(
+            [&](const uint32_t, const Core::ProxyType<Core::JSON::IElement>& json) {
+                string text;
+                EXPECT_TRUE(json->ToString(text));
+                EXPECT_EQ(text, string(_T("{\"jsonrpc\":\"2.0\","
+                                          "\"method\":\"org.rdk.ControlService.onXRConfigurationComplete\","
+                                          "\"params\":{\"remoteId\":1,\"remoteType\":\"XR11\","
+                                          "\"bindingType\":1,\"configurationStatus\":0}}")));
+                return Core::ERROR_NONE;
+            }));
+
+    ctrlm_rcu_iarm_event_configuration_complete_t eventData = {0};
+    eventData.api_revision  = CTRLM_RCU_IARM_BUS_API_REVISION;
+    eventData.controller_id = 1;
+    eventData.result        = CTRLM_RCU_CONFIGURATION_RESULT_SUCCESS;
+    eventData.binding_type  = CTRLM_RCU_BINDING_TYPE_AUTOMATIC;
+    sprintf(eventData.controller_type, "%s", "XR11");
+
+    handler_.Subscribe(0, _T("onXRConfigurationComplete"), _T("org.rdk.ControlService"), message_);
+    controlEventHandler_(CTRLM_MAIN_IARM_BUS_NAME, CTRLM_RCU_IARM_EVENT_CONFIGURATION_COMPLETE, &eventData, sizeof(ctrlm_rcu_iarm_event_configuration_complete_t));
+    handler_.Unsubscribe(0, _T("onXRConfigurationComplete"), _T("org.rdk.ControlService"), message_);
+}
+
+TEST_F(ControlServiceInitializedEventTest, onXRPairingStart)
+{
+    EXPECT_CALL(service_, Submit(_, _))
+        .Times(1)
+        .WillOnce(Invoke(
+            [&](const uint32_t, const Core::ProxyType<Core::JSON::IElement>& json) {
+                string text;
+                EXPECT_TRUE(json->ToString(text));
+                EXPECT_EQ(text, string(_T("{\"jsonrpc\":\"2.0\","
+                                          "\"method\":\"org.rdk.ControlService.onXRPairingStart\","
+                                          "\"params\":{\"remoteId\":1,\"remoteType\":\"XR11\","
+                                          "\"bindingType\":0,\"validationDigit1\":1,"
+                                          "\"validationDigit2\":3,\"validationDigit3\":5}}")));
+                return Core::ERROR_NONE;
+            }));
+
+    ctrlm_rcu_iarm_event_validation_begin_t eventData = {0};
+    eventData.api_revision       = CTRLM_RCU_IARM_BUS_API_REVISION;
+    eventData.controller_id      = 1;
+    eventData.binding_type       = CTRLM_RCU_BINDING_TYPE_INTERACTIVE;
+    eventData.validation_keys[0] = CTRLM_KEY_CODE_DIGIT_1;
+    eventData.validation_keys[1] = CTRLM_KEY_CODE_DIGIT_3;
+    eventData.validation_keys[2] = CTRLM_KEY_CODE_DIGIT_5;
+    sprintf(eventData.controller_type, "%s", "XR11");
+
+    handler_.Subscribe(0, _T("onXRPairingStart"), _T("org.rdk.ControlService"), message_);
+    controlEventHandler_(CTRLM_MAIN_IARM_BUS_NAME, CTRLM_RCU_IARM_EVENT_VALIDATION_BEGIN, &eventData, sizeof(ctrlm_rcu_iarm_event_validation_begin_t));
+    handler_.Unsubscribe(0, _T("onXRPairingStart"), _T("org.rdk.ControlService"), message_);
+}
+
+TEST_F(ControlServiceInitializedEventTest, onXRValidationComplete)
+{
+    EXPECT_CALL(service_, Submit(_, _))
+        .Times(1)
+        .WillOnce(Invoke(
+            [&](const uint32_t, const Core::ProxyType<Core::JSON::IElement>& json) {
+                string text;
+                EXPECT_TRUE(json->ToString(text));
+                EXPECT_EQ(text, string(_T("{\"jsonrpc\":\"2.0\","
+                                          "\"method\":\"org.rdk.ControlService.onXRValidationComplete\","
+                                          "\"params\":{\"remoteId\":1,\"remoteType\":\"XR11\","
+                                          "\"bindingType\":1,\"validationStatus\":0}}")));
+                return Core::ERROR_NONE;
+            }));
+
+    ctrlm_rcu_iarm_event_validation_end_t eventData = {0};
+    eventData.api_revision  = CTRLM_RCU_IARM_BUS_API_REVISION;
+    eventData.controller_id = 1;
+    eventData.binding_type  = CTRLM_RCU_BINDING_TYPE_AUTOMATIC;
+    eventData.result        = CTRLM_RCU_VALIDATION_RESULT_SUCCESS;
+    sprintf(eventData.controller_type, "%s", "XR11");
+
+    handler_.Subscribe(0, _T("onXRValidationComplete"), _T("org.rdk.ControlService"), message_);
+    controlEventHandler_(CTRLM_MAIN_IARM_BUS_NAME, CTRLM_RCU_IARM_EVENT_VALIDATION_END, &eventData, sizeof(ctrlm_rcu_iarm_event_validation_end_t));
+    handler_.Unsubscribe(0, _T("onXRValidationComplete"), _T("org.rdk.ControlService"), message_);
+}
+
+TEST_F(ControlServiceInitializedEventTest, onXRValidationUpdate)
+{
+    EXPECT_CALL(service_, Submit(_, _))
+        .WillOnce(Invoke(
+            [&](const uint32_t, const Core::ProxyType<Core::JSON::IElement>& json) {
+                string text;
+                EXPECT_TRUE(json->ToString(text));
+                EXPECT_EQ(text, string(_T("{\"jsonrpc\":\"2.0\","
+                                          "\"method\":\"org.rdk.ControlService.onXRPairingStart\","
+                                          "\"params\":{\"remoteId\":1,\"remoteType\":\"XR11\","
+                                          "\"bindingType\":0,\"validationDigit1\":1,"
+                                          "\"validationDigit2\":3,\"validationDigit3\":5}}")));
+                return Core::ERROR_NONE;
+            }))
+        .WillOnce(Invoke(
+            [&](const uint32_t, const Core::ProxyType<Core::JSON::IElement>& json) {
+                string text;
+                EXPECT_TRUE(json->ToString(text));
+                EXPECT_EQ(text, string(_T("{\"jsonrpc\":\"2.0\","
+                                          "\"method\":\"org.rdk.ControlService.onXRValidationUpdate\","
+                                          "\"params\":{\"remoteId\":1,\"remoteType\":\"XR11\","
+                                          "\"bindingType\":0,\"validationDigit1\":1}}")));
+                return Core::ERROR_NONE;
+            }));
+
+    ctrlm_rcu_iarm_event_validation_begin_t beginData = {0};
+    ctrlm_rcu_iarm_event_key_press_t        eventData = {0};
+
+    beginData.api_revision       = CTRLM_RCU_IARM_BUS_API_REVISION;
+    beginData.controller_id      = 1;
+    beginData.binding_type       = CTRLM_RCU_BINDING_TYPE_INTERACTIVE;
+    beginData.validation_keys[0] = CTRLM_KEY_CODE_DIGIT_1;
+    beginData.validation_keys[1] = CTRLM_KEY_CODE_DIGIT_3;
+    beginData.validation_keys[2] = CTRLM_KEY_CODE_DIGIT_5;
+    sprintf(beginData.controller_type, "%s", "XR11");
+
+    eventData.api_revision  = CTRLM_RCU_IARM_BUS_API_REVISION;
+    eventData.controller_id = 1;
+    eventData.binding_type  = CTRLM_RCU_BINDING_TYPE_INTERACTIVE;
+    eventData.key_code      = CTRLM_KEY_CODE_DIGIT_1;
+    eventData.key_status    = CTRLM_KEY_STATUS_DOWN;
+    sprintf(eventData.controller_type, "%s", "XR11");
+
+    handler_.Subscribe(0, _T("onXRPairingStart"), _T("org.rdk.ControlService"), message_);
+    controlEventHandler_(CTRLM_MAIN_IARM_BUS_NAME, CTRLM_RCU_IARM_EVENT_VALIDATION_BEGIN, &beginData, sizeof(ctrlm_rcu_iarm_event_validation_begin_t));
+    handler_.Unsubscribe(0, _T("onXRPairingStart"), _T("org.rdk.ControlService"), message_);
+
+    handler_.Subscribe(0, _T("onXRValidationUpdate"), _T("org.rdk.ControlService"), message_);
+    controlEventHandler_(CTRLM_MAIN_IARM_BUS_NAME, CTRLM_RCU_IARM_EVENT_VALIDATION_KEY_PRESS, &eventData, sizeof(ctrlm_rcu_iarm_event_key_press_t));
+    handler_.Unsubscribe(0, _T("onXRValidationUpdate"), _T("org.rdk.ControlService"), message_);
+}

--- a/Tests/tests/test_RemoteActionMapping.cpp
+++ b/Tests/tests/test_RemoteActionMapping.cpp
@@ -1,0 +1,639 @@
+/**
+ * If not stated otherwise in this file or this component's LICENSE
+ * file the following copyright and licenses apply:
+ *
+ * Copyright 2022 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "FactoriesImplementation.h"
+#include "RemoteActionMapping.h"
+
+#include "IarmBusMock.h"
+#include "ServiceMock.h"
+
+using namespace WPEFramework;
+using ::testing::NiceMock;
+using ::testing::_;
+using ::testing::Invoke;
+using ::testing::Test;
+using ::testing::StrEq;
+using ::testing::Contains;
+using ::testing::AnyOfArray;
+
+class RemoteActionMappingTest : public Test {
+protected:
+    Core::ProxyType<Plugin::RemoteActionMapping> plugin_;
+    Core::JSONRPC::Handler&                      handler_;
+    Core::JSONRPC::Connection                    connection_;
+    string                                       response_;
+    NiceMock<IarmBusImplMock>                    iarmBusImplMock_;
+
+    RemoteActionMappingTest()
+        : plugin_(Core::ProxyType<Plugin::RemoteActionMapping>::Create())
+        , handler_(*plugin_)
+        , connection_(1, 0)
+    {
+        IarmBus::getInstance().impl = &iarmBusImplMock_;
+    }
+
+    virtual ~RemoteActionMappingTest() override
+    {
+        IarmBus::getInstance().impl = nullptr;
+    }
+};
+
+class RemoteActionMappingKeyActionMapTest : public RemoteActionMappingTest {
+protected:
+    std::vector<uint8_t> actionMapKeys_{0x4D, 0x6A, 0x6D, 0x4E, 0x69,
+                                        0x6C, 0x40, 0x68, 0x6B, 0x43,
+                                        0x42, 0x41, 0x34};
+    std::vector<uint8_t> actionMapData_{0x00, 0x01, 0x02, 0x03, 0x04,
+                                        0x05, 0x06, 0x07, 0x08, 0x09,
+                                        0x0A, 0x21, 0x31, 0x4C, 0x8C,
+                                        0xC0};
+
+    //AssertionResult testkeyActionMapData(int key, char *data);
+
+    RemoteActionMappingKeyActionMapTest() :
+        RemoteActionMappingTest()
+    {
+    }
+
+    virtual ~RemoteActionMappingKeyActionMapTest() override
+    {
+    }
+};
+
+class RemoteActionMappingFiveDigitCodeTest : public RemoteActionMappingTest {
+protected:
+    char testFiveDigitCodeData_[CTRLM_RCU_MAX_RIB_ATTRIBUTE_SIZE] = {0};
+
+    RemoteActionMappingFiveDigitCodeTest() :
+        RemoteActionMappingTest()
+    {
+        testFiveDigitCodeData_[0] |= (XRC_RIB_TARGET_STATUS_FLAGS_TV_CODE_PRESENT_BIT | XRC_RIB_TARGET_STATUS_FLAGS_AVR_CODE_PRESENT_BIT);
+        for (int i = 1; i < 6; i++)
+            testFiveDigitCodeData_[i] |= (0x30 + i);
+        for (int i = 7; i < 12; i++)
+            testFiveDigitCodeData_[i] |= (0x2F + i);
+        testFiveDigitCodeData_[11] = '0';
+    }
+
+    virtual ~RemoteActionMappingFiveDigitCodeTest() override
+    {
+    }
+};
+
+class RemoteActionMappingInitializedEventTest : public RemoteActionMappingTest {
+protected:
+    IARM_EventHandler_t               ramEventHandler_;
+    NiceMock<ServiceMock>             service_;
+    NiceMock<FactoriesImplementation> factoriesImplementation_;
+    Core::JSONRPC::Message            message_;
+    PluginHost::IDispatcher*          dispatcher_;
+
+    RemoteActionMappingInitializedEventTest() :
+        RemoteActionMappingTest()
+    {
+        EXPECT_CALL(iarmBusImplMock_, IARM_Bus_RegisterEventHandler(StrEq(CTRLM_MAIN_IARM_BUS_NAME), CTRLM_RCU_IARM_EVENT_RIB_ACCESS_CONTROLLER, _))
+            .WillOnce(Invoke(
+                [&](const char* ownerName, IARM_EventId_t eventId, IARM_EventHandler_t handler) {
+                    ramEventHandler_ = handler;
+                    return IARM_RESULT_SUCCESS;
+                }));
+
+        EXPECT_EQ(string(""), plugin_->Initialize(nullptr));
+        PluginHost::IFactories::Assign(&factoriesImplementation_);
+        dispatcher_ = static_cast<PluginHost::IDispatcher*>(plugin_->QueryInterface(PluginHost::IDispatcher::ID));
+        dispatcher_->Activate(&service_);
+    }
+
+    virtual ~RemoteActionMappingInitializedEventTest() override
+    {
+        plugin_->Deinitialize(nullptr);
+        dispatcher_->Deactivate();
+        dispatcher_->Release();
+        PluginHost::IFactories::Assign(nullptr);
+    }
+};
+
+TEST_F(RemoteActionMappingTest, RegisteredMethods)
+{
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Exists(_T("getLastUsedDeviceID")));
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Exists(_T("getKeymap")));
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Exists(_T("setKeyActionMapping")));
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Exists(_T("clearKeyActionMapping")));
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Exists(_T("getFullKeyActionMapping")));
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Exists(_T("getSingleKeyActionMapping")));
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Exists(_T("cancelCodeDownload")));
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Exists(_T("setFiveDigitCode")));
+}
+
+TEST_F(RemoteActionMappingTest, getLastUsedDeviceID)
+{
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_MAIN_IARM_CALL_STATUS_GET), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_main_iarm_call_status_t*>(arg);
+                memset(param, 0, sizeof(ctrlm_main_iarm_call_status_t));
+
+                param->network_qty      = CTRLM_MAIN_MAX_NETWORKS;
+                param->networks[0].id   = 1;
+                param->networks[0].type = CTRLM_NETWORK_TYPE_RF4CE;
+                return IARM_RESULT_SUCCESS;
+            }));
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_MAIN_IARM_CALL_NETWORK_STATUS_GET), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_main_iarm_call_network_status_t*>(arg);
+                memset(param, 0, sizeof(ctrlm_main_iarm_call_network_status_t));
+
+                param->status.rf4ce.controller_qty = 1;
+
+                for (int i = 0; i < CTRLM_MAIN_MAX_BOUND_CONTROLLERS; i++) {
+                    param->status.rf4ce.controllers[i] = i+1;
+                }
+                return IARM_RESULT_SUCCESS;
+            }));
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_RCU_IARM_CALL_CONTROLLER_STATUS), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_rcu_iarm_call_controller_status_t*>(arg);
+                memset(param, 0, sizeof(ctrlm_rcu_iarm_call_controller_status_t));
+
+                sprintf(param->status.type, "%s", "XR15-2");
+                param->status.time_last_key                 = 1580263335;
+                param->status.ir_db_code_download_supported = 1;
+                return IARM_RESULT_SUCCESS;
+            }));
+
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Invoke(connection_, _T("getLastUsedDeviceID"), _T("{}"), response_));
+    EXPECT_EQ(response_, "{\"deviceID\":1,\"remoteType\":\"XR15-2\","
+                         "\"fiveDigitCodePresent\":false,"
+                         "\"setFiveDigitCodeSupported\":true,"
+                         "\"status_code\":0,\"success\":true}");
+}
+
+TEST_F(RemoteActionMappingTest, getKeymap)
+{
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Invoke(connection_, _T("getKeymap"), "{\"deviceID\":1,\"keymapType\":1}", response_));
+    EXPECT_EQ(response_, "{\"keyNames\":[80,81,128,138,139,140,208],"
+                         "\"status_code\":0,\"success\":true}");
+}
+
+TEST_F(RemoteActionMappingKeyActionMapTest, setKeyActionMapping)
+{
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_MAIN_IARM_CALL_STATUS_GET), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_main_iarm_call_status_t*>(arg);
+                memset(param, 0, sizeof(ctrlm_main_iarm_call_status_t));
+
+                param->network_qty      = CTRLM_MAIN_MAX_NETWORKS;
+                param->networks[0].id   = 1;
+                param->networks[0].type = CTRLM_NETWORK_TYPE_RF4CE;
+                return IARM_RESULT_SUCCESS;
+            }));
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_MAIN_IARM_CALL_NETWORK_STATUS_GET), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_main_iarm_call_network_status_t*>(arg);
+                memset(param, 0, sizeof(ctrlm_main_iarm_call_network_status_t));
+
+                param->status.rf4ce.controller_qty = 1;
+
+                for (int i = 0; i < CTRLM_MAIN_MAX_BOUND_CONTROLLERS; i++) {
+                    param->status.rf4ce.controllers[i] = i+1;
+                }
+                return IARM_RESULT_SUCCESS;
+            }));
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_RCU_IARM_CALL_CONTROLLER_STATUS), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_rcu_iarm_call_controller_status_t*>(arg);
+                memset(param, 0, sizeof(ctrlm_rcu_iarm_call_controller_status_t));
+                param->status.ir_db_state = CTRLM_RCU_IR_DB_STATE_NO_CODES;
+                return IARM_RESULT_SUCCESS;
+            }));
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_RCU_IARM_CALL_RIB_REQUEST_GET), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_rcu_iarm_call_rib_request_t*>(arg);
+                EXPECT_EQ(param->network_id,    1);
+                EXPECT_EQ(param->controller_id, 1);
+                EXPECT_EQ(param->attribute_id,  CTRLM_RCU_RIB_ATTR_ID_IR_RF_DATABASE_STATUS);
+                EXPECT_EQ(param->length,        1);
+                param->data[0] = XRC_RIB_IRRFSTATUS_DOWNLOAD_IRDB_BIT | XRC_RIB_IRRFSTATUS_FORCE_IRDB_BIT;
+                param->result = CTRLM_IARM_CALL_RESULT_SUCCESS;
+                return IARM_RESULT_SUCCESS;
+            }));
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_RCU_IARM_CALL_RIB_REQUEST_SET), _, _))
+        .WillByDefault(Invoke(
+            [&](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_rcu_iarm_call_rib_request_t*>(arg);
+                EXPECT_EQ(param->network_id,    1);
+                EXPECT_EQ(param->controller_id, 1);
+                EXPECT_EQ(param->attribute_id,  CTRLM_RCU_RIB_ATTR_ID_IR_RF_DATABASE);
+                EXPECT_THAT(param->attribute_index, AnyOfArray(actionMapKeys_));
+                EXPECT_THAT(param->data, Contains(AnyOfArray(actionMapData_)));
+                param->result = CTRLM_IARM_CALL_RESULT_SUCCESS;
+                return IARM_RESULT_SUCCESS;
+            }));
+
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Invoke(connection_,
+                                _T("setKeyActionMapping"),
+                                _T("{\"deviceID\":1,\"keymapType\":1,"
+                                "\"keyActionMapping\":["
+                                "{\"keyName\":80,\"rfKeyCode\":109,\"tvIRKeyCode\":[0,1,2,3,4,5,6,7,8,9],\"avrIRKeyCode\":[]},"
+                                "{\"keyName\":81,\"rfKeyCode\":108,\"tvIRKeyCode\":[0,1,2,3,4,5,6,7,8,9],\"avrIRKeyCode\":[]},"
+                                "{\"keyName\":128,\"rfKeyCode\":107,\"tvIRKeyCode\":[0,1,2,3,4,5,6,7,8,9],\"avrIRKeyCode\":[]},"
+                                "{\"keyName\":138,\"rfKeyCode\":65,\"tvIRKeyCode\":[0,1,2,3,4,5,6,7,8,9],\"avrIRKeyCode\":[]},"
+                                "{\"keyName\":139,\"rfKeyCode\":66,\"tvIRKeyCode\":[0,1,2,3,4,5,6,7,8,9],\"avrIRKeyCode\":[]},"
+                                "{\"keyName\":140,\"rfKeyCode\":67,\"tvIRKeyCode\":[0,1,2,3,4,5,6,7,8,9],\"avrIRKeyCode\":[]},"
+                                "{\"keyName\":208,\"rfKeyCode\":52,\"tvIRKeyCode\":[0,1,2,3,4,5,6,7,8,9],\"avrIRKeyCode\":[]}]}"),
+                                response_));
+    EXPECT_EQ(response_, "{\"status_code\":0,\"success\":true}");
+}
+
+TEST_F(RemoteActionMappingTest, clearKeyActionMapping)
+{
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_MAIN_IARM_CALL_STATUS_GET), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_main_iarm_call_status_t*>(arg);
+                memset(param, 0, sizeof(ctrlm_main_iarm_call_status_t));
+
+                param->network_qty      = CTRLM_MAIN_MAX_NETWORKS;
+                param->networks[0].id   = 1;
+                param->networks[0].type = CTRLM_NETWORK_TYPE_RF4CE;
+                return IARM_RESULT_SUCCESS;
+            }));
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_RCU_IARM_CALL_CONTROLLER_STATUS), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_rcu_iarm_call_controller_status_t*>(arg);
+                memset(param, 0, sizeof(ctrlm_rcu_iarm_call_controller_status_t));
+                param->status.ir_db_state   = CTRLM_RCU_IR_DB_STATE_NO_CODES;
+                return IARM_RESULT_SUCCESS;
+            }));
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_RCU_IARM_CALL_RIB_REQUEST_SET), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_rcu_iarm_call_rib_request_t*>(arg);
+                EXPECT_EQ(param->network_id,      1);
+                EXPECT_EQ(param->controller_id,   1);
+                EXPECT_EQ(param->attribute_id,    CTRLM_RCU_RIB_ATTR_ID_IR_RF_DATABASE);
+                EXPECT_EQ(param->length,          CONTROLMGR_MAX_IR_DATA_SIZE + 1 + 2);
+                EXPECT_EQ(param->data[0],         (char) (MSO_RIB_IRRFDB_PERMANENT_BIT | MSO_RIB_IRRFDB_DEFAULT_BIT));
+                param->result = CTRLM_IARM_CALL_RESULT_SUCCESS;
+                return IARM_RESULT_SUCCESS;
+            }));
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_RCU_IARM_CALL_RIB_REQUEST_GET), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_rcu_iarm_call_rib_request_t*>(arg);
+                EXPECT_EQ(param->network_id,      1);
+                EXPECT_EQ(param->controller_id,   1);
+                EXPECT_EQ(param->attribute_id,    CTRLM_RCU_RIB_ATTR_ID_IR_RF_DATABASE_STATUS);
+                EXPECT_EQ(param->length,          1);
+                param->data[0] = (XRC_RIB_IRRFSTATUS_DOWNLOAD_IRDB_BIT | XRC_RIB_IRRFSTATUS_FORCE_IRDB_BIT);
+                param->result = CTRLM_IARM_CALL_RESULT_SUCCESS;
+                return IARM_RESULT_SUCCESS;
+            }));
+
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Invoke(connection_,
+                                _T("clearKeyActionMapping"),
+                                _T("{\"deviceID\":1,\"keymapType\":0,\"keyNames\":"
+                                "[0x80,0x51,0x50,0x8A,0x8B,0x8C,0xD0]}"),
+                                response_));
+    EXPECT_EQ(response_, "{\"status_code\":0,\"success\":true}");
+}
+
+TEST_F(RemoteActionMappingKeyActionMapTest, getFullKeyActionMapping)
+{
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_MAIN_IARM_CALL_STATUS_GET), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_main_iarm_call_status_t*>(arg);
+                memset(param, 0, sizeof(ctrlm_main_iarm_call_status_t));
+
+                param->network_qty      = CTRLM_MAIN_MAX_NETWORKS;
+                param->networks[0].id   = 1;
+                param->networks[0].type = CTRLM_NETWORK_TYPE_RF4CE;
+                return IARM_RESULT_SUCCESS;
+            }));
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_RCU_IARM_CALL_RIB_REQUEST_GET), _, _))
+        .WillByDefault(Invoke(
+            [&](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_rcu_iarm_call_rib_request_t*>(arg);
+                EXPECT_EQ(param->network_id,    1);
+                EXPECT_EQ(param->controller_id, 1);
+                EXPECT_EQ(param->attribute_id,  CTRLM_RCU_RIB_ATTR_ID_IR_RF_DATABASE);
+                EXPECT_EQ(param->length,        CTRLM_RCU_MAX_RIB_ATTRIBUTE_SIZE);
+                EXPECT_THAT(param->attribute_index, AnyOfArray(actionMapKeys_));
+                param->data[0] = MSO_RIB_IRRFDB_IRSPECIFIED_BIT;
+                param->data[1] = 0xFF;
+                param->data[2] = 10;
+                for (int i = 3; i < 13; i++) {
+                    param->data[i] = i-3;
+                }
+                param->result = CTRLM_IARM_CALL_RESULT_SUCCESS;
+                return IARM_RESULT_SUCCESS;
+            }));
+
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Invoke(connection_, _T("getFullKeyActionMapping"), "{\"deviceID\":1,\"keymapType\":1}", response_));
+    EXPECT_EQ(response_, "{\"keyMappings\":["
+                         "{\"keyName\":80,\"rfKeyCode\":109,\"tvIRKeyCode\":\"[0,1,2,3,4,5,6,7,8,9]\",\"avrIRKeyCode\":\"[]\"},"
+                         "{\"keyName\":81,\"rfKeyCode\":108,\"tvIRKeyCode\":\"[0,1,2,3,4,5,6,7,8,9]\",\"avrIRKeyCode\":\"[]\"},"
+                         "{\"keyName\":128,\"rfKeyCode\":107,\"tvIRKeyCode\":\"[0,1,2,3,4,5,6,7,8,9]\",\"avrIRKeyCode\":\"[]\"},"
+                         "{\"keyName\":138,\"rfKeyCode\":65,\"tvIRKeyCode\":\"[0,1,2,3,4,5,6,7,8,9]\",\"avrIRKeyCode\":\"[]\"},"
+                         "{\"keyName\":139,\"rfKeyCode\":66,\"tvIRKeyCode\":\"[0,1,2,3,4,5,6,7,8,9]\",\"avrIRKeyCode\":\"[]\"},"
+                         "{\"keyName\":140,\"rfKeyCode\":67,\"tvIRKeyCode\":\"[0,1,2,3,4,5,6,7,8,9]\",\"avrIRKeyCode\":\"[]\"},"
+                         "{\"keyName\":208,\"rfKeyCode\":52,\"tvIRKeyCode\":\"[0,1,2,3,4,5,6,7,8,9]\",\"avrIRKeyCode\":\"[]\"}],"
+                         "\"status_code\":0,\"success\":true}");
+}
+
+TEST_F(RemoteActionMappingKeyActionMapTest, getSingleKeyActionMapping)
+{
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_MAIN_IARM_CALL_STATUS_GET), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_main_iarm_call_status_t*>(arg);
+                memset(param, 0, sizeof(ctrlm_main_iarm_call_status_t));
+
+                param->network_qty      = CTRLM_MAIN_MAX_NETWORKS;
+                param->networks[0].id   = 1;
+                param->networks[0].type = CTRLM_NETWORK_TYPE_RF4CE;
+                return IARM_RESULT_SUCCESS;
+            }));
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_RCU_IARM_CALL_RIB_REQUEST_GET), _, _))
+        .WillByDefault(Invoke(
+            [&](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_rcu_iarm_call_rib_request_t*>(arg);
+                EXPECT_EQ(param->network_id,      1);
+                EXPECT_EQ(param->controller_id,   1);
+                EXPECT_EQ(param->attribute_id,    CTRLM_RCU_RIB_ATTR_ID_IR_RF_DATABASE);
+                EXPECT_THAT(param->attribute_index, AnyOfArray(actionMapKeys_));
+                EXPECT_EQ(param->length,          CTRLM_RCU_MAX_RIB_ATTRIBUTE_SIZE);
+                param->data[0] = MSO_RIB_IRRFDB_IRSPECIFIED_BIT;
+                param->data[1] = 0xFF;
+                param->data[2] = 10;
+                for (int i = 3; i < 13; i++) {
+                    param->data[i] = i-3;
+                }
+                param->result = CTRLM_IARM_CALL_RESULT_SUCCESS;
+                return IARM_RESULT_SUCCESS;
+            }));
+
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Invoke(connection_,
+                                _T("getSingleKeyActionMapping"),
+                                "{\"deviceID\":1,\"keymapType\":1,\"keyName\":140}",
+                                response_));
+    EXPECT_EQ(response_, "{\"keyMapping\":{\"keyName\":140,\"rfKeyCode\":67,"
+                         "\"tvIRKeyCode\":\"[0,1,2,3,4,5,6,7,8,9]\",\"avrIRKeyCode\":\"[]\"},"
+                         "\"status_code\":0,\"success\":true}");
+}
+
+TEST_F(RemoteActionMappingTest, cancelCodeDownload)
+{
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_MAIN_IARM_CALL_STATUS_GET), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_main_iarm_call_status_t*>(arg);
+                memset(param, 0, sizeof(ctrlm_main_iarm_call_status_t));
+
+                param->network_qty      = CTRLM_MAIN_MAX_NETWORKS;
+                param->networks[0].id   = 1;
+                param->networks[0].type = CTRLM_NETWORK_TYPE_RF4CE;
+                return IARM_RESULT_SUCCESS;
+            }));
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_RCU_IARM_CALL_RIB_REQUEST_GET), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_rcu_iarm_call_rib_request_t*>(arg);
+                EXPECT_EQ(param->network_id,      1);
+                EXPECT_EQ(param->controller_id,   1);
+                EXPECT_EQ(param->attribute_id,    CTRLM_RCU_RIB_ATTR_ID_IR_RF_DATABASE_STATUS);
+                EXPECT_EQ(param->attribute_index, 0);
+                EXPECT_EQ(param->length,          1);
+                param->data[0] = XRC_RIB_IRRFSTATUS_DONT_DOWNLOAD_IRDB_BIT;
+                param->result = CTRLM_IARM_CALL_RESULT_SUCCESS;
+                return IARM_RESULT_SUCCESS;
+            }));
+
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Invoke(connection_, _T("cancelCodeDownload"), "{\"deviceID\":1}", response_));
+    EXPECT_EQ(response_, "{\"status_code\":0,\"success\":true}");
+}
+
+TEST_F(RemoteActionMappingFiveDigitCodeTest, setFiveDigitCode)
+{
+    EXPECT_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_MAIN_IARM_CALL_STATUS_GET), _, _))
+        .WillRepeatedly(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_main_iarm_call_status_t*>(arg);
+                memset(param, 0, sizeof(ctrlm_main_iarm_call_status_t));
+
+                param->network_qty      = CTRLM_MAIN_MAX_NETWORKS;
+                param->networks[0].id   = 1;
+                param->networks[0].type = CTRLM_NETWORK_TYPE_RF4CE;
+                return IARM_RESULT_SUCCESS;
+            }));
+    EXPECT_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_RCU_IARM_CALL_RIB_REQUEST_GET), _, _))
+        .WillOnce(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_rcu_iarm_call_rib_request_t*>(arg);
+                EXPECT_EQ(param->network_id,      1);
+                EXPECT_EQ(param->controller_id,   1);
+                EXPECT_EQ(param->attribute_id,    CTRLM_RCU_RIB_ATTR_ID_TARGET_IRDB_STATUS);
+                EXPECT_EQ(param->attribute_index, 0);
+                EXPECT_EQ(param->length,          CTRLM_RCU_RIB_ATTR_LEN_TARGET_IRDB_STATUS);
+                param->result = CTRLM_IARM_CALL_RESULT_SUCCESS;
+                return IARM_RESULT_SUCCESS;
+            }))
+        .WillOnce(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_rcu_iarm_call_rib_request_t*>(arg);
+                EXPECT_EQ(param->network_id,      1);
+                EXPECT_EQ(param->controller_id,   1);
+                EXPECT_EQ(param->attribute_id,    CTRLM_RCU_RIB_ATTR_ID_IR_RF_DATABASE_STATUS);
+                EXPECT_EQ(param->attribute_index, 0);
+                EXPECT_EQ(param->length,          1);
+                param->data[0] = (XRC_RIB_IRRFSTATUS_DONT_DOWNLOAD_IRDB_BIT |
+                                  XRC_RIB_IRRFSTATUS_DOWNLOAD_TV_5DCODE_BIT |
+                                  XRC_RIB_IRRFSTATUS_DOWNLOAD_AVR_5DCODE_BIT);
+                param->result = CTRLM_IARM_CALL_RESULT_SUCCESS;
+                return IARM_RESULT_SUCCESS;
+            }));
+    EXPECT_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_RCU_IARM_CALL_RIB_REQUEST_SET), _, _))
+        .WillOnce(Invoke(
+            [&](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_rcu_iarm_call_rib_request_t*>(arg);
+                EXPECT_EQ(param->network_id,      1);
+                EXPECT_EQ(param->controller_id,   1);
+                EXPECT_EQ(param->attribute_id,    CTRLM_RCU_RIB_ATTR_ID_TARGET_IRDB_STATUS);
+                EXPECT_EQ(param->attribute_index, 0);
+                EXPECT_EQ(param->length,          CTRLM_RCU_RIB_ATTR_LEN_TARGET_IRDB_STATUS);
+                for (int i = 0; i < CTRLM_RCU_RIB_ATTR_LEN_TARGET_IRDB_STATUS; i++) {
+                    EXPECT_EQ(param->data[i], testFiveDigitCodeData_[i]) << "Index: " << i;
+                }
+                param->result = CTRLM_IARM_CALL_RESULT_SUCCESS;
+                return IARM_RESULT_SUCCESS;
+            }));
+
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Invoke(connection_,
+                                _T("setFiveDigitCode"),
+                                "{\"deviceID\":1,\"tvFiveDigitCode\":12345,\"avrFiveDigitCode\":67890}",
+                                response_));
+    EXPECT_EQ(response_, "{\"status_code\":0,\"success\":true}");
+}
+
+TEST_F(RemoteActionMappingInitializedEventTest, onIRCodeLoad)
+{
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_MAIN_IARM_CALL_STATUS_GET), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_main_iarm_call_status_t*>(arg);
+                memset(param, 0, sizeof(ctrlm_main_iarm_call_status_t));
+
+                param->network_qty      = CTRLM_MAIN_MAX_NETWORKS;
+                param->networks[0].id   = 1;
+                param->networks[0].type = CTRLM_NETWORK_TYPE_RF4CE;
+                return IARM_RESULT_SUCCESS;
+            }));
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_RCU_IARM_CALL_CONTROLLER_STATUS), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_rcu_iarm_call_controller_status_t*>(arg);
+                memset(param, 0, sizeof(ctrlm_rcu_iarm_call_controller_status_t));
+                param->status.ir_db_state   = CTRLM_RCU_IR_DB_STATE_NO_CODES;
+                return IARM_RESULT_SUCCESS;
+            }));
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_RCU_IARM_CALL_RIB_REQUEST_SET), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_rcu_iarm_call_rib_request_t*>(arg);
+                param->result = CTRLM_IARM_CALL_RESULT_SUCCESS;
+                return IARM_RESULT_SUCCESS;
+            }));
+    EXPECT_CALL(service_, Submit(_, _))
+        .WillOnce(Invoke(
+            [&](const uint32_t, const Core::ProxyType<Core::JSON::IElement>& json) {
+                string text;
+                EXPECT_TRUE(json->ToString(text));
+                EXPECT_EQ(text, string(_T("{\"jsonrpc\":\"2.0\","
+                                          "\"method\":\"org.rdk.RemoteActionMapping.onIRCodeLoad\","
+                                          "\"params\":{\"deviceID\":1,\"keyNames\":[208,138,139,140,128,81,80],"
+                                          "\"rfKeyCodes\":[52,65,66,67,107,108,109],\"loadStatus\":0}}")));
+                return Core::ERROR_NONE;
+            }));
+
+    auto key_slots = {MSO_RFKEY_INPUT_SELECT,
+                      MSO_RFKEY_VOL_PLUS,
+                      MSO_RFKEY_VOL_MINUS,
+                      MSO_RFKEY_MUTE,
+                      MSO_RFKEY_PWR_TOGGLE,
+                      MSO_RFKEY_PWR_ON,
+                      MSO_RFKEY_PWR_OFF};
+    ctrlm_rcu_iarm_event_rib_entry_access_t eventData = {0};
+
+    eventData.api_revision  = CTRLM_RCU_IARM_BUS_API_REVISION;
+    eventData.network_id    = 1;
+    eventData.network_type  = CTRLM_NETWORK_TYPE_RF4CE;
+    eventData.controller_id = 1;
+    eventData.identifier    = CTRLM_RCU_RIB_ATTR_ID_IR_RF_DATABASE_STATUS;
+    eventData.index         = 0;
+    eventData.access_type   = CTRLM_ACCESS_TYPE_READ;
+
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Invoke(connection_,
+                                _T("clearKeyActionMapping"),
+                                _T("{\"deviceID\":1,\"keymapType\":0,\"keyNames\":"
+                                "[0x80,0x51,0x50,0x8A,0x8B,0x8C,0xD0]}"),
+                                response_));
+
+    handler_.Subscribe(0, _T("onIRCodeLoad"), _T("org.rdk.RemoteActionMapping"), message_);
+    ramEventHandler_(CTRLM_MAIN_IARM_BUS_NAME, CTRLM_RCU_IARM_EVENT_RIB_ACCESS_CONTROLLER, &eventData, sizeof(ctrlm_rcu_iarm_event_rib_entry_access_t));
+
+    eventData.identifier = CTRLM_RCU_RIB_ATTR_ID_IR_RF_DATABASE;
+    for (auto key : key_slots) {
+        eventData.index = key;
+        ramEventHandler_(CTRLM_MAIN_IARM_BUS_NAME, CTRLM_RCU_IARM_EVENT_RIB_ACCESS_CONTROLLER, &eventData, sizeof(ctrlm_rcu_iarm_event_rib_entry_access_t));
+    }
+    handler_.Unsubscribe(0, _T("onIRCodeLoad"), _T("org.rdk.RemoteActionMapping"), message_);
+}
+
+TEST_F(RemoteActionMappingInitializedEventTest, onFiveDigitCodeLoad)
+{
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_MAIN_IARM_CALL_STATUS_GET), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_main_iarm_call_status_t*>(arg);
+                memset(param, 0, sizeof(ctrlm_main_iarm_call_status_t));
+
+                param->network_qty      = CTRLM_MAIN_MAX_NETWORKS;
+                param->networks[0].id   = 1;
+                param->networks[0].type = CTRLM_NETWORK_TYPE_RF4CE;
+                return IARM_RESULT_SUCCESS;
+            }));
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_RCU_IARM_CALL_RIB_REQUEST_GET), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_rcu_iarm_call_rib_request_t*>(arg);
+                param->result = CTRLM_IARM_CALL_RESULT_SUCCESS;
+                return IARM_RESULT_SUCCESS;
+            }));
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_RCU_IARM_CALL_RIB_REQUEST_SET), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_rcu_iarm_call_rib_request_t*>(arg);
+                param->result = CTRLM_IARM_CALL_RESULT_SUCCESS;
+                return IARM_RESULT_SUCCESS;
+            }));
+    EXPECT_CALL(service_, Submit(_, _))
+        .WillOnce(Invoke(
+            [&](const uint32_t, const Core::ProxyType<Core::JSON::IElement>& json) {
+                string text;
+                EXPECT_TRUE(json->ToString(text));
+                EXPECT_EQ(text, string(_T("{\"jsonrpc\":\"2.0\","
+                                          "\"method\":\"org.rdk.RemoteActionMapping.onFiveDigitCodeLoad\","
+                                          "\"params\":{\"deviceID\":1,\"tvLoadStatus\":0,\"avrLoadStatus\":0}}")));
+                return Core::ERROR_NONE;
+            }));
+
+    ctrlm_rcu_iarm_event_rib_entry_access_t eventData = {0};
+    eventData.api_revision  = CTRLM_RCU_IARM_BUS_API_REVISION;
+    eventData.network_id    = 1;
+    eventData.network_type  = CTRLM_NETWORK_TYPE_RF4CE;
+    eventData.controller_id = 1;
+    eventData.identifier    = CTRLM_RCU_RIB_ATTR_ID_IR_RF_DATABASE_STATUS;
+    eventData.index         = 0;
+    eventData.access_type   = CTRLM_ACCESS_TYPE_READ;
+
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Invoke(connection_,
+                                _T("setFiveDigitCode"),
+                                "{\"deviceID\":1,\"tvFiveDigitCode\":0,\"avrFiveDigitCode\":0}",
+                                response_));
+
+    handler_.Subscribe(0, _T("onFiveDigitCodeLoad"), _T("org.rdk.RemoteActionMapping"), message_);
+    ramEventHandler_(CTRLM_MAIN_IARM_BUS_NAME,CTRLM_RCU_IARM_EVENT_RIB_ACCESS_CONTROLLER,&eventData, sizeof(ctrlm_rcu_iarm_event_rib_entry_access_t));
+
+    eventData.identifier  = CTRLM_RCU_RIB_ATTR_ID_CONTROLLER_IRDB_STATUS;
+    eventData.access_type = CTRLM_ACCESS_TYPE_WRITE;
+    ramEventHandler_(CTRLM_MAIN_IARM_BUS_NAME, CTRLM_RCU_IARM_EVENT_RIB_ACCESS_CONTROLLER, &eventData, sizeof(ctrlm_rcu_iarm_event_rib_entry_access_t));
+
+    handler_.Unsubscribe(0, _T("onFiveDigitCodeLoad"), _T("org.rdk.RemoteActionMapping"), message_);
+}

--- a/Tests/tests/test_VoiceControl.cpp
+++ b/Tests/tests/test_VoiceControl.cpp
@@ -1,0 +1,557 @@
+/**
+ * If not stated otherwise in this file or this component's LICENSE
+ * file the following copyright and licenses apply:
+ *
+ * Copyright 2022 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+#include "gtest/gtest.h"
+#include "FactoriesImplementation.h"
+#include "VoiceControl.h"
+
+#include "IarmBusMock.h"
+#include "ServiceMock.h"
+
+using namespace WPEFramework;
+using ::testing::NiceMock;
+using ::testing::Test;
+using ::testing::_;
+using ::testing::Invoke;
+using ::testing::StrEq;
+using ::testing::ContainsRegex;
+using ::testing::AssertionResult;
+using ::testing::AssertionSuccess;
+using ::testing::AssertionFailure;
+
+class VoiceControlTest : public Test {
+protected:
+    Core::ProxyType<Plugin::VoiceControl> plugin_;
+    Core::JSONRPC::Handler&               handler_;
+    Core::JSONRPC::Connection             connection_;
+    string                                response_;
+    NiceMock<IarmBusImplMock>             iarmBusImplMock_;
+
+    VoiceControlTest()
+        : plugin_(Core::ProxyType<Plugin::VoiceControl>::Create())
+        , handler_(*plugin_)
+        , connection_(1, 0)
+    {
+        IarmBus::getInstance().impl = &iarmBusImplMock_;
+    }
+
+    virtual ~VoiceControlTest() override
+    {
+        IarmBus::getInstance().impl = nullptr;
+    }
+};
+
+static AssertionResult isValidCtrlmVoiceIarmEvent(IARM_EventId_t ctrlmVoiceIarmEventId)
+{
+    switch (ctrlmVoiceIarmEventId) {
+        case CTRLM_VOICE_IARM_EVENT_JSON_SESSION_BEGIN:
+        case CTRLM_VOICE_IARM_EVENT_JSON_STREAM_BEGIN:
+        case CTRLM_VOICE_IARM_EVENT_JSON_KEYWORD_VERIFICATION:
+        case CTRLM_VOICE_IARM_EVENT_JSON_SERVER_MESSAGE:
+        case CTRLM_VOICE_IARM_EVENT_JSON_STREAM_END:
+        case CTRLM_VOICE_IARM_EVENT_JSON_SESSION_END:
+            return AssertionSuccess();
+        default:
+            return AssertionFailure();
+    }
+}
+
+class VoiceControlInitializedEventTest : public VoiceControlTest {
+protected:
+    IARM_EventHandler_t               voiceEventHandler_;
+    NiceMock<ServiceMock>             service_;
+    NiceMock<FactoriesImplementation> factoriesImplementation_;
+    Core::JSONRPC::Message            message_;
+    PluginHost::IDispatcher*          dispatcher_;
+
+    VoiceControlInitializedEventTest() :
+        VoiceControlTest()
+    {
+        EXPECT_CALL(iarmBusImplMock_, IARM_Bus_RegisterEventHandler(StrEq(CTRLM_MAIN_IARM_BUS_NAME), _, _))
+            .WillRepeatedly(Invoke(
+                [&](const char* ownerName, IARM_EventId_t eventId, IARM_EventHandler_t handler) {
+                    EXPECT_TRUE(isValidCtrlmVoiceIarmEvent(eventId));
+                    voiceEventHandler_ = handler;
+                    return IARM_RESULT_SUCCESS;
+                }));
+        ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_VOICE_IARM_CALL_STATUS), _, _))
+            .WillByDefault(Invoke(
+                [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                    auto param = static_cast<ctrlm_voice_iarm_call_json_t*>(arg);
+                    strncpy(param->result, "{\"maskPii\":true}", sizeof(param->result));
+                    return IARM_RESULT_SUCCESS;
+                }));
+
+        EXPECT_EQ(string(""), plugin_->Initialize(nullptr));
+        PluginHost::IFactories::Assign(&factoriesImplementation_);
+        dispatcher_ = static_cast<PluginHost::IDispatcher*>(plugin_->QueryInterface(PluginHost::IDispatcher::ID));
+        dispatcher_->Activate(&service_);
+    }
+
+    virtual ~VoiceControlInitializedEventTest() override
+    {
+        plugin_->Deinitialize(nullptr);
+        dispatcher_->Deactivate();
+        dispatcher_->Release();
+        PluginHost::IFactories::Assign(nullptr);
+    }
+};
+
+TEST_F(VoiceControlTest, RegisteredMethods)
+{
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Exists(_T("voiceStatus")));
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Exists(_T("configureVoice")));
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Exists(_T("setVoiceInit")));
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Exists(_T("sendVoiceMessage")));
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Exists(_T("voiceSessionByText")));
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Exists(_T("voiceSessionTypes")));
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Exists(_T("voiceSessionRequest")));
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Exists(_T("voiceSessionTerminate")));
+}
+
+TEST_F(VoiceControlTest, voiceStatus)
+{
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_VOICE_IARM_CALL_STATUS), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_voice_iarm_call_json_t*>(arg);
+                const string result =  "{\"maskPii\":true,"
+                                       "\"capabilities\":[\"PRV\"],"
+                                       "\"urlPtt\":\"proxyUrlPtt\","
+                                       "\"urlHf\":\"proxyUrlHf\","
+                                       "\"prv\":true,"
+                                       "\"wwFeedback\":false,"
+                                       "\"ptt\":{\"status\":\"ready\"},"
+                                       "\"ff\":{\"status\":\"ready\"},"
+                                       "\"mic\":{\"status\":\"ready\"},"
+                                       "\"success\":true}";
+                strncpy(param->result, result.c_str(), sizeof(param->result));
+                return IARM_RESULT_SUCCESS;
+            }));
+
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Invoke(connection_, _T("voiceStatus"), _T("{}"), response_));
+    EXPECT_EQ(response_, "{\"maskPii\":true,"
+                         "\"capabilities\":[\"PRV\"],"
+                         "\"urlPtt\":\"proxyUrlPtt\","
+                         "\"urlHf\":\"proxyUrlHf\","
+                         "\"prv\":true,"
+                         "\"wwFeedback\":false,"
+                         "\"ptt\":{\"status\":\"ready\"},"
+                         "\"ff\":{\"status\":\"ready\"},"
+                         "\"mic\":{\"status\":\"ready\"},"
+                         "\"success\":true}");
+}
+
+TEST_F(VoiceControlTest, configureVoice)
+{
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_VOICE_IARM_CALL_CONFIGURE_VOICE), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_voice_iarm_call_json_t*>(arg);
+                strncpy(param->result, "{\"success\":true}", sizeof(param->result));
+                return IARM_RESULT_SUCCESS;
+            }));
+
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Invoke(connection_,
+                                _T("configureVoice"),
+                                _T("{\"urlAll\":\"ws://voiceserver.com/voice/ptt\","
+                                "\"urlPtt\":\"vrng://vrex-next-gen-api.vrexcore.net/vrex/speech/websocket\","
+                                "\"urlHf\":\"ws://voiceserver.com/voice/hf\","
+                                "\"urlMicTap\":\"ws://voiceserver.com/voice/mictap\","
+                                "\"enable\":true,"
+                                "\"prv\":true,"
+                                "\"wwFeedback\":false,"
+                                "\"ptt\":{\"enable\":false},"
+                                "\"ff\":{\"enable\":false},"
+                                "\"mic\":{\"enable\":false}}"),
+                                response_));
+    EXPECT_EQ(response_, "{\"success\":true}");
+}
+
+TEST_F(VoiceControlTest, setVoiceInit)
+{
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_VOICE_IARM_CALL_SET_VOICE_INIT), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_voice_iarm_call_json_t*>(arg);
+                strncpy(param->result, "{\"success\":true}", sizeof(param->result));
+                return IARM_RESULT_SUCCESS;
+            }));
+
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Invoke(connection_,
+                                _T("setVoiceInit"),
+                                _T("{\"capabilities\":[\"PRV\"],\"language\":\"eng-USA\"}"),
+                                response_));
+    EXPECT_EQ(response_, "{\"success\":true}");
+}
+
+TEST_F(VoiceControlTest, sendVoiceMessage)
+{
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_VOICE_IARM_CALL_SEND_VOICE_MESSAGE), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_voice_iarm_call_json_t*>(arg);
+                strncpy(param->result, "{\"success\":true}", sizeof(param->result));
+                return IARM_RESULT_SUCCESS;
+            }));
+
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Invoke(connection_, _T("sendVoiceMessage"), _T("{}"), response_));
+    EXPECT_EQ(response_, "{\"success\":true}");
+}
+
+TEST_F(VoiceControlTest, voiceSessionTypes)
+{
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_VOICE_IARM_CALL_SESSION_TYPES), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_voice_iarm_call_json_t*>(arg);
+                const string result = "{\"types\":[\"ptt_transcription\"],\"success\":true}";
+                strncpy(param->result, result.c_str(), sizeof(param->result));
+                return IARM_RESULT_SUCCESS;
+            }));
+
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Invoke(connection_, _T("voiceSessionTypes"), _T("{}"), response_));
+    EXPECT_EQ(response_, "{\"types\":[\"ptt_transcription\"],\"success\":true}");
+}
+
+TEST_F(VoiceControlTest, voiceSessionByTextWithInvalidType)
+{
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_VOICE_IARM_CALL_SESSION_REQUEST), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_voice_iarm_call_json_t*>(arg);
+                EXPECT_THAT(param->payload, ContainsRegex(_T("\"type\":\"\"")));
+                strncpy(param->result, "{\"success\":true}", sizeof(param->result));
+                return IARM_RESULT_SUCCESS;
+            }));
+
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Invoke(connection_,
+                                 _T("voiceSessionByText"),
+                                 _T("{\"transcription\":\"Watch Comedy Central\","
+                                 "\"type\":\"null\"}"),
+                                 response_));
+}
+
+TEST_F(VoiceControlTest, voiceSessionByTextWithFfType)
+{
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_VOICE_IARM_CALL_SESSION_REQUEST), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_voice_iarm_call_json_t*>(arg);
+                EXPECT_THAT(param->payload, ContainsRegex(_T("\"type\":\"ff_transcription\"")));
+                strncpy(param->result, "{\"success\":true}", sizeof(param->result));
+                return IARM_RESULT_SUCCESS;
+            }));
+
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Invoke(connection_,
+                                _T("voiceSessionByText"),
+                                _T("{\"transcription\":\"Watch Comedy Central\","
+                                "\"type\":\"ff\"}"),
+                                response_));
+}
+
+TEST_F(VoiceControlTest, voiceSessionByTextWithMicType)
+{
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_VOICE_IARM_CALL_SESSION_REQUEST), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_voice_iarm_call_json_t*>(arg);
+                EXPECT_THAT(param->payload, ContainsRegex(_T("\"type\":\"mic_transcription\"")));
+                strncpy(param->result, "{\"success\":true}", sizeof(param->result));
+                return IARM_RESULT_SUCCESS;
+            }));
+
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Invoke(connection_,
+                                _T("voiceSessionByText"),
+                                _T("{\"transcription\":\"Watch Comedy Central\","
+                                "\"type\":\"mic\"}"),
+                                response_));
+}
+
+TEST_F(VoiceControlTest, voiceSessionByTextWithNoOrPttType)
+{
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_VOICE_IARM_CALL_SESSION_REQUEST), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_voice_iarm_call_json_t*>(arg);
+                EXPECT_THAT(param->payload, ::testing::ContainsRegex(_T("\"type\":\"ptt_transcription\"")));
+                strncpy(param->result, "{\"success\":true}", sizeof(param->result));
+                return IARM_RESULT_SUCCESS;
+            }));
+
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Invoke(connection_,
+                                _T("voiceSessionByText"),
+                                "{\"transcription\":\"Watch Comedy Central\"}",
+                                response_));
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Invoke(connection_,
+                                _T("voiceSessionByText"),
+                                "{\"transcription\":\"Watch Comedy Central\",\"type\":\"ptt\"}",
+                                response_));
+}
+
+TEST_F(VoiceControlTest, voiceSessionRequest)
+{
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_VOICE_IARM_CALL_SESSION_REQUEST), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_voice_iarm_call_json_t*>(arg);
+                EXPECT_THAT(param->payload, ::testing::ContainsRegex(_T("\"transcription\":\"Watch Comedy Central\"")));
+                strncpy(param->result, "{\"success\":true}", sizeof(param->result));
+                return IARM_RESULT_SUCCESS;
+            }));
+
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Invoke(connection_,
+                                _T("voiceSessionByText"),
+                                "{\"transcription\":\"Watch Comedy Central\",\"type\":\"ptt\"}",
+                                response_));
+    EXPECT_EQ(response_, "{\"success\":true}");
+}
+
+TEST_F(VoiceControlTest, voiceSessionTerminate)
+{
+    ON_CALL(iarmBusImplMock_, IARM_Bus_Call(StrEq(CTRLM_MAIN_IARM_BUS_NAME), StrEq(CTRLM_VOICE_IARM_CALL_SESSION_TERMINATE), _, _))
+        .WillByDefault(Invoke(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                auto param = static_cast<ctrlm_voice_iarm_call_json_t*>(arg);
+                strncpy(param->result, "{\"success\":true}", sizeof(param->result));
+                return IARM_RESULT_SUCCESS;
+            }));
+
+    EXPECT_EQ(Core::ERROR_NONE, handler_.Invoke(connection_,
+                                _T("voiceSessionTerminate"),
+                                _T("{\"sessionId\":\"1b11359e-23fe-4f2f-9ba8-cc19b87203cf\"}"),
+                                response_));
+    EXPECT_EQ(response_, "{\"success\":true}");
+}
+
+TEST_F(VoiceControlInitializedEventTest, onSessionBegin)
+{
+    EXPECT_CALL(service_, Submit(::testing::_, ::testing::_))
+        .WillOnce(::testing::Invoke(
+            [&](const uint32_t, const Core::ProxyType<Core::JSON::IElement>& json) {
+                string text;
+                EXPECT_TRUE(json->ToString(text));
+                EXPECT_EQ(text, string(_T("{\"jsonrpc\":\"2.0\","
+                                          "\"method\":\"org.rdk.VoiceControl.onSessionBegin\","
+                                          "\"params\":{\"remoteId\":1,"
+                                          "\"sessionId\":\"1b11359e-23fe-4f2f-9ba8-cc19b87203cf\","
+                                          "\"deviceType\":\"ptt\","
+                                          "\"keywordVerification\":true}}")));
+                return Core::ERROR_NONE;
+            }));
+
+    const string onSessionBeginParams = "{\"remoteId\":1,"
+                                        "\"sessionId\":\"1b11359e-23fe-4f2f-9ba8-cc19b87203cf\","
+                                        "\"deviceType\":\"ptt\","
+                                        "\"keywordVerification\":true}";
+    size_t len = sizeof(ctrlm_voice_iarm_event_json_t) + onSessionBeginParams.length() + 1;
+    ctrlm_voice_iarm_event_json_t *eventData = (ctrlm_voice_iarm_event_json_t *) malloc(len);
+
+    memset(eventData, 0, len);
+    eventData->api_revision = CTRLM_VOICE_IARM_BUS_API_REVISION;
+    sprintf(eventData->payload, "%s", onSessionBeginParams.c_str());
+
+    handler_.Subscribe(0, _T("onSessionBegin"), _T("org.rdk.VoiceControl"), message_);
+    voiceEventHandler_(CTRLM_MAIN_IARM_BUS_NAME, CTRLM_VOICE_IARM_EVENT_JSON_SESSION_BEGIN, eventData, len);
+    handler_.Unsubscribe(0, _T("onSessionBegin"), _T("org.rdk.VoiceControl"), message_);
+
+    free(eventData);
+}
+
+TEST_F(VoiceControlInitializedEventTest, onSessionEnd)
+{
+    EXPECT_CALL(service_, Submit(::testing::_, ::testing::_))
+        .WillOnce(::testing::Invoke(
+            [&](const uint32_t, const Core::ProxyType<Core::JSON::IElement>& json) {
+                string text;
+                EXPECT_TRUE(json->ToString(text));
+                EXPECT_EQ(text, string(_T("{\"jsonrpc\":\"2.0\","
+                                          "\"method\":\"org.rdk.VoiceControl.onSessionEnd\","
+                                          "\"params\":{\"serverStats\":{\"dnsTime\":1.0,"
+                                          "\"serverIp\":\"...\","
+                                          "\"connectTime\":1.0},"
+                                          "\"remoteId\":1,"
+                                          "\"sessionId\":\"1b11359e-23fe-4f2f-9ba8-cc19b87203cf\","
+                                          "\"result\":\"success\","
+                                          "\"success\":{\"transcription\":\"Comedy Central\"},"
+                                          "\"error\":{\"protocolErrorCode\":200,"
+                                          "\"protocolLibraryErrorCode\":\"...\","
+                                          "\"serverErrorCode\":1,"
+                                          "\"serverErrorString\":\"Error\","
+                                          "\"internalErrorCode\":0},"
+                                          "\"abort\":{\"reason\":1},"
+                                          "\"shortUtterance\":{\"reason\":1}}}")));
+                return Core::ERROR_NONE;
+            }));
+
+    const string onSessionEndParams = "{\"serverStats\":{\"dnsTime\":1.0,"
+                                      "\"serverIp\":\"...\","
+                                      "\"connectTime\":1.0},"
+                                      "\"remoteId\":1,"
+                                      "\"sessionId\":\"1b11359e-23fe-4f2f-9ba8-cc19b87203cf\","
+                                      "\"result\":\"success\","
+                                      "\"success\":{\"transcription\":\"Comedy Central\"},"
+                                      "\"error\":{\"protocolErrorCode\":200,"
+                                      "\"protocolLibraryErrorCode\":\"...\","
+                                      "\"serverErrorCode\":1,"
+                                      "\"serverErrorString\":\"Error\","
+                                      "\"internalErrorCode\":0},"
+                                      "\"abort\":{\"reason\":1},"
+                                      "\"shortUtterance\":{\"reason\":1}}";
+    size_t len = sizeof(ctrlm_voice_iarm_event_json_t) + onSessionEndParams.length() + 1;
+    ctrlm_voice_iarm_event_json_t *eventData = (ctrlm_voice_iarm_event_json_t *) malloc(len);
+
+    memset(eventData, 0, len);
+    eventData->api_revision = CTRLM_VOICE_IARM_BUS_API_REVISION;
+    sprintf(eventData->payload, "%s", onSessionEndParams.c_str());
+
+    handler_.Subscribe(0, _T("onSessionEnd"), _T("org.rdk.VoiceControl"), message_);
+    voiceEventHandler_(CTRLM_MAIN_IARM_BUS_NAME, CTRLM_VOICE_IARM_EVENT_JSON_SESSION_END, eventData, len);
+    handler_.Unsubscribe(0, _T("onSessionEnd"), _T("org.rdk.VoiceControl"), message_);
+
+    free(eventData);
+}
+
+TEST_F(VoiceControlInitializedEventTest, onStreamBegin)
+{
+    EXPECT_CALL(service_, Submit(::testing::_, ::testing::_))
+        .WillOnce(::testing::Invoke(
+            [&](const uint32_t, const Core::ProxyType<Core::JSON::IElement>& json) {
+                string text;
+                EXPECT_TRUE(json->ToString(text));
+                EXPECT_EQ(text, string(_T("{\"jsonrpc\":\"2.0\","
+                                          "\"method\":\"org.rdk.VoiceControl.onStreamBegin\","
+                                          "\"params\":{\"remoteId\":1,"
+                                          "\"sessionId\":\"1b11359e-23fe-4f2f-9ba8-cc19b87203cf\"}}")));
+                return Core::ERROR_NONE;
+            }));
+
+    const string onStreamBeginParams = "{\"remoteId\":1,"
+                                       "\"sessionId\":\"1b11359e-23fe-4f2f-9ba8-cc19b87203cf\"}";
+    size_t len = sizeof(ctrlm_voice_iarm_event_json_t) + onStreamBeginParams.length() + 1;
+    ctrlm_voice_iarm_event_json_t *eventData = (ctrlm_voice_iarm_event_json_t *) malloc(len);
+
+    memset(eventData, 0, len);
+    eventData->api_revision = CTRLM_VOICE_IARM_BUS_API_REVISION;
+    sprintf(eventData->payload, "%s", onStreamBeginParams.c_str());
+
+    handler_.Subscribe(0, _T("onStreamBegin"), _T("org.rdk.VoiceControl"), message_);
+    voiceEventHandler_(CTRLM_MAIN_IARM_BUS_NAME, CTRLM_VOICE_IARM_EVENT_JSON_STREAM_BEGIN, eventData, len);
+    handler_.Unsubscribe(0, _T("onStreamBegin"), _T("org.rdk.VoiceControl"), message_);
+
+    free(eventData);
+}
+
+TEST_F(VoiceControlInitializedEventTest, onStreamEnd)
+{
+    EXPECT_CALL(service_, Submit(::testing::_, ::testing::_))
+        .WillOnce(::testing::Invoke(
+            [&](const uint32_t, const Core::ProxyType<Core::JSON::IElement>& json) {
+                string text;
+                EXPECT_TRUE(json->ToString(text));
+                EXPECT_EQ(text, string(_T("{\"jsonrpc\":\"2.0\","
+                                          "\"method\":\"org.rdk.VoiceControl.onStreamEnd\","
+                                          "\"params\":{\"remoteId\":1,"
+                                          "\"sessionId\":\"1b11359e-23fe-4f2f-9ba8-cc19b87203cf\","
+                                          "\"reason\":0}}")));
+                return Core::ERROR_NONE;
+            }));
+
+    const string onStreamEndParams = "{\"remoteId\":1,"
+                                     "\"sessionId\":\"1b11359e-23fe-4f2f-9ba8-cc19b87203cf\","
+                                     "\"reason\":0}";
+    size_t len = sizeof(ctrlm_voice_iarm_event_json_t) + onStreamEndParams.length() + 1;
+    ctrlm_voice_iarm_event_json_t *eventData = (ctrlm_voice_iarm_event_json_t *) malloc(len);
+
+    memset(eventData, 0, len);
+    eventData->api_revision = CTRLM_VOICE_IARM_BUS_API_REVISION;
+    sprintf(eventData->payload, "%s", onStreamEndParams.c_str());
+
+    handler_.Subscribe(0, _T("onStreamEnd"), _T("org.rdk.VoiceControl"), message_);
+    voiceEventHandler_(CTRLM_MAIN_IARM_BUS_NAME, CTRLM_VOICE_IARM_EVENT_JSON_STREAM_END, eventData, len);
+    handler_.Unsubscribe(0, _T("onStreamEnd"), _T("org.rdk.VoiceControl"), message_);
+
+    free(eventData);
+}
+
+TEST_F(VoiceControlInitializedEventTest, onServerMessage)
+{
+    EXPECT_CALL(service_, Submit(::testing::_, ::testing::_))
+        .WillOnce(::testing::Invoke(
+            [&](const uint32_t, const Core::ProxyType<Core::JSON::IElement>& json) {
+                string text;
+                EXPECT_TRUE(json->ToString(text));
+                EXPECT_EQ(text, string(_T("{\"jsonrpc\":\"2.0\","
+                                          "\"method\":\"org.rdk.VoiceControl.onServerMessage\","
+                                          "\"params\":{\"msgType\":\"ars\","
+                                          "\"trx\":\"1b11359e-23fe-4f2f-9ba8-cc19b87203cf\","
+                                          "\"created\":91890278389232,"
+                                          "\"msgPayload\":{}}}")));
+                return Core::ERROR_NONE;
+            }));
+
+    const string onServerMessageParams = "{\"msgType\":\"ars\","
+                                         "\"trx\":\"1b11359e-23fe-4f2f-9ba8-cc19b87203cf\","
+                                         "\"created\":91890278389232,"
+                                         "\"msgPayload\":{}}";
+    size_t len = sizeof(ctrlm_voice_iarm_event_json_t) + onServerMessageParams.length() + 1;
+    ctrlm_voice_iarm_event_json_t *eventData = (ctrlm_voice_iarm_event_json_t *) malloc(len);
+
+    memset(eventData, 0, len);
+    eventData->api_revision = CTRLM_VOICE_IARM_BUS_API_REVISION;
+    sprintf(eventData->payload, "%s", onServerMessageParams.c_str());
+
+    handler_.Subscribe(0, _T("onServerMessage"), _T("org.rdk.VoiceControl"), message_);
+    voiceEventHandler_(CTRLM_MAIN_IARM_BUS_NAME, CTRLM_VOICE_IARM_EVENT_JSON_SERVER_MESSAGE, eventData, len);
+    handler_.Unsubscribe(0, _T("onServerMessage"), _T("org.rdk.VoiceControl"), message_);
+
+    free(eventData);
+}
+
+TEST_F(VoiceControlInitializedEventTest, onKeywordVerification)
+{
+    EXPECT_CALL(service_, Submit(::testing::_, ::testing::_))
+        .WillOnce(::testing::Invoke(
+            [&](const uint32_t, const Core::ProxyType<Core::JSON::IElement>& json) {
+                string text;
+                EXPECT_TRUE(json->ToString(text));
+                EXPECT_EQ(text, string(_T("{\"jsonrpc\":\"2.0\","
+                                          "\"method\":\"org.rdk.VoiceControl.onKeywordVerification\","
+                                          "\"params\":{\"remoteId\":1,"
+                                          "\"sessionId\":\"1b11359e-23fe-4f2f-9ba8-cc19b87203cf\","
+                                          "\"verified\":true}}")));
+                return Core::ERROR_NONE;
+            }));
+
+    const string onKeywordVerParams = "{\"remoteId\":1,"
+                                      "\"sessionId\":\"1b11359e-23fe-4f2f-9ba8-cc19b87203cf\","
+                                      "\"verified\":true}";
+    size_t len = sizeof(ctrlm_voice_iarm_event_json_t) + onKeywordVerParams.length() + 1;
+    ctrlm_voice_iarm_event_json_t *eventData = (ctrlm_voice_iarm_event_json_t *) malloc(len);
+
+    memset(eventData, 0, len);
+    eventData->api_revision = CTRLM_VOICE_IARM_BUS_API_REVISION;
+    sprintf(eventData->payload, "%s", onKeywordVerParams.c_str());
+
+    handler_.Subscribe(0, _T("onKeywordVerification"), _T("org.rdk.VoiceControl"), message_);
+    voiceEventHandler_(CTRLM_MAIN_IARM_BUS_NAME, CTRLM_VOICE_IARM_EVENT_JSON_KEYWORD_VERIFICATION, eventData, len);
+    handler_.Unsubscribe(0, _T("onKeywordVerification"), _T("org.rdk.VoiceControl"), message_);
+
+    free(eventData);
+}

--- a/VoiceControl/VoiceControl.cpp
+++ b/VoiceControl/VoiceControl.cpp
@@ -127,7 +127,7 @@ namespace WPEFramework {
 
                 if ((data == NULL) || (len <= sizeof(ctrlm_voice_iarm_event_json_t)))
                 {
-                    LOGERR("ERROR - got eventId(%u) with INVALID DATA: data: %p, len: %d.", (unsigned)eventId, data, len);
+                    LOGERR("ERROR - got eventId(%u) with INVALID DATA: data: %p, len: %zu.", (unsigned)eventId, data, len);
                     return;
                 }
 
@@ -180,14 +180,14 @@ namespace WPEFramework {
                         break;
 
                     default:
-                        LOGERR("ERROR - unexpected ControlMgr event: eventId: %u, data: %p, size: %d.",
+                        LOGERR("ERROR - unexpected ControlMgr event: eventId: %u, data: %p, size: %zu.",
                                (unsigned)eventId, data, len);
                         break;
                 }
             }
             else
             {
-                LOGERR("ERROR - unexpected event: owner %s, eventId: %u, data: %p, size: %d.",
+                LOGERR("ERROR - unexpected event: owner %s, eventId: %u, data: %p, size: %zu.",
                        owner, (unsigned)eventId, data, len);
             }
         }  // End iarmEventHandler()

--- a/tests.cmake
+++ b/tests.cmake
@@ -18,6 +18,8 @@ set(EMPTY_HEADERS_DIRS
         ${BASEDIR}/ccec/drivers/iarmbus
         ${BASEDIR}/ccec/host
         ${BASEDIR}/websocket
+        ${BASEDIR}/rdk/control
+        ${BASEDIR}/rdk/iarmmgrs
         )
 
 set(EMPTY_HEADERS
@@ -75,6 +77,12 @@ set(EMPTY_HEADERS
 	${BASEDIR}/ccec/drivers/iarmbus/CecIARMBusMgr.h
 	${BASEDIR}/dsRpc.h
 	${BASEDIR}/websocket/URL.h
+        ${BASEDIR}/rdk/iarmmgrs/irMgr.h
+        ${BASEDIR}/rdk/iarmmgrs/comcastIrKeyCodes.h
+        ${BASEDIR}/rdk/control/ctrlm_ipc.h
+        ${BASEDIR}/rdk/control/ctrlm_ipc_voice.h
+        ${BASEDIR}/rdk/control/ctrlm_ipc_rcu.h
+        ${BASEDIR}/rdk/control/ctrlm_ipc_key_codes.h
         )
 
 file(MAKE_DIRECTORY ${EMPTY_HEADERS_DIRS})
@@ -104,6 +112,7 @@ set(FAKE_HEADERS
         ${BASEDIR}/MotionDetection.h
         ${BASEDIR}/Dobby.h
         ${BASEDIR}/HdmiCec.h
+        ${BASEDIR}/Ctrlm.h
         )
 
 foreach (file ${FAKE_HEADERS})
@@ -169,5 +178,8 @@ set(PLUGIN_COMPOSITEINPUT ON)
 set(HAS_FRONT_PANEL ON)
 set(PLUGIN_OCICONTAINER ON)
 set(PLUGIN_HDMICECSINK ON)
+set(PLUGIN_VOICECONTROL ON)
+set(PLUGIN_CONTROLSERVICE ON)
+set(PLUGIN_REMOTEACTIONMAPPING ON)
 
 set(DS_FOUND ON)


### PR DESCRIPTION
Reason for change: Adding unit tests for VoiceControl, ControlService, and RemoteActionMapping plugins
Test Procedure: Run unit tests workflow and check test outcomes
Risks: Low

Signed-off-by: Kelvin Lu <kelvin_lu@comcast.com>