### PR TITLE
DELIA-57717: Fix for WPEFramework crash with callstack std::execute_n…

### DIFF
--- a/WifiManager/CHANGELOG.md
+++ b/WifiManager/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+## [1.0.5] - 2023-02-16
+### Fixed
+- Fix for WPEFramework crash with callstack std::execute
+
 ## [1.0.4] - 2022-12-13
 ### Added
 - Added WifiManager plugin unitTest cases.

--- a/WifiManager/WifiManager.cpp
+++ b/WifiManager/WifiManager.cpp
@@ -31,7 +31,7 @@
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 4
+#define API_VERSION_NUMBER_PATCH 5
 
 namespace {
     using WPEFramework::Plugin::WifiManager;
@@ -116,6 +116,7 @@ namespace WPEFramework
         void WifiManager::Deinitialize(PluginHost::IShell* service)
         {
             wifiScan.Deinitialize(service);
+            wifiSignalThreshold.stopSignalThresholdThread();
 
             instance = nullptr;
         }

--- a/WifiManager/impl/WifiManagerSignalThreshold.cpp
+++ b/WifiManager/impl/WifiManagerSignalThreshold.cpp
@@ -98,7 +98,12 @@ WifiManagerSignalThreshold::WifiManagerSignalThreshold():
 {
 }
 
+
 WifiManagerSignalThreshold::~WifiManagerSignalThreshold()
+{
+}
+
+void WifiManagerSignalThreshold::stopSignalThresholdThread()
 {
     stopThread();
 }
@@ -186,7 +191,6 @@ void WifiManagerSignalThreshold::loop(int interval)
         if (running)
         {
             getSignalData(signalStrength, strength);
-
 
             if (strength != lastStrength)
             {

--- a/WifiManager/impl/WifiManagerSignalThreshold.h
+++ b/WifiManager/impl/WifiManagerSignalThreshold.h
@@ -48,6 +48,7 @@ namespace WPEFramework {
             uint32_t setSignalThresholdChangeEnabled(const JsonObject& parameters, JsonObject& response);
             void setSignalThresholdChangeEnabled(bool enable);
             uint32_t isSignalThresholdChangeEnabled(const JsonObject& parameters, JsonObject& response) const;
+            void stopSignalThresholdThread();
 
         private:
             void setSignalThresholdChangeEnabled(bool enabled, int interval);


### PR DESCRIPTION
…… (#3575) (#3635)

* DELIA-57717: Fix for WPEFramework crash with callstack std::execute_native_thread_routine

Reason for change: Thread stop is not happening when wifiManager get deactivated Fix above issue: Calling thread stop before deactivated Test Procedure:
Risks:
Priority: P0
Signed-off-by: Kumar Santhanam <Kumar_Santhanam@comcast.com>

* Update WifiManagerInterface.h

* Update WifiManager.h

Co-authored-by: Karunakaran A <48997923+karuna2git@users.noreply.github.com>
(cherry picked from commit 9628b92658fa23b67188df043ab16509f8e08629) (cherry picked from commit fd20a5b0714ff56f29287b6db8bc6cc2d1884198)