### PR TITLE
RDKTV-22332 : typo fix

### DIFF
--- a/Warehouse/Warehouse.cpp
+++ b/Warehouse/Warehouse.cpp
@@ -204,7 +204,7 @@ namespace WPEFramework
         {
             if (Utils::IARM::isConnected()) {
                 IARM_Result_t res;
-                IARM_CHECK( IARM_Bus_RemoveEventHandler(IARM_BUS_PWRMGR_NAME, IARM_BUS_PWRMGR_EVENT_MODECHANGED, dsWareHouseOpnStatusChanged) );
+                IARM_CHECK( IARM_Bus_RemoveEventHandler(IARM_BUS_PWRMGR_NAME, IARM_BUS_PWRMGR_EVENT_WAREHOUSEOPS_STATUSCHANGED, dsWareHouseOpnStatusChanged) );
             }
         }
 


### PR DESCRIPTION
Reason for change: due to the design of iarm if someone forgets to unregister event handler and the plugin is unloaded, it can segfault with "dbusCallHandler" signature.
This was fixed but noticing a mismatch in one place. Test Procedure: None
Risks: None
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>