### PR TITLE
LLAMA-10690: Maintenance start via startMaintenance Api failed intermittently

### DIFF
--- a/MaintenanceManager/CHANGELOG.md
+++ b/MaintenanceManager/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.0.18] - 2023-05-16
+### Fixed
+- Updated unsolicited_maintenance completed status as true in stopMaintenance()
+
 ## [1.0.17] - 2023-05-11
 ### Fixed
 - Updated maintenance tasks names

--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -66,7 +66,7 @@ using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 17
+#define API_VERSION_NUMBER_PATCH 18
 #define SERVER_DETAILS  "127.0.0.1:9998"
 
 
@@ -1344,6 +1344,11 @@ namespace WPEFramework {
                 m_thread.join();
                 LOGINFO("Thread joined successfully\n");
             }
+
+            if (UNSOLICITED_MAINTENANCE == g_maintenance_type && !g_unsolicited_complete){
+                g_unsolicited_complete = true;
+	    }
+
             LOGINFO("Maintenance has been stopped. Hence setting maintenance status to MAINTENANCE_ERROR\n");
             MaintenanceManager::_instance->onMaintenanceStatusChange(MAINTENANCE_ERROR);
             m_statusMutex.unlock();


### PR DESCRIPTION

When unsolicited maintenance is in progress, if stopMaintenance() is invoked, it is aborting all the maintenance tasks that are currently running and exiting. It is not setting g_unsolicited_complete status as true. Since we are checking g_unsolicited_complete check inside startMaintenance, it got stuck.