### PR TITLE
RDK-42619: Cherry Video Plane/AudioMixing - HdmiInput Thunder changes

### DIFF
--- a/HdmiInput/HdmiInput.cpp
+++ b/HdmiInput/HdmiInput.cpp
@@ -42,6 +42,7 @@
 #define HDMIINPUT_METHOD_GET_EDID_VERSION "getEdidVersion"
 #define HDMIINPUT_METHOD_START_HDMI_INPUT "startHdmiInput"
 #define HDMIINPUT_METHOD_STOP_HDMI_INPUT "stopHdmiInput"
+#define HDMIINPUT_METHOD_SET_PLANE_TOP_MOST "setPlaneTopMost"
 #define HDMIINPUT_METHOD_SCALE_HDMI_INPUT "setVideoRectangle"
 #define HDMIINPUT_METHOD_SUPPORTED_GAME_FEATURES "getSupportedGameFeatures"
 #define HDMIINPUT_METHOD_GAME_FEATURE_STATUS "getHdmiGameFeatureStatus"
@@ -102,7 +103,8 @@ namespace WPEFramework
             registerMethod(HDMIINPUT_METHOD_GET_EDID_VERSION, &HdmiInput::getEdidVersionWrapper, this);
             registerMethod(HDMIINPUT_METHOD_START_HDMI_INPUT, &HdmiInput::startHdmiInput, this);
             registerMethod(HDMIINPUT_METHOD_STOP_HDMI_INPUT, &HdmiInput::stopHdmiInput, this);
-            registerMethod(HDMIINPUT_METHOD_SCALE_HDMI_INPUT, &HdmiInput::setVideoRectangleWrapper, this);
+            registerMethod(HDMIINPUT_METHOD_SET_PLANE_TOP_MOST, &HdmiInput::setPlaneTopMost, this);
+	    registerMethod(HDMIINPUT_METHOD_SCALE_HDMI_INPUT, &HdmiInput::setVideoRectangleWrapper, this);
 
             registerMethod(HDMIINPUT_METHOD_SUPPORTED_GAME_FEATURES, &HdmiInput::getSupportedGameFeatures, this);
             registerMethod(HDMIINPUT_METHOD_GAME_FEATURE_STATUS, &HdmiInput::getHdmiGameFeatureStatusWrapper, this);
@@ -172,9 +174,15 @@ namespace WPEFramework
             returnIfParamNotFound(parameters, "portId");
 
             string sPortId = parameters["portId"].String();
-            int portId = 0;
+            bool audioMix = parameters["requestAudioMix"].Boolean();
+	    int portId = 0;
+	    int planeType = 0;
             try {
                 portId = stoi(sPortId);
+		if (parameters.HasLabel("plane")){
+                        string sPlaneType = parameters["plane"].String();
+                        planeType = stoi(sPlaneType);
+                }
             }catch (const std::exception& err) {
 		    LOGWARN("sPortId invalid paramater: %s ", sPortId.c_str());
 		    returnResponse(false);
@@ -182,7 +190,7 @@ namespace WPEFramework
             bool success = true;
             try
             {
-                device::HdmiInput::getInstance().selectPort(portId);
+                device::HdmiInput::getInstance().selectPort(portId,audioMix,planeType);
             }
             catch (const device::Exception& err)
             {
@@ -211,7 +219,27 @@ namespace WPEFramework
 
         }
 
-        uint32_t HdmiInput::setVideoRectangleWrapper(const JsonObject& parameters, JsonObject& response)
+       	uint32_t HdmiInput::setPlaneTopMost(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            returnIfParamNotFound(parameters, "topMost");
+
+	     bool topMostPlane = parameters["topMost"].Boolean();
+		// need to add the logic properly after amlogic implementation
+
+            bool success = true;
+            try
+            {
+                device::HdmiInput::getInstance().setPlaneTopMost(topMostPlane);
+            }
+            catch (const device::Exception& err)
+            {
+                LOGWARN("HdmiInputService::setPlaneTopMost Failed");
+                success = false;
+            }
+	     returnResponse(success);
+	}
+	uint32_t HdmiInput::setVideoRectangleWrapper(const JsonObject& parameters, JsonObject& response)
         {
             LOGINFOMETHOD();
 

--- a/HdmiInput/HdmiInput.h
+++ b/HdmiInput/HdmiInput.h
@@ -60,7 +60,7 @@ namespace WPEFramework {
             uint32_t getEdidVersionWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t startHdmiInput(const JsonObject& parameters, JsonObject& response);
             uint32_t stopHdmiInput(const JsonObject& parameters, JsonObject& response);
-
+	    uint32_t setPlaneTopMost(const JsonObject& parameters, JsonObject& response);
             uint32_t setVideoRectangleWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t getSupportedGameFeatures(const JsonObject& parameters, JsonObject& response);
             uint32_t getHdmiGameFeatureStatusWrapper(const JsonObject& parameters, JsonObject& response);

--- a/Tests/mocks/devicesettings.h
+++ b/Tests/mocks/devicesettings.h
@@ -578,7 +578,7 @@ public:
     virtual uint8_t getNumberOfInputs() const = 0;
     virtual bool isPortConnected(int8_t Port) const = 0;
     virtual std::string getCurrentVideoMode() const = 0;
-    virtual void selectPort(int8_t Port) const = 0;
+    virtual void selectPort(int8_t Port, bool audioMix = false, int videoPlane = 0) const = 0;
     virtual void scaleVideo(int32_t x, int32_t y, int32_t width, int32_t height) const = 0;
 
     virtual void getEDIDBytesInfo(int iHdmiPort, std::vector<uint8_t>& edid) const = 0;
@@ -586,6 +586,7 @@ public:
     virtual void setEdidVersion(int iHdmiPort, int iEdidVersion) const = 0;
     virtual void getEdidVersion(int iHdmiPort, int* iEdidVersion) const = 0;
     virtual void getHdmiALLMStatus(int iHdmiPort, bool* allmStatus) const = 0;
+    virtual void setPlaneTopMost(bool topMostPlane) const = 0;
     virtual void getSupportedGameFeatures(std::vector<std::string>& featureList) const = 0;
 };
 
@@ -639,6 +640,10 @@ public:
     void getHdmiALLMStatus(int iHdmiPort, bool* allmStatus) const
     {
         return impl->getHdmiALLMStatus(iHdmiPort, allmStatus);
+    }
+    void setPlaneTopMost(bool topMostPlane) const
+    {
+        return impl->setPlaneTopMost(topMostPlane);
     }
     void getSupportedGameFeatures(std::vector<std::string>& featureList) const
     {

--- a/Tests/mocks/devicesettings.h
+++ b/Tests/mocks/devicesettings.h
@@ -612,9 +612,9 @@ public:
     {
         return impl->getCurrentVideoMode();
     }
-    void selectPort(int8_t Port) const
+    void selectPort(int8_t Port,bool audioMix = false,int videoPlane = 0) const
     {
-        return impl->selectPort(Port);
+        return impl->selectPort(Port,audioMix,videoPlane);
     }
     void scaleVideo(int32_t x, int32_t y, int32_t width, int32_t height) const
     {

--- a/Tests/mocks/devicesettings/HdmiInputMock.h
+++ b/Tests/mocks/devicesettings/HdmiInputMock.h
@@ -11,7 +11,7 @@ public:
     MOCK_METHOD(uint8_t, getNumberOfInputs, (), (const, override));
     MOCK_METHOD(bool, isPortConnected, (int8_t Port), (const, override));
     MOCK_METHOD(std::string, getCurrentVideoMode, (), (const, override));
-    MOCK_METHOD(void, selectPort, (int8_t Port), (const, override));
+    MOCK_METHOD(void, selectPort, (int8_t Port,bool audioMix = false, int videoPlane = 0), (const, override));
     MOCK_METHOD(void, scaleVideo, (int32_t x, int32_t y, int32_t width, int32_t height), (const, override));
     MOCK_METHOD(void, getEDIDBytesInfo, (int iHdmiPort, std::vector<uint8_t> &edid), (const, override));
     MOCK_METHOD(void, getHDMISPDInfo, (int iHdmiPort, std::vector<uint8_t> &data), (const, override));

--- a/Tests/mocks/devicesettings/HdmiInputMock.h
+++ b/Tests/mocks/devicesettings/HdmiInputMock.h
@@ -18,5 +18,6 @@ public:
     MOCK_METHOD(void, setEdidVersion, (int iHdmiPort, int iEdidVersion), (const, override));
     MOCK_METHOD(void, getEdidVersion, (int iHdmiPort, int *iEdidVersion), (const, override));
     MOCK_METHOD(void, getHdmiALLMStatus, (int iHdmiPort, bool *allmStatus), (const, override));
+    MOCK_METHOD(void, setPlaneTopMost, (bool planeTopMost), (const, override));
     MOCK_METHOD(void, getSupportedGameFeatures, (std::vector<std::string> &featureList), (const, override));
 };

--- a/Tests/mocks/devicesettings/HdmiInputMock.h
+++ b/Tests/mocks/devicesettings/HdmiInputMock.h
@@ -11,7 +11,7 @@ public:
     MOCK_METHOD(uint8_t, getNumberOfInputs, (), (const, override));
     MOCK_METHOD(bool, isPortConnected, (int8_t Port), (const, override));
     MOCK_METHOD(std::string, getCurrentVideoMode, (), (const, override));
-    MOCK_METHOD(void, selectPort, (int8_t Port,bool audioMix = false, int videoPlane = 0), (const, override));
+    MOCK_METHOD(void, selectPort, (int8_t Port,bool audioMix, int videoPlane), (const, override));
     MOCK_METHOD(void, scaleVideo, (int32_t x, int32_t y, int32_t width, int32_t height), (const, override));
     MOCK_METHOD(void, getEDIDBytesInfo, (int iHdmiPort, std::vector<uint8_t> &edid), (const, override));
     MOCK_METHOD(void, getHDMISPDInfo, (int iHdmiPort, std::vector<uint8_t> &data), (const, override));


### PR DESCRIPTION
Reason for change: changes done in thunder layer for secondary video plane and audio mixing
Test Procedure: Build and Verify.
Risks: Low
Signed-off-by: Aishwariya B <aishwariya.bhaskar@sky.uk>