### PR TITLE
RDKTV-21700 - UsbAccess Plugin clearlink method observations

### DIFF
--- a/Tests/tests/test_UsbAccess.cpp
+++ b/Tests/tests/test_UsbAccess.cpp
@@ -27,6 +27,7 @@ TEST_F(UsbAccessTest, RegisteredMethods)
     EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("getFileList")));
     EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("createLink")));
     EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("clearLink")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("getLinks")));
     EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("getAvailableFirmwareFiles")));
     EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("getMounted")));
     EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("updateFirmware")));

--- a/UsbAccess/CHANGELOG.md
+++ b/UsbAccess/CHANGELOG.md
@@ -16,6 +16,13 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.2.0] - 2023-02-01
+### Added
+- Added new api getLinks, to get all the created links
+### Changed
+- Fixed bug with APIs getFileList(), createLink(), clearLink(), archiveLogs(), when invalid path is provided
+- Added "path" tag to getFileList() API's response
+
 ## [1.1.0] - 2023-01-26
 ### Changed
 - Added support for multiple usb drives

--- a/UsbAccess/UsbAccess.cpp
+++ b/UsbAccess/UsbAccess.cpp
@@ -15,7 +15,7 @@
 #include "UtilsIarm.h"
 
 #define API_VERSION_NUMBER_MAJOR 1
-#define API_VERSION_NUMBER_MINOR 1
+#define API_VERSION_NUMBER_MINOR 2
 #define API_VERSION_NUMBER_PATCH 0
 const string WPEFramework::Plugin::UsbAccess::SERVICE_NAME = "org.rdk.UsbAccess";
 const string WPEFramework::Plugin::UsbAccess::METHOD_GET_FILE_LIST = "getFileList";
@@ -138,10 +138,13 @@ namespace Plugin {
         }
 
         //From usb number 2, it returns the next available number
-        int nextAvailableNumber(const std::set<int>& numList) {
+        int nextAvailableNumber(const std::map<int, std::string>& numList) {
             int nNum = 2;
             for(auto const& it : numList) {
-                if(it != nNum) {
+                //Treat 1 as special case, since we create this as usbdrive (no number suffix)
+                if(it.first == 1)
+                    continue;
+                if(it.first != nNum) {
                     break;
                 }
                 nNum++;
@@ -150,6 +153,7 @@ namespace Plugin {
         }
 
         //Returns if the incomingPath already has existing link
+        // availableLink: /tmp/usbdrive, incomingPath: /run/media/sda1
         bool isSymlinkExists(const string& availableLink, const string& incomingPath)
         {
             bool bLinkExists = false;
@@ -170,6 +174,14 @@ namespace Plugin {
             }
             return bLinkExists;
         }
+
+        bool isParamsEmpty(const JsonObject &parameters)
+        {
+            std::string strJson; 
+            parameters.ToString(strJson);
+            return ((strJson == "{}") ? true : false);
+        }
+
     }
 
     SERVICE_REGISTRATION(UsbAccess, API_VERSION_NUMBER_MAJOR, API_VERSION_NUMBER_MINOR, API_VERSION_NUMBER_PATCH);
@@ -185,6 +197,7 @@ namespace Plugin {
         registerMethod(_T("getFileList"), &UsbAccess::getFileListWrapper, this);
         registerMethod(_T("createLink"), &UsbAccess::createLinkWrapper, this);
         registerMethod(_T("clearLink"), &UsbAccess::clearLinkWrapper, this);
+        registerMethod(_T("getLinks"), &UsbAccess::getLinksWrapper, this);
         registerMethod(_T("getAvailableFirmwareFiles"), &UsbAccess::getAvailableFirmwareFilesWrapper, this);
         registerMethod(_T("getMounted"), &UsbAccess::getMountedWrapper, this);
         registerMethod(_T("updateFirmware"), &UsbAccess::updateFirmware, this);
@@ -225,13 +238,18 @@ namespace Plugin {
         string pathParam;
         if (parameters.HasLabel("path"))
             pathParam = parameters["path"].String();
+        else if (!isParamsEmpty(parameters))
+        {
+            LOGWARN("path is missing from the parameters");
+            return Core::ERROR_BAD_REQUEST;
+        }
 
         FileList files;
+        string absPath;
         std::list<string> paths;
         getMounted(paths);
         if (!paths.empty())
         {
-            string absPath;
             //Loop through all the paths to match for absolute path
             for(auto const& it : paths)
             {
@@ -253,6 +271,7 @@ namespace Plugin {
             response["error"] = "not found";
         else
         {
+            response["path"] = absPath;
             JsonArray arr;
             for_each(files.begin(), files.end(), [&arr](const FileEnt& it)
             {
@@ -280,6 +299,11 @@ namespace Plugin {
 		string pathParam;
 		if (parameters.HasLabel("path"))
 			pathParam = parameters["path"].String();
+        else if (!isParamsEmpty(parameters))
+        {
+            LOGWARN("path is missing from the parameters");
+            return Core::ERROR_BAD_REQUEST;
+        }
         else if(!paths.empty())
             pathParam = *paths.begin();
 
@@ -291,12 +315,12 @@ namespace Plugin {
                 bLinkExists = true;
             else {
                 //Loop through all the existing IDs and set bLinkExists to true, if it already has the link
-                for(auto itr : m_CreatedLinkIds)
+                for(auto const& itr : m_CreatedLinkIds)
                 {
-                    string linkPath = LINK_PATH+std::to_string(itr);
+                    string linkPath = LINK_PATH+std::to_string(itr.first);
                     bLinkExists = isSymlinkExists(linkPath, pathParam);
                     if(bLinkExists) {
-                        baseURL = baseURL + std::to_string(itr);
+                        baseURL = baseURL + std::to_string(itr.first);
                         break;
                     }
                 }
@@ -308,6 +332,8 @@ namespace Plugin {
                 if((*paths.begin()).compare(pathParam) == 0 )
                 {
                     result = createLink(*paths.begin(), LINK_PATH);
+                    if (result)
+                        m_CreatedLinkIds.insert(std::make_pair(1, *paths.begin()));
                 }
                 else
                 {
@@ -320,7 +346,7 @@ namespace Plugin {
                             baseURL = baseURL + std::to_string(nUsbNum);    //Add number suffix
                             result = createLink(it, LINK_PATH+std::to_string(nUsbNum));
                             if (result)
-                                m_CreatedLinkIds.insert(nUsbNum);
+                                m_CreatedLinkIds.insert(std::make_pair(nUsbNum, it));
                             break;
                         }
                     }
@@ -348,16 +374,23 @@ namespace Plugin {
         string urlParam;
         if (parameters.HasLabel("baseURL"))
             urlParam = parameters["baseURL"].String();
+        else if (!isParamsEmpty(parameters))
+        {
+            LOGWARN("baseURL is missing from the parameters");
+            return Core::ERROR_BAD_REQUEST;
+        }
 
         if(urlParam.empty() || (urlParam.compare(LINK_URL_HTTP)) == 0)
         {
             result = clearLink(LINK_PATH);
+            if (result)
+                m_CreatedLinkIds.erase(1);
         }
         else
         {
             //Validate incoming path
             std::smatch match;
-            if (regex_search(urlParam, match, std::regex("http://localhost:50050/usbdrive[0-9]+")) &&  match.size() >= 1) {
+            if (regex_search(urlParam, match, std::regex("http://localhost:50050/usbdrive[0-9]+$")) &&  match.size() >= 1) {
                 nUsbNum = std::stoi(urlParam.substr(urlParam.find_last_not_of("0123456789") + 1));
                 result = clearLink(LINK_PATH+std::to_string(nUsbNum));
                 if (result)
@@ -369,6 +402,28 @@ namespace Plugin {
             response["error"] = "could not remove symlink";
 
         returnResponse(result);
+    }
+
+    uint32_t UsbAccess::getLinksWrapper(const JsonObject &parameters, JsonObject &response)
+    {
+        LOGINFOMETHOD();
+
+        JsonArray arr;
+        //Loop through all created links
+        for(auto const& itr : m_CreatedLinkIds)
+        {
+            std::string strLink = LINK_URL_HTTP;
+            //Special case for first drive, where the number suffix is not needed
+            if(itr.first != 1)
+                strLink += std::to_string(itr.first);
+
+            JsonObject links;
+            links["path"] = itr.second;
+            links["baseURL"] = strLink;
+            arr.Add(links);
+        }
+        response["links"] = arr;
+        returnResponse(true);
     }
 
     uint32_t UsbAccess::getAvailableFirmwareFilesWrapper(const JsonObject &parameters, JsonObject &response)
@@ -469,6 +524,12 @@ namespace Plugin {
     uint32_t UsbAccess::archiveLogs(const JsonObject& parameters, JsonObject& response)
     {
         LOGINFOMETHOD();
+
+        if (!isParamsEmpty(parameters) && !parameters.HasLabel("path"))
+        {
+            LOGWARN("path is missing from the parameters");
+            return Core::ERROR_BAD_REQUEST;
+        }
 
         if (archiveLogsThread.joinable())
             archiveLogsThread.join();

--- a/UsbAccess/UsbAccess.h
+++ b/UsbAccess/UsbAccess.h
@@ -64,6 +64,7 @@ namespace Plugin {
         uint32_t getFileListWrapper(const JsonObject& parameters, JsonObject& response);
         uint32_t createLinkWrapper(const JsonObject& parameters, JsonObject& response);
         uint32_t clearLinkWrapper(const JsonObject& parameters, JsonObject& response);
+        uint32_t getLinksWrapper(const JsonObject& parameters, JsonObject& response);
         uint32_t getAvailableFirmwareFilesWrapper(const JsonObject& parameters, JsonObject& response);
         uint32_t getMountedWrapper(const JsonObject& parameters, JsonObject& response);
         uint32_t updateFirmware(const JsonObject& parameters, JsonObject& response);
@@ -93,7 +94,7 @@ namespace Plugin {
         void archiveLogsInternal();
         void onArchiveLogs(ArchiveLogsError error, const string& filePath);
         std::thread archiveLogsThread;
-        std::set<int> m_CreatedLinkIds;
+        std::map<int, std::string> m_CreatedLinkIds;
         JsonObject m_oArchiveParams;
     };
 

--- a/UsbAccess/UsbAccess.json
+++ b/UsbAccess/UsbAccess.json
@@ -79,7 +79,45 @@
                 ]
             }
         },
-        "getAvailableFirmwareFiles": {
+        "getLinks": {
+            "summary": "Returns a list of created links and the associated root folder of the USB drive.",
+            "result": {
+                "type": "object",
+                "properties": {
+                    "links": {
+                        "summary": "The list of links and associated baseURL paths (empty if there are no results)",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "path": {
+                                    "summary": "The root folder of the mounted USB Drive as returned by getMounted API",
+                                    "type": "string",
+                                    "example": "/run/media/sda1"
+                                },
+                                "baseURL": {
+                                    "summary": "The URL of the web server that points to the path as returned by createLink",
+                                    "type": "string",
+                                    "example": "http://localhost/usbdrive"
+                                }
+                            },
+                            "required": [
+                                "path",
+                                "baseURL"
+                            ]
+                        }
+                    },
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "links",
+                    "success"
+                ]
+            }
+        },
+         "getAvailableFirmwareFiles": {
             "summary": "Gets a list of firmware files on the device. These files should start with the PMI or model number for that device and end with `.bin`. For example `HSTP11MWR_4.11p5s1_VBN_sdy.bin`.  \nFirmware files are scanned in the root directories. If multiple USB devices are found, then the available firmware files are checked and listed from each device.",
             "result": {
                 "type": "object",
@@ -119,6 +157,11 @@
             "result": {
                 "type": "object",
                 "properties": {
+                    "path": {
+                        "summary": "Absolute path for which the contents are returned",
+                        "type":"string",
+                        "example": "\/run\/media\/sda1\/logs\/PreviousLogs"
+                    },
                     "contents": {
                         "summary": "A list of files and directories (empty if there are no results)",
                         "type": "array",
@@ -152,6 +195,7 @@
                     }
                 },
                 "required": [
+                    "path",
                     "contents",
                     "success"
                 ]

--- a/docs/api/UsbAccessPlugin.md
+++ b/docs/api/UsbAccessPlugin.md
@@ -2,7 +2,7 @@
 <a name="UsbAccess_Plugin"></a>
 # UsbAccess Plugin
 
-**Version: [1.1.0](https://github.com/rdkcentral/rdkservices/blob/main/UsbAccess/CHANGELOG.md)**
+**Version: [1.2.0](https://github.com/rdkcentral/rdkservices/blob/main/UsbAccess/CHANGELOG.md)**
 
 A org.rdk.UsbAccess plugin for Thunder framework.
 
@@ -49,6 +49,7 @@ UsbAccess interface methods:
 | :-------- | :-------- |
 | [clearLink](#clearLink) | Clears or removes the symbolic link created by the `createLink` method |
 | [createLink](#createLink) | Creates a symbolic link to the root folder of the USB drive |
+| [getLinks](#getLinks) | Returns a list of created links and the associated root folder of the USB drive |
 | [getAvailableFirmwareFiles](#getAvailableFirmwareFiles) | Gets a list of firmware files on the device |
 | [getFileList](#getFileList) | Gets a list of files and folders from the specified directory or path |
 | [getMounted](#getMounted) | Returns a list of mounted USB devices |
@@ -162,6 +163,60 @@ No Events
 }
 ```
 
+<a name="getLinks"></a>
+## *getLinks*
+
+Returns a list of created links and the associated root folder of the USB drive.
+
+### Events
+
+No Events
+
+### Parameters
+
+This method takes no parameters.
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.links | array | The list of links and associated baseURL paths (empty if there are no results) |
+| result.links[#] | object |  |
+| result.links[#].path | string | The root folder of the mounted USB Drive as returned by getMounted API |
+| result.links[#].baseURL | string | The URL of the web server that points to the path as returned by createLink |
+| result.success | boolean | Whether the request succeeded |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.UsbAccess.getLinks"
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "links": [
+            {
+                "path": "/run/media/sda1",
+                "baseURL": "http://localhost/usbdrive"
+            }
+        ],
+        "success": true
+    }
+}
+```
+
 <a name="getAvailableFirmwareFiles"></a>
 ## *getAvailableFirmwareFiles*
 
@@ -233,6 +288,7 @@ No Events
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
 | result | object |  |
+| result.path | string | Absolute path for which the contents are returned |
 | result.contents | array | A list of files and directories (empty if there are no results) |
 | result.contents[#] | object |  |
 | result.contents[#].name | string | the name of the file or directory |
@@ -262,6 +318,7 @@ No Events
     "jsonrpc": "2.0",
     "id": 42,
     "result": {
+        "path": "/run/media/sda1/logs/PreviousLogs",
         "contents": [
             {
                 "name": "img1.jpg",


### PR DESCRIPTION
- Handled error cases fir optional parameters
- Added getLinks API

(cherry picked from commit 9ef0fd35bbafa6ecfe4f502ab8f3384f1bc75eb5)

RDKTV-21700 - UsbAccess Plugin clearlink method observations

Updated documentation

(cherry picked from commit 12ac79ebd9a37b37a006ea30eea8c38e5b30435b)

RDKTV-21700 - Corrected API name in documentation

(cherry picked from commit 1b90b6305c65a7c3494bf160768be8c5e3f878e8)

RDKTV-21700 - UsbAccess Plugin clearlink method observations

- Fixed missing "path" tag in the getFileList API response

(cherry picked from commit 8c4bd8fe561041469562d9d454133f3d25e2b6d8)

RDKTV-21700 - UsbAccess Plugin clearlink method observations

- Fixed API doc

(cherry picked from commit 2f69f00209b08aa812433222fd19bcf2b63668cd) (cherry picked from commit d89f85d342e5752c89329a62a4a3e3f2d63efd7b)

RDKTV-21700 - [Thunder]-UsbAccess Plugin clearlink method observations

(cherry picked from commit 4f2270ee26bb65df58932e26e0dde8829e45faa5)

RDKTV-21700 - [Thunder]-UsbAccess Plugin clearlink method observations

Fixed versioning

(cherry picked from commit 8efd5b4823fdfd5b1a2ae818ddbf2f867ed8238a)