### PR TITLE
RDK-38589 - GTests for HdmiCec2

### DIFF
--- a/HdmiCecSource/HdmiCecSource.cpp
+++ b/HdmiCecSource/HdmiCecSource.cpp
@@ -1244,6 +1244,19 @@ namespace WPEFramework
                 m_sendKeyEventThreadRun = true;
                 m_sendKeyCV.notify_one();
             }
+            try
+	        {
+                if (m_sendKeyEventThread.get().joinable())
+                    m_sendKeyEventThread.get().join();
+	        }
+	        catch(const std::system_error& e)
+	        {
+		        LOGERR("system_error exception in thread join %s", e.what());
+	        }
+	        catch(const std::exception& e)
+	        {
+		        LOGERR("exception in thread join %s", e.what());
+	        }
 
             if (smConnection != NULL)
             {

--- a/HdmiCec_2/HdmiCec_2.cpp
+++ b/HdmiCec_2/HdmiCec_2.cpp
@@ -1244,6 +1244,19 @@ namespace WPEFramework
                 m_sendKeyEventThreadRun = true;
                 m_sendKeyCV.notify_one();
             }
+            try
+	        {
+                if (m_sendKeyEventThread.get().joinable())
+                    m_sendKeyEventThread.get().join();
+	        }
+	        catch(const std::system_error& e)
+	        {
+		        LOGERR("system_error exception in thread join %s", e.what());
+	        }
+	        catch(const std::exception& e)
+	        {
+		        LOGERR("exception in thread join %s", e.what());
+	        }
 
             if (smConnection != NULL)
             {


### PR DESCRIPTION
Reason for change:
Adding Gtests for HdmiCec2
and HdmiCecSource
TestProcedure: None
Risks: Low