### PR TITLE
DELIA-62413: TexttoSpeech Plugin Compilation Error for Thunder R4

### DIFF
--- a/TextToSpeech/TextToSpeechImplementation.h
+++ b/TextToSpeech/TextToSpeechImplementation.h
@@ -70,7 +70,11 @@ namespace Plugin {
 
        public:
             static Core::ProxyType<Core::IDispatch> Create(TextToSpeechImplementation *tts, Event event, JsonValue params) {
+#ifndef USE_THUNDER_R4
                 return (Core::proxy_cast<Core::IDispatch>(Core::ProxyType<Job>::Create(tts, event, params)));
+#else
+                return (Core::ProxyType<Core::IDispatch>(Core::ProxyType<Job>::Create(tts, event, params)));
+#endif
             }
 
             virtual void Dispatch() {

--- a/TextToSpeech/impl/SatToken.cpp
+++ b/TextToSpeech/impl/SatToken.cpp
@@ -45,7 +45,7 @@ string SatToken::getSecurityToken()
     }
 
     if(endpoint.empty()) {
-        Core::File file("/etc/WPEFramework/config.json", false);
+        Core::File file("/etc/WPEFramework/config.json");
         if(file.Open(true)) {
             JsonObject config;
             if(config.IElement::FromFile(file)) {


### PR DESCRIPTION
Reason for change: update the proxy_cast  based on USE_THUNDER_R4 and File Function compialtion error
Test Procedure: Verify in Jenkin Build
Risks: High
Signed-off-by: Thamim  Razith <tabbas651@cable.comcast.com>