### PR TITLE
DELIA-60044: HDMICEC plugin update thread handling

### DIFF
--- a/HdmiCec/CHANGELOG.md
+++ b/HdmiCec/CHANGELOG.md
@@ -14,6 +14,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
+## [1.0.7] - 2023-03-20
+### Fixed
+- Fixed thread handling issue in CECDisable.
+
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 ## [1.0.6] - 2023-02-09
 ### Fixed

--- a/HdmiCec/HdmiCec.cpp
+++ b/HdmiCec/HdmiCec.cpp
@@ -57,7 +57,7 @@
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 6
+#define API_VERSION_NUMBER_PATCH 7
 
 enum {
 	HDMICEC_EVENT_DEVICE_ADDED=0,
@@ -528,13 +528,23 @@ namespace WPEFramework
 
                 m_updateThreadExit = true;
                 //Trigger codition to exit poll loop
+                pthread_mutex_lock(&(_instance->m_lockUpdate)); //Join mutex lock to wait until thread is in its wait condition
                 pthread_cond_signal(&(_instance->m_condSigUpdate));
+                pthread_mutex_unlock(&(_instance->m_lockUpdate));
+                if (m_UpdateThread.get().joinable()) {//Join thread to make sure it's deleted before moving on.
+                    m_UpdateThread.get().join();
+                }
                 LOGWARN("Deleted update Thread %p", smConnection );
 
 
                 m_pollThreadExit = true;
                 //Trigger codition to exit poll loop
+                pthread_mutex_lock(&(_instance->m_lock)); //Join mutex lock to wait until thread is in its wait condition
                 pthread_cond_signal(&(_instance->m_condSig));
+                pthread_mutex_unlock(&(_instance->m_lock));
+                if (m_pollThread.get().joinable()) {//Join thread to make sure it's deleted before moving on.
+                    m_pollThread.get().join();
+                }
                 LOGWARN("Deleted Thread %p", smConnection );
                 //Clear cec device cache.
                 removeAllCecDevices();

--- a/HdmiCecSource/CHANGELOG.md
+++ b/HdmiCecSource/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.0.2] - 2023-03-20
+### Fixed
+- Fixed thread handling issue in CECDisable.
+
 ## [1.0.1] - 2022-12-31
 ### Fixed
 - Updated documentation for sendKeyEvent thunder API.

--- a/HdmiCec_2/CHANGELOG.md
+++ b/HdmiCec_2/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.0.8] - 2023-03-20
+### Fixed
+- Fixed thread handling issue in CECDisable.
+
 ## [1.0.7] - 2022-12-31
 ### Fixed
 - Updated documentation for sendKeyEvent thunder API.

--- a/HdmiCec_2/HdmiCec_2.cpp
+++ b/HdmiCec_2/HdmiCec_2.cpp
@@ -61,7 +61,7 @@
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 7
+#define API_VERSION_NUMBER_PATCH 8
 
 enum {
 	HDMICEC2_EVENT_DEVICE_ADDED=0,
@@ -1251,12 +1251,22 @@ namespace WPEFramework
 
                 m_updateThreadExit = true;
                 //Trigger codition to exit poll loop
+                pthread_mutex_lock(&(_instance->m_lockUpdate)); //Join mutex lock to wait until thread is in its wait condition
                 pthread_cond_signal(&(_instance->m_condSigUpdate));
+                pthread_mutex_unlock(&(_instance->m_lockUpdate));
+                if (m_UpdateThread.get().joinable()) {//Join thread to make sure it's deleted before moving on.
+                    m_UpdateThread.get().join();
+                }
                 LOGWARN("Deleted update Thread %p", smConnection );
 
                 m_pollThreadExit = true;
                 //Trigger codition to exit poll loop
+                pthread_mutex_lock(&(_instance->m_lock)); //Join mutex lock to wait until thread is in its wait condition
                 pthread_cond_signal(&(_instance->m_condSig));
+                pthread_mutex_unlock(&(_instance->m_lock));
+                if (m_pollThread.get().joinable()) {//Join thread to make sure it's deleted before moving on.
+                    m_pollThread.get().join();
+                }
                 LOGWARN("Deleted Thread %p", smConnection );
                 //Clear cec device cache.
                 removeAllCecDevices();


### PR DESCRIPTION
Reason for change:
Updating Hdmicec, Hdmicec_2 and HdmicecSource
to properly wait for threads to enter wait,
before closing them down.
Test Procedure: None
Risks: Low
Priority: P2