### PR TITLE
SERXIONE-1402: WPEFramework crash HdmiCecSource

### DIFF
--- a/HdmiCec/CHANGELOG.md
+++ b/HdmiCec/CHANGELOG.md
@@ -14,6 +14,11 @@ All notable changes to this RDK Service will be documented in this file.
 
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
+
+## [1.0.10] - 2023-04-20
+### Fixed
+- Fixed CEC crash by initializing status variables inside the ctor.
+
 ## [1.0.9] - 2023-04-12
 ### Fixed
 - Fixed IARM_Bus_UnRegisterEventHandler  call to IARM_Bus_RemoveEventHandler

--- a/HdmiCec/HdmiCec.cpp
+++ b/HdmiCec/HdmiCec.cpp
@@ -57,7 +57,7 @@
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 9
+#define API_VERSION_NUMBER_PATCH 10
 
 enum {
 	HDMICEC_EVENT_DEVICE_ADDED=0,
@@ -174,6 +174,9 @@ namespace WPEFramework
         HdmiCec::HdmiCec()
         : PluginHost::JSONRPC(),cecEnableStatus(false),smConnection(nullptr)
         {
+            LOGWARN("ctor");
+            smConnection = NULL;
+            cecEnableStatus = false;
             HdmiCec::_instance = this;
 
             Register(HDMICEC_METHOD_SET_ENABLED, &HdmiCec::setEnabledWrapper, this);

--- a/HdmiCecSource/CHANGELOG.md
+++ b/HdmiCecSource/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.0.4] - 2023-04-20
+### Fixed
+- Fixed CEC crash by initializing status variables inside the ctor.
+
 ## [1.0.3] - 2023-04-11
 ### Fixed
 - Updated Logging, and initialize function to be more verbose for testing purposes

--- a/HdmiCecSource/HdmiCecSource.cpp
+++ b/HdmiCecSource/HdmiCecSource.cpp
@@ -61,7 +61,7 @@
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 3
+#define API_VERSION_NUMBER_PATCH 4
 
 enum {
 	HDMICECSOURCE_EVENT_DEVICE_ADDED=0,
@@ -388,6 +388,8 @@ namespace WPEFramework
        : PluginHost::JSONRPC(),cecEnableStatus(false),smConnection(nullptr), m_sendKeyEventThreadRun(false)
        {
            LOGWARN("ctor");
+           smConnection = NULL;
+           cecEnableStatus = false;
            IsCecMgrActivated = false;
            Register(HDMICECSOURCE_METHOD_SET_ENABLED, &HdmiCecSource::setEnabledWrapper, this);
            Register(HDMICECSOURCE_METHOD_GET_ENABLED, &HdmiCecSource::getEnabledWrapper, this);

--- a/HdmiCec_2/CHANGELOG.md
+++ b/HdmiCec_2/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+## [1.0.11] - 2023-04-20
+### Fixed
+- Fixed CEC crash by initializing status variables inside the ctor.
+
 ## [1.0.10] - 2023-04-12
 ### Fixed
 - Fixed IARM_Bus_UnRegisterEventHandler  call to IARM_Bus_RemoveEventHandler

--- a/HdmiCec_2/HdmiCec_2.cpp
+++ b/HdmiCec_2/HdmiCec_2.cpp
@@ -61,7 +61,7 @@
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 10
+#define API_VERSION_NUMBER_PATCH 11
 
 enum {
 	HDMICEC2_EVENT_DEVICE_ADDED=0,
@@ -388,6 +388,8 @@ namespace WPEFramework
        : PluginHost::JSONRPC(),cecEnableStatus(false),smConnection(nullptr), m_sendKeyEventThreadRun(false)
        {
            LOGWARN("ctor");
+           smConnection = NULL;
+          cecEnableStatus = false;
            IsCecMgrActivated = false;
            Register(HDMICEC2_METHOD_SET_ENABLED, &HdmiCec_2::setEnabledWrapper, this);
            Register(HDMICEC2_METHOD_GET_ENABLED, &HdmiCec_2::getEnabledWrapper, this);


### PR DESCRIPTION
Reason for change:
WPEFramework crash HdmiCecSource
Test Procedure: None
Risks: Low

Change-Id: Iaeb877d6218933d03f56fd36e7e124b308c9d391 Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com> (cherry picked from commit 1781dd7408e53af982c7403d4d4dde9b452ae9f4)