### PR TITLE
RDKTV-22068 - Updated Network Plugin to handle the boot order of netsrmgr

### DIFF
--- a/Network/CHANGELOG.md
+++ b/Network/CHANGELOG.md
@@ -15,6 +15,13 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+## [1.0.7] - 2023-03-18
+### Fixed
+- Updated Network Plugin to handle the boot order of netsrmgr.
+
+## [1.0.6] - 2022-12-13
+### Fixed
+- Fixed empty IP Address value being returned.
 
 ## [1.0.5] - 2022-12-13
 ### Added

--- a/Network/Network.cpp
+++ b/Network/Network.cpp
@@ -173,6 +173,7 @@ typedef struct _IARM_BUS_NetSrvMgr_Iface_EventData_t {
         {
             if (Utils::IARM::init())
             {
+                IARM_Result_t res;
                 IARM_Result_t retVal = IARM_RESULT_SUCCESS;
 
 #ifndef NET_DISABLE_NETSRVMGR_CHECK
@@ -207,6 +208,7 @@ typedef struct _IARM_BUS_NetSrvMgr_Iface_EventData_t {
 
             if (Utils::IARM::isConnected())
             {
+                IARM_Result_t res;
                 IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_NETWORK_MANAGER_EVENT_INTERFACE_ENABLED_STATUS) );
                 IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_NETWORK_MANAGER_EVENT_INTERFACE_CONNECTION_STATUS) );
                 IARM_CHECK( IARM_Bus_UnRegisterEventHandler(IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_NETWORK_MANAGER_EVENT_INTERFACE_IPADDRESS) );
@@ -291,6 +293,7 @@ typedef struct _IARM_BUS_NetSrvMgr_Iface_EventData_t {
 
         void  Network::EnsureNetSrvMgrRunning()
         {
+            IARM_Result_t res;
             IARM_Result_t retVal = IARM_RESULT_SUCCESS;
 
             if (m_isPluginInited)

--- a/Network/Network.h
+++ b/Network/Network.h
@@ -150,7 +150,6 @@ namespace WPEFramework {
 
             //Private variables
             std::atomic_bool m_isPluginInited{false};
-            std::thread m_registrationThread;
 
             //Begin methods
             uint32_t getQuirks(const JsonObject& parameters, JsonObject& response);
@@ -192,7 +191,7 @@ namespace WPEFramework {
             bool _getDefaultInterface(std::string& interface, std::string& gateway);
 
             void retryIarmEventRegistration();
-            void threadEventRegistration();
+            void EnsureNetSrvMgrRunning();
 
             bool _doTrace(std::string &endpoint, int packets, JsonObject& response);
             bool _doTraceNamedEndpoint(std::string &endpointName, int packets, JsonObject& response);


### PR DESCRIPTION
Updated Network Plugin to handle the boot order of netsrmgr.
- Removed error message that was returned if Initialize() was called when the netsrvmgr is NOT running.
- Removed the thread that runs continuously to look for the netsrvmgr process and subscribe to events.
- Changed the retry logic into 1sec timeout and only once if the plugin is not inited (or the netsrvmgr dependency was not met)
