### PR TITLE
Fix mixed content

### DIFF
--- a/WebKitBrowser/WebKitImplementation.cpp
+++ b/WebKitBrowser/WebKitImplementation.cpp
@@ -2820,7 +2820,6 @@ static GSourceFuncs _handlerIntervention =
             // Allow mixed content.
             bool enableWebSecurity = _config.Secure.Value();
             g_object_set(G_OBJECT(preferences),
-                     "enable-websecurity", enableWebSecurity,
                      "allow-running-of-insecure-content", !enableWebSecurity,
                      "allow-display-of-insecure-content", !enableWebSecurity, nullptr);
 


### PR DESCRIPTION
"enable-websecurity" property does not exist on wpe 2.38. It has been renamed to "disable-web-security", with reversed meaning.

As a result, the entire g_object_set call fails and the other properties are not set.

"disable-web-security" disables the same-origin policy, which is separate from mixed content and not required here.