### PR TITLE
RDKTV-22517: HDMI CEC On, no audio from LG soundbar

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -4199,6 +4199,8 @@ namespace WPEFramework {
 			       {
 				   if(m_arcEarcAudioEnabled == false ) 
 			 	   {
+                                        LOGINFO("%s: Audio Port : [HDMI_ARC0] sendHdmiCecSinkAudioDevicePowerOn !!! \n", __FUNCTION__);
+                                        sendMsgToQueue(SEND_AUDIO_DEVICE_POWERON_MSG, NULL);
 					/* Check SAD for passthru and Auto mode only */
 					if ((mode == device::AudioStereoMode::kPassThru)  || (aPort.getStereoAuto() == true))
 					{


### PR DESCRIPTION
RDKTV-22517: HDMI CEC On, no audio from LG soundbar

Reason for change: Send Audio Device power on to 
prevent LG soundbars to enter into Optical Input 
mode

Test Procedure: Verify CEC On/Off on mutliple
ARC devices
Risks: Low
Priority: P1


Signed-off-by: Krishna Prasad <krishna.prasad2@sky.uk>