### PR TITLE
RDKTV-12796:Move iarmmgrs oem patches

### DIFF
--- a/DeviceInfo/Implementation/DeviceInfo.cpp
+++ b/DeviceInfo/Implementation/DeviceInfo.cpp
@@ -109,7 +109,7 @@ namespace Plugin {
         return
         // TYPE_SKYMODELNAME exists for oem-sky-realtek
 #ifdef ENABLE_DEVICE_MANUFACTURER_INFO
-            (GetMFRData(mfrSERIALIZED_TYPE_SKYMODELNAME, model) == Core::ERROR_NONE)
+            (GetMFRData(mfrSERIALIZED_TYPE_PROVISIONED_MODELNAME, model) == Core::ERROR_NONE)
             ? Core::ERROR_NONE
             :
 #endif

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -1035,7 +1035,7 @@ namespace WPEFramework {
 		LOGWARN("SystemService getDeviceInfo query %s", parameter.c_str());
 		IARM_Bus_MFRLib_GetSerializedData_Param_t param;
 		param.bufLen = 0;
-		param.type = mfrSERIALIZED_TYPE_SKYMODELNAME;
+		param.type = mfrSERIALIZED_TYPE_PROVISIONED_MODELNAME;
 		IARM_Result_t result = IARM_Bus_Call(IARM_BUS_MFRLIB_NAME, IARM_BUS_MFRLIB_API_GetSerializedData, &param, sizeof(param));
 		param.buffer[param.bufLen] = '\0';
 		LOGWARN("SystemService getDeviceInfo param type %d result %s", param.type, param.buffer);
@@ -1108,7 +1108,7 @@ namespace WPEFramework {
             param.bufLen = 0;
             param.type = mfrSERIALIZED_TYPE_MANUFACTURER;
             if (!parameter.compare(MODEL_NAME)) {
-                param.type = mfrSERIALIZED_TYPE_SKYMODELNAME;
+                param.type = mfrSERIALIZED_TYPE_PROVISIONED_MODELNAME;
             } else if (!parameter.compare(HARDWARE_ID)) {
                 param.type = mfrSERIALIZED_TYPE_HWID;
             }


### PR DESCRIPTION
Reason for change: mfr enum changes
Test Procedure: mfrmgr test cases
Risks: Create None
Signed-off-by: Rahamataunnisa shaik rahamtaunnisa.shaik@sky.uk