### PR TITLE
RDKTV-23740: Add support to retrieve platform ms12 config details

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -340,7 +340,8 @@ namespace WPEFramework {
             registerMethodLockedApi("setPreferredColorDepth", &DisplaySettings::setPreferredColorDepth, this);
             registerMethodLockedApi("getPreferredColorDepth", &DisplaySettings::getPreferredColorDepth, this);
             registerMethodLockedApi("getColorDepthCapabilities", &DisplaySettings::getColorDepthCapabilities, this);
-            
+	    registerMethodLockedApi("getSupportedMS12Config", &DisplaySettings::getSupportedMS12Config, this);
+           
 
 	    m_subscribed = false; //HdmiCecSink event subscription
 	    m_hdmiInAudioDeviceConnected = false;// Tells about the device connection state, for eArc will be updated on audio device power status event handler after tinymix command and incase of ARC will be true after ARC Initiation
@@ -4047,6 +4048,24 @@ namespace WPEFramework {
             setResponseArray(response, "capabilities", colorDepthCapabilities);
             returnResponse(true);
         }
+
+	uint32_t DisplaySettings::getSupportedMS12Config(const JsonObject& parameters, JsonObject& response)
+       {
+           LOGINFOMETHOD();
+           bool success = true;
+           std::string type;
+           try {
+               device::Host::getInstance().getMS12ConfigDetails(type);
+               LOGINFO("Platform supports MS12 Config Z\n");
+               response["ms12config"] = type;
+           }
+           catch(const device::Exception& err)
+            {
+                LOG_DEVICE_EXCEPTION1(string("MS12ConfigType"));
+                success = false;
+            }
+           returnResponse(success);
+       }
 
         bool DisplaySettings::setUpHdmiCecSinkArcRouting (bool arcEnable)
         {

--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -150,6 +150,7 @@ namespace WPEFramework {
             uint32_t setPreferredColorDepth(const JsonObject& parameters, JsonObject& response);
             uint32_t getPreferredColorDepth(const JsonObject& parameters, JsonObject& response);
             uint32_t getColorDepthCapabilities(const JsonObject& parameters, JsonObject& response);
+	    uint32_t getSupportedMS12Config(const JsonObject& parameters, JsonObject& response);
 
             void InitAudioPorts();
             void AudioPortsReInitialize();

--- a/DisplaySettings/DisplaySettings.json
+++ b/DisplaySettings/DisplaySettings.json
@@ -194,7 +194,13 @@
                 "Auto"
             ],
             "example": "12 Bit"
+        },
+	"ms12config": {
+            "summary": "Supported ms12 config by platforms, possible values, CONFIG_Z, CONFIG_X, CONFIG_Y, CONFIG_NONE",
+            "type": "string",
+            "example": "CONFIG_X"
         }
+
     },
     "methods": {
         "enableSurroundDecoder":{
@@ -2349,6 +2355,24 @@
                     }
                 },
                 "required": [
+                    "success"
+                ]
+            }
+        },
+        "getSupportedMS12Config":{
+            "summary": "Returns supported ms12 config by the platform, possible values couldbe CONFG_Z, CONFIG_X, CONFIG_Y, CONFIG_NONE",
+            "result": {
+                "type":"object",
+                "properties": {
+                    "ms12config": {
+                        "$ref": "#/definitions/ms12config"
+                    },
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "ms12config",
                     "success"
                 ]
             }


### PR DESCRIPTION
Reason for change: TO retrieve the platform MS12 config type
Test Procedure: Run curl command to fetch the data
Risks: Low