### PR TITLE
RDKTV-22146 DALS support in hdmicecSink

### DIFF
--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -1036,7 +1036,7 @@ namespace WPEFramework
 		return;
 
 	    LOGINFO("Send Report Current Latency message \n");
-	    _instance->smConnection->sendTo(LogicalAddress::BROADCAST,MessageEncoder().encode(ReportCurrentLatency(physical_addr,video_latency,latency_flags,audio_output_delay)));
+	    _instance->smConnection->sendTo(LogicalAddress::BROADCAST,MessageEncoder().encode(ReportCurrentLatency(physical_addr,m_video_latency,m_latency_flags,m_audio_output_delay)));
 
         }
 

--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -64,6 +64,7 @@
 #define HDMICECSINK_METHOD_SEND_GIVE_AUDIO_STATUS          "sendGetAudioStatusMessage"
 #define HDMICECSINK_METHOD_GET_AUDIO_DEVICE_CONNECTED_STATUS   "getAudioDeviceConnectedStatus"
 #define HDMICECSINK_METHOD_REQUEST_AUDIO_DEVICE_POWER_STATUS   "requestAudioDevicePowerStatus"
+#define HDMICECSINK_METHOD_SET_LATENCY_INFO	"setLatencyInfo"
 
 #define TEST_ADD 0
 #define HDMICECSINK_REQUEST_MAX_RETRY 				3
@@ -82,6 +83,10 @@
 #define SYSTEM_AUDIO_MODE_ON 0x01
 #define SYSTEM_AUDIO_MODE_OFF 0x00
 #define AUDIO_DEVICE_POWERSTATE_OFF 1
+
+#define DEFAULT_VIDEO_LATENCY 100
+#define DEFAULT_LATENCY_FLAGS 3
+#define DEFAULT_AUDIO_OUTPUT_DELAY 100
 
 enum {
 	DEVICE_POWER_STATE_ON = 0,
@@ -540,6 +545,20 @@ namespace WPEFramework
              LOGINFO("Command: ReportAudioStatus  %s audio Mute status %d  means %s  and current Volume level is %d \n",GetOpName(msg.opCode()),msg.status.getAudioMuteStatus(),msg.status.toString().c_str(),msg.status.getAudioVolume());
              HdmiCecSink::_instance->Process_ReportAudioStatus_msg(msg);
        }
+
+      void HdmiCecSinkProcessor::process (const RequestCurrentLatency &msg, const Header &header)
+       {
+	     printHeader(header);
+             LOGINFO("Command: Request Current Latency :%s, physical address: %s",GetOpName(msg.opCode()),msg.physicaladdress.toString().c_str());
+
+	     if(msg.physicaladdress.toString() == physical_addr.toString()) {
+		     HdmiCecSink::_instance->setLatencyInfo();
+	     }
+	     else {
+		     LOGINFO("Physical Address does not match with TV's physical address");
+		     return;
+	     }
+       }
 //=========================================== HdmiCecSink =========================================
 
        HdmiCecSink::HdmiCecSink()
@@ -559,6 +578,9 @@ namespace WPEFramework
 		   m_pollNextState = POLL_THREAD_STATE_NONE;
 		   m_pollThreadState = POLL_THREAD_STATE_NONE;
 		   dsHdmiInGetNumberOfInputsParam_t hdmiInput;
+		   m_video_latency = DEFAULT_VIDEO_LATENCY;
+		   m_latency_flags = DEFAULT_LATENCY_FLAGS ;
+		   m_audio_output_delay = DEFAULT_AUDIO_OUTPUT_DELAY;
 
            InitializeIARM();
 
@@ -585,6 +607,7 @@ namespace WPEFramework
 		   Register(HDMICECSINK_METHOD_SEND_GIVE_AUDIO_STATUS,&HdmiCecSink::sendGiveAudioStatusWrapper,this);
 		   Register(HDMICECSINK_METHOD_GET_AUDIO_DEVICE_CONNECTED_STATUS,&HdmiCecSink::getAudioDeviceConnectedStatusWrapper,this);
                    Register(HDMICECSINK_METHOD_REQUEST_AUDIO_DEVICE_POWER_STATUS,&HdmiCecSink::requestAudioDevicePowerStatusWrapper,this);
+		     Register(HDMICECSINK_METHOD_SET_LATENCY_INFO, &HdmiCecSink::setLatencyInfoWrapper, this);
            logicalAddressDeviceType = "None";
            logicalAddress = 0xFF;
            m_sendKeyEventThreadExit = false;
@@ -991,6 +1014,30 @@ namespace WPEFramework
 		    audiodescriptor.Add(descriptor);
 	    }
 	   HdmiCecSink::_instance->Send_ShortAudioDescriptor_Event(audiodescriptor);
+        }
+
+        void HdmiCecSink::updateCurrentLatency(uint8_t videoLatency, uint8_t lowLatencyMode,uint8_t audioOutputCompensated, uint8_t audioOutputDelay = 0)
+        { 
+	    uint8_t latencyFlags = 0;
+	    latencyFlags = ((lowLatencyMode & 0x1) << 2) | (audioOutputCompensated & 0x3);
+	    LOGINFO("Video Latency : %d , Low Latency Mode : %d ,Audio Output Compensated value : %d , Audio Output Delay : %d , Latency Flags: %d ", videoLatency, lowLatencyMode, audioOutputCompensated, audioOutputDelay, latencyFlags);
+	    m_video_latency = videoLatency;
+	    m_latency_flags = latencyFlags;
+	    m_audio_output_delay = audioOutputDelay;
+	    setLatencyInfo();
+        }
+
+        void HdmiCecSink::setLatencyInfo()
+        {
+	    if(!HdmiCecSink::_instance)
+	        return;
+
+	    if(!(_instance->smConnection))
+		return;
+
+	    LOGINFO("Send Report Current Latency message \n");
+	    _instance->smConnection->sendTo(LogicalAddress::BROADCAST,MessageEncoder().encode(ReportCurrentLatency(physical_addr,video_latency,latency_flags,audio_output_delay)));
+
         }
 
         void HdmiCecSink::Process_SetSystemAudioMode_msg(const SetSystemAudioMode &msg)
@@ -1564,6 +1611,23 @@ namespace WPEFramework
 	      sendGiveAudioStatusMsg();
 	      returnResponse(true);
 	   }
+	   uint32_t HdmiCecSink::setLatencyInfoWrapper(const JsonObject& parameters, JsonObject& response)
+           {
+	       uint8_t video_latency, low_latency_mode, audio_output_compensated,audio_output_delay;
+
+	       returnIfParamNotFound(parameters, "videoLatency");
+	       returnIfParamNotFound(parameters, "lowLatencyMode");
+	       returnIfParamNotFound(parameters, "audioOutputCompensated");
+	       returnIfParamNotFound(parameters, "audioOutputDelay");
+	       video_latency = stoi(parameters["videoLatency"].String());
+	       low_latency_mode = stoi(parameters["lowLatencyMode"].String());
+	       audio_output_compensated = stoi(parameters["audioOutputCompensated"].String());
+	       audio_output_delay = stoi(parameters["audioOutputDelay"].String());
+
+	       updateCurrentLatency(video_latency, low_latency_mode,audio_output_compensated, audio_output_delay);
+	       returnResponse(true);
+	   }
+
         bool HdmiCecSink::loadSettings()
         {
             Core::File file;

--- a/HdmiCecSink/HdmiCecSink.h
+++ b/HdmiCecSink/HdmiCecSink.h
@@ -87,6 +87,7 @@ namespace WPEFramework {
                 void process (const ReportShortAudioDescriptor  &msg, const Header &header);
 		void process (const SetSystemAudioMode &msg, const Header &header);
 		void process (const ReportAudioStatus &msg, const Header &header);
+		void process (const RequestCurrentLatency &msg, const Header &header);
         private:
             Connection conn;
             void printHeader(const Header &header)
@@ -255,6 +256,7 @@ namespace WPEFramework {
                    int logicalAddr;
                    int keyCode;
                 }SendKeyInfo;
+
 
 		class HdmiPortMap {
 			public:
@@ -555,6 +557,8 @@ private:
 			void sendDeviceUpdateInfo(const int logicalAddress);
 			void sendFeatureAbort(const LogicalAddress logicalAddress, const OpCode feature, const AbortReason reason);
 			void systemAudioModeRequest();
+			void updateCurrentLatency(uint8_t videoLatency, uint8_t lowLatencyMode,uint8_t audioOutputCompensated, uint8_t audioOutputDelay);
+			void setLatencyInfo();
                         void SendStandbyMsgEvent(const int logicalAddress);
                         void requestAudioDevicePowerStatus();
                         void reportAudioDevicePowerStatusInfo(const int logicalAddress, const int powerStatus);
@@ -599,6 +603,7 @@ private:
 	                uint32_t sendGiveAudioStatusWrapper(const JsonObject& parameters, JsonObject& response);
 			uint32_t getAudioDeviceConnectedStatusWrapper(const JsonObject& parameters, JsonObject& response);
                         uint32_t requestAudioDevicePowerStatusWrapper(const JsonObject& parameters, JsonObject& response);
+			uint32_t setLatencyInfoWrapper(const JsonObject& parameters, JsonObject& response);
                         //End methods
             std::string logicalAddressDeviceType;
             bool cecSettingEnabled;
@@ -624,6 +629,11 @@ private:
             std::queue<SendKeyInfo> m_SendKeyQueue;
             std::condition_variable m_sendKeyCV;
 	    std::condition_variable m_ThreadExitCV;
+	    
+	    /* DALS - Latency Values */
+	    uint8_t m_video_latency;
+	    uint8_t m_latency_flags;
+	    uint8_t m_audio_output_delay;
 
             /* ARC related */
             std::thread m_arcRoutingThread;

--- a/HdmiCecSink/HdmiCecSink.json
+++ b/HdmiCecSink/HdmiCecSink.json
@@ -567,7 +567,42 @@
             "result": {
                 "$ref": "#/common/result"
             }
-        }
+        },
+        "setLatencyInfo": {
+	    "summary": "Sets the Current Latency Values such as Video Latency, Latency Flags,Audio Output Compensated value and Audio Output Delay by sending \\<Report Current Latency\\> message for Dynamic Auto LipSync Feature",
+	    "params": {
+                "type":"object",
+                "properties": {
+		    "videoLatency": {
+			"summary": "Indicates the Video Latency value of the target device",
+			"type":"integer",
+			"example": 2
+		    },
+		    "lowLatencyMode": {
+			"summary": "Indicates whether low latency Mode is 0 or 1",
+			"type":"integer",
+			"example": 1
+		    },
+                    "audioOuputCompensated": {
+                        "summary": "Indicates whether Audio Output is delay compensated or not. 0 - (NA)Sent by Non-TV, 1 = TV's audio Output is delay compensated, 2 = Not delay compensated, 3 = Partially delayed",
+                        "type":"integer",
+                        "example": 1
+                    },
+		    "audioOutputDelay": {
+			"summary": "Indicates the Audio Output Delay value of the target device",
+			"type":"integer",
+			"example": 20
+		    }
+		},
+		"required": [
+		    "videoLatency",
+		    "lowLatencyMode",
+		    "audioOutputCompensated",
+		    "audioOutputDelay"
+                ]
+	    }
+
+	}
     },
     "events": {
         "arcInitiationEvent": {


### PR DESCRIPTION
Added methods for handling Dynamic Auto LipSync feature. 
1. Request Current Latency - Process to handle the incoming <Request Current Latency> message and respond with <Report Current Latency>
2. reportCurrentLatencyWrapper - To get the Latency Values such as Video Latency, Low Latency Mode, Audio Output Compensated and Audio Output Delay from DisplaySettings whenever there is change in latency .
  The above method will invoke reportCurrentLatency() 
3. reportCurrentLatency - To encode the latency values and Broadcast it to Connected Devices