### PR TITLE
RDKDEV-671 HX44X-237: RDKCOM-3597 USBAccess upstream feature

### DIFF
--- a/UsbAccess/CHANGELOG.md
+++ b/UsbAccess/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.0.3] - 2023-03-08
+### Added
+- Added support for 2 more methods in USBAccess plugin
+
 ## [1.0.2] - 2022-10-18
 ### Changed
 - API access on all versions of the handler

--- a/UsbAccess/UsbAccess.h
+++ b/UsbAccess/UsbAccess.h
@@ -36,6 +36,8 @@ namespace Plugin {
         static const string METHOD_GET_MOUNTED;
         static const string METHOD_UPDATE_FIRMWARE;
         static const string METHOD_ARCHIVE_LOGS;
+        static const string METHOD_GET_USB_SIZE;
+        static const string METHOD_UNMOUNT_USB;
         //events
         static const string EVT_ON_USB_MOUNT_CHANGED;
         static const string EVT_ON_ARCHIVE_LOGS;
@@ -69,6 +71,8 @@ namespace Plugin {
         uint32_t getMountedWrapper(const JsonObject& parameters, JsonObject& response);
         uint32_t updateFirmware(const JsonObject& parameters, JsonObject& response);
         uint32_t archiveLogs(const JsonObject& parameters, JsonObject& response);
+        uint32_t getUSBSizeWrapper(const JsonObject& parameters, JsonObject& response);
+        uint32_t unmountUSBWrapper(const JsonObject& parameters, JsonObject& response);
 
     private/*iarm*/:
         void InitializeIARM();


### PR DESCRIPTION
RDKDEV-671 HX44X-237: RDKCOM-3597 USBAccess upstream feature
Reason for change: Added support for 2 more methods in USBAccess plugin.
Test Procedure: Please see ticket for details.
Risks: Low
Source: Skyworth
License: Inherited
Upstream-Status: Pending
Priority: P3

Signed-off-by: yangkang <yangkang@skyworth.com>
(cherry picked from commit da81dc942e3a67ed8fbabffe7c2cf408165b587a)