### PR TITLE
RDKTV-9523: Enhance getSinkAtmosCapability() API

### DIFF
--- a/DisplaySettings/CHANGELOG.md
+++ b/DisplaySettings/CHANGELOG.md
@@ -15,11 +15,14 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+## [1.2.0] - 2023-08-02
+### Changed
+- Handled identifying Atmos sink capability for all audio output ports and host capability
+
 ## [1.1.1] - 2023-08-03
 ### Fixed
 - Fixed issues when ARC init and audio disconnected events occur at same time in some AVR
 - Fixed issues when Audio routing in progress and user disables CEC through UI
-
 
 ## [1.1.0] - 2023-06-12
 ### Fixed

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -81,8 +81,8 @@ using namespace std;
 #define ZOOM_SETTINGS_DIRECTORY "/opt/persistent/rdkservices"
 
 #define API_VERSION_NUMBER_MAJOR 1
-#define API_VERSION_NUMBER_MINOR 1
-#define API_VERSION_NUMBER_PATCH 1
+#define API_VERSION_NUMBER_MINOR 2
+#define API_VERSION_NUMBER_PATCH 0
 
 static bool isCecEnabled = false;
 static int  hdmiArcPortId = -1;
@@ -585,6 +585,7 @@ namespace WPEFramework {
                 IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_AUDIO_OUT_HOTPLUG, dsHdmiEventHandler) );
 		IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_AUDIO_FORMAT_UPDATE, formatUpdateEventHandler) );
 		IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_VIDEO_FORMAT_UPDATE, formatUpdateEventHandler) );
+                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_ATMOS_CAPS_CHANGED, checkAtmosCapsEventHandler) );
                 IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_PWRMGR_NAME, IARM_BUS_PWRMGR_EVENT_MODECHANGED, powerEventHandler) );
                 IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_AUDIO_PORT_STATE, audioPortStateEventHandler) );
                 IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_AUDIO_ASSOCIATED_AUDIO_MIXING_CHANGED, dsSettingsChangeEventHandler) );
@@ -883,7 +884,20 @@ namespace WPEFramework {
 		    break;
            }
         }
-        
+
+	void DisplaySettings::checkAtmosCapsEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
+    {
+
+        dsATMOSCapability_t atmosCaps = dsAUDIO_ATMOS_NOTSUPPORTED;
+        bool atmosCapsChangedstatus;
+        IARM_Bus_DSMgr_EventData_t *eventData = (IARM_Bus_DSMgr_EventData_t *)data;
+        atmosCaps = eventData->data.AtmosCapsChange.caps;
+        atmosCapsChangedstatus = eventData->data.AtmosCapsChange.status;
+        LOGINFO("Received IARM_BUS_DSMGR_EVENT_ATMOS_CAPS_CHANGED: %d \n", atmosCaps);
+        if(DisplaySettings::_instance && atmosCapsChangedstatus) {
+        DisplaySettings::_instance->notifyAtmosCapabilityChange(atmosCaps);
+        }
+    }        
         void DisplaySettings::audioPortStateEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
         {
             dsAudioPortState_t audioPortState = dsAUDIOPORT_STATE_UNINITIALIZED;
@@ -2212,6 +2226,22 @@ namespace WPEFramework {
              sendNotify("audioFormatChanged", params);
 	}
 
+    void DisplaySettings::notifyAtmosCapabilityChange(dsATMOSCapability_t atmosCaps)
+    {
+         JsonObject params;
+         switch (atmosCaps) {
+        case dsAUDIO_ATMOS_ATMOSMETADATA:
+            params["currentAtmosCapability"] = "ATMOS_SUPPORTED";
+            break;
+        case dsAUDIO_ATMOS_NOTSUPPORTED:
+            params["currentAtmosCapability"] = "ATMOS_NOT_SUPPORTED";
+            break;
+        default:
+            LOGINFO("Atmos capability unknown, not notifying");
+            break;
+         }
+             sendNotify("AtmosCapabilityChanged", params);
+    }
 	void DisplaySettings::notifyVideoFormatChange(dsHDRStandard_t videoFormat)
 	{
             JsonObject params;
@@ -3751,30 +3781,66 @@ namespace WPEFramework {
         uint32_t DisplaySettings::getSinkAtmosCapability (const JsonObject& parameters, JsonObject& response) 
         {   //sample servicemanager response:
             LOGINFOMETHOD();
-			bool success = true;
-			dsATMOSCapability_t atmosCapability;
+            bool success = true;
+            bool isValidAudioPort =  false;
+            dsATMOSCapability_t atmosCapability;
+            string audioPort = parameters.HasLabel("audioPort") ? parameters["audioPort"].String() : "NULL";
             try
             {
-                if (device::Host::getInstance().isHDMIOutPortPresent())
+                if(audioPort != "NULL") {
+                    device::List<device::AudioOutputPort> aPorts = device::Host::getInstance().getAudioOutputPorts();
+                    for (size_t i = 0; i < aPorts.size(); i++)
+                    {
+                        device::AudioOutputPort port = aPorts.at(i);
+                        if(audioPort == port.getName()) {
+                            isValidAudioPort = true;
+                            break;
+                        }
+                    }
+
+                    if(isValidAudioPort != true) {
+                         success = false;
+                         LOGERR("getSinkAtmosCapability failure: Unsupported Audio Port!!!\n");
+                         returnResponse(success);
+                    }
+		}
+
+                if (device::Host::getInstance().isHDMIOutPortPresent()) //STB
                 {
                     device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort("HDMI0");
+                    if(isValidAudioPort) {
+                        aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
+                    }
                     if (aPort.isConnected()) {
                         aPort.getSinkDeviceAtmosCapability (atmosCapability);
                         response["atmos_capability"] = (int)atmosCapability;
                     }
                     else {
-                        LOGERR("getSinkAtmosCapability failure: HDMI0 not connected!\n");
+                        LOGERR("getSinkAtmosCapability failure: %s not connected!\n", aPort.getName().c_str());
                         success = false;
                     }
                 }
-                else {
-                    device::Host::getInstance().getSinkDeviceAtmosCapability (atmosCapability);
-                    response["atmos_capability"] = (int)atmosCapability;
+                else { //TV
+                    if(isValidAudioPort) {
+                        device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
+                        if ( (aPort.getName() == "HDMI_ARC0" && aPort.isConnected() && m_arcEarcAudioEnabled == true) || (aPort.getName() != "HDMI_ARC0" && aPort.isConnected()) )  {
+                            aPort.getSinkDeviceAtmosCapability (atmosCapability);
+                            response["atmos_capability"] = (int)atmosCapability;
+                        }
+                        else {
+                            LOGERR("getSinkAtmosCapability failure: %s not connected!\n", audioPort.c_str());
+                            success = false;
+                        }
+                    }
+                    else {
+                        device::Host::getInstance().getSinkDeviceAtmosCapability (atmosCapability);
+                        response["atmos_capability"] = (int)atmosCapability;
+                    }
                 }
             }
             catch(const device::Exception& err)
             {
-                LOG_DEVICE_EXCEPTION1(string("HDMI0"));
+                LOG_DEVICE_EXCEPTION1(audioPort);
                 success = false;
             }
             returnResponse(success);

--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -164,6 +164,7 @@ namespace WPEFramework {
             void connectedVideoDisplaysUpdated(int hdmiHotPlugEvent);
             void connectedAudioPortUpdated (int iAudioPortType, bool isPortConnected);
 	    void notifyAudioFormatChange(dsAudioFormat_t audioFormat);
+		void notifyAtmosCapabilityChange(dsATMOSCapability_t atmoCaps);
             void notifyAssociatedAudioMixingChange(bool mixing);
             void notifyFaderControlChange(bool mixerbalance);
             void notifyPrimaryLanguageChange(std::string pLang);
@@ -198,6 +199,7 @@ namespace WPEFramework {
             static void DisplResolutionHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
             static void dsHdmiEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
 	    static void formatUpdateEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
+        static void checkAtmosCapsEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
             static void powerEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
             static void audioPortStateEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
             static void dsSettingsChangeEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);

--- a/DisplaySettings/DisplaySettings.json
+++ b/DisplaySettings/DisplaySettings.json
@@ -174,6 +174,11 @@
             "type": "number",
             "example": 50
         },
+        "currentAtmosCapability" : {
+            "summary": "Atmos capability of the connected device, ATMOS_SUPPORTED, ATMOS_NOT_SUPPORTED",
+            "type" : "string",
+            "example" : "ATMOS_SUPPORTED"
+        },
         "zoomSetting": {
             "summary": "Zoom setting. Possible values: `FULL`,  `NONE,`  `Letterbox 16x9`, `Letterbox 14x9`, `CCO`, `PanScan`, `Letterbox 2.21 on 4x3`, `Letterbox 2.21 on 16x9`, `Platform`, `Zoom 16x9`, `Pillarbox 4x3`, `Widescreen 4x3`",
             "type": "string",
@@ -951,6 +956,17 @@
         },
         "getSinkAtmosCapability":{
             "summary": "Returns the ATMOS capability of the sink (HDMI0).",
+            "params": {
+                "type":"object",
+                "properties": {
+                    "audioPort": {
+                        "$ref": "#/definitions/audioPort1"
+                    }
+                },
+                "required": [
+                    ""
+                ]
+            },
             "result": {
                 "type":"object",
                 "properties": {
@@ -2511,6 +2527,20 @@
                 },
                 "required": [
                     "volumeLevel"
+		]
+	    }
+	},
+        "AtmosCapabilityChanged": {
+            "summary": "Triggered when the audio sink device Atmos capability is changed.",
+            "params": {
+                "type": "object",
+                "properties": {
+                    "currentAtmosCapability":  {
+                       "$ref": "#/definitions/currentAtmosCapability"
+                    }
+                },
+                "required": [
+		    "currentAtmosCapability"
                 ]
             }
         }


### PR DESCRIPTION
Reason for change: Added DS HAL implementation for dsGetSinkAtmosCapability. Handled for all audio output ports and host capability
Test Procedure: Refer Ticket
Risks: Low