### PR TITLE
SERXIONE-1402: WPEFramework crash HdmiCecSource

### DIFF
--- a/HdmiCec/HdmiCec.cpp
+++ b/HdmiCec/HdmiCec.cpp
@@ -174,6 +174,9 @@ namespace WPEFramework
         HdmiCec::HdmiCec()
         : PluginHost::JSONRPC(),cecEnableStatus(false),smConnection(nullptr)
         {
+            LOGWARN("ctor");
+            smConnection = NULL;
+            cecEnableStatus = false;
             HdmiCec::_instance = this;
 
             Register(HDMICEC_METHOD_SET_ENABLED, &HdmiCec::setEnabledWrapper, this);

--- a/HdmiCecSource/HdmiCecSource.cpp
+++ b/HdmiCecSource/HdmiCecSource.cpp
@@ -388,6 +388,8 @@ namespace WPEFramework
        : PluginHost::JSONRPC(),cecEnableStatus(false),smConnection(nullptr), m_sendKeyEventThreadRun(false)
        {
            LOGWARN("ctor");
+           smConnection = NULL;
+           cecEnableStatus = false;
            IsCecMgrActivated = false;
            Register(HDMICECSOURCE_METHOD_SET_ENABLED, &HdmiCecSource::setEnabledWrapper, this);
            Register(HDMICECSOURCE_METHOD_GET_ENABLED, &HdmiCecSource::getEnabledWrapper, this);

--- a/HdmiCec_2/HdmiCec_2.cpp
+++ b/HdmiCec_2/HdmiCec_2.cpp
@@ -388,6 +388,8 @@ namespace WPEFramework
        : PluginHost::JSONRPC(),cecEnableStatus(false),smConnection(nullptr), m_sendKeyEventThreadRun(false)
        {
            LOGWARN("ctor");
+           smConnection = NULL;
+           cecEnableStatus = false;
            IsCecMgrActivated = false;
            Register(HDMICEC2_METHOD_SET_ENABLED, &HdmiCec_2::setEnabledWrapper, this);
            Register(HDMICEC2_METHOD_GET_ENABLED, &HdmiCec_2::getEnabledWrapper, this);


### PR DESCRIPTION
Reason for change:
WPEFramework crash HdmiCecSource
Test Procedure: None
Risks: Low

Change-Id: Ie71fa56ecdc603ecaa42078bb73006e05ab09761 Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>