### PR TITLE
RDK-41086: Consolidate F/W download to use swupdate_utility.sh

### DIFF
--- a/SystemServices/CHANGELOG.md
+++ b/SystemServices/CHANGELOG.md
@@ -16,6 +16,9 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.4.0] - 2023-05-15
+### Changed
+- Changed references to deviceInitiatedFWDnld.sh to swupdate_utility.sh
 
 ## [1.3.0] - 2023-04-17
 ### Added

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -66,7 +66,7 @@
 using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 1
-#define API_VERSION_NUMBER_MINOR 3
+#define API_VERSION_NUMBER_MINOR 4
 #define API_VERSION_NUMBER_PATCH 0
 
 #define MAX_REBOOT_DELAY 86400 /* 24Hr = 86400 sec */
@@ -1195,7 +1195,7 @@ namespace WPEFramework {
                 JsonObject& response)
         {
             LOGWARN("SystemService updatingFirmware\n");
-            string command("/lib/rdk/deviceInitiatedFWDnld.sh 0 4 >> /opt/logs/swupdate.log &");
+            string command("/lib/rdk/swupdate_utility.sh 0 4 >> /opt/logs/swupdate.log &");
             Utils::cRunScript(command.c_str());
             returnResponse(true);
         }

--- a/Tests/tests/test_SystemServices.cpp
+++ b/Tests/tests/test_SystemServices.cpp
@@ -588,7 +588,7 @@ TEST_F(SystemServicesTest, updateFirmware)
         .Times(::testing::AnyNumber())
         .WillRepeatedly(::testing::Invoke(
             [&](const char* command, const char* type) {
-                EXPECT_EQ(string(command), string(_T("/lib/rdk/deviceInitiatedFWDnld.sh 0 4 >> /opt/logs/swupdate.log &")));
+                EXPECT_EQ(string(command), string(_T("/lib/rdk/swupdate_utility.sh 0 4 >> /opt/logs/swupdate.log &")));
                 return nullptr;
             }));
 


### PR DESCRIPTION
Reason for change: Ensure entry point for firmware download is swupdate_utility.sh.

Test Procedure: Ensure firmware downloads work successfully with both rdkvfwupgrader enabled and disabled.

Risks: Low

Priority: P1