### PR TITLE
Updated Network Plugin to handle the boot order of netsrmgr 

### DIFF
--- a/Network/Network.cpp
+++ b/Network/Network.cpp
@@ -241,8 +241,7 @@ namespace WPEFramework
 
                 if(retVal != IARM_RESULT_SUCCESS)
                 {
-                    LOGERR("NETWORK_NOT_READY: The NetSrvMgr Component is not available.Retrying in separate thread");
-                    retryIarmEventRegistration();
+                    LOGERR("NETWORK_NOT_READY: Lets handle it in the future request to NetSrvMgr Component");
                 }
                 else {
                     IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_NETWORK_MANAGER_EVENT_INTERFACE_ENABLED_STATUS, eventHandler) );

--- a/Network/Network.cpp
+++ b/Network/Network.cpp
@@ -401,7 +401,7 @@ namespace WPEFramework
             IARM_BUS_NetSrvMgr_InterfaceList_t list;
             bool result = false;
 
-            if(m_isPluginInited)
+            if(!m_isPluginInited)
                 EnsureNetSrvMgrRunning();
 
             if(m_isPluginInited)
@@ -460,7 +460,7 @@ namespace WPEFramework
             string gateway;
 
             bool result = false;
-            if(m_isPluginInited)
+            if(!m_isPluginInited)
                 EnsureNetSrvMgrRunning();
 
             if(m_isPluginInited)
@@ -490,7 +490,7 @@ namespace WPEFramework
         {
             bool result = false;
 
-            if(m_isPluginInited)
+            if(!m_isPluginInited)
                 EnsureNetSrvMgrRunning();
 
             if(m_isPluginInited)
@@ -535,7 +535,7 @@ namespace WPEFramework
 
             bool result = false;
 
-            if(m_isPluginInited)
+            if(!m_isPluginInited)
                 EnsureNetSrvMgrRunning();
 
             if(m_isPluginInited)
@@ -569,7 +569,7 @@ namespace WPEFramework
         {
             bool result = false;
 
-            if(m_isPluginInited)
+            if(!m_isPluginInited)
                 EnsureNetSrvMgrRunning();
 
             if(m_isPluginInited)
@@ -613,7 +613,7 @@ namespace WPEFramework
         {
             bool result = false;
 
-            if(m_isPluginInited)
+            if(!m_isPluginInited)
                 EnsureNetSrvMgrRunning();
 
             if(m_isPluginInited)
@@ -654,7 +654,7 @@ namespace WPEFramework
         {
             bool result = false;
 
-            if(m_isPluginInited)
+            if(!m_isPluginInited)
                 EnsureNetSrvMgrRunning();
 
             if(m_isPluginInited)
@@ -708,7 +708,7 @@ namespace WPEFramework
         {
             bool result = false;
 
-            if(m_isPluginInited)
+            if(!m_isPluginInited)
                 EnsureNetSrvMgrRunning();
 
             if(m_isPluginInited)
@@ -742,7 +742,7 @@ namespace WPEFramework
         {
             bool result = false;
 
-            if(m_isPluginInited)
+            if(!m_isPluginInited)
                 EnsureNetSrvMgrRunning();
 
             if(m_isPluginInited)
@@ -782,7 +782,7 @@ namespace WPEFramework
 
             bool result = false;
 
-            if(m_isPluginInited)
+            if(!m_isPluginInited)
                 EnsureNetSrvMgrRunning();
 
             if(m_isPluginInited)
@@ -816,7 +816,7 @@ namespace WPEFramework
 
             bool result = false;
 
-            if(m_isPluginInited)
+            if(!m_isPluginInited)
                 EnsureNetSrvMgrRunning();
 
             if(m_isPluginInited)
@@ -845,7 +845,7 @@ namespace WPEFramework
         uint32_t Network::setIPSettings(const JsonObject& parameters, JsonObject& response)
         {
             bool result = false;
-            if(m_isPluginInited)
+            if(!m_isPluginInited)
                 EnsureNetSrvMgrRunning();
 
             if(m_isPluginInited)
@@ -869,7 +869,7 @@ namespace WPEFramework
             bool autoconfig = true;
             bool result = false;
 
-            if(m_isPluginInited)
+            if(!m_isPluginInited)
                 EnsureNetSrvMgrRunning();
 
             if(m_isPluginInited)
@@ -1023,7 +1023,7 @@ namespace WPEFramework
             bool result = false;
             string interface = "";
             string ipversion = "";
-            if(m_isPluginInited)
+            if(!m_isPluginInited)
                 EnsureNetSrvMgrRunning();
 
             if(m_isPluginInited)
@@ -1065,7 +1065,7 @@ namespace WPEFramework
             bool result = false;
             string interface = "";
             string ipversion = "";
-            if(m_isPluginInited)
+            if(!m_isPluginInited)
                 EnsureNetSrvMgrRunning();
 
             if(m_isPluginInited)
@@ -1218,7 +1218,7 @@ namespace WPEFramework
             bool result = false;
             bool isconnected = false;
 
-            if(m_isPluginInited)
+            if(!m_isPluginInited)
                 EnsureNetSrvMgrRunning();
 
             if(m_isPluginInited)
@@ -1245,7 +1245,7 @@ namespace WPEFramework
         {
             bool result = false;
             JsonArray endpoints = parameters["endpoints"].Array();
-            if(m_isPluginInited)
+            if(!m_isPluginInited)
                 EnsureNetSrvMgrRunning();
 
             if(m_isPluginInited)
@@ -1324,7 +1324,7 @@ namespace WPEFramework
             IARM_BUS_NetSrvMgr_Iface_StunRequest_t iarmData = { 0 };
             string server, iface;
 
-            if(m_isPluginInited)
+            if(!m_isPluginInited)
                 EnsureNetSrvMgrRunning();
 
             if(m_isPluginInited)
@@ -1549,7 +1549,7 @@ namespace WPEFramework
         {
             bool result = false;
 
-            if(m_isPluginInited)
+            if(!m_isPluginInited)
                 EnsureNetSrvMgrRunning();
 
             if(m_isPluginInited)

--- a/Network/Network.cpp
+++ b/Network/Network.cpp
@@ -231,7 +231,6 @@ namespace WPEFramework
         {
             if (Utils::IARM::init())
             {
-                IARM_Result_t res;
                 IARM_Result_t retVal = IARM_RESULT_SUCCESS;
 
 #ifndef NET_DISABLE_NETSRVMGR_CHECK
@@ -266,7 +265,6 @@ namespace WPEFramework
 
             if (Utils::IARM::isConnected())
             {
-                IARM_Result_t res;
                 IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_NETWORK_MANAGER_EVENT_INTERFACE_ENABLED_STATUS) );
                 IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_NETWORK_MANAGER_EVENT_INTERFACE_CONNECTION_STATUS) );
                 IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_NETWORK_MANAGER_EVENT_INTERFACE_IPADDRESS) );
@@ -351,7 +349,6 @@ namespace WPEFramework
 
         void  Network::EnsureNetSrvMgrRunning()
         {
-            IARM_Result_t res = IARM_RESULT_SUCCESS;
             IARM_Result_t retVal = IARM_RESULT_SUCCESS;
 
             if (m_isPluginInited)
@@ -359,22 +356,12 @@ namespace WPEFramework
 
 #ifndef NET_DISABLE_NETSRVMGR_CHECK
             char c;
-            uint32_t retry = 0;
-            do
-            {
-                /* Try 1sec timeout to check whether the NetSrvMgr is running or not */
-                retVal = IARM_Bus_Call_with_IPCTimeout(IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_NETSRVMGR_API_isAvailable, (void *)&c, sizeof(c), 1000);
-                if(retVal != IARM_RESULT_SUCCESS){
-                    LOGERR("NetSrvMgr is not available yet. Retry = %d", retry);
-                    usleep(500*1000);
-                    retry++;
-                }
-            }while((retVal != IARM_RESULT_SUCCESS) && (retry < 20));
+            /* Try 1sec timeout to check whether the NetSrvMgr is running or not */
+            retVal = IARM_Bus_Call_with_IPCTimeout(IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_NETSRVMGR_API_isAvailable, (void *)&c, sizeof(c), 1000);
 #endif
-
             if(retVal != IARM_RESULT_SUCCESS)
             {
-                LOGERR("EnsureNetSrvMgrRunning NetSrvMgr is not available. Failed to activate Network Plugin, retrying new cycle");
+                LOGERR("EnsureNetSrvMgrRunning NetSrvMgr is not available. lets check in next cycle");
             }
             else
             {
@@ -382,7 +369,7 @@ namespace WPEFramework
                 IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_NETWORK_MANAGER_EVENT_INTERFACE_CONNECTION_STATUS, eventHandler) );
                 IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_NETWORK_MANAGER_EVENT_INTERFACE_IPADDRESS, eventHandler) );
                 IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_NETWORK_MANAGER_EVENT_DEFAULT_INTERFACE, eventHandler) );
-                LOGINFO("NETWORK_AVAILABILITY_RETRY_SUCCESS: EnsureNetSrvMgrRunning successfully subscribed to IARM event for Network Plugin");
+                LOGINFO("EnsureNetSrvMgrRunning successfully subscribed to IARM event for Network Plugin");
                 m_isPluginInited = true;
             }
 

--- a/Network/Network.h
+++ b/Network/Network.h
@@ -93,7 +93,6 @@ namespace WPEFramework {
 
             //Private variables
             std::atomic_bool m_isPluginInited{false};
-            std::thread m_registrationThread;
 
             //Begin methods
             uint32_t getQuirks(const JsonObject& parameters, JsonObject& response);
@@ -135,7 +134,7 @@ namespace WPEFramework {
             bool _getDefaultInterface(std::string& interface, std::string& gateway);
 
             void retryIarmEventRegistration();
-            void threadEventRegistration();
+            void EnsureNetSrvMgrRunning();
 
             bool _doTrace(std::string &endpoint, int packets, JsonObject& response);
             bool _doTraceNamedEndpoint(std::string &endpointName, int packets, JsonObject& response);


### PR DESCRIPTION
Updated Network Plugin to handle the boot order of netsrmgr.
- Removed error message that was returned if Initialize() was called when the netsrvmgr is NOT running.
- Removed the thread that runs continuously to look for the netsrvmgr process and subscribe to events.
- Changed the retry logic into 1sec timeout and only once if the plugin is not inited  (or the netsrvmgr dependency was not met)