### PR TITLE
RDKTV-19740: Modify the frequency of CEC messages sent from TV

### DIFF
--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -325,6 +325,10 @@ namespace WPEFramework
 	     updateStatus = HdmiCecSink::_instance->deviceList[header.from.toInt()].m_isOSDNameUpdated;
 	     LOGINFO("updateStatus %d\n",updateStatus);
 	     HdmiCecSink::_instance->deviceList[header.from.toInt()].update(msg.osdName);
+	     if(HdmiCecSink::_instance->deviceList[header.from.toInt()].m_isRequestRetry > 0 &&
+			HdmiCecSink::_instance->deviceList[header.from.toInt()].m_isRequested == CECDeviceParams::REQUEST_OSD_NAME) {
+	         HdmiCecSink::_instance->deviceList[header.from.toInt()].m_isRequestRetry = 0;
+	     }
              if(!updateStatus)
 	     HdmiCecSink::_instance->sendDeviceUpdateInfo(header.from.toInt());
        }
@@ -364,7 +368,10 @@ namespace WPEFramework
 	     LOGINFO("updateDeviceTypeStatus %d updatePAStatus %d \n",updateDeviceTypeStatus,updatePAStatus);
 	     HdmiCecSink::_instance->deviceList[header.from.toInt()].update(msg.physicalAddress);
 	     HdmiCecSink::_instance->deviceList[header.from.toInt()].update(msg.deviceType);
-	     HdmiCecSink::_instance->deviceList[header.from.toInt()].m_isRequestRetry = 0;
+	     if(HdmiCecSink::_instance->deviceList[header.from.toInt()].m_isRequestRetry > 0 &&
+			HdmiCecSink::_instance->deviceList[header.from.toInt()].m_isRequested == CECDeviceParams::REQUEST_PHISICAL_ADDRESS) {
+	         HdmiCecSink::_instance->deviceList[header.from.toInt()].m_isRequestRetry = 0;
+	     }
 	     HdmiCecSink::_instance->updateDeviceChain(header.from, msg.physicalAddress);
 	     if (!updateDeviceTypeStatus || !updatePAStatus)
              HdmiCecSink::_instance->sendDeviceUpdateInfo(header.from.toInt());
@@ -2492,7 +2499,12 @@ namespace WPEFramework
 
 					case CECDeviceParams::REQUEST_OSD_NAME :	
 					{
-						_instance->deviceList[logicalAddress].update(OSDName("NA"));
+						if ( _instance->deviceList[logicalAddress].m_isRequestRetry++ >= HDMICECSINK_REQUEST_MAX_RETRY )
+						{
+							LOGINFO("Max retry for REQUEST_OSD_NAME = %d", _instance->deviceList[logicalAddress].m_isRequestRetry);
+							_instance->deviceList[logicalAddress].update(OSDName(""));
+							_instance->deviceList[logicalAddress].m_isRequestRetry = 0;
+						}
 					}
 						break;
 


### PR DESCRIPTION
Reason for change: Improve the CEC retry mechanism on I2c cec bus busy
Test Procedure: Please refer the ticket for test procedure.
Risks: Low
Priority: P1
Signed-off-by: bp-tdora114 dautapankumar.dora@sky.uk

Merge pull request #3692 from dautapankumardora/23Q1_19740

Merge pull request #3494 from dautapankumardora/sprint/22Q4_19740_OSD_retry