### PR TITLE
RDKTV-22342 RDK Build/Version in Thunder API Does Not Match Image Name

### DIFF
--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -3844,7 +3844,42 @@ namespace WPEFramework {
             return "unknown";
 #endif
         }
+	string SystemServices::getStbBranchString()
+	{
+		static string stbBranchStr;
+		if (stbBranchStr.length())
+			return stbBranchStr;
 
+		std::string str;
+		std::string str2 = "BRANCH=";
+		vector<string> lines;
+
+		if (getFileContent(VERSION_FILE_NAME, lines)) {
+			for (int i = 0; i < (int)lines.size(); ++i) {
+				string line = lines.at(i);
+
+				std::string trial = line.c_str();
+				if (!trial.compare(0, 7, str2)) {
+					std::string temp = trial.c_str();
+					std::string delimiter = "=";
+					temp = temp.substr((temp.find(delimiter)+1));
+					delimiter = "_";
+					stbBranchStr = temp.substr((temp.find(delimiter)+1));
+					break;
+				}
+			}
+			if (stbBranchStr.length()) {
+				LOGWARN("getStbBranchString::STB's branch found in file: '%s'\n", stbBranchStr.c_str());
+				return stbBranchStr;
+			} else {
+				LOGWARN("getStbBranchString::could not find 'BRANCH=' in '%s'\n", VERSION_FILE_NAME);
+				return "unknown";
+			}
+		} else {
+			LOGERR("file %s open failed\n", VERSION_FILE_NAME);
+			return "unknown";
+		}
+	}
         /***
          * TODO: Stub implementation; Decide whether needed or not since setProperty
          * and getProperty functionalities are XRE/RTRemote dependent.
@@ -3872,9 +3907,18 @@ namespace WPEFramework {
                 JsonObject& response)
         {
             bool status = false;
+	    response["stbVersion"]      = getStbVersionString();
+	    string  stbBranchString     = getStbBranchString();            
+            std::regex stbBranchString_regex("^[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}$");
+            if (std::regex_match (stbBranchString, stbBranchString_regex))
+            {             
+                    response["receiverVersion"] = stbBranchString;
+            }
+            else
+            {                    
+                    response["receiverVersion"] = getClientVersionString();
+            }
 
-            response["stbVersion"]      = getStbVersionString();
-            response["receiverVersion"] = getClientVersionString();
             response["stbTimestamp"]    = getStbTimestampString();
             status = true;
             returnResponse(status);

--- a/SystemServices/SystemServices.h
+++ b/SystemServices/SystemServices.h
@@ -178,6 +178,7 @@ namespace WPEFramework {
                 std::string getStbVersionString();
                 std::string getClientVersionString();
                 std::string getStbTimestampString();
+		std::string getStbBranchString();
 
 #if defined(USE_IARMBUS) || defined(USE_IARM_BUS)
                 void InitializeIARM();


### PR DESCRIPTION
Reason for change:  To return the version from the BRANCH value instead of using the existing value from VERSION
Test Procedure: TBD
Risks: None
Priority: P1
Signed-off-by: Ramkumar_Prabaharan Ramkumar_Prabaharan@comcast.com