### PR TITLE
RDKTV-24279: HDMI AVI Content type Signalling for Film Maker Mode via…

### DIFF
--- a/AVInput/AVInput.cpp
+++ b/AVInput/AVInput.cpp
@@ -58,6 +58,7 @@
 #define AVINPUT_EVENT_ON_STATUS_CHANGED "onInputStatusChanged"
 #define AVINPUT_EVENT_ON_VIDEO_MODE_UPDATED "videoStreamInfoUpdate"
 #define AVINPUT_EVENT_ON_GAME_FEATURE_STATUS_CHANGED "gameFeatureStatusUpdate"
+#define AVINPUT_EVENT_ON_AVI_CONTENT_TYPE_CHANGED "aviContentTypeUpdate"
 
 using namespace std;
 int getTypeOfInput(string sType)
@@ -159,6 +160,10 @@ void AVInput::InitializeIARM()
             IARM_BUS_DSMGR_NAME,
             IARM_BUS_DSMGR_EVENT_COMPOSITE_IN_STATUS,
             dsAVStatusEventHandler));
+	IARM_CHECK(IARM_Bus_RegisterEventHandler(
+            IARM_BUS_DSMGR_NAME,
+            IARM_BUS_DSMGR_EVENT_HDMI_IN_AVI_CONTENT_TYPE,
+            dsAviContentTypeEventHandler));
     }
 }
 
@@ -190,6 +195,9 @@ void AVInput::DeinitializeIARM()
         IARM_CHECK(IARM_Bus_RemoveEventHandler(
             IARM_BUS_DSMGR_NAME,
             IARM_BUS_DSMGR_EVENT_COMPOSITE_IN_STATUS, dsAVStatusEventHandler));
+	IARM_CHECK(IARM_Bus_RemoveEventHandler(
+            IARM_BUS_DSMGR_NAME,
+            IARM_BUS_DSMGR_EVENT_HDMI_IN_AVI_CONTENT_TYPE, dsAviContentTypeEventHandler));
     }
 }
 
@@ -804,6 +812,30 @@ void AVInput::AVInputVideoModeUpdate( int port , dsVideoPortResolution_t resolut
 
     sendNotify(AVINPUT_EVENT_ON_VIDEO_MODE_UPDATED, params);
 }
+
+void AVInput::dsAviContentTypeEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
+{
+	if(!AVInput::_instance)
+		return;
+
+	if (IARM_BUS_DSMGR_EVENT_HDMI_IN_AVI_CONTENT_TYPE == eventId)
+	{
+		IARM_Bus_DSMgr_EventData_t *eventData = (IARM_Bus_DSMgr_EventData_t *)data;
+		int hdmi_in_port = eventData->data.hdmi_in_content_type.port;
+		int avi_content_type = eventData->data.hdmi_in_content_type.aviContentType;
+		LOGINFO("Received IARM_BUS_DSMGR_EVENT_HDMI_IN_AVI_CONTENT_TYPE  event  port: %d, Content Type : %d", hdmi_in_port,avi_content_type);
+AVInput::_instance->hdmiInputAviContentTypeChange(hdmi_in_port, avi_content_type);
+	}
+}
+
+void AVInput::hdmiInputAviContentTypeChange( int port , int content_type)
+{
+	JsonObject params;
+	params["id"] = port;
+	params["aviContentType"] = content_type;
+	sendNotify(AVINPUT_EVENT_ON_AVI_CONTENT_TYPE_CHANGED, params);
+}
+
 
 void AVInput::dsAVEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
 {

--- a/AVInput/AVInput.h
+++ b/AVInput/AVInput.h
@@ -103,6 +103,8 @@ private:
     void AVInputALLMChange( int port , bool allmMode);
     static void dsAVGameFeatureStatusEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
 
+    void hdmiInputAviContentTypeChange(int port, int content_type);
+    static void dsAviContentTypeEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
 public:
     static AVInput* _instance;
 };

--- a/AVInput/AVInput.json
+++ b/AVInput/AVInput.json
@@ -702,6 +702,30 @@
                     "mode"
                 ]
             }
-        }
+    	},
+    	"hdmiContentTypeUpdate": {
+            "deprecated" : true,
+            "referenceUrl" : "https://rdkcentral.github.io/rdkservices/#/api/AVInputPlugin?id=hdmiContentTypeUpdate",
+            "summary": "Triggered whenever AV Infoframe content type changes for an HDMI Input",
+            "params": {
+                "type": "object",
+                "properties": {
+                   "id": {
+                        "summary": "Hdmi Input port ID for which content type change event received and possible values are port id 0, 1 and 2 for three Hdmi Input ports",
+                        "type": "integer",
+                        "example": 1
+		   },
+                   "aviContentType": {
+                        "summary": "new Content type received for the active hdmi input port and the possible integer values indicates following accordingly 0 - Graphics, 1 - Photo, 2 - Cinema, 3 - Game, 4 - Invalid data",
+                        "type": "integer",
+                        "example": 1
+		   }
+                },
+                "required": [
+                    "id",
+                    "aviContentType"
+                ]
+            }
+	}
     }
 }


### PR DESCRIPTION
… AVInput

Reason for change: Added the events for sending thew content type in HdmiInput Thunder plugin.
Test Procedure: Build and Verify.
Risks: Low
Signed-off-by: Aishwariya B aishwariya.bhaskar@sky.uk