### PR TITLE
RDK-38587 - GTests for Xcast plugin

### DIFF
--- a/XCast/CMakeLists.txt
+++ b/XCast/CMakeLists.txt
@@ -44,7 +44,9 @@ target_include_directories(${MODULE_NAME} PRIVATE $ENV{PKG_CONFIG_SYSROOT_DIR}/u
 target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins ${RFC_LIBRARIES} ${IARMBUS_LIBRARIES})
 
 if(NOT RDK_SERVICES_TEST)
-    target_link_libraries(${MODULE_NAME} PRIVATE rtError rtRemote rtCore )
+        target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins rtRemote rtCore ${RFC_LIBRARIES} ${IARMBUS_LIBRARIES})
+else(RDK_SERVICES_TEST)
+      target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins ${RFC_LIBRARIES} ${IARMBUS_LIBRARIES})  
 endif()
 
 install(TARGETS ${MODULE_NAME}


### PR DESCRIPTION
RDK-38587 - GTests for Xcast plugin
Reason for change:
Fixing error in CMake changes
TestProcedure: None
Risks: Low