### PR TITLE
DELIA-60116: Removing Cjson from xCast.

### DIFF
--- a/XCast/CMakeLists.txt
+++ b/XCast/CMakeLists.txt
@@ -41,7 +41,7 @@ target_include_directories(${MODULE_NAME} PRIVATE ${IARMBUS_INCLUDE_DIRS} ../hel
 target_include_directories(${MODULE_NAME} PRIVATE ${RFC_INCLUDE_DIRS} ../helpers)
 target_include_directories(${MODULE_NAME} PRIVATE $ENV{PKG_CONFIG_SYSROOT_DIR}/usr/include/pxcore)
 
-target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins rtRemote rtCore cjson ${RFC_LIBRARIES} ${IARMBUS_LIBRARIES})
+target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins rtRemote rtCore ${RFC_LIBRARIES} ${IARMBUS_LIBRARIES})
 
 
 install(TARGETS ${MODULE_NAME}

--- a/XCast/RtXcastConnector.cpp
+++ b/XCast/RtXcastConnector.cpp
@@ -21,7 +21,6 @@
 #include "Module.h"
 #include "UtilsJsonRpc.h"
 #include "rfcapi.h"
-#include <cjson/cJSON.h>
 
 using namespace std;
 using namespace WPEFramework;

--- a/XCast/XCast.cpp
+++ b/XCast/XCast.cpp
@@ -26,7 +26,6 @@
 #endif //RFC_ENABLED
 #include <syscall.h>
 #include <cstring>
-#include <cjson/cJSON.h>
 #include "RtXcastConnector.h"
 using namespace std;
 
@@ -430,27 +429,16 @@ bool XCast::deleteFromDynamicAppCache(vector<string>& appsToDelete) {
     return ret;
 }
 
-bool XCast::deleteFromDynamicAppCache(string strAppNames)
+bool XCast::deleteFromDynamicAppCache(JsonArray applications)
 {
     bool ret = false;
-    cJSON *itrName = NULL;
-    if (!strAppNames.empty()) {
-        cJSON *applications = cJSON_Parse(strAppNames.c_str());
-        if (!cJSON_IsArray(applications)) {
-            LOGINFO ("deleteFromDynamicAppCache::applications array passed: %s", strAppNames.c_str());
-            LOGINFO ("deleteFromDynamicAppCache::Invalid applications array exititng");
-            cJSON_Delete(applications);
-            return ret;
-        }
-        int iIndex = 0;
+    std::string itrName = "";
+    if (applications.Length() != 0) {
         vector<string> appsToDelete;
-        cJSON_ArrayForEach(itrName, applications) {
-            if (!cJSON_IsString(itrName)) {
-                LOGINFO ("Invalid name format at application index. Skipping%d", iIndex);
-                continue;
-            }
-            LOGINFO("App name to delete: %s, size:%d", itrName->valuestring, strlen (itrName->valuestring));
-            appsToDelete.push_back(string(itrName->valuestring));
+        for (int iIndex = 0; iIndex < applications.Length(); iIndex++) {
+            itrName = applications[iIndex].String();
+            LOGINFO("App name to delete: %s, size:%d", itrName.c_str(), strlen (itrName.c_str()));
+            appsToDelete.push_back(itrName);
             iIndex++;
         }
         //If empty list is passed, dynamic cache is cleared. This will clear static list also
@@ -466,70 +454,54 @@ bool XCast::deleteFromDynamicAppCache(string strAppNames)
             ret = deleteFromDynamicAppCache (appsToDelete);
             appsToDelete.clear();
         }
-        cJSON_Delete(applications);
     }
     return ret;
 }
 
-void XCast::updateDynamicAppCache(string strApps)
+void XCast::updateDynamicAppCache(JsonArray applications)
 {
     LOGINFO("XcastService::UpdateDynamicAppCache");
 
-    cJSON *itrApp = NULL;
+    JsonObject itrApp;
 
-    cJSON *jNames = NULL;
-    cJSON *itrName = NULL;
+    JsonArray jNames;
+    std::string itrName = "";
 
-    cJSON *jPrefixes = NULL;
-    cJSON *itrPrefix = NULL;
+    JsonArray jPrefixes;
+    std::string itrPrefix = "";
 
-    cJSON *jCors = NULL;
-    cJSON *itrCor = NULL;
+    JsonArray jCors;
+    std::string itrCor = "";
 
-    cJSON *jProperties = NULL;
-    cJSON *jAllowStop = NULL;
+    JsonObject jProperties;
+    bool jAllowStop = 0;
 
-    cJSON *jLaunchParam = NULL;
-    cJSON *jQuery = NULL;
-    cJSON *jPayload = NULL;
+    JsonObject jLaunchParam;
+    std::string jQuery = "";
+    std::string jPayload = "";
 
     std::vector <DynamicAppConfig*> appConfigList;
-    if (!strApps.empty()) {
-        cJSON *applications = cJSON_Parse(strApps.c_str());
-        if (!cJSON_IsArray(applications)) {
-            LOGINFO ("applications array passed: %s", strApps.c_str());
-            LOGINFO ("Invalid applications array exititng");
-            cJSON_Delete(applications);
-            return;
-        }
-
+    if (applications.Length() != 0) {
         /* iterate over ints */
         LOGINFO("Applications:");
-        int iIndex = 0;
 
-        cJSON_ArrayForEach(itrApp, applications) {
+        for (int iIndex = 0; iIndex < applications.Length(); iIndex++) {
             std::vector <DynamicAppConfig*> appConfigListTemp;
             LOGINFO("Application: %d", iIndex);
-            if (!cJSON_IsObject(itrApp)) {
-                LOGINFO ("Invalid appliaction format at index. Skipping%d", iIndex);
-                continue;
-            }
-            jNames = cJSON_GetObjectItem(itrApp, "names");
-            if (!cJSON_IsArray(jNames)) {
+            itrApp = applications[iIndex].Object();
+            if (!itrApp.HasLabel("names")) {
                 LOGINFO ("Invalid names format at application index %d. Skipping the application", iIndex);
                 continue;
             }
             else {
-                cJSON_ArrayForEach(itrName, jNames) {
-                    if (!cJSON_IsString(itrName)) {
-                        LOGINFO ("Invalid name format at application index. Skipping%d", iIndex);
-                        continue;
-                    }
-                    LOGINFO("%s, size:%d", itrName->valuestring, strlen (itrName->valuestring));
+                jNames = itrApp["names"].Array();
+                for (int i = 0; i < jNames.Length(); i++) {
+                    itrName = jNames[i].String().c_str();
+                    LOGINFO("%s, size:%d", itrName.c_str(), strlen (itrName.c_str()));
                     DynamicAppConfig* pDynamicAppConfig = (DynamicAppConfig*) malloc (sizeof(DynamicAppConfig));
                     memset ((void*)pDynamicAppConfig, '0', sizeof(DynamicAppConfig));
                     memset (pDynamicAppConfig->appName, '\0', sizeof(pDynamicAppConfig->appName));
-                    strcpy (pDynamicAppConfig->appName, itrName->valuestring);
+                    strcpy (pDynamicAppConfig->appName, itrName.c_str());
                     memset (pDynamicAppConfig->prefixes, '\0', sizeof(pDynamicAppConfig->prefixes));
                     memset (pDynamicAppConfig->cors, '\0', sizeof(pDynamicAppConfig->cors));
                     memset (pDynamicAppConfig->query, '\0', sizeof(pDynamicAppConfig->query));
@@ -538,84 +510,78 @@ void XCast::updateDynamicAppCache(string strApps)
                 }
             }
 
-            jPrefixes = cJSON_GetObjectItem(itrApp, "prefixes");
-            if (!cJSON_IsArray(jPrefixes)) {
+            if (!itrApp.HasLabel("prefixes")) {
                 LOGINFO ("Invalid prefixes format at application index %d", iIndex);
             }
             else {
-                cJSON_ArrayForEach(itrPrefix, jPrefixes) {
-                    if (!cJSON_IsString(itrPrefix)) {
-                        LOGINFO ("Invalid prefix format at application index. Skipping%d", iIndex);
-                        continue;
-                    }
-                    LOGINFO("%s, size:%d", itrPrefix->valuestring, strlen (itrPrefix->valuestring));
+                jPrefixes = itrApp["prefixes"].Array();
+                for (int i = 0; i < jPrefixes.Length(); i++) {
+                    itrPrefix = jPrefixes[i].String().c_str();
+                    LOGINFO("%s, size:%d", itrPrefix.c_str(), strlen (itrPrefix.c_str()));
                     for (DynamicAppConfig* pDynamicAppConfig : appConfigListTemp) {
-                        strcpy (pDynamicAppConfig->prefixes, itrPrefix->valuestring);
+                        strcpy (pDynamicAppConfig->prefixes, itrPrefix.c_str());
                     }
                 }
             }
 
-            jCors = cJSON_GetObjectItem(itrApp, "cors");
-            if (!cJSON_IsArray(jCors)) {
+            if (!itrApp.HasLabel("cors")) {
                 LOGINFO ("Invalid cors format at application index %d. Skipping the application", iIndex);
                 continue;
             }
             else {
-                cJSON_ArrayForEach(itrCor, jCors) {
-                    if (!cJSON_IsString(itrCor)) {
-                        LOGINFO ("Invalid cor format at application index. Skipping%d", iIndex);
-                        continue;
-                    }
-                    LOGINFO("%s, size:%d", itrCor->valuestring, strlen (itrCor->valuestring));
+                jCors = itrApp["cors"].Array();
+                for (int i = 0; i < jCors.Length(); i++) {
+                    itrCor = jCors[i].String().c_str();
+                    LOGINFO("%s, size:%d", itrCor.c_str(), strlen (itrCor.c_str()));
                     for (DynamicAppConfig* pDynamicAppConfig : appConfigListTemp) {
-                        strcpy (pDynamicAppConfig->cors, itrCor->valuestring);
+                        strcpy (pDynamicAppConfig->cors, itrCor.c_str());
                     }
                 }
             }
 
-            jProperties = cJSON_GetObjectItem(itrApp, "properties");
-            if (!cJSON_IsObject(jProperties)) {
+            if (!itrApp.HasLabel("properties")) {
                 LOGINFO ("Invalid property format at application index %d", iIndex);
             }
             else {
-                jAllowStop = cJSON_GetObjectItem(jProperties, "allowStop");
-                if (!cJSON_IsBool(jAllowStop)) {
+                jProperties = itrApp["properties"].Object();
+                if (!jProperties.HasLabel("properties")) {
                     LOGINFO ("Invalid allowStop format at application index %d", iIndex);
                 }
                 else {
-                    LOGINFO("allowStop: %d", jAllowStop->valueint);
+                    jAllowStop = jProperties["allowStop"].Boolean();
+                    LOGINFO("allowStop: %d", jAllowStop);
                     for (DynamicAppConfig* pDynamicAppConfig : appConfigListTemp) {
-                        pDynamicAppConfig->allowStop = jAllowStop->valueint;
+                        pDynamicAppConfig->allowStop = jAllowStop;
                     }
                 }
             }
 
-            jLaunchParam = cJSON_GetObjectItem(itrApp, "launchParameters");
-            if (!cJSON_IsObject(jLaunchParam)) {
+            if (!itrApp.HasLabel("launchParameters")) {
                 LOGINFO ("Invalid Launch param format at application index %d", iIndex);
             }
             else {
-                jQuery = cJSON_GetObjectItem(jLaunchParam, "query");
-                if (!cJSON_IsString(jQuery)) {
+                jLaunchParam = itrApp["launchParameters"].Object();
+                if (!jLaunchParam.HasLabel("query")) {
                     LOGINFO ("Invalid query format at application index %d", iIndex);
                 }
                 else {
-                    LOGINFO("query: %s, size:%d", jQuery->valuestring, strlen (jQuery->valuestring));
+                    jQuery = itrApp["query"].String();
+                    LOGINFO("query: %s, size:%d", jQuery.c_str(), strlen (jQuery.c_str()));
                 }
-                jPayload = cJSON_GetObjectItem(jLaunchParam, "payload");
-                if (!cJSON_IsString(jPayload)) {
+                if (!jLaunchParam.HasLabel("payload")) {
                     LOGINFO ("Invalid payload format at application index %d", iIndex);
                 }
                 else {
-                    LOGINFO("payload: %s, size:%d", jPayload->valuestring, strlen (jPayload->valuestring));
+                    jPayload = itrApp["payload"].String();
+                    LOGINFO("payload: %s, size:%d", jPayload.c_str(), strlen (jPayload.c_str()));
                 }
                 //Set launchParameters in list for later usage
                 for (DynamicAppConfig* pDynamicAppConfig : appConfigListTemp) {
-                    if (cJSON_IsString(jQuery)) {
-                        strcpy (pDynamicAppConfig->query, jQuery->valuestring);
+                    if (jLaunchParam.HasLabel("query")) {
+                        strcpy (pDynamicAppConfig->query, jQuery.c_str());
                     }
-                    if (cJSON_IsString(jPayload)) {
-                        strcpy (pDynamicAppConfig->payload, jPayload->valuestring);
+                    if (jLaunchParam.HasLabel("payload")) {
+                        strcpy (pDynamicAppConfig->payload, jPayload.c_str());
                     }
                 }
 
@@ -644,7 +610,6 @@ void XCast::updateDynamicAppCache(string strApps)
         //Clear the tempopary list here
         appsToDelete.clear();
         appConfigList.clear();
-        cJSON_Delete(applications);
     }
     dumpDynamicAppConfigCache(string("m_appConfigCache"), m_appConfigCache);
     return;
@@ -666,7 +631,7 @@ uint32_t XCast::registerApplications(const JsonObject& parameters, JsonObject& r
 
                m_isDynamicRegistrationsRequired = true;
                //Register dynamic application list to app cache map
-               updateDynamicAppCache(parameters["applications"].String());
+               updateDynamicAppCache(parameters["applications"].Array());
                std::vector<DynamicAppConfig*> appConfigList;
                {lock_guard<mutex> lck(m_appConfigMutex);
                    appConfigList = m_appConfigCache;
@@ -712,7 +677,7 @@ uint32_t XCast::unregisterApplications(const JsonObject& parameters, JsonObject&
                _rtConnector->enableCastService(m_friendlyName,false);
                m_isDynamicRegistrationsRequired = true;
                //Remove app names from cache map
-               bool ret = deleteFromDynamicAppCache (parameters["applications"].String());
+               bool ret = deleteFromDynamicAppCache (parameters["applications"].Array());   
                std::vector<DynamicAppConfig*> appConfigList;
                {lock_guard<mutex> lck(m_appConfigMutex);
                    appConfigList = m_appConfigCache;

--- a/XCast/XCast.h
+++ b/XCast/XCast.h
@@ -115,9 +115,9 @@ private:
     void getUrlFromAppLaunchParams (const char *app_name, const char *payload, const char *query_string, const char *additional_data_url, char *url);
     bool getEntryFromAppLaunchParamList (const char* appName, DynamicAppConfig& retAppConfig);
     void dumpDynamicAppConfigCache(string strListName, std::vector<DynamicAppConfig*> appConfigList);
-    bool deleteFromDynamicAppCache(string strAppNames);
+    bool deleteFromDynamicAppCache(JsonArray applications);
     bool deleteFromDynamicAppCache(vector<string>& appsToDelete);
-    void updateDynamicAppCache(string strApps);
+    void updateDynamicAppCache(JsonArray applications);
 
     /**
      * Check whether the xdial service is allowed in this device.


### PR DESCRIPTION
DELIA-60116: Removing Cjson from xCast.

Reason for change:
Changing CJson to JSon in WPEFramework.
Test Procedure: None
Risks: Low
Priority: P2

Signed-off-by:Hayden Gfeller Hayden_Gfeller@comcast.com