### PR TITLE
DELIA-62255: ResidenApp Plugin failed to activate and crash in Thunder R4

### DIFF
--- a/Monitor/Monitor.h
+++ b/Monitor/Monitor.h
@@ -820,12 +820,14 @@ namespace Plugin {
                 _adminLock.Unlock();
             }
 #ifdef USE_THUNDER_R4
-            void Activation(const string& name, PluginHost::IShell* plugin) override
+            void Activation(const string& name, PluginHost::IShell* service) override
             {
+                StateChange(service);
             }
 
-           void Deactivation(const string& name, PluginHost::IShell* plugin) override
+           void Deactivation(const string& name, PluginHost::IShell* service) override
            {
+               StateChange(service);
            }
 
            void Activated (const string& callsign, PluginHost::IShell* service) override

--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -1015,9 +1015,17 @@ namespace WPEFramework {
         }
 
 #ifdef USE_THUNDER_R4
+       void RDKShell::MonitorClients::Activation(const string& callsign, PluginHost::IShell* service)
+       {
+           StateChange(service);
+       }
        void RDKShell::MonitorClients::Activated(const string& callsign, PluginHost::IShell* service)
        {
             StateChange(service);
+       }
+       void RDKShell::MonitorClients::Deactivation(const string& callsign, PluginHost::IShell* service)
+       {
+           StateChange(service);
        }
        void RDKShell::MonitorClients::Deactivated(const string& callsign, PluginHost::IShell* service)
        {

--- a/RDKShell/RDKShell.h
+++ b/RDKShell/RDKShell.h
@@ -414,14 +414,8 @@ namespace WPEFramework {
               private:
                   virtual void StateChange(PluginHost::IShell* shell);
 #ifdef USE_THUNDER_R4
-                  void Activation(const string& name, PluginHost::IShell* plugin) override
-                  {
-                  }
-
-                  void Deactivation(const string& name, PluginHost::IShell* plugin) override
-                  {
-                  }
-
+                  virtual void Activation(const string& name, PluginHost::IShell* plugin);
+                  virtual void Deactivation(const string& name, PluginHost::IShell* plugin);
                   virtual void  Activated(const string& callSign,  PluginHost::IShell* plugin);
                   virtual void  Deactivated(const string& callSign,  PluginHost::IShell* plugin);
                   virtual void  Unavailable(const string& callSign,  PluginHost::IShell* plugin);


### PR DESCRIPTION
Reason for change:Activation and Deactivation pure virtual function is not declared & define  properly in RDKShell & Monitor Plugins Test Procedure: Verify in Jenkin Build
Risks: High
Signed-off-by: Thamim Razith tabbas651@cable.comcast.com