### PR TITLE
RDK-42827: Cherry Hdmi Video Plane - Thunder Changes

### DIFF
--- a/AVInput/AVInput.cpp
+++ b/AVInput/AVInput.cpp
@@ -336,11 +336,16 @@ uint32_t AVInput::startInput(const JsonObject& parameters, JsonObject& response)
         LOGWARN("Required parameters are not passed");
         return Core::ERROR_BAD_REQUEST;
     }
-
+    int planeType = 0; // default value
+    if (parameters.HasLabel("plane")){
+        //optional parameter only
+        string sPlaneType = parameters["plane"].String();
+        planeType = stoi(sPlaneType);
+    }
     try
     {
         if (iType == HDMI) {
-            device::HdmiInput::getInstance().selectPort(portId);
+            device::HdmiInput::getInstance().selectPort(portId,planeType);
     }
     else if(iType == COMPOSITE) {
             device::CompositeInput::getInstance().selectPort(portId);

--- a/HdmiInput/HdmiInput.cpp
+++ b/HdmiInput/HdmiInput.cpp
@@ -170,11 +170,18 @@ namespace WPEFramework
         {
             LOGINFOMETHOD();
             returnIfParamNotFound(parameters, "portId");
+            //returnIfParamNotFound(parameters, "plane");/will not be used as this is optional parameter
+            //returnIfParamNotFound(parameters, "topmost");// will be used later
 
             string sPortId = parameters["portId"].String();
             int portId = 0;
+	    int planeType = 0;
             try {
                 portId = stoi(sPortId);
+		if (parameters.HasLabel("plane")){
+                        string sPlaneType = parameters["plane"].String();
+                        planeType = stoi(sPlaneType);
+                }
             }catch (const std::exception& err) {
 		    LOGWARN("sPortId invalid paramater: %s ", sPortId.c_str());
 		    returnResponse(false);
@@ -182,7 +189,7 @@ namespace WPEFramework
             bool success = true;
             try
             {
-                device::HdmiInput::getInstance().selectPort(portId);
+                device::HdmiInput::getInstance().selectPort(portId,planeType);
             }
             catch (const device::Exception& err)
             {

--- a/Tests/mocks/devicesettings.h
+++ b/Tests/mocks/devicesettings.h
@@ -602,7 +602,7 @@ public:
     {
         return impl->getCurrentVideoMode();
     }
-    void selectPort(int8_t Port) const
+    void selectPort(int8_t Port,int planeType = 0) const
     {
         return impl->selectPort(Port);
     }


### PR DESCRIPTION
Reason for change: changes done in DS layer for selecting the port with plane
Test Procedure: Build and Verify.
Risks: Low
Signed-off-by: Aishwariya B <aishwariya.bhaskar@sky.uk>