### PR TITLE
RDK-38434: Fix for SystemAudioPlayer build errors (r4.1)

### DIFF
--- a/SystemAudioPlayer/CMakeLists.txt
+++ b/SystemAudioPlayer/CMakeLists.txt
@@ -6,6 +6,8 @@ set(PLUGIN_SYSTEMAUDIOPLAYER_MODE "Local" CACHE STRING "Controls if the plugin s
 set(PLUGIN_SYSTEMAUDIOPLAYER_STARTUPORDER "40" CACHE STRING "To configure startup order of SystemAudioPlayer plugin")
 
 find_package(${NAMESPACE}Plugins REQUIRED)
+find_package(${NAMESPACE}COM REQUIRED)
+find_package(${NAMESPACE}WebSocket REQUIRED)
 
 find_package(Boost COMPONENTS system filesystem REQUIRED)
 find_package(websocketpp REQUIRED)
@@ -73,6 +75,8 @@ target_link_libraries(${MODULE_NAME} PRIVATE ${Boost_SYSTEM_LIBRARY})
 target_link_libraries(${MODULE_NAME} PRIVATE OpenSSL::SSL)
 target_link_libraries(${MODULE_NAME} PRIVATE OpenSSL::Crypto)
 target_link_libraries(${MODULE_NAME} PRIVATE ${Boost_FILESYSTEM_LIBRARY})
+target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}COM::${NAMESPACE}COM)
+target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}WebSocket::${NAMESPACE}WebSocket)
 
 install(TARGETS ${MODULE_NAME}
         DESTINATION lib/${STORAGE_DIRECTORY}/plugins)

--- a/SystemAudioPlayer/ProxyStubs_SystemAudioPlayer.cpp
+++ b/SystemAudioPlayer/ProxyStubs_SystemAudioPlayer.cpp
@@ -46,7 +46,7 @@ namespace ProxyStubs {
 
             // read parameters
             RPC::Data::Frame::Reader reader(input.Reader());
-            RPC::instance_id param0 = reader.Number<RPC::instance_id>();
+            Core::instance_id param0 = reader.Number<Core::instance_id>();
             PluginHost::IShell* param0_proxy = nullptr;
             ProxyStub::UnknownProxy* param0_proxy_inst = nullptr;
             if (param0 != 0) {
@@ -79,7 +79,7 @@ namespace ProxyStubs {
 
             // read parameters
             RPC::Data::Frame::Reader reader(input.Reader());
-            RPC::instance_id param0 = reader.Number<RPC::instance_id>();
+            Core::instance_id param0 = reader.Number<Core::instance_id>();
             ISystemAudioPlayer::INotification* param0_proxy = nullptr;
             ProxyStub::UnknownProxy* param0_proxy_inst = nullptr;
             if (param0 != 0) {
@@ -108,7 +108,7 @@ namespace ProxyStubs {
 
             // read parameters
             RPC::Data::Frame::Reader reader(input.Reader());
-            RPC::instance_id param0 = reader.Number<RPC::instance_id>();
+            Core::instance_id param0 = reader.Number<Core::instance_id>();
             ISystemAudioPlayer::INotification* param0_proxy = nullptr;
             ProxyStub::UnknownProxy* param0_proxy_inst = nullptr;
             if (param0 != 0) {
@@ -434,7 +434,7 @@ namespace ProxyStubs {
 
     class SystemAudioPlayerProxy final : public ProxyStub::UnknownProxyType<ISystemAudioPlayer> {
     public:
-        SystemAudioPlayerProxy(const Core::ProxyType<Core::IPCChannel>& channel, RPC::instance_id implementation, const bool otherSideInformed)
+        SystemAudioPlayerProxy(const Core::ProxyType<Core::IPCChannel>& channel, Core::instance_id implementation, const bool otherSideInformed)
             : BaseClass(channel, implementation, otherSideInformed)
         {
         }
@@ -445,7 +445,7 @@ namespace ProxyStubs {
 
             // write parameters
             RPC::Data::Frame::Writer writer(newMessage->Parameters().Writer());
-            writer.Number<RPC::instance_id>(RPC::instance_cast<PluginHost::IShell*>(param0));
+            writer.Number<Core::instance_id>(RPC::instance_cast<PluginHost::IShell*>(param0));
 
             // invoke the method handler
             uint32_t output{};
@@ -466,7 +466,7 @@ namespace ProxyStubs {
 
             // write parameters
             RPC::Data::Frame::Writer writer(newMessage->Parameters().Writer());
-            writer.Number<RPC::instance_id>(RPC::instance_cast<ISystemAudioPlayer::INotification*>(param0));
+            writer.Number<Core::instance_id>(RPC::instance_cast<ISystemAudioPlayer::INotification*>(param0));
 
             // invoke the method handler
             if (Invoke(newMessage) == Core::ERROR_NONE) {
@@ -482,7 +482,7 @@ namespace ProxyStubs {
 
             // write parameters
             RPC::Data::Frame::Writer writer(newMessage->Parameters().Writer());
-            writer.Number<RPC::instance_id>(RPC::instance_cast<ISystemAudioPlayer::INotification*>(param0));
+            writer.Number<Core::instance_id>(RPC::instance_cast<ISystemAudioPlayer::INotification*>(param0));
 
             // invoke the method handler
             if (Invoke(newMessage) == Core::ERROR_NONE) {
@@ -745,7 +745,7 @@ namespace ProxyStubs {
 
     class SystemAudioPlayerNotificationProxy final : public ProxyStub::UnknownProxyType<ISystemAudioPlayer::INotification> {
     public:
-        SystemAudioPlayerNotificationProxy(const Core::ProxyType<Core::IPCChannel>& channel, RPC::instance_id implementation, const bool otherSideInformed)
+        SystemAudioPlayerNotificationProxy(const Core::ProxyType<Core::IPCChannel>& channel, Core::instance_id implementation, const bool otherSideInformed)
             : BaseClass(channel, implementation, otherSideInformed)
         {
         }

--- a/SystemAudioPlayer/SystemAudioPlayerImplementation.h
+++ b/SystemAudioPlayer/SystemAudioPlayerImplementation.h
@@ -82,7 +82,7 @@ namespace Plugin {
 
        public:
             static Core::ProxyType<Core::IDispatch> Create(SystemAudioPlayerImplementation *sap, Event event, string data) {
-                return (Core::proxy_cast<Core::IDispatch>(Core::ProxyType<Job>::Create(sap, event, data)));
+                return (Core::ProxyType<Core::IDispatch>(Core::ProxyType<Job>::Create(sap, event, data)));
             }
 
             virtual void Dispatch() {


### PR DESCRIPTION
Reason for change: Fix Compilation issues
Fix above issue:
Test Procedure: Build and verify
Risks: High
Priority: P1
Signed-off-by: Kumar Santhanam <Kumar_Santhanam@comcast.com>