### PR TITLE
Release/xumo 1

### DIFF
--- a/DisplaySettings/CHANGELOG.md
+++ b/DisplaySettings/CHANGELOG.md
@@ -15,6 +15,11 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+## [1.0.17] - 2023-04-06
+### Fixed
+- Fixed Audio Mute Issue seen on LG SB by sending Audio Device power on message
+- It prevents LG soundbars to enter into Optical Input mode
+
 ## [1.0.16] - 2023-03-07
 ### Fixed
 - Reduced Arc/eArc audio routing dependency based on HPD

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -4190,6 +4190,8 @@ namespace WPEFramework {
 			       {
 				   if(m_arcEarcAudioEnabled == false ) 
 			 	   {
+                                        LOGINFO("%s: Audio Port : [HDMI_ARC0] sendHdmiCecSinkAudioDevicePowerOn !!! \n", __FUNCTION__);
+                                        sendMsgToQueue(SEND_AUDIO_DEVICE_POWERON_MSG, NULL);
 					/* Check SAD for passthru and Auto mode only */
 					if ((mode == device::AudioStereoMode::kPassThru)  || (aPort.getStereoAuto() == true))
 					{


### PR DESCRIPTION
RDKTV-22517: HDMI CEC On, no audio from LG soundbar

Reason for change: Send Audio Device power on to 
prevent LG soundbars to enter into Optical Input 
mode

Test Procedure: Verify CEC On/Off on mutliple
ARC devices
Risks: Low
Priority: P1

Signed-off-by: Krishna Prasad krishna.prasad2@sky.uk