### PR TITLE
DELIA-62149: Add wpe-webkit 2.38 specific lib name to search list

### DIFF
--- a/WebKitBrowser/cmake/FindWPEWebKit.cmake
+++ b/WebKitBrowser/cmake/FindWPEWebKit.cmake
@@ -28,6 +28,10 @@
 find_package(PkgConfig)
 
 if (NOT PC_WPE_WEBKIT_FOUND)
+pkg_check_modules(PC_WPE_WEBKIT wpe-webkit-1.1)
+endif()
+
+if (NOT PC_WPE_WEBKIT_FOUND)
 pkg_check_modules(PC_WPE_WEBKIT wpe-webkit-1.0)
 endif()
 


### PR DESCRIPTION
Reason for change : Build error with wpe 2.38 due changed lib name
Test Procedure: Verify component builds
Priority: P2
Risks: None