### PR TITLE
DELIA-60222: Fix undefined symbols on qemu x86 platform

### DIFF
--- a/WebKitBrowser/Extension/main.cpp
+++ b/WebKitBrowser/Extension/main.cpp
@@ -250,3 +250,7 @@ G_MODULE_EXPORT void webkit_web_extension_initialize_with_user_data(WebKitWebExt
 }
 
 }
+
+// explicit instantiation so that -O1/2/3 flags do not introduce undefined symbols
+template void WPEFramework::Core::IPCMessageType<2u, WPEFramework::RPC::Data::Input, WPEFramework::RPC::Data::Output>::RawSerializedType<WPEFramework::RPC::Data::Input, 4u>::AddRef() const;
+template void WPEFramework::Core::IPCMessageType<2u, WPEFramework::RPC::Data::Input, WPEFramework::RPC::Data::Output>::RawSerializedType<WPEFramework::RPC::Data::Output, 5u>::AddRef() const;

--- a/WebKitBrowser/InjectedBundle/main.cpp
+++ b/WebKitBrowser/InjectedBundle/main.cpp
@@ -417,3 +417,7 @@ EXTERNAL void WKBundleInitialize(WKBundleRef bundle, WKTypeRef)
 }
 
 }
+
+// explicit instantiation so that -O1/2/3 flags do not introduce undefined symbols
+template void WPEFramework::Core::IPCMessageType<2u, WPEFramework::RPC::Data::Input, WPEFramework::RPC::Data::Output>::RawSerializedType<WPEFramework::RPC::Data::Input, 4u>::AddRef() const;
+template void WPEFramework::Core::IPCMessageType<2u, WPEFramework::RPC::Data::Input, WPEFramework::RPC::Data::Output>::RawSerializedType<WPEFramework::RPC::Data::Output, 5u>::AddRef() const;


### PR DESCRIPTION
On qemu x86 platform the gcc with `-O2` is used. Such flag leaves few symbols undefined (stripped when `-Os` is used) therefore making the injected bundle shared object not loadable.