### PR TITLE
LLAMA-10144:Typo correction in AVInput

### DIFF
--- a/AVInput/AVInput.cpp
+++ b/AVInput/AVInput.cpp
@@ -927,7 +927,7 @@ uint32_t AVInput::getSupportedGameFeatures(const JsonObject& parameters, JsonObj
         return Core::ERROR_GENERAL;
     }
     else {
-        setResponseArray(response, "suppoortedGameFeatures", supportedFeatures);
+        setResponseArray(response, "supportedGameFeatures", supportedFeatures);
         return Core::ERROR_NONE;
     }
 }

--- a/AVInput/CHANGELOG.md
+++ b/AVInput/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.2.0] - 2023-04-03
+### Added
+- Typo in RPC response to AVInput call org.rdk.AVInput.getSupportedGameFeatures
+
 ## [1.1.0] - 2022-10-10
 ### Added
 - Combine HdmiInput and CompositeInput Plugins into AVInput


### PR DESCRIPTION
Reason for change: Typo error corrected in getSupportedGameFeatures method response
Test Procedure: Build and Verify.
Risks: Low
Signed-off-by: Aishwariya B <aishwariya.bhaskar@sky.uk>