### PR TITLE
LLAMA-9747: Remove DisplaySettings::setVolumeLevel response log spam

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -2817,7 +2817,7 @@ namespace WPEFramework {
 
         uint32_t DisplaySettings::setVolumeLevel(const JsonObject& parameters, JsonObject& response)
         {
-                //LOGINFOMETHOD();
+                //LOGINFOMETHOD();/*prevent log spam*/
                 returnIfParamNotFound(parameters, "volumeLevel");
                 string sLevel = parameters["volumeLevel"].String();
                 float level = 0;
@@ -2841,7 +2841,9 @@ namespace WPEFramework {
                         LOG_DEVICE_EXCEPTION2(audioPort, sLevel);
                         success = false;
                 }
-                returnResponse(success);
+                //returnResponse(success);/*prevent log spam*/
+                response["success"] = success;
+                return (WPEFramework::Core::ERROR_NONE);
         }
 
         uint32_t DisplaySettings::setDRCMode(const JsonObject& parameters, JsonObject& response)


### PR DESCRIPTION
Reason for change: Too many response logs during rapid volume change impacting performance
Test Procedure: Build Pass
Risks: None
Priority : P1

Signed-off-by: Mark Rollins mark_rollins@cable.comcast.com