### PR TITLE
RDK-40620: Update Captive Portal specific access methods

### DIFF
--- a/Network/CHANGELOG.md
+++ b/Network/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.0.8] - 2023-04-12
+### Added
+- Added Captive Portal specific access methods.
+
 ## [1.0.7] - 2023-04-04
 ### Fixed
 - Fixed traceroute command error.

--- a/Network/Network.h
+++ b/Network/Network.h
@@ -33,7 +33,8 @@
 #define MAX_IP_ADDRESS_LEN 46
 #define NETSRVMGR_INTERFACES_MAX 16
 #define MAX_ENDPOINTS 5
-#define MAX_ENDPOINT_SIZE 260 // 253 + 1 + 5 + 1 (domain name max length + ':' + port number max chars + '\0')
+#define MAX_ENDPOINT_SIZE 512
+#define MAX_URI_LEN 512
 #define MAX_HOST_NAME_LEN 128
 
 typedef enum _NetworkManager_EventId_t {
@@ -44,6 +45,7 @@ typedef enum _NetworkManager_EventId_t {
     IARM_BUS_NETWORK_MANAGER_EVENT_INTERFACE_CONNECTION_STATUS,
     IARM_BUS_NETWORK_MANAGER_EVENT_INTERFACE_IPADDRESS,
     IARM_BUS_NETWORK_MANAGER_EVENT_DEFAULT_INTERFACE,
+    IARM_BUS_NETWORK_MANAGER_EVENT_INTERNET_CONNECTION_CHANGED,
     IARM_BUS_NETWORK_MANAGER_MAX,
 } IARM_Bus_NetworkManager_EventId_t;
 
@@ -88,6 +90,21 @@ typedef struct
     unsigned char size;
     char          endpoints[MAX_ENDPOINTS][MAX_ENDPOINT_SIZE];
 } IARM_BUS_NetSrvMgr_Iface_TestEndpoints_t;
+
+typedef enum _InternetConnectionState_t {
+    NO_INTERNET,
+    LIMITED_INTERNET,
+    CAPTIVE_PORTAL,
+    FULLY_CONNECTED
+}InternetConnectionState_t;
+
+typedef struct
+{
+    int connectivityState;
+    int monitorInterval;
+    bool monitorConnectivity;
+    char captivePortalURI[MAX_URI_LEN];
+} IARM_BUS_NetSrvMgr_Iface_InternetConnectivityStatus_t;
 
 typedef struct {
     char interface[16];
@@ -174,12 +191,17 @@ namespace WPEFramework {
             uint32_t getSTBIPFamily(const JsonObject& parameters, JsonObject& response);
             uint32_t isConnectedToInternet(const JsonObject& parameters, JsonObject& response);
             uint32_t setConnectivityTestEndpoints(const JsonObject& parameters, JsonObject& response);
+            uint32_t getInternetConnectionState(const JsonObject& parameters, JsonObject& response);
+            uint32_t monitorConnectivity(const JsonObject& parameters, JsonObject& response);
+            uint32_t getCaptivePortalURI(const JsonObject& parameters, JsonObject& response);
+            uint32_t stopConnectivityMonitoring(const JsonObject& parameters, JsonObject& response);
             uint32_t getPublicIP(const JsonObject& parameters, JsonObject& response);
             uint32_t setStunEndPoint(const JsonObject& parameters, JsonObject& response);
             bool getIPIARMWrapper(IARM_BUS_NetSrvMgr_Iface_Settings_t& iarmData, const string interface, const string ipversion);
 
             void onInterfaceEnabledStatusChanged(std::string interface, bool enabled);
             void onInterfaceConnectionStatusChanged(std::string interface, bool connected);
+            void onInternetStatusChange(InternetConnectionState_t InternetConnectionState);
             void onInterfaceIPAddressChanged(std::string interface, std::string ipv6Addr, std::string ipv4Addr, bool acquired);
             void onDefaultInterfaceChanged(std::string oldInterface, std::string newInterface);
 

--- a/Network/Network.json
+++ b/Network/Network.json
@@ -2,7 +2,7 @@
     "$schema": "https://raw.githubusercontent.com/rdkcentral/rdkservices/main/Tools/json_generator/schemas/interface.schema.json",
     "jsonrpc": "2.0",
     "info": {
-        "title": "Network API", 
+        "title": "Network API",
         "class": "Network", 
         "description": "The `Network` plugin allows you to manage network interfaces on a set-top box."
     },
@@ -129,6 +129,11 @@
             "summary": "The results from `traceroute`",
             "type": "string",
             "example": "<<<traceroute command results>>>"
+        },
+        "state": {
+            "summary": "Internet Connection state",
+            "type": "integer",
+            "example": 2
         },
         
         "guid": {
@@ -391,6 +396,28 @@
                 ]
             }
         },
+        "setConnectivityTestEndpoints":{
+            "summary": "Sets the default list of endpoints used for a connectivity test. Maximum number of endpoints is 5.",
+            "params": {
+                "type":"object",
+                "properties": {
+                    "endpoints": {
+                        "summary": "A list of endpoints to test",
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "example": "http://clients3.google.com/generate_204"
+                        }
+                    }
+                },
+                "required": [
+                    "endpoints"
+                ]
+            },
+            "result": {
+                "$ref": "#/common/result"
+            }
+        },
         "isConnectedToInternet":{
             "summary": "Whether the device has internet connectivity. This API might take up to 2s to validate internet connectivity.",
             "result": {
@@ -407,6 +434,93 @@
                 },
                 "required": [
                     "connectedToInternet",
+                    "success"
+                ]
+            }
+        },
+        "getInternetConnectionState":{
+            "summary": "Returns the internet connection state. The possible internet connection state are as follows. \n* `0`: NO_INTERNET - No internet connection  \n* `1`: LIMITED_INTERNET - Internet connection limited  \n* `2`: CAPTIVE_PORTAL - Captive portal found  \n* `3`: FULLY_CONNECTED - Fully connected to internet",
+            "result": {
+                "type": "object",
+                "properties": {
+                    "state": {
+                        "$ref": "#/definitions/state"
+                    },
+                     "URI": {
+                        "summary": "Captive portal URI",
+                        "type": "string",
+                        "example": "http://10.0.0.1/captiveportal.jst"
+                    },
+                    "success":{
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "state",
+                    "success"
+                ]
+            }
+        },
+        "getCaptivePortalURI":{
+            "summary": "Returns the captive portal URI if connected to any captive portal network.",
+            "result": {
+                "type": "object",
+                "properties": {
+                     "URI": {
+                        "summary": "Captive portal URI",
+                        "type": "string",
+                        "example": "http://10.0.0.1/captiveportal.jst"
+                    },
+                    "success":{
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "URI",
+                    "success"
+                ]
+            }
+        },
+        "monitorConnectivity":{
+            "summary": "Enable a continuous monitoring of internet connectivity with heart beat interval thats given.",
+            "events":{
+                 "onInternetStatusChange" : "Triggered when internet connection state changed."
+            },
+            "params": {
+                "type":"object",
+                "properties": {
+                    "interval": {
+                        "summary": "Interval in sec. Default value 600 sec and Minium intervale should be 600 sec",
+                        "type": "number",
+                        "example": "900"
+                    }
+                },
+                "required": [
+                    "interval"
+                ]
+            },
+            "result": {
+                "type": "object",
+                "properties": {
+                    "success":{
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "success"
+                ]
+            }
+        },
+        "stopConnectivityMonitoring":{
+            "summary": "Stops the connectivity monitoring.",
+            "result": {
+                "type": "object",
+                "properties": {
+                    "success":{
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
                     "success"
                 ]
             }
@@ -986,6 +1100,22 @@
                 "required": [
                     "oldInterfaceName",
                     "newInterfaceName"
+                ]
+            }
+        },
+        "onInternetStatusChange":{
+            "summary": "Triggered when internet connection state changed.The possible internet connection state are `NO_INTERNET`, `LIMITED_INTERNET`, `CAPTIVE_PORTAL`, `FULLY_CONNECTED`",
+            "params": {
+                "type": "object",
+                "properties": {
+                    "state":{
+                        "summary": "The internet connection state",
+                        "type": "string",
+                        "example": "NO_INTERNET"
+                    }
+                },
+                "required": [
+                    "state"
                 ]
             }
         }

--- a/Tests/mocks/Iarm.h
+++ b/Tests/mocks/Iarm.h
@@ -826,7 +826,6 @@ typedef enum _IARM_Bus_NMgr_WiFi_EventId_t {
 #define MAX_IP_ADDRESS_LEN 46
 #define MAX_IP_FAMILY_SIZE 10
 #define MAX_HOST_NAME_LEN 128
-#define MAX_ENDPOINT_SIZE 260 // 253 + 1 + 5 + 1 (domain name max length + ':' + port number max chars + '\0')
 #define IARM_BUS_NETSRVMGR_API_getActiveInterface "getActiveInterface"
 #define IARM_BUS_NETSRVMGR_API_getNetworkInterfaces "getNetworkInterfaces"
 #define IARM_BUS_NETSRVMGR_API_getInterfaceList "getInterfaceList"
@@ -840,6 +839,9 @@ typedef enum _IARM_Bus_NMgr_WiFi_EventId_t {
 #define IARM_BUS_NETSRVMGR_API_getSTBip_family "getSTBip_family"
 #define IARM_BUS_NETSRVMGR_API_isConnectedToInternet "isConnectedToInternet"
 #define IARM_BUS_NETSRVMGR_API_setConnectivityTestEndpoints "setConnectivityTestEndpoints"
+#define IARM_BUS_NETSRVMGR_API_getInternetConnectionState "getInternetConnectionState"
+#define IARM_BUS_NETSRVMGR_API_monitorConnectivity "monitorConnectivity"
+#define IARM_BUS_NETSRVMGR_API_stopConnectivityMonitoring "stopConnectivityMonitoring"
 #define IARM_BUS_NETSRVMGR_API_isAvailable "isAvailable"
 #define IARM_BUS_NETSRVMGR_API_getPublicIP "getPublicIP"
 

--- a/Tests/tests/test_Network.cpp
+++ b/Tests/tests/test_Network.cpp
@@ -62,6 +62,7 @@ protected:
         IARM_EventHandler_t interfaceConnection;
         IARM_EventHandler_t interfaceIpaddress;
         IARM_EventHandler_t defaultInterface;
+        IARM_EventHandler_t internetStateChanged;
 
         EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call_with_IPCTimeout)
             .Times(::testing::AnyNumber())
@@ -86,6 +87,9 @@ protected:
             }
             if ((string(IARM_BUS_NM_SRV_MGR_NAME) == string(ownerName)) && (eventId == IARM_BUS_NETWORK_MANAGER_EVENT_DEFAULT_INTERFACE)) {
                 defaultInterface = handler;
+            }
+            if ((string(IARM_BUS_NM_SRV_MGR_NAME) == string(ownerName)) && (eventId == IARM_BUS_NETWORK_MANAGER_EVENT_INTERNET_CONNECTION_CHANGED)) {
+                internetStateChanged = handler;
             }
             return IARM_RESULT_SUCCESS;
         }));
@@ -112,6 +116,9 @@ TEST_F(NetworkTest, RegisteredMethods)
     EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("getPublicIP")));
     EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("getSTBIPFamily")));
     EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("setConnectivityTestEndpoints")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("getCaptivePortalURI")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("monitorConnectivity")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("stopConnectivityMonitoring")));
     EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("setDefaultInterface")));
     EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("setIPSettings")));
     EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("trace")));
@@ -352,7 +359,111 @@ TEST_F(NetworkTest, setConnectivityTestEndpoints)
 
                 return IARM_RESULT_SUCCESS;
             });
-    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("setConnectivityTestEndpoints"), _T("{\"endpoints\": [\"xfinity.com:8080\"]}"), response));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("setConnectivityTestEndpoints"), _T("{\"endpoints\": [\"http://clients3.google.com/generate_204\"]}"), response));
+    EXPECT_EQ(response, string("{\"success\":true}"));
+}
+
+TEST_F(NetworkTest, getInternetConnectionState)
+{
+    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_getInternetConnectionState)));
+                auto param = static_cast<IARM_BUS_NetSrvMgr_Iface_InternetConnectivityStatus_t *>(arg);
+
+				param->connectivityState = LIMITED_INTERNET;
+                return IARM_RESULT_SUCCESS;
+            });
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getInternetConnectionState"), _T("{}"), response));
+	EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"state\":1")));
+	EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"success\":true")));
+
+    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+    .Times(::testing::AnyNumber())
+    .WillRepeatedly(
+        [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+            EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+            EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_getInternetConnectionState)));
+            auto param = static_cast<IARM_BUS_NetSrvMgr_Iface_InternetConnectivityStatus_t *>(arg);
+
+			param->connectivityState = CAPTIVE_PORTAL;
+			memcpy(param->captivePortalURI, "http://10.0.0.1/captiveportal.jst", sizeof("http://10.0.0.1/captiveportal.jst"));
+            return IARM_RESULT_SUCCESS;
+        });
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getInternetConnectionState"), _T("{}"), response));
+	EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"state\":2")));
+
+	EXPECT_THAT(response, ::testing::ContainsRegex(_T("captiveportal.jst")));
+	EXPECT_THAT(response, ::testing::ContainsRegex(_T("10.0.0.1")));
+	EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"success\":true")));
+}
+
+TEST_F(NetworkTest, getCaptivePortalURI)
+{
+    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+    .Times(::testing::AnyNumber())
+    .WillRepeatedly(
+        [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+            EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+            EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_getInternetConnectionState)));
+            auto param = static_cast<IARM_BUS_NetSrvMgr_Iface_InternetConnectivityStatus_t *>(arg);
+
+			param->connectivityState = LIMITED_INTERNET;
+            return IARM_RESULT_SUCCESS;
+        });
+
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getCaptivePortalURI"), _T("{}"), response));
+	EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"URI\":\"\"")));
+	EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"success\":true")));
+	EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+    .Times(::testing::AnyNumber())
+    .WillRepeatedly(
+        [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+            EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+            EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_getInternetConnectionState)));
+            auto param = static_cast<IARM_BUS_NetSrvMgr_Iface_InternetConnectivityStatus_t *>(arg);
+
+			param->connectivityState = CAPTIVE_PORTAL;
+			memcpy(param->captivePortalURI, "http://10.0.0.1/captiveportal.jst", sizeof("http://10.0.0.1/captiveportal.jst"));
+            return IARM_RESULT_SUCCESS;
+        });
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getCaptivePortalURI"), _T("{}"), response));
+	EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"URI\"")));
+	EXPECT_THAT(response, ::testing::ContainsRegex(_T("captiveportal.jst")));
+	EXPECT_THAT(response, ::testing::ContainsRegex(_T("10.0.0.1")));
+	EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"success\":true")));
+}
+
+TEST_F(NetworkTest, monitorConnectivity)
+{
+    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_monitorConnectivity)));
+                return IARM_RESULT_SUCCESS;
+            });
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("monitorConnectivity"), _T("{\"interval\": 900}"), response));
+    EXPECT_EQ(response, string("{\"success\":true}"));
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("monitorConnectivity"), _T("{}"), response));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("")));
+}
+
+TEST_F(NetworkTest, stopConnectivityMonitoring)
+{
+    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_stopConnectivityMonitoring)));
+
+                return IARM_RESULT_SUCCESS;
+            });
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("stopConnectivityMonitoring"), _T("{}"), response));
     EXPECT_EQ(response, string("{\"success\":true}"));
 }
 

--- a/docs/api/NetworkPlugin.md
+++ b/docs/api/NetworkPlugin.md
@@ -1,32 +1,32 @@
 <!-- Generated automatically, DO NOT EDIT! -->
-<a name="NetworkPlugin"></a>
+<a name="head.NetworkPlugin"></a>
 # NetworkPlugin
 
-**Version: [1.0.6](https://github.com/rdkcentral/rdkservices/blob/main/Network/CHANGELOG.md)**
+**Version: [1.0.8](https://github.com/rdkcentral/rdkservices/blob/main/Network/CHANGELOG.md)**
 
 A org.rdk.Network plugin for Thunder framework.
 
 ### Table of Contents
 
-- [Abbreviation, Acronyms and Terms](#Abbreviation,_Acronyms_and_Terms)
-- [Description](#Description)
-- [Configuration](#Configuration)
-- [Methods](#Methods)
-- [Notifications](#Notifications)
+- [Abbreviation, Acronyms and Terms](#head.Abbreviation,_Acronyms_and_Terms)
+- [Description](#head.Description)
+- [Configuration](#head.Configuration)
+- [Methods](#head.Methods)
+- [Notifications](#head.Notifications)
 
-<a name="Abbreviation,_Acronyms_and_Terms"></a>
+<a name="head.Abbreviation,_Acronyms_and_Terms"></a>
 # Abbreviation, Acronyms and Terms
 
 [[Refer to this link](userguide/aat.md)]
 
-<a name="Description"></a>
+<a name="head.Description"></a>
 # Description
 
 The `Network` plugin allows you to manage network interfaces on a set-top box.
 
-The plugin is designed to be loaded and executed within the Thunder framework. For more information about the framework refer to [[Thunder](#Thunder)].
+The plugin is designed to be loaded and executed within the Thunder framework. For more information about the framework refer to [[Thunder](#ref.Thunder)].
 
-<a name="Configuration"></a>
+<a name="head.Configuration"></a>
 # Configuration
 
 The table below lists configuration options of the plugin.
@@ -38,7 +38,7 @@ The table below lists configuration options of the plugin.
 | locator | string | Library name: *libWPEFrameworkNetwork.so* |
 | autostart | boolean | Determines if the plugin shall be started automatically along with the framework |
 
-<a name="Methods"></a>
+<a name="head.Methods"></a>
 # Methods
 
 The following methods are provided by the org.rdk.Network plugin:
@@ -47,29 +47,33 @@ Network interface methods:
 
 | Method | Description |
 | :-------- | :-------- |
-| [getDefaultInterface](#getDefaultInterface) | Gets the default network interface |
-| [getInterfaces](#getInterfaces) | Returns a list of interfaces supported by this device including their state |
-| [getIPSettings](#getIPSettings) | Gets the IP setting for the given interface |
-| [getNamedEndpoints](#getNamedEndpoints) | Returns a list of endpoint names |
-| [getQuirks](#getQuirks) | Get standard string `RDK-20093` |
-| [getStbIp](#getStbIp) | Gets the IP address of the default interface |
-| [getSTBIPFamily](#getSTBIPFamily) | Gets the IP address of the default interface by address family |
-| [isConnectedToInternet](#isConnectedToInternet) | Whether the device has internet connectivity |
-| [isInterfaceEnabled](#isInterfaceEnabled) | Whether the specified interface is enabled |
-| [ping](#ping) | Pings the specified endpoint with the specified number of packets |
-| [pingNamedEndpoint](#pingNamedEndpoint) | Pings the specified named endpoint with the specified number of packets |
-| [setConnectivityTestEndpoints](#setConnectivityTestEndpoints) | Sets the default list of endpoints used for a connectivity test |
-| [setDefaultInterface](#setDefaultInterface) | Sets the default interface |
-| [setInterfaceEnabled](#setInterfaceEnabled) | Enables the specified interface |
-| [setIPSettings](#setIPSettings) | Sets the IP settings |
-| [getPublicIP](#getPublicIP) | It allows either zero parameter or with only interface and ipv6 parameter to determine WAN ip address |
-| [setStunEndPoint](#setStunEndPoint) | Set the Stun Endpoint used for getPublicIP |
-| [trace](#trace) | Traces the specified endpoint with the specified number of packets using `traceroute` |
-| [traceNamedEndpoint](#traceNamedEndpoint) | Traces the specified named endpoint with the specified number of packets using `traceroute` |
+| [getDefaultInterface](#method.getDefaultInterface) | Gets the default network interface |
+| [getInterfaces](#method.getInterfaces) | Returns a list of interfaces supported by this device including their state |
+| [getIPSettings](#method.getIPSettings) | Gets the IP setting for the given interface |
+| [getNamedEndpoints](#method.getNamedEndpoints) | Returns a list of endpoint names |
+| [getQuirks](#method.getQuirks) | Get standard string `RDK-20093` |
+| [getStbIp](#method.getStbIp) | Gets the IP address of the default interface |
+| [getSTBIPFamily](#method.getSTBIPFamily) | Gets the IP address of the default interface by address family |
+| [setConnectivityTestEndpoints](#method.setConnectivityTestEndpoints) | Sets the default list of endpoints used for a connectivity test |
+| [isConnectedToInternet](#method.isConnectedToInternet) | Whether the device has internet connectivity |
+| [getInternetConnectionState](#method.getInternetConnectionState) | Returns the internet connection state |
+| [getCaptivePortalURI](#method.getCaptivePortalURI) | Returns the captive portal URI if connected to any captive portal network |
+| [monitorConnectivity](#method.monitorConnectivity) | Enable a continuous monitoring of internet connectivity with heart beat interval thats given |
+| [stopConnectivityMonitoring](#method.stopConnectivityMonitoring) | Stops the connectivity monitoring |
+| [isInterfaceEnabled](#method.isInterfaceEnabled) | Whether the specified interface is enabled |
+| [ping](#method.ping) | Pings the specified endpoint with the specified number of packets |
+| [pingNamedEndpoint](#method.pingNamedEndpoint) | Pings the specified named endpoint with the specified number of packets |
+| [setDefaultInterface](#method.setDefaultInterface) | Sets the default interface |
+| [setInterfaceEnabled](#method.setInterfaceEnabled) | Enables the specified interface |
+| [setIPSettings](#method.setIPSettings) | Sets the IP settings |
+| [getPublicIP](#method.getPublicIP) | It allows either zero parameter or with only interface and ipv6 parameter to determine WAN ip address |
+| [setStunEndPoint](#method.setStunEndPoint) | Set the Stun Endpoint used for getPublicIP |
+| [trace](#method.trace) | Traces the specified endpoint with the specified number of packets using `traceroute` |
+| [traceNamedEndpoint](#method.traceNamedEndpoint) | Traces the specified named endpoint with the specified number of packets using `traceroute` |
 
 
-<a name="getDefaultInterface"></a>
-## *getDefaultInterface*
+<a name="method.getDefaultInterface"></a>
+## *getDefaultInterface [<sup>method</sup>](#head.Methods)*
 
 Gets the default network interface. The active network interface is defined as the one that can make requests to the external network. Returns one of the supported interfaces as per `getInterfaces`, or an empty value which indicates that there is no default network interface.
 
@@ -114,8 +118,8 @@ This method takes no parameters.
 }
 ```
 
-<a name="getInterfaces"></a>
-## *getInterfaces*
+<a name="method.getInterfaces"></a>
+## *getInterfaces [<sup>method</sup>](#head.Methods)*
 
 Returns a list of interfaces supported by this device including their state.
 
@@ -172,8 +176,8 @@ This method takes no parameters.
 }
 ```
 
-<a name="getIPSettings"></a>
-## *getIPSettings*
+<a name="method.getIPSettings"></a>
+## *getIPSettings [<sup>method</sup>](#head.Methods)*
 
 Gets the IP setting for the given interface.
 
@@ -242,8 +246,8 @@ No Events
 }
 ```
 
-<a name="getNamedEndpoints"></a>
-## *getNamedEndpoints*
+<a name="method.getNamedEndpoints"></a>
+## *getNamedEndpoints [<sup>method</sup>](#head.Methods)*
 
 Returns a list of endpoint names. Currently supported endpoint names are: `CMTS`.
 
@@ -291,8 +295,8 @@ This method takes no parameters.
 }
 ```
 
-<a name="getQuirks"></a>
-## *getQuirks*
+<a name="method.getQuirks"></a>
+## *getQuirks [<sup>method</sup>](#head.Methods)*
 
 Get standard string `RDK-20093`.
 
@@ -337,8 +341,8 @@ This method takes no parameters.
 }
 ```
 
-<a name="getStbIp"></a>
-## *getStbIp*
+<a name="method.getStbIp"></a>
+## *getStbIp [<sup>method</sup>](#head.Methods)*
 
 Gets the IP address of the default interface.
 
@@ -383,8 +387,8 @@ This method takes no parameters.
 }
 ```
 
-<a name="getSTBIPFamily"></a>
-## *getSTBIPFamily*
+<a name="method.getSTBIPFamily"></a>
+## *getSTBIPFamily [<sup>method</sup>](#head.Methods)*
 
 Gets the IP address of the default interface by address family.
 
@@ -435,8 +439,61 @@ No Events
 }
 ```
 
-<a name="isConnectedToInternet"></a>
-## *isConnectedToInternet*
+<a name="method.setConnectivityTestEndpoints"></a>
+## *setConnectivityTestEndpoints [<sup>method</sup>](#head.Methods)*
+
+Sets the default list of endpoints used for a connectivity test. Maximum number of endpoints is 5.
+
+### Events
+
+No Events
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.endpoints | array | A list of endpoints to test |
+| params.endpoints[#] | string |  |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.success | boolean | Whether the request succeeded |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.Network.setConnectivityTestEndpoints",
+    "params": {
+        "endpoints": [
+            "http://clients3.google.com/generate_204"
+        ]
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "success": true
+    }
+}
+```
+
+<a name="method.isConnectedToInternet"></a>
+## *isConnectedToInternet [<sup>method</sup>](#head.Methods)*
 
 Whether the device has internet connectivity. This API might take up to 2s to validate internet connectivity.
 
@@ -481,8 +538,201 @@ This method takes no parameters.
 }
 ```
 
-<a name="isInterfaceEnabled"></a>
-## *isInterfaceEnabled*
+<a name="method.getInternetConnectionState"></a>
+## *getInternetConnectionState [<sup>method</sup>](#head.Methods)*
+
+Returns the internet connection state. The possible internet connection state are as follows. 
+* `0`: NO_INTERNET - No internet connection  
+* `1`: LIMITED_INTERNET - Internet connection limited  
+* `2`: CAPTIVE_PORTAL - Captive portal found  
+* `3`: FULLY_CONNECTED - Fully connected to internet.
+
+### Events
+
+No Events
+
+### Parameters
+
+This method takes no parameters.
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.state | integer | Internet Connection state |
+| result?.URI | string | <sup>*(optional)*</sup> Captive portal URI |
+| result.success | boolean | Whether the request succeeded |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.Network.getInternetConnectionState"
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "state": 2,
+        "URI": "http://10.0.0.1/captiveportal.jst",
+        "success": true
+    }
+}
+```
+
+<a name="method.getCaptivePortalURI"></a>
+## *getCaptivePortalURI [<sup>method</sup>](#head.Methods)*
+
+Returns the captive portal URI if connected to any captive portal network.
+
+### Events
+
+No Events
+
+### Parameters
+
+This method takes no parameters.
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.URI | string | Captive portal URI |
+| result.success | boolean | Whether the request succeeded |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.Network.getCaptivePortalURI"
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "URI": "http://10.0.0.1/captiveportal.jst",
+        "success": true
+    }
+}
+```
+
+<a name="method.monitorConnectivity"></a>
+## *monitorConnectivity [<sup>method</sup>](#head.Methods)*
+
+Enable a continuous monitoring of internet connectivity with heart beat interval thats given.
+
+### Events
+
+| Event | Description |
+| :-------- | :-------- |
+| [onInternetStatusChange](#event.onInternetStatusChange) | Triggered when internet connection state changed. |
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.interval | number | Interval in sec. Default value 600 sec and Minium intervale should be 600 sec |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.success | boolean | Whether the request succeeded |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.Network.monitorConnectivity",
+    "params": {
+        "interval": 900
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "success": true
+    }
+}
+```
+
+<a name="method.stopConnectivityMonitoring"></a>
+## *stopConnectivityMonitoring [<sup>method</sup>](#head.Methods)*
+
+Stops the connectivity monitoring.
+
+### Events
+
+No Events
+
+### Parameters
+
+This method takes no parameters.
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.success | boolean | Whether the request succeeded |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.Network.stopConnectivityMonitoring"
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "success": true
+    }
+}
+```
+
+<a name="method.isInterfaceEnabled"></a>
+## *isInterfaceEnabled [<sup>method</sup>](#head.Methods)*
 
 Whether the specified interface is enabled.
 
@@ -533,8 +783,8 @@ No Events
 }
 ```
 
-<a name="ping"></a>
-## *ping*
+<a name="method.ping"></a>
+## *ping [<sup>method</sup>](#head.Methods)*
 
 Pings the specified endpoint with the specified number of packets.
 
@@ -607,8 +857,8 @@ No Events
 }
 ```
 
-<a name="pingNamedEndpoint"></a>
-## *pingNamedEndpoint*
+<a name="method.pingNamedEndpoint"></a>
+## *pingNamedEndpoint [<sup>method</sup>](#head.Methods)*
 
 Pings the specified named endpoint with the specified number of packets. Only names returned by `getNamedEndpoints` can be used. The named endpoint is resolved to a specific host or IP address on the device side based on the `endpointName`.
 
@@ -681,61 +931,8 @@ No Events
 }
 ```
 
-<a name="setConnectivityTestEndpoints"></a>
-## *setConnectivityTestEndpoints*
-
-Sets the default list of endpoints used for a connectivity test. Maximum number of endpoints is 5.
-
-### Events
-
-No Events
-
-### Parameters
-
-| Name | Type | Description |
-| :-------- | :-------- | :-------- |
-| params | object |  |
-| params.endpoints | array | A list of endpoints to test |
-| params.endpoints[#] | string |  |
-
-### Result
-
-| Name | Type | Description |
-| :-------- | :-------- | :-------- |
-| result | object |  |
-| result.success | boolean | Whether the request succeeded |
-
-### Example
-
-#### Request
-
-```json
-{
-    "jsonrpc": "2.0",
-    "id": 42,
-    "method": "org.rdk.Network.setConnectivityTestEndpoints",
-    "params": {
-        "endpoints": [
-            "xfinity.com:8080"
-        ]
-    }
-}
-```
-
-#### Response
-
-```json
-{
-    "jsonrpc": "2.0",
-    "id": 42,
-    "result": {
-        "success": true
-    }
-}
-```
-
-<a name="setDefaultInterface"></a>
-## *setDefaultInterface*
+<a name="method.setDefaultInterface"></a>
+## *setDefaultInterface [<sup>method</sup>](#head.Methods)*
 
 Sets the default interface. The call fails if the interface is not enabled.
 
@@ -743,10 +940,10 @@ Sets the default interface. The call fails if the interface is not enabled.
 
 | Event | Description |
 | :-------- | :-------- |
-| [onInterfaceStatusChanged](#onInterfaceStatusChanged) | Triggered when device’s default interface changed. |
-| [onConnectionStatusChanged](#onConnectionStatusChanged) | Triggered when interface’s status changes to enabled/disabled. |
-| [onIPAddressStatusChanged](#onIPAddressStatusChanged) | Triggered when the device connects to router. |
-| [onDefaultInterfaceChanged](#onDefaultInterfaceChanged) | Triggered when each IP address is lost or acquired. |
+| [onInterfaceStatusChanged](#event.onInterfaceStatusChanged) | Triggered when device’s default interface changed. |
+| [onConnectionStatusChanged](#event.onConnectionStatusChanged) | Triggered when interface’s status changes to enabled/disabled. |
+| [onIPAddressStatusChanged](#event.onIPAddressStatusChanged) | Triggered when the device connects to router. |
+| [onDefaultInterfaceChanged](#event.onDefaultInterfaceChanged) | Triggered when each IP address is lost or acquired. |
 ### Parameters
 
 | Name | Type | Description |
@@ -790,8 +987,8 @@ Sets the default interface. The call fails if the interface is not enabled.
 }
 ```
 
-<a name="setInterfaceEnabled"></a>
-## *setInterfaceEnabled*
+<a name="method.setInterfaceEnabled"></a>
+## *setInterfaceEnabled [<sup>method</sup>](#head.Methods)*
 
 Enables the specified interface.
 
@@ -799,7 +996,7 @@ Enables the specified interface.
 
 | Event | Description |
 | :-------- | :-------- |
-| [onInterfaceStatusChanged](#onInterfaceStatusChanged) | Triggered when interface’s status changes to enabled/disabled. |
+| [onInterfaceStatusChanged](#event.onInterfaceStatusChanged) | Triggered when interface’s status changes to enabled/disabled. |
 ### Parameters
 
 | Name | Type | Description |
@@ -845,8 +1042,8 @@ Enables the specified interface.
 }
 ```
 
-<a name="setIPSettings"></a>
-## *setIPSettings*
+<a name="method.setIPSettings"></a>
+## *setIPSettings [<sup>method</sup>](#head.Methods)*
 
 Sets the IP settings.All the inputs are mandatory for v1. But for v2, the interface and autconfig params are mandatory input to autoconfig IP settings & other parameters not required. For manual IP, all the input parameters are mandatory except secondaryDNS.
 
@@ -854,7 +1051,7 @@ Sets the IP settings.All the inputs are mandatory for v1. But for v2, the interf
 
 | Event | Description |
 | :-------- | :-------- |
-| [onIPAddressStatusChanged](#onIPAddressStatusChanged) | Triggered when each IP address is lost or acquired. |
+| [onIPAddressStatusChanged](#event.onIPAddressStatusChanged) | Triggered when each IP address is lost or acquired. |
 ### Parameters
 
 | Name | Type | Description |
@@ -912,8 +1109,8 @@ Sets the IP settings.All the inputs are mandatory for v1. But for v2, the interf
 }
 ```
 
-<a name="getPublicIP"></a>
-## *getPublicIP*
+<a name="method.getPublicIP"></a>
+## *getPublicIP [<sup>method</sup>](#head.Methods)*
 
 It allows either zero parameter or with only interface and ipv6 parameter to determine WAN ip address.
 
@@ -966,8 +1163,8 @@ No Events
 }
 ```
 
-<a name="setStunEndPoint"></a>
-## *setStunEndPoint*
+<a name="method.setStunEndPoint"></a>
+## *setStunEndPoint [<sup>method</sup>](#head.Methods)*
 
 Set the Stun Endpoint used for getPublicIP.
 
@@ -1024,8 +1221,8 @@ No Events
 }
 ```
 
-<a name="trace"></a>
-## *trace*
+<a name="method.trace"></a>
+## *trace [<sup>method</sup>](#head.Methods)*
 
 Traces the specified endpoint with the specified number of packets using `traceroute`.
 
@@ -1082,8 +1279,8 @@ No Events
 }
 ```
 
-<a name="traceNamedEndpoint"></a>
-## *traceNamedEndpoint*
+<a name="method.traceNamedEndpoint"></a>
+## *traceNamedEndpoint [<sup>method</sup>](#head.Methods)*
 
 Traces the specified named endpoint with the specified number of packets using `traceroute`.
 
@@ -1140,10 +1337,10 @@ No Events
 }
 ```
 
-<a name="Notifications"></a>
+<a name="head.Notifications"></a>
 # Notifications
 
-Notifications are autonomous events, triggered by the internals of the implementation, and broadcasted via JSON-RPC to all registered observers. Refer to [[Thunder](#Thunder)] for information on how to register for a notification.
+Notifications are autonomous events, triggered by the internals of the implementation, and broadcasted via JSON-RPC to all registered observers. Refer to [[Thunder](#ref.Thunder)] for information on how to register for a notification.
 
 The following events are provided by the org.rdk.Network plugin:
 
@@ -1151,14 +1348,15 @@ Network interface events:
 
 | Event | Description |
 | :-------- | :-------- |
-| [onInterfaceStatusChanged](#onInterfaceStatusChanged) | Triggered when an interface becomes enabled or disabled |
-| [onConnectionStatusChanged](#onConnectionStatusChanged) | Triggered when a connection is made or lost |
-| [onIPAddressStatusChanged](#onIPAddressStatusChanged) | Triggered when an IP Address is assigned or lost |
-| [onDefaultInterfaceChanged](#onDefaultInterfaceChanged) | Triggered when the default interface changes, regardless if it's from a system operation or through the `setDefaultInterface` method |
+| [onInterfaceStatusChanged](#event.onInterfaceStatusChanged) | Triggered when an interface becomes enabled or disabled |
+| [onConnectionStatusChanged](#event.onConnectionStatusChanged) | Triggered when a connection is made or lost |
+| [onIPAddressStatusChanged](#event.onIPAddressStatusChanged) | Triggered when an IP Address is assigned or lost |
+| [onDefaultInterfaceChanged](#event.onDefaultInterfaceChanged) | Triggered when the default interface changes, regardless if it's from a system operation or through the `setDefaultInterface` method |
+| [onInternetStatusChange](#event.onInternetStatusChange) | Triggered when internet connection state changed |
 
 
-<a name="onInterfaceStatusChanged"></a>
-## *onInterfaceStatusChanged*
+<a name="event.onInterfaceStatusChanged"></a>
+## *onInterfaceStatusChanged [<sup>event</sup>](#head.Notifications)*
 
 Triggered when an interface becomes enabled or disabled.
 
@@ -1183,8 +1381,8 @@ Triggered when an interface becomes enabled or disabled.
 }
 ```
 
-<a name="onConnectionStatusChanged"></a>
-## *onConnectionStatusChanged*
+<a name="event.onConnectionStatusChanged"></a>
+## *onConnectionStatusChanged [<sup>event</sup>](#head.Notifications)*
 
 Triggered when a connection is made or lost.
 
@@ -1209,8 +1407,8 @@ Triggered when a connection is made or lost.
 }
 ```
 
-<a name="onIPAddressStatusChanged"></a>
-## *onIPAddressStatusChanged*
+<a name="event.onIPAddressStatusChanged"></a>
+## *onIPAddressStatusChanged [<sup>event</sup>](#head.Notifications)*
 
 Triggered when an IP Address is assigned or lost.
 
@@ -1239,10 +1437,10 @@ Triggered when an IP Address is assigned or lost.
 }
 ```
 
-<a name="onDefaultInterfaceChanged"></a>
-## *onDefaultInterfaceChanged*
+<a name="event.onDefaultInterfaceChanged"></a>
+## *onDefaultInterfaceChanged [<sup>event</sup>](#head.Notifications)*
 
-Triggered when the default interface changes, regardless if it's from a system operation or through the `setDefaultInterface` 
+Triggered when the default interface changes, regardless if it's from a system operation or through the `setDefaultInterface` method.
 
 ### Parameters
 
@@ -1261,6 +1459,30 @@ Triggered when the default interface changes, regardless if it's from a system o
     "params": {
         "oldInterfaceName": "ETHERNET",
         "newInterfaceName": "WIFI"
+    }
+}
+```
+
+<a name="event.onInternetStatusChange"></a>
+## *onInternetStatusChange [<sup>event</sup>](#head.Notifications)*
+
+Triggered when internet connection state changed.The possible internet connection state are `NO_INTERNET`, `LIMITED_INTERNET`, `CAPTIVE_PORTAL`, `FULLY_CONNECTED`.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.state | string | The internet connection state |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.onInternetStatusChange",
+    "params": {
+        "state": "NO_INTERNET"
     }
 }
 ```


### PR DESCRIPTION
-) New api added
    getInternetConnectionState
    getCaptivePortalURI
    monitorConnectivity
    stopConnectivityMonitoring

-) Updated network plugin document
-) Updated Unit test cases