### PR TITLE
DELIA-62255: ResidenApp Plugin failed to activate and crash in Thunder R4(#4122)

### DIFF
--- a/Monitor/CHANGELOG.md
+++ b/Monitor/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.0.3] - 2023-06-21
+### Fixed
+- Fixed the ResidentApp failed to activate & crash in Thunder R4
+
 ## [1.0.2] - 2023-06-05
 ### Added 
 - Added Support to build the plugin to both R4 & R2

--- a/Monitor/Monitor.h
+++ b/Monitor/Monitor.h
@@ -820,12 +820,14 @@ namespace Plugin {
                 _adminLock.Unlock();
             }
 #ifdef USE_THUNDER_R4
-            void Activation(const string& name, PluginHost::IShell* plugin) override
+            void Activation(const string& name, PluginHost::IShell* service) override
             {
+                StateChange(service);
             }
 
-           void Deactivation(const string& name, PluginHost::IShell* plugin) override
+           void Deactivation(const string& name, PluginHost::IShell* service) override
            {
+               StateChange(service);
            }
 
            void Activated (const string& callsign, PluginHost::IShell* service) override

--- a/RDKShell/CHANGELOG.md
+++ b/RDKShell/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.3.15] - 2023-06-21
+### Fixed
+- Fixed the ResidentApp failed to activate & crash in Thunder R4
+
 ## [1.3.14] - 2023-06-13
 ### Fixed
 - Fixed the crash while launching WebKitBrowser with "type": "HtmlApp" in container mode.

--- a/RDKShell/CHANGELOG.md
+++ b/RDKShell/CHANGELOG.md
@@ -16,13 +16,13 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.4.1] - 2023-06-21
+### Fixed
+- Fixed the ResidentApp failed to activate & crash in Thunder R4
+
 ## [1.4.0] - 2023-06-07
 ### Modified
 -Rialto support for RDKShell
-
-## [1.3.15] - 2023-06-21
-### Fixed
-- Fixed the ResidentApp failed to activate & crash in Thunder R4
 
 ## [1.3.14] - 2023-06-13
 ### Fixed

--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -1007,9 +1007,17 @@ namespace WPEFramework {
         }
 
 #ifdef USE_THUNDER_R4
+       void RDKShell::MonitorClients::Activation(const string& callsign, PluginHost::IShell* service)
+       {
+           StateChange(service);
+       }
        void RDKShell::MonitorClients::Activated(const string& callsign, PluginHost::IShell* service)
        {
             StateChange(service);
+       }
+       void RDKShell::MonitorClients::Deactivation(const string& callsign, PluginHost::IShell* service)
+       {
+           StateChange(service);
        }
        void RDKShell::MonitorClients::Deactivated(const string& callsign, PluginHost::IShell* service)
        {

--- a/RDKShell/RDKShell.h
+++ b/RDKShell/RDKShell.h
@@ -400,14 +400,8 @@ namespace WPEFramework {
               private:
                   virtual void StateChange(PluginHost::IShell* shell);
 #ifdef USE_THUNDER_R4
-                  void Activation(const string& name, PluginHost::IShell* plugin) override
-                  {
-                  }
-
-                  void Deactivation(const string& name, PluginHost::IShell* plugin) override
-                  {
-                  }
-
+                  virtual void Activation(const string& name, PluginHost::IShell* plugin);
+                  virtual void Deactivation(const string& name, PluginHost::IShell* plugin);
                   virtual void  Activated(const string& callSign,  PluginHost::IShell* plugin);
                   virtual void  Deactivated(const string& callSign,  PluginHost::IShell* plugin);
                   virtual void  Unavailable(const string& callSign,  PluginHost::IShell* plugin);


### PR DESCRIPTION
Reason for change:Activation and Deactivation pure virtual function is not declared & define  properly in RDKShell & Monitor Plugins Test Procedure: Verify in Jenkin Build
Risks: High
Signed-off-by: Thamim Razith tabbas651@cable.comcast.com (cherry picked from commit 13721fff58a1c37d72c3e2c228b1d5dc5a3b03ed)