### PR TITLE
RDKTV-24211:Hisense][V2]Audio lag on Voice guidance is observed all o…

### DIFF
--- a/TextToSpeech/TextToSpeechJsonRpc.cpp
+++ b/TextToSpeech/TextToSpeechJsonRpc.cpp
@@ -176,6 +176,9 @@ namespace Plugin {
             getNumberParameter("rate", rate);
             config.rate = static_cast<uint8_t>(rate);
         }
+        else {
+            config.rate = 0;
+        }
 
         if(parameters.HasLabel("authinfo")) {
             JsonObject auth;


### PR DESCRIPTION
…ver EPG or apps

Reason for change: Init rate to NULL when optional argument not supplied
Test Procedure: Mentioned in ticket
Risks: Low