### PR TITLE
RDKDEV-774 Add support for dm-verity based bundles

### DIFF
--- a/OCIContainer/CHANGELOG.md
+++ b/OCIContainer/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.0.2] - 2023-07-03
+### Added
+- Added support for dm-verity based encrypted bundles
+
 ## [1.0.1] - 2023-03-27
 ### Added
 - Added unit tests for OCIContainer

--- a/OCIContainer/CMakeLists.txt
+++ b/OCIContainer/CMakeLists.txt
@@ -3,11 +3,19 @@ set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
 
 set(PLUGIN_OCICONTAINER_STARTUPORDER "" CACHE STRING "To configure startup order of OCIContainer plugin")
 
+find_package(PkgConfig)
 find_package(${NAMESPACE}Plugins REQUIRED)
 find_package(Dobby CONFIG)
 
 # Temporary fix to get defines in Dobby. Will be removed later.
 add_definitions( -DRDK )
+
+pkg_search_module(OMI_CLIENT "omiclientlib")
+
+if(NOT OMI_CLIENT_FOUND)
+    set(OMI_CLIENT_INCLUDE_DIRS stubs)
+    message("Using stubs for omiclientlib")
+endif()
 
 add_library(${MODULE_NAME} SHARED
         OCIContainer.cpp
@@ -37,11 +45,13 @@ find_package_handle_standard_args(
     SYSTEMD_LIBRARIES SYSTEMD_INCLUDE_DIRS
 )
 
+
 target_include_directories(${MODULE_NAME}
         PRIVATE
         ../helpers
+        ${OMI_CLIENT_INCLUDE_DIRS}
+)
 
-        )
 
 target_link_libraries(${MODULE_NAME}
         PRIVATE
@@ -49,6 +59,7 @@ target_link_libraries(${MODULE_NAME}
         ${DOBBY_LIBRARIES}
         ${NAMESPACE}Plugins::${NAMESPACE}Plugins
         ${SYSTEMD_LIBRARIES}
+        ${OMI_CLIENT_LIBRARIES}
 )
 # ${NAMESPACE}Protocols::${NAMESPACE}Protocols
 install(TARGETS ${MODULE_NAME}

--- a/OCIContainer/OCIContainer.h
+++ b/OCIContainer/OCIContainer.h
@@ -8,6 +8,8 @@
 #include <vector>
 #include <map>
 
+#include <i_omi_proxy.hpp>
+
 namespace WPEFramework
 {
 
@@ -48,6 +50,7 @@ public:
     //Begin events
     void onContainerStarted(int32_t descriptor, const std::string& name);
     void onContainerStopped(int32_t descriptor, const std::string& name);
+    void onVerityFailed(const std::string& name);
     //End events
 
     //Build QueryInterface implementation, specifying all possible interfaces to be returned.
@@ -65,10 +68,13 @@ public:
 
 private:
     int mEventListenerId; // Dobby event listener ID
+    long unsigned mOmiListenerId;
     std::shared_ptr<IDobbyProxy> mDobbyProxy; // DobbyProxy instance
     std::shared_ptr<AI_IPC::IIpcService> mIpcService; // Ipc Service instance
     const int GetContainerDescriptorFromId(const std::string& containerId);
     static const void stateListener(int32_t descriptor, const std::string& name, IDobbyProxyEvents::ContainerState state, const void* _this);
+    static const void omiErrorListener(const std::string& id, omi::IOmiProxy::ErrorType err, const void* _this);
+    std::shared_ptr<omi::IOmiProxy> mOmiProxy;
 };
 } // namespace Plugin
 } // namespace WPEFramework

--- a/OCIContainer/stubs/i_omi_proxy.hpp
+++ b/OCIContainer/stubs/i_omi_proxy.hpp
@@ -1,0 +1,68 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2021 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+#ifndef I_OMI_PROXY_HPP_
+#define I_OMI_PROXY_HPP_
+
+#include <string>
+#include <functional>
+
+namespace omi
+{
+
+/**
+ *  @interface IOmiProxy
+ *  @brief Wrapper around an omi_dbus_api that provides simpler method
+ *  calls and give possibility to register/unregister for incoming signals.
+ */
+class IOmiProxy
+{
+public:
+    enum class ErrorType { verityFailed };
+
+    typedef std::function<void(const std::string&, ErrorType, const void*)> OmiErrorListener;
+
+    // Mount crypted bundle
+    // id               [IN]  - Container ID in reverse domain name notation
+    // rootfs_file_path [IN]  - Absolute pathname for filesystem image
+    // config_json_path [IN]  - Absolute pathname for config.json.jwt
+    // bundlePath       [OUT] - Absolute pathname for decrypted config.json payload
+    // Returns TRUE on success, FALSE on error
+    virtual bool mountCryptedBundle(const std::string& id,
+                                    const std::string& rootfs_file_path,
+                                    const std::string& config_json_path,
+                                    std::string& bundlePath /*out parameter*/) = 0;
+
+    // Unmount crypted bundle
+    // id               [IN]  - Container ID in reverse domain name notation
+    // Returns TRUE on success, FALSE on error
+    virtual bool umountCryptedBundle(const std::string& id) = 0;
+
+    // Register listener
+    // listener         [IN]  - OMI error listener which will be called on error event occurrence
+    // Returns listener ID (0<) or 0 on error
+    virtual long unsigned registerListener(const OmiErrorListener &listener, const void* cbParams) = 0;
+
+    // Unregister listener
+    // tag           [IN]  - ID which defines listener to be unregistered
+    virtual void unregisterListener(long unsigned tag) = 0;
+
+};
+} // namespace omi
+#endif // #ifndef I_OMI_PROXY_HPP_

--- a/OCIContainer/stubs/omi_proxy.hpp
+++ b/OCIContainer/stubs/omi_proxy.hpp
@@ -1,0 +1,48 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2021 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+#ifndef OMI_PROXY_HPP_
+#define OMI_PROXY_HPP_
+
+#include <i_omi_proxy.hpp>
+
+namespace omi
+{
+
+class OmiProxy : public IOmiProxy
+{
+public:
+    OmiProxy() = default;
+    virtual ~OmiProxy() = default;
+
+    virtual bool mountCryptedBundle(const std::string& id,
+                                       const std::string& rootfs_file_path,
+                                       const std::string& config_json_path,
+                                       std::string& bundlePath) { return true; }
+
+    virtual bool umountCryptedBundle(const std::string& id) { return true; }
+
+    virtual long unsigned registerListener(const OmiErrorListener &listener, const void* cbParams) { return 0; }
+
+    virtual void unregisterListener(long unsigned tag) {}
+};
+
+} // namespace omi
+
+#endif // OMI_PROXY_HPP_

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -177,6 +177,7 @@ target_include_directories(${PROJECT_NAME}
         mocks
         mocks/devicesettings
         mocks/thunder
+        ${CMAKE_CURRENT_SOURCE_DIR}/../OCIContainer/stubs
         )
 
 install(TARGETS ${PROJECT_NAME} DESTINATION bin)


### PR DESCRIPTION
Adds support for dm-verity[1] based encrypted
bundles.

It uses OMI[2] service to mount encrypted bundles.

[1] https://docs.kernel.org/admin-guide/device-mapper/verity.html
[2] https://code.rdkcentral.com/r/plugins/gitiles/rdk/components/generic/rdk-oe/meta-cmf/+/refs/heads/rdk-next/recipes-support/omi/omi.bb

Signed-off-by: Damian Wrobel <dwrobel.contractor@libertyglobal.com>
Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>

Change-Id: Iac4e76b9dcbe411ee4226a24a9b1ea8f197df681