### PR TITLE
DELIA-62413: TexttoSpeech Plugin Compilation Error for Thunder R4

### DIFF
--- a/TextToSpeech/TextToSpeechImplementation.h
+++ b/TextToSpeech/TextToSpeechImplementation.h
@@ -70,7 +70,11 @@ namespace Plugin {
 
        public:
             static Core::ProxyType<Core::IDispatch> Create(TextToSpeechImplementation *tts, Event event, JsonValue params) {
+#ifndef USE_THUNDER_R4
                 return (Core::proxy_cast<Core::IDispatch>(Core::ProxyType<Job>::Create(tts, event, params)));
+#else
+                return (Core::ProxyType<Core::IDispatch>(Core::ProxyType<Job>::Create(tts, event, params)));
+#endif
             }
 
             virtual void Dispatch() {


### PR DESCRIPTION
Reason for change: update the proxy_cast based on USE_THUNDER_R4
Test Procedure: Verify in Jenkin Build
Risks: High
Signed-off-by: Thamim  Razith <tabbas651@cable.comcast.com>