### PR TITLE
RDKDEV-652: ONEMPERS-685: RDKCOM-3561 XCast plugin enabled by default

### DIFF
--- a/XCast/CHANGELOG.md
+++ b/XCast/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+## [1.0.10] - 2023-03-05
+### Changed
+- control initial state/setup of the XCast plugin via compilation flags
+
 ## [1.0.9] - 2023-03-02
 ### Fixed
 - XCast: updated documentation

--- a/XCast/XCast.cpp
+++ b/XCast/XCast.cpp
@@ -64,7 +64,7 @@ using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 9
+#define API_VERSION_NUMBER_PATCH 10
 
 namespace WPEFramework {
 
@@ -89,9 +89,17 @@ SERVICE_REGISTRATION(XCast, API_VERSION_NUMBER_MAJOR, API_VERSION_NUMBER_MINOR, 
 static RtXcastConnector * _rtConnector  = RtXcastConnector::getInstance();
 static int locateCastObjectRetryCount = 0;
 bool XCast::isCastEnabled = false;
-bool XCast::m_xcastEnable= false;
+#ifdef XCAST_ENABLED_BY_DEFAULT
+bool XCast::m_xcastEnable = true;
+#else
+bool XCast::m_xcastEnable = false;
+#endif
 string XCast::m_friendlyName = "";
+#ifdef XCAST_ENABLED_BY_DEFAULT_IN_STANDBY
+bool XCast::m_standbyBehavior = true;
+#else
 bool XCast::m_standbyBehavior = false;
+#endif
 bool XCast::m_enableStatus = false;
 
 IARM_Bus_PWRMgr_PowerState_t XCast::m_powerState = IARM_BUS_PWRMGR_POWERSTATE_STANDBY;


### PR DESCRIPTION
RDKDEV-652: ONEMPERS-685: RDKCOM-3561 XCast plugin enabled by default
no need to use XCast API to enable:
- setStandbyBehavior => default value could be set to true by -DXCAST_ENABLED_BY_DEFAULT
- setEnabled => default value could be set to true by -DXCAST_ENABLED_BY_DEFAULT_IN_STANDBY

Signed-off-by: Michal Kucharczyk <mstaworzynski.contractor@libertyglobal.com>" (cherry picked from commit 4a3ab49f96ea995d39fb31b36ec096cfaefbf826)