### PR TITLE
RDKTV-21748: Removing OSD name Updated to FA on Feature Abort

### DIFF
--- a/HdmiCecSink/CHANGELOG.md
+++ b/HdmiCecSink/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.0.10] - 2023-02-16
+### Fixed
+- Updated OSDName to empty string as default and when FeatureAbort frame received for GiveOSDName.
+
 ## [1.0.9] - 2022-12-31
 ### Fixed
 - Updated documentation for sendKeyEvent thunder API.

--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -148,7 +148,7 @@ static int32_t HdmiArcPortID = -1;
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 9
+#define API_VERSION_NUMBER_PATCH 10
 
 namespace WPEFramework
 {
@@ -443,7 +443,7 @@ namespace WPEFramework
 					
 					case GIVE_OSD_NAME :
 			 		{
-			 			HdmiCecSink::_instance->deviceList[header.from.toInt()].update(OSDName("FA"));
+			 			HdmiCecSink::_instance->deviceList[header.from.toInt()].update(OSDName(""));
 			 		}
 						break;
 
@@ -1849,7 +1849,7 @@ namespace WPEFramework
 	
 		void HdmiCecSink::sendMenuLanguage()
 		{
-			Language lang = "NA";
+			Language lang = "";
 			if(!HdmiCecSink::_instance)
 				return;
 
@@ -2480,7 +2480,7 @@ namespace WPEFramework
 						if ( _instance->deviceList[logicalAddress].m_isRequestRetry++ >= HDMICECSINK_REQUEST_MAX_RETRY )
 						{
 							LOGINFO("Max retry for REQUEST_OSD_NAME = %d", _instance->deviceList[logicalAddress].m_isRequestRetry);
-							_instance->deviceList[logicalAddress].update(OSDName("NA"));
+							_instance->deviceList[logicalAddress].update(OSDName(""));
 							_instance->deviceList[logicalAddress].m_isRequestRetry = 0;
 						}
 					}

--- a/HdmiCecSink/HdmiCecSink.h
+++ b/HdmiCecSink/HdmiCecSink.h
@@ -139,7 +139,7 @@ namespace WPEFramework {
 			std::chrono::system_clock::time_point m_lastPowerUpdateTime;
 			
 			CECDeviceParams() 
-			: m_deviceType(0), m_logicalAddress(0),m_physicalAddr(0x0f,0x0f,0x0f,0x0f),m_cecVersion(0),m_vendorID(0,0,0),m_osdName("NA"),m_powerStatus(0),m_currentLanguage("NA")
+			: m_deviceType(0), m_logicalAddress(0),m_physicalAddr(0x0f,0x0f,0x0f,0x0f),m_cecVersion(0),m_vendorID(0,0,0),m_osdName(""),m_powerStatus(0),m_currentLanguage("")
 			{
 				m_isDevicePresent = false;
 				m_isActiveSource = false;
@@ -160,9 +160,9 @@ namespace WPEFramework {
 				m_physicalAddr = PhysicalAddress(0x0f,0x0f,0x0f,0x0f);
 				m_cecVersion = 0;
 				m_vendorID = VendorID(0,0,0);
-				m_osdName = "NA";
+				m_osdName = "";
 				m_powerStatus = 0;
- 				m_currentLanguage = "NA";
+ 				m_currentLanguage = "";
 				m_isDevicePresent = false;
 				m_isActiveSource = false;
 				m_isPAUpdated = false;


### PR DESCRIPTION
Reason for change: OSD name is set as "NA" by default and set to "FA" when Feature Abort command is received. Changing this values to empty string "" Test Procedure: Steps mentioned in ticket
Risks: Low
Signed-off-by: Dhivya Ilangovan <dhivya.dilangovan@sky.uk>