### PR TITLE
Fix for WifiManagerState::setEnabled()

### DIFF
--- a/WifiManager/impl/WifiManagerState.cpp
+++ b/WifiManager/impl/WifiManagerState.cpp
@@ -119,6 +119,11 @@ uint32_t WifiManagerState::setEnabled(const JsonObject &parameters, JsonObject &
     // disables wifi interface when ethernet interface is active
     IARM_Result_t retVal = IARM_Bus_Call(IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_NETSRVMGR_API_setInterfaceEnabled, (void *)&param, sizeof(param));
 
+    // Update wifi state cache if wifi interface was disabled
+    if (retVal == IARM_RESULT_SUCCESS && !param.isInterfaceEnabled) {
+        setWifiStateCache(true, WifiState::DISABLED);
+    }
+
     returnResponse(retVal == IARM_RESULT_SUCCESS);
 }
 


### PR DESCRIPTION
Reason for change:  After setting wifi's enable state as false, returning wrong value.

Test Procedure: Build and verify.