### PR TITLE
DELIA-60116: Removing Cjson from xCast.

### DIFF
--- a/XCast/XCast.cpp
+++ b/XCast/XCast.cpp
@@ -438,7 +438,6 @@ bool XCast::deleteFromDynamicAppCache(JsonArray applications)
         itrName = applications[iIndex].String();
         LOGINFO("App name to delete: %s, size:%d", itrName.c_str(), strlen (itrName.c_str()));
         appsToDelete.push_back(itrName);
-        iIndex++;
     }
     //If empty list is passed, dynamic cache is cleared. This will clear static list also
     //Net result will be not app will be able to launch.
@@ -589,7 +588,6 @@ void XCast::updateDynamicAppCache(JsonArray applications)
                 appConfigList.push_back(pDynamicAppConfig);
             }
             appConfigListTemp.clear();
-            iIndex++;
         }
         dumpDynamicAppConfigCache(string("appConfigList"), appConfigList);
         vector<string> appsToDelete;


### PR DESCRIPTION
DELIA-60116: Removing Cjson from xCast.

Reason for change:
Removing unneeded iIndex
increments
Test Procedure: None
Risks: Low
Priority: P2

Signed-off-by:Hayden Gfeller Hayden_Gfeller@comcast.com