### PR TITLE
DELIA-62167: Bring MessageControl Plugin for Thunder R4 (#4110)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,6 +359,10 @@ if(PLUGIN_LEDCONTROL)
     add_subdirectory(LEDControl)
 endif()
 
+if(PLUGIN_MESSAGECONTROL)
+    add_subdirectory(MessageControl)
+endif()
+
 if(WPEFRAMEWORK_CREATE_IPKG_TARGETS)
     set(CPACK_GENERATOR "DEB")
     set(CPACK_DEB_COMPONENT_INSTALL ON)

--- a/MessageControl/CHANGELOG.md
+++ b/MessageControl/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this RDK Service will be documented in this file.
+
+* Each RDK Service has a CHANGELOG file that contains all changes done so far. When version is updated, add a entry in the CHANGELOG.md at the top with user friendly information on what was changed with the new version. Please don't mention JIRA tickets in CHANGELOG. 
+
+* Please Add entry in the CHANGELOG for each version change and indicate the type of change with these labels:
+    * **Added** for new features.
+    * **Changed** for changes in existing functionality.
+    * **Deprecated** for soon-to-be removed features.
+    * **Removed** for now removed features.
+    * **Fixed** for any bug fixes.
+    * **Security** in case of vulnerabilities.
+
+* Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
+
+* For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+
+## [1.0.0] - 2023-06-21
+### Added
+- Added MessageControl Plugin for Thunder R4
+- Added MessageControlPlugin.md for docs
+

--- a/MessageControl/CMakeLists.txt
+++ b/MessageControl/CMakeLists.txt
@@ -1,0 +1,62 @@
+# If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2022 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+project(MessageControl)
+
+cmake_minimum_required(VERSION 3.3)
+
+find_package(WPEFramework)
+
+project_version(1.0.0)
+
+set(MODULE_NAME ${NAMESPACE}${PROJECT_NAME})
+
+message("Setup ${MODULE_NAME} v${PROJECT_VERSION}")
+
+set(PLUGIN_MESSAGECONTROL_AUTOSTART true CACHE STRING "Automatically start plugin")
+set(PLUGIN_MESSAGECONTROL_ABBREVIATED true CACHE STRING "Display abbreviated messages")
+set(PLUGIN_MESSAGECONTROL_MAX_EXPORTCONNECTIONS 5 CACHE STRING "Maximum allowed export connections")
+set(PLUGIN_MESSAGECONTROL_REMOTE "false" CACHE STRING "Remote binding details enabled")
+set(PLUGIN_MESSAGECONTROL_PORT "0" CACHE STRING "PORT address")
+set(PLUGIN_MESSAGECONTROL_BINDING "0.0.0.0" CACHE STRING "Binding IP Address")
+
+find_package(${NAMESPACE}Plugins REQUIRED)
+find_package(${NAMESPACE}Definitions REQUIRED)
+find_package(${NAMESPACE}Messaging REQUIRED)
+find_package(CompileSettingsDebug CONFIG REQUIRED)
+
+add_library(${MODULE_NAME} SHARED 
+    MessageControl.cpp
+    MessageOutput.cpp
+    MessageControlImplementation.cpp
+    Module.cpp)
+
+set_target_properties(${MODULE_NAME} PROPERTIES
+        CXX_STANDARD 11
+        CXX_STANDARD_REQUIRED YES)
+
+target_link_libraries(${MODULE_NAME} 
+    PRIVATE
+        CompileSettingsDebug::CompileSettingsDebug
+        ${NAMESPACE}Plugins::${NAMESPACE}Plugins
+        ${NAMESPACE}Definitions::${NAMESPACE}Definitions
+        ${NAMESPACE}Messaging::${NAMESPACE}Messaging)
+
+install(TARGETS ${MODULE_NAME} 
+    DESTINATION lib/${STORAGE_DIRECTORY}/plugins)
+
+write_config()

--- a/MessageControl/MessageControl.conf.in
+++ b/MessageControl/MessageControl.conf.in
@@ -1,0 +1,23 @@
+autostart = "@PLUGIN_MESSAGECONTROL_AUTOSTART@"
+
+configuration = JSON()
+
+if boolean("@PLUGIN_MESSAGECONTROL_CONSOLE@"):
+  configuration.add("console", "@PLUGIN_MESSAGECONTROL_CONSOLE@")
+
+if boolean("@PLUGIN_MESSAGECONTROL_SYSLOG@"):
+  configuration.add("syslog", "@PLUGIN_MESSAGECONTROL_SYSLOG@")
+
+if boolean("@PLUGIN_MESSAGECONTROL_FILENAME@"):
+  configuration.add("filepath", "@PLUGIN_MESSAGECONTROL_FILENAME@")
+
+if boolean("@PLUGIN_MESSAGECONTROL_ABBREVIATED@"):
+  configuration.add("abbreviated", "@PLUGIN_MESSAGECONTROL_ABBREVIATED@")
+
+configuration.add("maxexportconnections", "@PLUGIN_MESSAGECONTROL_MAX_EXPORTCONNECTIONS@")
+
+if boolean("@PLUGIN_MESSAGECONTROL_REMOTE@"):
+  remote = JSON()
+  remote.add("port", "@PLUGIN_MESSAGECONTROL_PORT@")
+  remote.add("binding", "@PLUGIN_MESSAGECONTROL_BINDING@")
+  configuration.add("remote", remote)

--- a/MessageControl/MessageControl.config
+++ b/MessageControl/MessageControl.config
@@ -1,0 +1,31 @@
+set(autostart ${PLUGIN_MESSAGECONTROL_AUTOSTART})
+map()
+  
+  if(PLUGIN_MESSAGECONTROL_CONSOLE)
+    kv(console ${PLUGIN_MESSAGECONTROL_CONSOLE})
+  endif()
+
+  if(PLUGIN_MESSAGECONTROL_SYSLOG)
+    kv(syslog ${PLUGIN_MESSAGECONTROL_SYSLOG})
+  endif()
+
+  if(PLUGIN_MESSAGECONTROL_FILENAME)
+    kv(filepath ${PLUGIN_MESSAGECONTROL_FILENAME})
+  endif()
+
+  if(PLUGIN_MESSAGECONTROL_ABBREVIATED)
+    kv(abbreviated ${PLUGIN_MESSAGECONTROL_ABBREVIATED})
+  endif()
+
+  kv(maxexportconnections ${PLUGIN_MESSAGECONTROL_MAX_EXPORTCONNECTIONS})
+
+  if(PLUGIN_MESSAGECONTROL_REMOTE)
+  key(remote)
+  map()
+    kv(port ${PLUGIN_MESSAGECONTROL_PORT})
+    kv(binding ${PLUGIN_MESSAGECONTROL_BINDING})
+  end()
+  endif()
+  
+end()
+ans(configuration)

--- a/MessageControl/MessageControl.cpp
+++ b/MessageControl/MessageControl.cpp
@@ -1,0 +1,212 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "MessageControl.h"
+#include "MessageOutput.h"
+#include <interfaces/json/JMessageControl.h>
+
+namespace WPEFramework {
+
+    namespace Plugin {
+
+    namespace {
+
+        static Metadata<MessageControl> metadata(
+            // Version
+            1, 0, 0,
+            // Preconditions
+            {},
+            // Terminations
+            {},
+            // Controls
+            {}
+        );
+    }
+
+    MessageControl::Config::NetworkNode::NetworkNode()
+        : Core::JSON::Container()
+        , Port(2200)
+        , Binding("0.0.0.0")
+    {
+        Add(_T("port"), &Port);
+        Add(_T("binding"), &Binding);
+    }
+
+    MessageControl::Config::NetworkNode::NetworkNode(const NetworkNode& copy)
+        : Core::JSON::Container()
+        , Port(copy.Port)
+        , Binding(copy.Binding)
+    {
+        Add(_T("port"), &Port);
+        Add(_T("binding"), &Binding);
+    }
+
+    MessageControl::MessageControl()
+        : _adminLock()
+        , _outputLock()
+        , _config()
+        , _outputDirector()
+        , _webSocketExporter()
+        , _control(nullptr)
+        , _collect(nullptr)
+        , _observer(*this)
+        , _connectionId(0)
+        , _service(nullptr) {
+    }
+
+    const string MessageControl::Initialize(PluginHost::IShell* service)
+    {
+        string message;
+
+        ASSERT(service != nullptr);
+
+        _config.Clear();
+        _config.FromString(service->ConfigLine());
+
+        _service = service;
+        _service->AddRef();
+
+        _control = _service->Root<Exchange::IMessageControl>(_connectionId, RPC::CommunicationTimeOut, _T("MessageControlImplementation"));
+        ASSERT(_control != nullptr);
+
+        if (_control != nullptr) {
+            // Lets see if we can create the Message catcher...
+            _collect = _control->QueryInterface<Exchange::IMessageControl::ICollect>();
+            ASSERT(_collect != nullptr);
+        }
+
+        if (_control == nullptr) {
+            message = _T("MessageControl plugin could not be instantiated.");
+        }
+        else if (_collect == nullptr) {
+            message = _T("MessageControl plugin could not be instantiated (collect).");
+        }
+        else {
+            if ((service->Background() == false) && (((_config.SysLog.IsSet() == false) && (_config.Console.IsSet() == false)) || (_config.Console.Value() == true))) {
+                Announce(new Publishers::ConsoleOutput(_config.Abbreviated.Value()));
+            }
+            if ((service->Background() == true) && (((_config.SysLog.IsSet() == false) && (_config.Console.IsSet() == false)) || (_config.SysLog.Value() == true))) {
+                Announce(new Publishers::SyslogOutput(_config.Abbreviated.Value()));
+            }
+            if (_config.FileName.Value().empty() == false) {
+                _config.FileName = service->VolatilePath() + _config.FileName.Value();
+                Announce(new Publishers::FileOutput(_config.Abbreviated.Value(), _config.FileName.Value()));
+            }
+            if ((_config.Remote.Binding.Value().empty() == false) && (_config.Remote.Port.Value() != 0)) {
+                Announce(new Publishers::UDPOutput(Core::NodeId(_config.Remote.NodeId())));
+            }
+
+            _webSocketExporter.Initialize(service, _config.MaxExportConnections.Value());
+
+            Exchange::JMessageControl::Register(*this, _control);
+
+            _service->Register(&_observer);
+
+            if (_collect->Callback(&_observer) != Core::ERROR_NONE) {
+                message = _T("MessageControl plugin could not be _configured.");
+            }
+        }
+
+        return message;
+    }
+
+    void MessageControl::Deinitialize(PluginHost::IShell* service)
+    {
+        ASSERT (_service == service);
+
+        if ((_collect != nullptr) && (_control != nullptr)) {
+            Exchange::JMessageControl::Unregister(*this);
+
+            _collect->Callback(nullptr);
+
+            service->Unregister(&_observer);
+        }
+
+        _outputLock.Lock();
+
+        _outputDirector.clear();
+        _webSocketExporter.Deinitialize();
+
+        _outputLock.Unlock();
+
+        RPC::IRemoteConnection* connection(service->RemoteConnection(_connectionId));
+
+        if (_collect != nullptr) {
+            _collect->Release();
+            _collect = nullptr;
+        }
+
+        if (_control != nullptr) {
+            VARIABLE_IS_NOT_USED uint32_t result = _control->Release();
+            _control = nullptr;
+
+            // It should have been the last reference we are releasing,
+            // so it should endup in a DESTRUCTION_SUCCEEDED, if not we
+            // are leaking...
+            ASSERT(result == Core::ERROR_DESTRUCTION_SUCCEEDED);
+        }
+
+        // The process can disappear in the meantime...
+        if (connection != nullptr) {
+            // But if it did not dissapear in the meantime, forcefully terminate it. Shoot to kill :-)
+            connection->Terminate();
+            connection->Release();
+        }
+
+        while (_outputDirector.empty() == false) {
+            delete _outputDirector.back();
+            _outputDirector.pop_back();
+        }
+
+        _service->Release();
+        _service = nullptr;
+
+        _connectionId = 0;
+    }
+
+    string MessageControl::Information() const
+    {
+        // No additional info to report.
+        return (string());
+    }
+
+    bool MessageControl::Attach(PluginHost::Channel& channel)
+    {
+        TRACE(Trace::Information, (Core::Format(_T("Attaching channel ID [%d]"), channel.Id()).c_str()));
+        return (_webSocketExporter.Attach(channel.Id()));
+    }
+
+    void MessageControl::Detach(PluginHost::Channel& channel)
+    {
+        TRACE(Trace::Information, (Core::Format(_T("Detaching channel ID [%d]"), channel.Id()).c_str()));
+        _webSocketExporter.Detach(channel.Id());
+    }
+
+    Core::ProxyType<Core::JSON::IElement> MessageControl::Inbound(const string&)
+    {
+        return (_webSocketExporter.Command());
+    }
+
+    Core::ProxyType<Core::JSON::IElement> MessageControl::Inbound(const uint32_t ID, const Core::ProxyType<Core::JSON::IElement>& element)
+    {
+        return (Core::ProxyType<Core::JSON::IElement>(_webSocketExporter.Received(ID, element)));
+    }
+
+} // namespace Plugin
+} // namespace WPEFramework

--- a/MessageControl/MessageControl.h
+++ b/MessageControl/MessageControl.h
@@ -1,0 +1,286 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "Module.h"
+#include "MessageOutput.h"
+
+namespace WPEFramework {
+namespace Plugin {
+    class MessageControl : public PluginHost::JSONRPC, public PluginHost::IPluginExtended, public PluginHost::IWebSocket {
+    private:
+        using OutputList = std::vector<Publishers::IPublish*>;
+
+        class Config : public Core::JSON::Container {
+        private:
+            class NetworkNode : public Core::JSON::Container {
+            public:
+                NetworkNode();
+                NetworkNode(const NetworkNode& copy);
+                ~NetworkNode() = default;
+
+            public:
+                Core::NodeId NodeId() const {
+                    return (Core::NodeId(Binding.Value().c_str(), Port.Value()));
+                }
+
+            public:
+                Core::JSON::DecUInt16 Port;
+                Core::JSON::String Binding;
+            };
+
+        public:
+            Config()
+                : Core::JSON::Container()
+                , Console(false)
+                , SysLog(false)
+                , FileName()
+                , Abbreviated(true)
+                , MaxExportConnections(Publishers::WebSocketOutput::DefaultMaxConnections)
+                , Remote()
+            {
+                Add(_T("console"), &Console);
+                Add(_T("syslog"), &SysLog);
+                Add(_T("filepath"), &FileName);
+                Add(_T("abbreviated"), &Abbreviated);
+                Add(_T("maxexportconnections"), &MaxExportConnections);
+                Add(_T("remote"), &Remote);
+            }
+            ~Config() = default;
+
+            Config(const Config&) = delete;
+            Config& operator=(const Config&) = delete;
+
+            Core::JSON::Boolean Console;
+            Core::JSON::Boolean SysLog;
+            Core::JSON::String FileName;
+            Core::JSON::Boolean Abbreviated;
+            Core::JSON::DecUInt16 MaxExportConnections;
+            NetworkNode Remote;
+        };
+
+        class Observer
+            : public RPC::IRemoteConnection::INotification
+            , public Exchange::IMessageControl::ICollect::ICallback {
+        private:
+            enum state {
+                ATTACHING,
+                DETACHING,
+                OBSERVING
+            };
+            using ObservingMap = std::unordered_map<uint32_t, state>;
+
+        public:
+            Observer() = delete;
+            Observer(const Observer&) = delete;
+            Observer& operator= (const Observer&) = delete;
+
+            explicit Observer(MessageControl& parent)
+                : _parent(parent)
+                , _adminLock()
+                , _observing()
+                , _job(*this) {
+            }
+            ~Observer() override {
+                _job.Revoke();
+            }
+
+        public:
+            //
+            // Exchange::IMessageControl::INotification
+            // ----------------------------------------------------------
+            void Message(const Exchange::IMessageControl::messagetype type,
+                const string& module, const string& category, const string& fileName,
+                const uint16_t lineNumber, const string& className,
+                const uint64_t timestamp, const string& message) override {
+                _parent.Message(static_cast<Core::Messaging::Metadata::type>(type), module, category , fileName, lineNumber, className, timestamp, message);
+            }
+
+            //
+            // RPC::IRemoteConnection::INotification
+            // ----------------------------------------------------------
+            void Activated(RPC::IRemoteConnection* connection) override {
+
+                uint32_t id = connection->Id();
+
+                _adminLock.Lock();
+
+                // Seems the ID is already in here, thats odd, and impossible :-)
+                ObservingMap::iterator index = _observing.find(id);
+
+                if (index == _observing.end()) {
+                    _observing.emplace(std::piecewise_construct,
+                        std::make_tuple(id),
+                        std::make_tuple(state::ATTACHING));
+                }
+                else if (index->second == state::DETACHING) {
+                    index->second = state::OBSERVING;
+                }
+
+                _adminLock.Unlock();
+
+                _job.Submit();
+            }
+            void Deactivated(RPC::IRemoteConnection* connection) override {
+
+                uint32_t id = connection->Id();
+
+                _adminLock.Lock();
+
+                // Seems the ID is already in here, thats odd, and impossible :-)
+                ObservingMap::iterator index = _observing.find(id);
+
+                if (index != _observing.end()) {
+                    if (index->second == state::ATTACHING) {
+                        _observing.erase(index);
+                    }
+                    else if (index->second == state::OBSERVING) {
+                        _observing.emplace(std::piecewise_construct,
+                            std::make_tuple(id),
+                            std::make_tuple(state::DETACHING));
+                    }
+                }
+
+                _adminLock.Unlock();
+
+                _job.Submit();
+            }
+
+            BEGIN_INTERFACE_MAP(Observer)
+                INTERFACE_ENTRY(RPC::IRemoteConnection::INotification)
+                INTERFACE_ENTRY(Exchange::IMessageControl::ICollect::ICallback)
+            END_INTERFACE_MAP
+
+        private:
+            friend class Core::ThreadPool::JobType<Observer&>;
+
+            void Dispatch()
+            {
+                _adminLock.Lock();
+
+                ObservingMap::iterator index = _observing.begin();
+
+                while (index != _observing.end()) {
+                    if (index->second == state::ATTACHING) {
+                        index->second = state::OBSERVING;
+                        _parent.Attach(index->first);
+                        index++;
+                    }
+                    else if (index->second == state::DETACHING) {
+                        _parent.Detach(index->first);
+                        index = _observing.erase(index);
+                    }
+                    else {
+                        index++;
+                    }
+                }
+
+                _adminLock.Unlock();
+            }
+
+        private:
+            MessageControl& _parent;
+            Core::CriticalSection _adminLock;
+            ObservingMap _observing;
+            Core::WorkerPool::JobType<Observer&> _job;
+        };
+
+    public:
+        MessageControl(const MessageControl&) = delete;
+        MessageControl& operator=(const MessageControl&) = delete;
+
+        MessageControl();
+        ~MessageControl() override = default;
+
+        BEGIN_INTERFACE_MAP(MessageControl)
+            INTERFACE_ENTRY(PluginHost::IPlugin)
+            INTERFACE_ENTRY(PluginHost::IDispatcher)
+            INTERFACE_ENTRY(PluginHost::IPluginExtended)
+            INTERFACE_ENTRY(PluginHost::IWebSocket)
+        END_INTERFACE_MAP
+
+    public:
+        const string Initialize(PluginHost::IShell* service) override;
+        void Deinitialize(PluginHost::IShell* service) override;
+        string Information() const override;
+
+        bool Attach(PluginHost::Channel&) override;
+        void Detach(PluginHost::Channel&) override;
+        Core::ProxyType<Core::JSON::IElement> Inbound(const string& identifier) override;
+        Core::ProxyType<Core::JSON::IElement> Inbound(const uint32_t ID, const Core::ProxyType<Core::JSON::IElement>& element) override;
+
+    private:
+        void Announce(Publishers::IPublish* output) {
+
+            _outputLock.Lock();
+
+            ASSERT(std::find(_outputDirector.begin(), _outputDirector.end(), output) == _outputDirector.end());
+
+            _outputDirector.emplace_back(output);
+
+            _outputLock.Unlock();
+        }
+        void Message(const Core::Messaging::Metadata::type type,
+            const string & module, const string& category, const string & fileName,
+            const uint16_t lineNumber, const string & className,
+            const uint64_t timestamp, const string & message) {
+
+            // Time to start sending it to all interested parties...
+            _outputLock.Lock();
+
+            for (auto& entry : _outputDirector) {
+                entry->Message(type, module, category, fileName, lineNumber, className, timestamp, message);
+            }
+
+            _webSocketExporter.Message(type, module, category, fileName, lineNumber, className, timestamp, message);
+
+            _outputLock.Unlock();
+        }
+        void Attach(const uint32_t id) {
+            _adminLock.Lock();
+            _collect->Attach(id);
+            _adminLock.Unlock();
+        }
+        void Detach(const uint32_t id) {
+            _adminLock.Lock();
+            _collect->Detach(id);
+            _adminLock.Unlock();
+
+            if (id == _connectionId) {
+                ASSERT(_service != nullptr);
+                Core::IWorkerPool::Instance().Submit(PluginHost::IShell::Job::Create(_service, PluginHost::IShell::DEACTIVATED, PluginHost::IShell::FAILURE));
+            }
+        }
+
+    private:
+        Core::CriticalSection _adminLock;
+        Core::CriticalSection _outputLock;
+        Config _config;
+        OutputList _outputDirector;
+        Publishers::WebSocketOutput _webSocketExporter;
+        Exchange::IMessageControl* _control;
+        Exchange::IMessageControl::ICollect* _collect;
+        Core::Sink<Observer> _observer;
+        uint32_t _connectionId;
+        PluginHost::IShell* _service;
+    };
+
+} // namespace Plugin
+} // namespace WPEFramework

--- a/MessageControl/MessageControl.vcxproj
+++ b/MessageControl/MessageControl.vcxproj
@@ -1,0 +1,191 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>15.0</VCProjectVersion>
+    <ProjectGuid>{ACA665CC-3DFA-4C67-A6F4-2DF827A9378A}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>MessageControl</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)..\artifacts\$(Configuration)\</OutDir>
+    <IntDir>$(OutDir)Plugins\$(TargetName)\</IntDir>
+    <TargetName>lib$(ProjectName)</TargetName>
+    <TargetExt>.so</TargetExt>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)..\artifacts\$(Configuration)\</OutDir>
+    <IntDir>$(OutDir)Plugins\$(TargetName)\</IntDir>
+    <TargetName>lib$(ProjectName)</TargetName>
+    <TargetExt>.so</TargetExt>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)..\artifacts\$(Configuration)\</OutDir>
+    <IntDir>$(OutDir)Plugins\$(TargetName)\</IntDir>
+    <TargetName>lib$(ProjectName)</TargetName>
+    <TargetExt>.so</TargetExt>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)..\artifacts\$(Configuration)\</OutDir>
+    <IntDir>$(OutDir)Plugins\$(TargetName)\</IntDir>
+    <TargetName>lib$(ProjectName)</TargetName>
+    <TargetExt>.so</TargetExt>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_DEBUG;TRACECONTROL_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(FrameworkPath);$(ContractsPath);$(WindowsPath);$(WindowsPath)zlib</AdditionalIncludeDirectories>
+      <UseStandardPreprocessor>true</UseStandardPreprocessor>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(OutDir)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;TRACECONTROL_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(FrameworkPath);$(ContractsPath);$(WindowsPath);$(WindowsPath)zlib</AdditionalIncludeDirectories>
+      <UseStandardPreprocessor>true</UseStandardPreprocessor>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(OutDir)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;TRACECONTROL_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(FrameworkPath);$(ContractsPath);$(WindowsPath);$(WindowsPath)zlib</AdditionalIncludeDirectories>
+      <UseStandardPreprocessor>true</UseStandardPreprocessor>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(OutDir)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;NDEBUG;TRACECONTROL_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(FrameworkPath);$(ContractsPath);$(WindowsPath);$(WindowsPath)zlib</AdditionalIncludeDirectories>
+      <UseStandardPreprocessor>true</UseStandardPreprocessor>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(OutDir)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="MessageControl.cpp" />
+    <ClCompile Include="MessageControlImplementation.cpp" />
+    <ClCompile Include="MessageOutput.cpp" />
+    <ClCompile Include="Module.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="MessageControl.h" />
+    <ClInclude Include="MessageOutput.h" />
+    <ClInclude Include="Module.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/MessageControl/MessageControl.vcxproj.filters
+++ b/MessageControl/MessageControl.vcxproj.filters
@@ -1,0 +1,36 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="Module.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="MessageOutput.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="MessageControlImplementation.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="MessageControl.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="Module.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="MessageOutput.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="MessageControl.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{2b6ccb25-f586-4a44-9592-dfb31982e7ef}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{06617fda-b01a-4420-9ac9-7cb45a8437a4}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+</Project>

--- a/MessageControl/MessageControlImplementation.cpp
+++ b/MessageControl/MessageControlImplementation.cpp
@@ -1,0 +1,209 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "MessageOutput.h"
+#include "Module.h"
+#include <functional>
+
+namespace WPEFramework {
+
+namespace {
+
+    class MessageSettings : public Messaging::MessageUnit::Settings {
+    private:
+        MessageSettings() {
+            Messaging::MessageUnit::Settings::Load();
+        };
+
+    public:
+        MessageSettings(const MessageSettings&) = delete;
+        MessageSettings& operator= (const MessageSettings&) = delete;
+
+        static MessageSettings& Instance() {
+            static MessageSettings singleton;
+            return (singleton);
+        }
+    };
+}
+
+namespace Plugin {
+
+    class MessageControlImplementation : public Exchange::IMessageControl, public Exchange::IMessageControl::ICollect {
+    private:
+        class WorkerThread : public Core::Thread {
+        public:
+            WorkerThread() = delete;
+            WorkerThread(const WorkerThread&) = delete;
+            WorkerThread& operator= (const WorkerThread&) = delete;
+
+            WorkerThread(MessageControlImplementation& parent)
+                : Core::Thread()
+                , _parent(parent)
+            {
+            }
+            ~WorkerThread() override = default;
+
+        private:
+            uint32_t Worker() override
+            {
+                _parent.Dispatch();
+
+                return (Core::infinite);
+            }
+
+        private:
+            MessageControlImplementation& _parent;
+        };
+
+    public:
+        MessageControlImplementation(const MessageControlImplementation&) = delete;
+        MessageControlImplementation& operator=(const MessageControlImplementation&) = delete;
+
+        MessageControlImplementation()
+            : _adminLock()
+            , _callback(nullptr)
+            , _dispatcherIdentifier(MessageSettings::Instance().Identifier())
+            , _dispatcherBasePath(MessageSettings::Instance().BasePath())
+            , _worker(*this)
+            , _client(_dispatcherIdentifier, _dispatcherBasePath, MessageSettings::Instance().SocketPort())
+            , _factory()
+        {
+            _client.AddInstance(0);
+            _client.AddFactory(Core::Messaging::Metadata::type::TRACING, &_factory);
+            _client.AddFactory(Core::Messaging::Metadata::type::LOGGING, &_factory);
+        }
+
+        ~MessageControlImplementation() override
+        {
+            ASSERT(_callback == nullptr);
+
+            _worker.Stop();
+            _worker.Wait(Core::Thread::STOPPED, Core::infinite);
+            _client.ClearInstances();
+        }
+
+    public:
+        uint32_t Callback(Exchange::IMessageControl::ICollect::ICallback* callback) override
+        {
+            _adminLock.Lock();
+
+            ASSERT((_callback != nullptr) ^ (callback != nullptr));
+
+            if (_callback != nullptr) {
+
+                _worker.Block();
+                _client.SkipWaiting();
+
+                _adminLock.Unlock();
+
+                _worker.Wait(Core::Thread::BLOCKED, Core::infinite);
+
+                _adminLock.Lock();
+
+                _callback->Release();
+            }
+            _callback = callback;
+
+            if (_callback != nullptr) {
+                _callback->AddRef();
+                _worker.Run();
+            }
+
+            _adminLock.Unlock();
+
+            return (Core::ERROR_NONE);
+        }
+
+        uint32_t Attach(const uint32_t id) override
+        {
+            _adminLock.Lock();
+            _client.AddInstance(id);
+            _adminLock.Unlock();
+
+            return (Core::ERROR_NONE);
+        }
+
+        uint32_t Detach(const uint32_t id) override
+        {
+            _adminLock.Lock();
+            _client.RemoveInstance(id);
+            _adminLock.Unlock();
+
+            return (Core::ERROR_NONE);
+        }
+
+        uint32_t Enable(const messagetype type, const string& category, const string& module, const bool enabled) override
+        {
+            _client.Enable({static_cast<Core::Messaging::Metadata::type>(type), category, module}, enabled);
+
+            return (Core::ERROR_NONE);
+        }
+
+        uint32_t Controls(Exchange::IMessageControl::IControlIterator*& controls) const override
+        {
+            std::list<Exchange::IMessageControl::Control> list;
+            Messaging::MessageUnit::Iterator index;
+
+            _client.Controls(index);
+
+            while (index.Next() == true) {
+                list.push_back( { static_cast<messagetype>(index.Type()), index.Category(), index.Module(), index.Enabled() } );
+            }
+
+            using Implementation = RPC::IteratorType<Exchange::IMessageControl::IControlIterator>;
+            controls = Core::Service<Implementation>::Create<Exchange::IMessageControl::IControlIterator>(list);
+
+            return (Core::ERROR_NONE);
+        }
+
+    public:
+        BEGIN_INTERFACE_MAP(MessageControlImplementation)
+        INTERFACE_ENTRY(Exchange::IMessageControl)
+        INTERFACE_ENTRY(Exchange::IMessageControl::ICollect)
+        END_INTERFACE_MAP
+
+    private:
+        void Dispatch()
+        {
+            _client.WaitForUpdates(Core::infinite);
+
+            _client.PopMessagesAndCall([this](const Core::Messaging::IStore::Information& info, const Core::ProxyType<Core::Messaging::IEvent>& message) {
+                ASSERT(_callback != nullptr);
+
+                // Turn data into piecies to trasfer over the wire
+                _callback->Message(static_cast<Exchange::IMessageControl::messagetype>(info.Type()), info.Module(), info.Category(), info.FileName(), info.LineNumber(), info.ClassName(), info.TimeStamp(), message->Data());
+            });
+        }
+
+    private:
+        Core::CriticalSection _adminLock;
+        IMessageControl::ICollect::ICallback* _callback;
+
+        const string _dispatcherIdentifier;
+        const string _dispatcherBasePath;
+
+        WorkerThread _worker;
+        Messaging::MessageClient _client;
+        Messaging::TraceFactory _factory;
+    };
+
+    SERVICE_REGISTRATION(MessageControlImplementation, 1, 0);
+
+} // namespace Plugin
+}

--- a/MessageControl/MessageControlPlugin.json
+++ b/MessageControl/MessageControlPlugin.json
@@ -1,0 +1,56 @@
+{
+    "$schema": "plugin.schema.json",
+    "info": {
+      "title": "MessageControl Plugin",
+      "callsign": "MessageControl",
+      "locator": "libWPEFrameworkMessageControl.so",
+      "status": "alpha",
+      "description": "The MessageControl plugin allows reading of the traces from WPEFramework, and controlling them tracing and logging. Allows for outputting logging messages to the websocket",
+      "version": "1.0"
+    },
+    "configuration": {
+      "type": "object",
+      "properties": {
+        "console": {
+          "type": "boolean",
+          "description": "Enables message output messages to the console"
+        },
+        "syslog": {
+          "type": "boolean",
+          "description": "Enables message ouutput to syslog"
+        },
+        "filepath": {
+          "type": "string",
+          "description": "Path to file (inside VolatilePath) where messages will be stored"
+        },
+        "abbreviated": {
+          "type": "boolean",
+          "description": "Denotes if the messages should be abbreviated"
+        },
+        "maxexportconnections": {
+          "type": "number",
+          "description": "Specifies to how many websockets can the messages be outputted"
+        },
+        "remote": {
+          "type": "object",
+          "properties": {
+            "port" : {
+              "type": "number",
+              "size": "16",
+              "description": "Port"
+            },
+            "bindig" : {
+              "type": "string",
+              "description": "Binding address"
+            }
+          },
+          "required": [ "port", "binding" ]
+        }
+      },
+      "required": [
+      ]
+    },
+    "interface": {
+      "$ref": "{cppinterfacedir}/IMessageControl.h"
+    }
+  }

--- a/MessageControl/MessageOutput.cpp
+++ b/MessageControl/MessageOutput.cpp
@@ -1,0 +1,189 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "MessageOutput.h"
+
+namespace WPEFramework {
+namespace Publishers {
+
+    string Text::Convert(const Core::Messaging::Metadata::type,
+        const string& module, const string& category, const string& fileName,
+        const uint16_t lineNumber, const string& className,
+        const uint64_t timeStamp, const string& text) /* override */
+    {
+        string output;
+
+        const Core::Time now(timeStamp);
+
+        if (_abbreviated == true) {
+            const string time(now.ToTimeOnly(true));
+            output = Core::Format("[%s]:[%s]:[%s]: %s\n",
+                    time.c_str(),
+                    module.c_str(),
+                    category.c_str(),
+                    text.c_str());
+        } else {
+            const string time(now.ToRFC1123(true));
+            output = Core::Format("[%s]:[%s:%u]:[%s]:[%s]: %s\n",
+                    time.c_str(),
+                    Core::FileNameOnly(fileName.c_str()),
+                    lineNumber,
+                    className.c_str(),
+                    category.c_str(),
+                    text.c_str());
+        }
+
+        return (output);
+    }
+
+    void ConsoleOutput::Message(const Core::Messaging::Metadata::type type,
+        const string& module, const string& category, const string& fileName,
+        const uint16_t lineNumber, const string& className,
+        const uint64_t timeStamp, const string& text) /* override */
+    {
+        std::cout << _convertor.Convert(type, category,module,fileName, lineNumber, className, timeStamp, text);
+    }
+
+    void SyslogOutput::Message(const Core::Messaging::Metadata::type type,
+            const string& module, const string& category, const string& fileName,
+            const uint16_t lineNumber, const string& className,
+            const uint64_t timeStamp, const string& text) /* override */
+    {
+#ifndef __WINDOWS__
+        syslog(LOG_NOTICE, _T("%s"), _convertor.Convert(type, module, category, fileName, lineNumber, className, timeStamp, text).c_str());
+#else
+        printf(_T("%s"), _convertor.Convert(type, module, category, fileName, lineNumber, className, timeStamp, text).c_str());
+#endif
+    }
+
+    void FileOutput::Message(const Core::Messaging::Metadata::type type,
+        const string& module, const string& category, const string& fileName,
+        const uint16_t lineNumber, const string& className,
+        const uint64_t timeStamp, const string& text) /* override */
+    {
+        if (_file.IsOpen()) {
+            string line = _convertor.Convert(type, module, category, fileName, lineNumber, className, timeStamp, text);
+            _file.Write(reinterpret_cast<const uint8_t*>(line.c_str()), static_cast<uint32_t>(line.length()));
+        }
+    }
+
+    void JSON::Convert(const Core::Messaging::Metadata::type,
+        const string& module, const string& category, const string& fileName,
+        const uint16_t lineNumber, const string& className,
+        const uint64_t, const string& text, Data& data)
+    {
+        ExtraOutputOptions options = _outputOptions;
+
+        if ((AsNumber(options) & AsNumber(ExtraOutputOptions::PAUSED)) == 0) {
+
+            if ((AsNumber(options) & AsNumber(ExtraOutputOptions::INCLUDINGDATE)) != 0) {
+                data.Time = Core::Time::Now().ToRFC1123(true);
+            } else {
+                data.Time = Core::Time::Now().ToTimeOnly(true);
+            }
+
+            if ((AsNumber(options) & AsNumber(ExtraOutputOptions::FILENAME)) != 0) {
+                data.FileName = fileName;
+            }
+
+            if ((AsNumber(options) & AsNumber(ExtraOutputOptions::LINENUMBER)) != 0) {
+                data.LineNumber = lineNumber;
+            }
+
+            if( (AsNumber(options) & AsNumber(ExtraOutputOptions::CLASSNAME) ) != 0 ) {
+                data.ClassName = className;
+            }
+
+            if ((AsNumber(options) & AsNumber(ExtraOutputOptions::MODULE)) != 0) {
+                data.Module = module;
+            }
+
+            if ((AsNumber(options) & AsNumber(ExtraOutputOptions::CATEGORY)) != 0) {
+                data.Category = category;
+            }
+
+            data.Message = text;
+        }
+    }
+
+    //UDPOutput
+    UDPOutput::Channel::Channel(const Core::NodeId& nodeId)
+        : Core::SocketDatagram(false, nodeId.Origin(), nodeId, Messaging::MessageUnit::DataSize, 0)
+        , _loaded(0)
+    {
+    }
+    UDPOutput::Channel::~Channel()
+    {
+        Close(Core::infinite);
+    }
+
+    uint16_t UDPOutput::Channel::SendData(uint8_t* dataFrame, const uint16_t maxSendSize)
+    {
+        _adminLock.Lock();
+
+        uint16_t actualByteCount = (_loaded > maxSendSize ? maxSendSize : _loaded);
+        memcpy(dataFrame, _sendBuffer, actualByteCount);
+        _loaded = 0;
+
+        _adminLock.Unlock();
+        return (actualByteCount);
+    }
+
+    //unused
+    uint16_t UDPOutput::Channel::ReceiveData(uint8_t*, const uint16_t)
+    {
+        return 0;
+    }
+    void UDPOutput::Channel::StateChange()
+    {
+    }
+
+    void UDPOutput::Channel::Output(const Core::Messaging::IStore::Information& info, const Core::Messaging::IEvent* message)
+    {
+        _adminLock.Lock();
+
+        uint16_t length = 0;
+        length += info.Serialize(_sendBuffer + length, sizeof(_sendBuffer) - length);
+        length += message->Serialize(_sendBuffer + length, sizeof(_sendBuffer) - length);
+        _loaded = length;
+
+        _adminLock.Unlock();
+
+        Trigger();
+    }
+
+    UDPOutput::UDPOutput(const Core::NodeId& nodeId)
+        : _output(nodeId)
+    {
+        _output.Open(0);
+    }
+
+    void UDPOutput::Message(const Core::Messaging::Metadata::type type,
+            const string& module, const string& category, const string& fileName,
+            const uint16_t lineNumber, const string& className,
+            const uint64_t timeStamp, const string& text) /* override */
+    {
+        //yikes, recreating stuff from received pieces
+        Messaging::TextMessage textMessage(text);
+        Core::Messaging::IStore::Information info(Core::Messaging::Metadata(type, category, module), fileName, lineNumber, className, timeStamp);
+
+        _output.Output(info, &textMessage);
+    }
+}
+}

--- a/MessageControl/MessageOutput.h
+++ b/MessageControl/MessageOutput.h
@@ -1,0 +1,543 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include "Module.h"
+
+namespace WPEFramework {
+
+namespace Publishers {
+
+    struct IPublish {
+        virtual ~IPublish() = default;
+
+        virtual void Message(const Core::Messaging::Metadata::type type,
+            const string& module, const string& category, 
+            const string& fileName, const uint16_t lineNumber, 
+            const string& className, const uint64_t timeStamp, const string& text) = 0;
+    };
+
+    class Text {
+    public:
+        Text() = delete;
+        Text(const Text&) = delete;
+        Text& operator=(const Text&) = delete;
+
+        explicit Text(const bool abbreviated)
+            : _abbreviated(abbreviated) {
+        }
+        ~Text() = default;
+
+    public:
+        string Convert (const Core::Messaging::Metadata::type type,
+            const string& module, const string& category, const string& fileName,
+            const uint16_t lineNumber, const string& className,
+            const uint64_t timeStamp, const string& text);
+
+    private:
+        bool _abbreviated;
+    };
+
+    class ConsoleOutput : public IPublish {
+    public:
+        ConsoleOutput() = delete;
+        ConsoleOutput(const ConsoleOutput&) = delete;
+        ConsoleOutput& operator=(const ConsoleOutput&) = delete;
+
+        explicit ConsoleOutput(const bool abbreviate)
+            : _convertor(abbreviate) {
+        }
+        ~ConsoleOutput() override = default;
+
+    public:
+        void Message(const Core::Messaging::Metadata::type type, 
+            const string& module, const string& category, const string& fileName,
+            const uint16_t lineNumber, const string& className,
+            const uint64_t timeStamp, const string& text) override;
+
+    private:
+        Text _convertor;
+    };
+
+    class SyslogOutput : public IPublish {
+    public:
+        SyslogOutput() = delete;
+        SyslogOutput(const SyslogOutput&) = delete;
+        SyslogOutput& operator=(const SyslogOutput&) = delete;
+
+        explicit SyslogOutput(const bool abbreviate)
+            : _convertor(abbreviate) {
+        }
+        ~SyslogOutput() override = default;
+
+    public:
+        void Message(const Core::Messaging::Metadata::type type,
+            const string& module, const string& category, const string& fileName,
+            const uint16_t lineNumber, const string& className,
+            const uint64_t timeStamp, const string& text) override;
+
+    private:
+        Text _convertor;
+    };
+  
+    class FileOutput : public IPublish {
+    public:
+        FileOutput() = delete;
+        FileOutput(const FileOutput&) = delete;
+        FileOutput& operator=(const FileOutput&) = delete;
+
+        explicit FileOutput(const bool abbreviate, const string& filepath)
+            : _convertor(abbreviate)
+            , _file(filepath) {
+            _file.Create();
+
+            if (!_file.IsOpen()) {
+                TRACE(Trace::Error, (_T("Could not open file <%s>. Outputting warnings to file unavailable."), filepath));
+            }
+        }
+        ~FileOutput() override {
+            if (_file.IsOpen()) {
+                _file.Close();
+            }
+        }
+
+    public:
+        void Message(const Core::Messaging::Metadata::type type,
+            const string& module, const string& category, const string& fileName,
+            const uint16_t lineNumber, const string& className,
+            const uint64_t timeStamp, const string& text) override;
+
+    private:
+        Text _convertor;
+        Core::File _file;
+    };
+
+    class JSON  {
+    private:
+        enum class ExtraOutputOptions {
+            ABREVIATED    = 0x00,
+            FILENAME      = 0x01,
+            LINENUMBER    = 0x03, // selecting LINENUMBER will automatically select FILENAME
+            CLASSNAME     = 0x04,
+            MODULE        = 0x08,
+            CATEGORY      = 0x10,
+            INCLUDINGDATE = 0x20,
+            ALL           = 0x3F,
+            PAUSED        = 0x40
+        };
+
+    public:
+        class Data : public Core::JSON::Container {
+        public:
+            Data(const Data&) = delete;
+            Data& operator=(const Data&) = delete;
+
+            Data()
+                : Core::JSON::Container()
+                , Time()
+                , FileName()
+                , LineNumber()
+                , ClassName()
+                , Category()
+                , Module()
+                , Message()
+            {
+                Add(_T("time"), &Time);
+                Add(_T("filename"), &FileName);
+                Add(_T("linenumber"), &LineNumber);
+                Add(_T("classname"), &ClassName);
+                Add(_T("category"), &Category);
+                Add(_T("module"), &Module);
+                Add(_T("message"), &Message);
+            }
+            ~Data() override = default;
+
+        public:
+            Core::JSON::String Time;
+            Core::JSON::String FileName;
+            Core::JSON::DecUInt32 LineNumber;
+            Core::JSON::String ClassName;
+            Core::JSON::String Category;
+            Core::JSON::String Module;
+            Core::JSON::String Message;
+        };
+
+    public:
+        JSON(const JSON&) = delete;
+        JSON& operator=(const JSON&) = delete;
+
+        JSON()
+            : _outputOptions(ExtraOutputOptions::ALL) {
+        }
+
+        ~JSON() = default;
+
+    public:
+        bool FileName() const {
+            return ((AsNumber<ExtraOutputOptions>(_outputOptions) & AsNumber(ExtraOutputOptions::FILENAME)) != 0);
+        }
+        void FileName(const bool enabled) {
+            if (enabled == true) {
+                _outputOptions = static_cast<ExtraOutputOptions>(AsNumber<ExtraOutputOptions>(_outputOptions) | AsNumber(ExtraOutputOptions::FILENAME));
+            }
+            else {
+                _outputOptions = static_cast<ExtraOutputOptions>(AsNumber<ExtraOutputOptions>(_outputOptions) & ~AsNumber(ExtraOutputOptions::FILENAME));
+            }
+        }
+        bool LineNumber() const {
+            return ((AsNumber<ExtraOutputOptions>(_outputOptions) & AsNumber(ExtraOutputOptions::LINENUMBER)) != 0);
+        }
+        void LineNumber(const bool enabled) {
+            if (enabled == true) {
+                _outputOptions = static_cast<ExtraOutputOptions>(AsNumber<ExtraOutputOptions>(_outputOptions) | AsNumber(ExtraOutputOptions::LINENUMBER));
+            }
+            else {
+                _outputOptions = static_cast<ExtraOutputOptions>(AsNumber<ExtraOutputOptions>(_outputOptions) & ~AsNumber(ExtraOutputOptions::LINENUMBER));
+            }
+        }
+        bool ClassName() const {
+            return ((AsNumber<ExtraOutputOptions>(_outputOptions) & AsNumber(ExtraOutputOptions::CLASSNAME)) != 0);
+        }
+        void ClassName(const bool enabled) {
+            if (enabled == true) {
+                _outputOptions = static_cast<ExtraOutputOptions>(AsNumber<ExtraOutputOptions>(_outputOptions) | AsNumber(ExtraOutputOptions::CLASSNAME));
+            }
+            else {
+                _outputOptions = static_cast<ExtraOutputOptions>(AsNumber<ExtraOutputOptions>(_outputOptions) & ~AsNumber(ExtraOutputOptions::CLASSNAME));
+            }
+        }
+        bool Module() const {
+            return ((AsNumber<ExtraOutputOptions>(_outputOptions) & AsNumber(ExtraOutputOptions::MODULE)) != 0);
+        }
+        void Module(const bool enabled) {
+            if (enabled == true) {
+                _outputOptions = static_cast<ExtraOutputOptions>(AsNumber<ExtraOutputOptions>(_outputOptions) | AsNumber(ExtraOutputOptions::MODULE));
+            }
+            else {
+                _outputOptions = static_cast<ExtraOutputOptions>(AsNumber<ExtraOutputOptions>(_outputOptions) & ~AsNumber(ExtraOutputOptions::MODULE));
+            }
+        }
+        bool Category() const {
+            return ((AsNumber<ExtraOutputOptions>(_outputOptions) & AsNumber(ExtraOutputOptions::CATEGORY)) != 0);
+        }
+        void Category(const bool enabled) {
+            if (enabled == true) {
+                _outputOptions = static_cast<ExtraOutputOptions>(AsNumber<ExtraOutputOptions>(_outputOptions) | AsNumber(ExtraOutputOptions::CATEGORY));
+            }
+            else {
+                _outputOptions = static_cast<ExtraOutputOptions>(AsNumber<ExtraOutputOptions>(_outputOptions) & ~AsNumber(ExtraOutputOptions::CATEGORY));
+            }
+        }
+        bool Date() const {
+            return ((AsNumber<ExtraOutputOptions>(_outputOptions) & AsNumber(ExtraOutputOptions::INCLUDINGDATE)) != 0);
+        }
+        void Date(const bool enabled) {
+            if (enabled == true) {
+                _outputOptions = static_cast<ExtraOutputOptions>(AsNumber<ExtraOutputOptions>(_outputOptions) | AsNumber(ExtraOutputOptions::INCLUDINGDATE));
+            }
+            else {
+                _outputOptions = static_cast<ExtraOutputOptions>(AsNumber<ExtraOutputOptions>(_outputOptions) & ~AsNumber(ExtraOutputOptions::INCLUDINGDATE));
+            }
+        }
+        bool Paused() const {
+            return ((AsNumber<ExtraOutputOptions>(_outputOptions) & AsNumber(ExtraOutputOptions::PAUSED)) != 0);
+        }
+        void Paused(const bool enabled) {
+            if (enabled == true) {
+                _outputOptions = static_cast<ExtraOutputOptions>(AsNumber<ExtraOutputOptions>(_outputOptions) | AsNumber(ExtraOutputOptions::PAUSED));
+            }
+            else {
+                _outputOptions = static_cast<ExtraOutputOptions>(AsNumber<ExtraOutputOptions>(_outputOptions) & ~AsNumber(ExtraOutputOptions::PAUSED));
+            }
+        }
+
+        void Convert(const Core::Messaging::Metadata::type type,
+            const string& module, const string& category, const string& fileName,
+            const uint16_t lineNumber, const string& className,
+            const uint64_t timeStamp, const string& text, Data& info);
+
+    private:
+        template <typename E>
+        static inline auto AsNumber(E t) -> typename std::underlying_type<E>::type
+        {
+            return static_cast<typename std::underlying_type<E>::type>(t);
+        }
+
+    private:
+        std::atomic<ExtraOutputOptions> _outputOptions;
+    };
+
+    class UDPOutput : public IPublish {
+    private:
+        class Channel : public Core::SocketDatagram {
+        public:
+            Channel() = delete;
+            Channel(const Channel&) = delete;
+            Channel& operator=(const Channel&) = delete;
+
+            explicit Channel(const Core::NodeId& nodeId);
+            ~Channel() override;
+
+            void Output(const Core::Messaging::IStore::Information& info, const Core::Messaging::IEvent* message);
+
+        private:
+            uint16_t SendData(uint8_t* dataFrame, const uint16_t maxSendSize) override;
+            // Unused
+            uint16_t ReceiveData(uint8_t*, const uint16_t) override;
+            void StateChange() override;
+
+            uint8_t _sendBuffer[Messaging::MessageUnit::DataSize];
+            uint16_t _loaded;
+            Core::CriticalSection _adminLock;
+        };
+
+    public:
+        UDPOutput() = delete;
+        UDPOutput(const UDPOutput&) = delete;
+        UDPOutput& operator=(const UDPOutput&) = delete;
+
+        explicit UDPOutput(const Core::NodeId& nodeId);
+        ~UDPOutput() = default;
+
+        void Message(const Core::Messaging::Metadata::type type,
+            const string& module, const string& category, const string& fileName,
+            const uint16_t lineNumber, const string& className,
+            const uint64_t timeStamp, const string& text) override;
+
+    private:
+        Channel _output;
+    };
+
+    class WebSocketOutput : public IPublish {
+    private:
+        class ExportCommand : public Core::JSON::Container {
+        public:
+            ExportCommand(const ExportCommand&) = delete;
+            ExportCommand& operator=(const ExportCommand&) = delete;
+
+            ExportCommand()
+                : Core::JSON::Container()
+                , FileName()
+                , LineNumber()
+                , Category()
+                , Module()
+                , IncludingDate()
+                , Paused()
+            {
+                Add(_T("filename"), &FileName);
+                Add(_T("linenumber"), &LineNumber);
+                Add(_T("classname"), &ClassName);
+                Add(_T("category"), &Category);
+                Add(_T("module"), &Module);
+                Add(_T("includingdate"), &IncludingDate);
+                Add(_T("paused"), &Paused);
+            }
+
+            ~ExportCommand() override = default;
+
+        public:
+            Core::JSON::Boolean FileName;
+            Core::JSON::Boolean LineNumber;
+            Core::JSON::Boolean ClassName;
+            Core::JSON::Boolean Category;
+            Core::JSON::Boolean Module;
+            Core::JSON::Boolean IncludingDate;
+            Core::JSON::Boolean Paused;
+        };
+
+        using ChannelMap = std::unordered_map<uint32_t, JSON>;
+
+    public:
+        static constexpr uint16_t DefaultMaxConnections = 5;
+
+    public:
+        WebSocketOutput(const WebSocketOutput& copy) = delete;
+        WebSocketOutput& operator=(const WebSocketOutput&) = delete;
+
+        explicit WebSocketOutput()
+            : _lock()
+            , _server(nullptr)
+            , _channels()
+            , _maxExportConnections(0)
+            , _jsonExportDataFactory(2)
+            , _jsonExportCommandFactory(2)
+        {
+        }
+        ~WebSocketOutput() override = default;
+
+    public:
+        void Initialize(PluginHost::IShell* service, const uint32_t maxConnections = DefaultMaxConnections) {
+            _lock.Lock();
+            _server = service;
+            _server->AddRef();
+            _maxExportConnections = maxConnections;
+            _lock.Unlock();
+        }
+        void Deinitialize() {
+            _lock.Lock();
+            _server->Release();
+            _server = nullptr;
+            _channels.clear();
+            _maxExportConnections = 0;
+            _lock.Unlock();
+        }
+        bool Attach(const uint32_t id)
+        {
+            bool accepted = false;
+            _lock.Lock();
+
+            if (_channels.size() < _maxExportConnections) {
+
+                ASSERT(_channels.find(id) == _channels.end());
+
+                _channels.emplace(std::piecewise_construct,
+                    std::forward_as_tuple(id),
+                    std::forward_as_tuple());
+
+                accepted = true;
+            }
+
+            _lock.Unlock();
+
+            return accepted;
+        }
+
+        bool Detach(const uint32_t id) {
+            bool deactivated = false;
+
+            _lock.Lock();
+
+            ChannelMap::iterator index = _channels.find(id);
+
+            if (index != _channels.end()) {
+                _channels.erase(index);
+                deactivated = true;
+            }
+
+            _lock.Unlock();
+
+            return deactivated;
+        }
+
+        uint32_t MaxConnections() const {
+            return (_maxExportConnections);
+        }
+
+        Core::ProxyType<Core::JSON::IElement> Received(const uint32_t id, const Core::ProxyType<Core::JSON::IElement>& element) {
+            Core::ProxyType<ExportCommand> info = Core::ProxyType<ExportCommand>(element);
+
+            if (info.IsValid() == false) {
+                element.Release();
+            }
+            else {
+                _lock.Lock();
+
+                ChannelMap::iterator index = _channels.find(id);
+
+                if (index != _channels.end()) {
+                    if (info->FileName.IsSet() == true) {
+                        index->second.FileName(info->FileName == true);
+                    }
+                    if (info->LineNumber.IsSet() == true) {
+                        index->second.LineNumber(info->LineNumber == true);
+                    }
+                    if (info->ClassName.IsSet() == true) {
+                        index->second.ClassName(info->ClassName == true);
+                    }
+                    if (info->Category.IsSet() == true) {
+                        index->second.Category(info->Category == true);
+                    }
+                    if (info->Module.IsSet() == true) {
+                        index->second.Module(info->Module == true);
+                    }
+                    if (info->IncludingDate.IsSet() == true) {
+                        index->second.Date(info->IncludingDate == true);
+                    }
+                    if (info->Paused.IsSet() == true) {
+                        index->second.Paused(info->Paused == true);
+                    }
+
+                    info->Clear();
+                    info->FileName = index->second.FileName();
+                    info->LineNumber = index->second.LineNumber();
+                    info->ClassName = index->second.ClassName();
+                    info->Category = index->second.Category();
+                    info->Module = index->second.Module();
+                    info->IncludingDate = index->second.Date();
+                    info->Paused = index->second.Paused();
+                }
+
+                _lock.Unlock();
+            }
+
+            return (element);
+        }
+
+        void Message(const Core::Messaging::Metadata::type type,
+            const string& module, const string& category, const string& fileName,
+            const uint16_t lineNumber, const string& className,
+            const uint64_t timeStamp, const string& text) override {
+
+            std::list<std::pair<uint32_t, Core::ProxyType<Core::JSON::IElement>>> cachedList;
+            PluginHost::IShell* server = nullptr;
+
+            _lock.Lock();
+
+            if (_server != nullptr) {
+
+                for (auto& item : _channels) {
+                    if (item.second.Paused() == false) {
+                        Core::ProxyType<JSON::Data> data = _jsonExportDataFactory.Element();
+                        item.second.Convert(type, category, module, fileName, lineNumber, className, timeStamp, text, *data);
+                        cachedList.emplace_back(item.first, Core::ProxyType<Core::JSON::IElement>(data));
+                    }
+                }
+
+                if (cachedList.empty() == false) {
+                    server = _server;
+                    server->AddRef();
+                }
+            }
+
+            _lock.Unlock();
+
+            if (server != nullptr) {
+                for (std::pair<uint32_t, Core::ProxyType<Core::JSON::IElement>>& entry : cachedList) {
+                    _server->Submit(entry.first, entry.second);
+                }
+                cachedList.clear();
+                server->Release();
+            }
+        }
+
+        Core::ProxyType<Core::JSON::IElement> Command() {
+            return (Core::ProxyType<Core::JSON::IElement>(_jsonExportCommandFactory.Element()));
+        }
+
+    private:
+        mutable Core::CriticalSection _lock;
+        PluginHost::IShell* _server;
+        ChannelMap _channels;
+        uint32_t _maxExportConnections;
+        Core::ProxyPoolType<JSON::Data> _jsonExportDataFactory;
+        Core::ProxyPoolType<ExportCommand> _jsonExportCommandFactory;
+    };
+
+}
+}

--- a/MessageControl/Module.cpp
+++ b/MessageControl/Module.cpp
@@ -1,0 +1,22 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+#include "Module.h"
+
+MODULE_NAME_DECLARATION(BUILD_REFERENCE)

--- a/MessageControl/Module.h
+++ b/MessageControl/Module.h
@@ -1,0 +1,35 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2020 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef MODULE_NAME
+#define MODULE_NAME Plugin_MessageControl
+#endif
+
+#include <messaging/messaging.h>
+#include <plugins/plugins.h>
+#include <interfaces/definitions.h>
+
+#include <interfaces/IMessageControl.h>
+#include <interfaces/json/JsonData_MessageControl.h>
+
+
+#undef EXTERNAL
+#define EXTERNAL

--- a/docs/api/MessageControlPlugin.md
+++ b/docs/api/MessageControlPlugin.md
@@ -1,0 +1,216 @@
+<!-- Generated automatically, DO NOT EDIT! -->
+<a name="head.MessageControl_Plugin"></a>
+# MessageControl Plugin
+
+**Version: 1.0**
+
+**Status: :black_circle::white_circle::white_circle:**
+
+MessageControl plugin for Thunder framework.
+
+### Table of Contents
+
+- [Introduction](#head.Introduction)
+- [Description](#head.Description)
+- [Configuration](#head.Configuration)
+- [Interfaces](#head.Interfaces)
+- [Methods](#head.Methods)
+- [Properties](#head.Properties)
+
+<a name="head.Introduction"></a>
+# Introduction
+
+<a name="head.Scope"></a>
+## Scope
+
+This document describes purpose and functionality of the MessageControl plugin. It includes detailed specification about its configuration, methods and properties provided.
+
+<a name="head.Case_Sensitivity"></a>
+## Case Sensitivity
+
+All identifiers of the interfaces described in this document are case-sensitive. Thus, unless stated otherwise, all keywords, entities, properties, relations and actions should be treated as such.
+
+<a name="head.Acronyms,_Abbreviations_and_Terms"></a>
+## Acronyms, Abbreviations and Terms
+
+The table below provides and overview of acronyms used in this document and their definitions.
+
+| Acronym | Description |
+| :-------- | :-------- |
+| <a name="acronym.API">API</a> | Application Programming Interface |
+| <a name="acronym.HTTP">HTTP</a> | Hypertext Transfer Protocol |
+| <a name="acronym.JSON">JSON</a> | JavaScript Object Notation; a data interchange format |
+| <a name="acronym.JSON-RPC">JSON-RPC</a> | A remote procedure call protocol encoded in JSON |
+
+The table below provides and overview of terms and abbreviations used in this document and their definitions.
+
+| Term | Description |
+| :-------- | :-------- |
+| <a name="term.callsign">callsign</a> | The name given to an instance of a plugin. One plugin can be instantiated multiple times, but each instance the instance name, callsign, must be unique. |
+
+<a name="head.References"></a>
+## References
+
+| Ref ID | Description |
+| :-------- | :-------- |
+| <a name="ref.HTTP">[HTTP](http://www.w3.org/Protocols)</a> | HTTP specification |
+| <a name="ref.JSON-RPC">[JSON-RPC](https://www.jsonrpc.org/specification)</a> | JSON-RPC 2.0 specification |
+| <a name="ref.JSON">[JSON](http://www.json.org/)</a> | JSON specification |
+| <a name="ref.Thunder">[Thunder](https://github.com/WebPlatformForEmbedded/Thunder/blob/master/doc/WPE%20-%20API%20-%20WPEFramework.docx)</a> | Thunder API Reference |
+
+<a name="head.Description"></a>
+# Description
+
+The MessageControl plugin allows reading of the traces from WPEFramework, and controlling them tracing and logging. Allows for outputting logging messages to the websocket.
+
+The plugin is designed to be loaded and executed within the Thunder framework. For more information about the framework refer to [[Thunder](#ref.Thunder)].
+
+<a name="head.Configuration"></a>
+# Configuration
+
+The table below lists configuration options of the plugin.
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| callsign | string | Plugin instance name (default: *MessageControl*) |
+| classname | string | Class name: *MessageControl* |
+| locator | string | Library name: *libWPEFrameworkMessageControl.so* |
+| autostart | boolean | Determines if the plugin shall be started automatically along with the framework |
+| console | boolean | <sup>*(optional)*</sup> Enables message output messages to the console |
+| syslog | boolean | <sup>*(optional)*</sup> Enables message ouutput to syslog |
+| filepath | string | <sup>*(optional)*</sup> Path to file (inside VolatilePath) where messages will be stored |
+| abbreviated | boolean | <sup>*(optional)*</sup> Denotes if the messages should be abbreviated |
+| maxexportconnections | number | <sup>*(optional)*</sup> Specifies to how many websockets can the messages be outputted |
+| remote | object | <sup>*(optional)*</sup>  |
+| remote.port | number | Port |
+| remote?.bindig | string | <sup>*(optional)*</sup> Binding address |
+
+<a name="head.Interfaces"></a>
+# Interfaces
+
+This plugin implements the following interfaces:
+
+- Exchange::IMessageControl ([IMessageControl.h](https://github.com/rdkcentral/ThunderInterfaces/blob/master/interfaces/IMessageControl.h)) (version 1.0.0) (compliant format)
+
+<a name="head.Methods"></a>
+# Methods
+
+The following methods are provided by the MessageControl plugin:
+
+MessageControl interface methods:
+
+| Method | Description |
+| :-------- | :-------- |
+| [enable](#method.enable) | Enables/disables a message control |
+
+
+<a name="method.enable"></a>
+## *enable [<sup>method</sup>](#head.Methods)*
+
+Enables/disables a message control.
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.type | string | Message type (must be one of the following: *Tracing*, *Logging*) |
+| params.category | string | Name of the message category |
+| params.module | string | Name of the module the message is originating from |
+| params.enabled | boolean | Denotes if control should be enabled (true) or disabled (false) |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | null | Always null |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "MessageControl.1.enable",
+    "params": {
+        "type": "Tracing",
+        "category": "Information",
+        "module": "Plugin_BluetoothControl",
+        "enabled": false
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": null
+}
+```
+
+<a name="head.Properties"></a>
+# Properties
+
+The following properties are provided by the MessageControl plugin:
+
+MessageControl interface properties:
+
+| Property | Description |
+| :-------- | :-------- |
+| [controls](#property.controls) <sup>RO</sup> | Retrieves a list of current message controls |
+
+
+<a name="property.controls"></a>
+## *controls [<sup>property</sup>](#head.Properties)*
+
+Provides access to the retrieves a list of current message controls.
+
+> This property is **read-only**.
+
+### Value
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | array | Retrieves a list of current message controls |
+| result[#] | object |  |
+| result[#].type | string | Type of message (must be one of the following: *Tracing*, *Logging*) |
+| result[#].category | string | Name of the message category |
+| result[#].module | string | Name of the module the message is originating from |
+| result[#].enabled | boolean | Denotes if the control is enabled (true) or disabled (false) |
+
+### Example
+
+#### Get Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "MessageControl.1.controls"
+}
+```
+
+#### Get Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": [
+        {
+            "type": "Tracing",
+            "category": "Information",
+            "module": "Plugin_BluetoothControl",
+            "enabled": false
+        }
+    ]
+}
+```
+


### PR DESCRIPTION
Reason for change:this MessageControl Plugin required for Thunder R4, It allows reading of the traces from WPEFramework, and controlling them tracing and logging Test Procedure: Verify in Jenkin Build
Risks: High
Signed-off-by: Thamim  Razith <tabbas651@cable.comcast.com>
(cherry picked from commit da0eb8b4acd2866be1fb57f2a4e6902465e4f43f)