### PR TITLE
RDKCOM-3891: RDKServices: Observing mismatch in the webBrowser userag…

### DIFF
--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -3403,8 +3403,14 @@ namespace WPEFramework {
                 if (res == IARM_RESULT_SUCCESS) {
                     if (param.curState == IARM_BUS_PWRMGR_POWERSTATE_ON)
                         currentState = "ON";
-                    else if ((param.curState == IARM_BUS_PWRMGR_POWERSTATE_STANDBY) || (param.curState == IARM_BUS_PWRMGR_POWERSTATE_STANDBY_LIGHT_SLEEP) || (param.curState == IARM_BUS_PWRMGR_POWERSTATE_STANDBY_DEEP_SLEEP))
-                        currentState = "STANDBY";
+		    else if (param.curState == IARM_BUS_PWRMGR_POWERSTATE_OFF)
+			currentState = "OFF";
+		    else if (param.curState == IARM_BUS_PWRMGR_POWERSTATE_STANDBY)
+			currentState = "STANDBY";
+		    else if (param.curState == IARM_BUS_PWRMGR_POWERSTATE_STANDBY_LIGHT_SLEEP)
+			currentState = "LIGHT_SLEEP";
+		    else if (param.curState == IARM_BUS_PWRMGR_POWERSTATE_STANDBY_DEEP_SLEEP)
+			currentState = "DEEP_SLEEP";
                 }
                 
                 powerState = currentState;

--- a/SystemServices/platformcaps/platformcapsdata.cpp
+++ b/SystemServices/platformcaps/platformcapsdata.cpp
@@ -238,8 +238,8 @@ PlatformCapsData::BrowserInfo PlatformCapsData::GetBrowser() const {
 
   if (type == "rdkbrowser") {
     result = {"WPE", "1.0.0.0",
-              "Mozilla/5.0 (Linux; x86_64 GNU/Linux) AppleWebKit/601.1 "
-              "(KHTML, like Gecko) Version/8.0 Safari/601.1 WPE"};
+              "Mozilla/5.0 (X11; Linux armv7l) AppleWebKit/605.1.15 "
+              "(KHTML, like Gecko) Version/13.0 Safari/605.1.15 WPE/1.0"};
   } else if (type == "cef") {
     result = {"CEF", "1.0.0.0",
               "Mozilla/5.0 (Unknown; Linux i686) AppleWebKit/537.21 "
@@ -250,8 +250,8 @@ PlatformCapsData::BrowserInfo PlatformCapsData::GetBrowser() const {
               "(KHTML, like Gecko) NativeXREReceiver"};
   } else {
     result = {"WPE", "1.0.0.0",
-              "Mozilla/5.0 (Linux; x86_64 GNU/Linux) AppleWebKit/601.1 "
-              "(KHTML, like Gecko) Version/8.0 Safari/601.1 WPE"};
+              "Mozilla/5.0 (X11; Linux armv7l) AppleWebKit/605.1.15 "
+              "(KHTML, like Gecko) Version/13.0 Safari/605.1.15 WPE/1.0"};
   }
 
   return result;


### PR DESCRIPTION
…ent details returned

Reason for change: Fix for mismatch of WebKitBrowser.1.useragent and org.rdk.System.2.getPlatformConfiguration APIs response

Test Procedure: Build and verify.

Risks: Low