### PR TITLE
RDKTV-22508:HDMI AVI Content type Signalling for Film Maker Mode

### DIFF
--- a/HdmiInput/HdmiInput.cpp
+++ b/HdmiInput/HdmiInput.cpp
@@ -51,6 +51,7 @@
 #define HDMIINPUT_EVENT_ON_STATUS_CHANGED "onInputStatusChanged"
 #define HDMIINPUT_EVENT_ON_VIDEO_MODE_UPDATED "videoStreamInfoUpdate"
 #define HDMIINPUT_EVENT_ON_GAME_FEATURE_STATUS_CHANGED "hdmiGameFeatureStatusUpdate"
+#define HDMIINPUT_EVENT_ON_AVI_CONTENT_TYPE_CHANGED "hdmiContentTypeUpdate"
 
 // TODO: remove this
 #define registerMethod(...) for (uint8_t i = 1; GetHandler(i); i++) GetHandler(i)->Register<JsonObject, JsonObject>(__VA_ARGS__)
@@ -147,7 +148,8 @@ namespace WPEFramework
 		IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_IN_STATUS, dsHdmiStatusEventHandler) );
 		IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_IN_VIDEO_MODE_UPDATE, dsHdmiVideoModeEventHandler) );
 		IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_IN_ALLM_STATUS, dsHdmiGameFeatureStatusEventHandler) );
-            }
+                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_IN_AVI_CONTENT_TYPE, dsHdmiAviContentTypeEventHandler) );
+	    }
         }
 
         void HdmiInput::DeinitializeIARM()
@@ -160,7 +162,8 @@ namespace WPEFramework
 		IARM_CHECK( IARM_Bus_RemoveEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_IN_STATUS, dsHdmiStatusEventHandler) );
 		IARM_CHECK( IARM_Bus_RemoveEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_IN_VIDEO_MODE_UPDATE, dsHdmiVideoModeEventHandler) );
 		IARM_CHECK( IARM_Bus_RemoveEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_IN_ALLM_STATUS, dsHdmiGameFeatureStatusEventHandler) );
-            }
+                IARM_CHECK( IARM_Bus_RemoveEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_IN_AVI_CONTENT_TYPE,dsHdmiAviContentTypeEventHandler) );
+	    }
         }
 
         uint32_t HdmiInput::startHdmiInput(const JsonObject& parameters, JsonObject& response)
@@ -687,6 +690,29 @@ namespace WPEFramework
             params["mode"] = allm_mode;
 
             sendNotify(HDMIINPUT_EVENT_ON_GAME_FEATURE_STATUS_CHANGED, params);
+        }
+
+	void HdmiInput::dsHdmiAviContentTypeEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
+        {
+            if(!HdmiInput::_instance)
+                return;
+
+            if (IARM_BUS_DSMGR_EVENT_HDMI_IN_AVI_CONTENT_TYPE == eventId)
+            {
+                IARM_Bus_DSMgr_EventData_t *eventData = (IARM_Bus_DSMgr_EventData_t *)data;
+                int hdmi_in_port = eventData->data.hdmi_in_content_type.port;
+                int avi_content_type = eventData->data.hdmi_in_content_type.aviContentType;
+                LOGINFO("Received IARM_BUS_DSMGR_EVENT_HDMI_IN_AVI_CONTENT_TYPE  event  port: %d, Content Type : %d", hdmi_in_port,avi_content_type);
+		HdmiInput::_instance->hdmiInputAviContentTypeChange(hdmi_in_port, avi_content_type);
+            }
+        }
+
+	void HdmiInput::hdmiInputAviContentTypeChange( int port , int content_type)
+        {
+            JsonObject params;
+            params["id"] = port;
+            params["aviContentType"] = content_type;
+            sendNotify(HDMIINPUT_EVENT_ON_AVI_CONTENT_TYPE_CHANGED, params);
         }
 
         uint32_t HdmiInput::getSupportedGameFeatures(const JsonObject& parameters, JsonObject& response)

--- a/HdmiInput/HdmiInput.h
+++ b/HdmiInput/HdmiInput.h
@@ -92,7 +92,10 @@ namespace WPEFramework {
             void hdmiInputALLMChange( int port , bool allmMode);
             static void dsHdmiGameFeatureStatusEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
 
-        public:
+            void hdmiInputAviContentTypeChange(int port, int content_type);
+            static void dsHdmiAviContentTypeEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
+	
+	public:
             HdmiInput();
             virtual ~HdmiInput();
             virtual const string Initialize(PluginHost::IShell* shell) override;

--- a/HdmiInput/HdmiInput.json
+++ b/HdmiInput/HdmiInput.json
@@ -549,7 +549,31 @@
                     "mode"
                 ]
             }
-        }
+        },
+	"hdmiContentTypeUpdate": {
+            "deprecated" : true,
+            "referenceUrl" : "https://rdkcentral.github.io/rdkservices/#/api/HdmiInputPlugin?id=hdmiContentTypeUpdate",
+            "summary": "Triggered whenever AV Infoframe content type changes for an HDMI Input",
+            "params": {
+                "type": "object",
+                "properties": {
+                   "id": {
+                        "summary": "Hdmi Input port ID for which content type change event received",
+                        "type": "integer",
+                        "example": 1
+                    },
+                   "aviContentType": {
+                        "summary": "new Content type received for the active hdmi input port",
+                        "type": "integer",
+                        "example": 1
+                    }
+                },
+                "required": [
+                    "id",
+                    "aviContentType"
+                ]
+            }
+	}
 
     }
 }

--- a/Tests/mocks/Iarm.h
+++ b/Tests/mocks/Iarm.h
@@ -724,6 +724,7 @@ typedef enum _DSMgr_EventId_t {
     IARM_BUS_DSMGR_EVENT_DISPLAY_FRAMRATE_POSTCHANGE, /*!< Frame rate post change */
     IARM_BUS_DSMGR_EVENT_AUDIO_PORT_STATE, /*!< Audio Port Init State */
     IARM_BUS_DSMGR_EVENT_SLEEP_MODE_CHANGED, /*!< Sleep Mode Change Event*/
+    IARM_BUS_DSMGR_EVENT_HDMI_IN_AVI_CONTENT_TYPE, /*<HDMI IN content type event */
     IARM_BUS_DSMGR_EVENT_MAX, /*!< Max Event  */
 } IARM_Bus_DSMgr_EventId_t;
 

--- a/Tests/mocks/devicesettings.h
+++ b/Tests/mocks/devicesettings.h
@@ -219,6 +219,14 @@ typedef enum _dsHdmiInSignalStatus_t {
     dsHDMI_IN_SIGNAL_STATUS_MAX
 } dsHdmiInSignalStatus_t;
 
+typedef enum dsAviContentType {
+  dsAVICONTENT_TYPE_GRAPHICS,
+  dsAVICONTENT_TYPE_PHOTO,
+  dsAVICONTENT_TYPE_CINEMA,
+  dsAVICONTENT_TYPE_GAME,
+  dsAVICONTENT_TYPE_INVALID,
+}dsAviContentType_t;
+
 struct dsSpd_infoframe_st {
     uint8_t pkttype;
     uint8_t version;
@@ -408,7 +416,10 @@ typedef struct _DSMgr_EventData_t {
             dsHdmiInPort_t port;
             bool allm_mode;
         } hdmi_in_allm_mode; /*HDMI in ALLM Mode change*/
-
+	struct _HDMI_IN_CONTENT_TYPE_DATA{
+            dsHdmiInPort_t port;
+            dsAviContentType_t aviContentType;
+        }hdmi_in_content_type;
     } data;
 } IARM_Bus_DSMgr_EventData_t;
 

--- a/docs/api/HdmiInputPlugin.md
+++ b/docs/api/HdmiInputPlugin.md
@@ -889,4 +889,28 @@ Triggered whenever game feature(ALLM) status changes for an HDMI Input.
     }
 }
 ```
+<a name="hdmiContentTypeUpdate"></a>
+## *hdmiContentTypeUpdate*
 
+Triggered whenever AVI content type changed for a HDMI Input.
+
+> This API is **deprecated** and may be removed in the future. It is no longer recommended for use in new implementations. [Refer this link for the new api](https://rdkcentral.github.io/rdkservices/#/api/AVInputPlugin?id=hdmiContentTypeUpdate)
+### Parameters
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.id | integer | An ID of an HDMI Input port as returned by the `getHdmiInputDevices` method |
+| params.aviContentType | integer | Content type info of a Hdmi Input of type dsAviContentType_t and the integer values indicates following accordingly 0 - Graphics, 1 - Photo, 2 - Cinema, 3 - Game, 4 - Invalid data|
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.hdmiContentTypeUpdate",
+    "params": {
+        "id": 1,
+        "aviContentType": 1
+    }
+}
+```


### PR DESCRIPTION
Reason for change: Added the events for sending thew content type in HdmiInput Thunder plugin.
Test Procedure: Build and Verify.
Risks: Low
Signed-off-by: Aishwariya B <aishwariya.bhaskar@sky.uk>