### PR TITLE
LLAMA-10144:Typo correction in AVInput

### DIFF
--- a/AVInput/AVInput.cpp
+++ b/AVInput/AVInput.cpp
@@ -927,7 +927,7 @@ uint32_t AVInput::getSupportedGameFeatures(const JsonObject& parameters, JsonObj
         return Core::ERROR_GENERAL;
     }
     else {
-        setResponseArray(response, "suppoortedGameFeatures", supportedFeatures);
+        setResponseArray(response, "supportedGameFeatures", supportedFeatures);
         return Core::ERROR_NONE;
     }
 }


### PR DESCRIPTION
Reason for change: Typo error corrected in getSupportedGameFeatures method response
Test Procedure: Build and Verify.
Risks: Low
Signed-off-by: Aishwariya B <aishwariya.bhaskar@sky.uk>