### PR TITLE
LLAMA-9877: Reduce Displaysettings log during volume change

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -2352,7 +2352,7 @@ namespace WPEFramework {
 
         uint32_t DisplaySettings::getVolumeLevel (const JsonObject& parameters, JsonObject& response)
         {
-            LOGINFOMETHOD();
+            //LOGINFOMETHOD();
             bool success = true;
             float level = 0;
 
@@ -2817,7 +2817,7 @@ namespace WPEFramework {
 
         uint32_t DisplaySettings::setVolumeLevel(const JsonObject& parameters, JsonObject& response)
         {
-                LOGINFOMETHOD();
+                //LOGINFOMETHOD();
                 returnIfParamNotFound(parameters, "volumeLevel");
                 string sLevel = parameters["volumeLevel"].String();
                 float level = 0;


### PR DESCRIPTION
Reason for change: Reduce Displaysettings volume control API logs
Test Procedure: Build Pass
Risks: None
Priority : P1

Signed-off-by: Deekshit Devadas deekshit.devadasy@sky.uk