### PR TITLE
RDKTV-22342 RDK Build/Version in Thunder API Does Not Match ImageName.

### DIFF
--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -3795,7 +3795,7 @@ namespace WPEFramework {
                     if (!trial.compare(0, 8, str2)) {
                         std::string gp = trial.c_str();
                         std::string delimiter = "=";
-                        clientVersionStr = gp.substr((gp.find(delimiter)+1), 12);
+                        clientVersionStr = gp.substr((gp.find(delimiter)+1));
                         break;
                     }
                 }


### PR DESCRIPTION
Reason for change: Allow clientVersion accept more than 12 digit .
Test Procedure: TBD
Risks: None
Priority: P2
Signed-off-by: Ramkumar_Prabaharan Ramkumar_Prabaharan@comcast.com