### PR TITLE
RDKTV-22342 RDK Build/Version in Thunder API Does Not Match Image Name

### DIFF
--- a/SystemServices/CHANGELOG.md
+++ b/SystemServices/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.5.2] - 2023-07-03
+### Added
+- Added In getSystemVersions response the version value taken from the BRANCH value instead of using the existing value from VERSION
+
 ## [1.5.1] - 2023-06-05
 ### Added 
 - Added Support to build the plugin to both R4 & R2

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -67,7 +67,7 @@ using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 5
-#define API_VERSION_NUMBER_PATCH 0
+#define API_VERSION_NUMBER_PATCH 2
 
 #define MAX_REBOOT_DELAY 86400 /* 24Hr = 86400 sec */
 #define TR181_FW_DELAY_REBOOT "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.AutoReboot.fwDelayReboot"
@@ -3844,7 +3844,42 @@ namespace WPEFramework {
             return "unknown";
 #endif
         }
+	string SystemServices::getStbBranchString()
+	{
+		static string stbBranchStr;
+		if (stbBranchStr.length())
+			return stbBranchStr;
 
+		std::string str;
+		std::string str2 = "BRANCH=";
+		vector<string> lines;
+
+		if (getFileContent(VERSION_FILE_NAME, lines)) {
+			for (int i = 0; i < (int)lines.size(); ++i) {
+				string line = lines.at(i);
+
+				std::string trial = line.c_str();
+				if (!trial.compare(0, 7, str2)) {
+					std::string temp = trial.c_str();
+					std::string delimiter = "=";
+					temp = temp.substr((temp.find(delimiter)+1));
+					delimiter = "_";
+					stbBranchStr = temp.substr((temp.find(delimiter)+1));
+					break;
+				}
+			}
+			if (stbBranchStr.length()) {
+				LOGWARN("getStbBranchString::STB's branch found in file: '%s'\n", stbBranchStr.c_str());
+				return stbBranchStr;
+			} else {
+				LOGWARN("getStbBranchString::could not find 'BRANCH=' in '%s'\n", VERSION_FILE_NAME);
+				return "unknown";
+			}
+		} else {
+			LOGERR("file %s open failed\n", VERSION_FILE_NAME);
+			return "unknown";
+		}
+	}
         /***
          * TODO: Stub implementation; Decide whether needed or not since setProperty
          * and getProperty functionalities are XRE/RTRemote dependent.
@@ -3872,9 +3907,18 @@ namespace WPEFramework {
                 JsonObject& response)
         {
             bool status = false;
+	    response["stbVersion"]      = getStbVersionString();
+	    string  stbBranchString     = getStbBranchString();            
+            std::regex stbBranchString_regex("^[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}$");
+            if (std::regex_match (stbBranchString, stbBranchString_regex))
+            {             
+                    response["receiverVersion"] = stbBranchString;
+            }
+            else
+            {                    
+                    response["receiverVersion"] = getClientVersionString();
+            }
 
-            response["stbVersion"]      = getStbVersionString();
-            response["receiverVersion"] = getClientVersionString();
             response["stbTimestamp"]    = getStbTimestampString();
             status = true;
             returnResponse(status);

--- a/SystemServices/SystemServices.h
+++ b/SystemServices/SystemServices.h
@@ -178,6 +178,7 @@ namespace WPEFramework {
                 std::string getStbVersionString();
                 std::string getClientVersionString();
                 std::string getStbTimestampString();
+		std::string getStbBranchString();
 
 #if defined(USE_IARMBUS) || defined(USE_IARM_BUS)
                 void InitializeIARM();


### PR DESCRIPTION
Reason for change:  To return the version from the BRANCH value instead of using the existing value from VERSION
Test Procedure: TBD
Risks: None
Priority: P1
Signed-off-by: Ramkumar_Prabaharan Ramkumar_Prabaharan@comcast.com