### PR TITLE
RDK-42620: RDKservices update for Cherry Audio mixing

### DIFF
--- a/AVInput/AVInput.cpp
+++ b/AVInput/AVInput.cpp
@@ -319,6 +319,7 @@ uint32_t AVInput::startInput(const JsonObject& parameters, JsonObject& response)
     LOGINFOMETHOD();
 
     string sType = parameters["typeOfInput"].String();
+    bool audioMix = parameters["reqeustAudioMix"].Boolean();
     int portId = 0;
     int iType = 0;
 
@@ -340,7 +341,7 @@ uint32_t AVInput::startInput(const JsonObject& parameters, JsonObject& response)
     try
     {
         if (iType == HDMI) {
-            device::HdmiInput::getInstance().selectPort(portId);
+            device::HdmiInput::getInstance().selectPort(portId,audioMix);
     }
     else if(iType == COMPOSITE) {
             device::CompositeInput::getInstance().selectPort(portId);

--- a/HdmiInput/HdmiInput.cpp
+++ b/HdmiInput/HdmiInput.cpp
@@ -170,8 +170,10 @@ namespace WPEFramework
         {
             LOGINFOMETHOD();
             returnIfParamNotFound(parameters, "portId");
+            //returnIfParamNotFound(parameters, "requestAudioMix");//will be uncommented later
 
             string sPortId = parameters["portId"].String();
+            bool audioMix = parameters["requestAudioMix"].Boolean();
             int portId = 0;
             try {
                 portId = stoi(sPortId);
@@ -182,7 +184,7 @@ namespace WPEFramework
             bool success = true;
             try
             {
-                device::HdmiInput::getInstance().selectPort(portId);
+                device::HdmiInput::getInstance().selectPort(portId,audioMix);
             }
             catch (const device::Exception& err)
             {


### PR DESCRIPTION
Reason for change: New fearure request to use MS12 system input path for Cherry stereo PCM from HDMI with
media streaming mixing.

When sys_low_latency is enabled, the audio patch
created assumes the HDMI input is fixed two channel PCM and the input data is redirected to MS12 system sound path in continuous output mode.
Test Procedure: In Jira AMLOGIC-4098
Risks: low
Priority: P1
Signed-off-by: Aishwariya B <aishwariya.bhaskar@sky.uk>

Change-Id: I6b8084dc587899ae567aaf269e4db4f668479688