### PR TITLE
RDKCOM-4076: [RDKServices]: Failed to get Event "client.events.1.onDi…

### DIFF
--- a/FrameRate/FrameRate.cpp
+++ b/FrameRate/FrameRate.cpp
@@ -17,6 +17,8 @@
 * limitations under the License.
 **/
 
+#include <cstring>
+
 #include "FrameRate.h"
 #include "host.hpp"
 #include "exception.hpp"
@@ -468,15 +470,28 @@ namespace WPEFramework
 
         void FrameRate::FrameRatePostChange(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
         {
+	    char dispFrameRate[20] ={0};
+	    if (strcmp(owner, IARM_BUS_DSMGR_NAME) == 0)
+	    {
+		switch (eventId) {
+		    case IARM_BUS_DSMGR_EVENT_DISPLAY_FRAMRATE_POSTCHANGE:
+			IARM_Bus_DSMgr_EventData_t *eventData = (IARM_Bus_DSMgr_EventData_t *)data;
+			strcpy(dispFrameRate,eventData->data.DisplayFrameRateChange.framerate);
+			break;
+		}
+	    }
+
             if(FrameRate::_instance)
             {
-                FrameRate::_instance->frameRatePostChange();
+                FrameRate::_instance->frameRatePostChange(dispFrameRate);
             }
         }
 
-        void FrameRate::frameRatePostChange()
+        void FrameRate::frameRatePostChange(char *displayFrameRate)
         {
-            sendNotify(EVENT_FRAMERATE_POSTCHANGE, JsonObject());
+            JsonObject params;
+	    params["displayFrameRate"] = std::string(displayFrameRate);
+	    sendNotify(EVENT_FRAMERATE_POSTCHANGE, params);
         }
 
         

--- a/FrameRate/FrameRate.h
+++ b/FrameRate/FrameRate.h
@@ -69,7 +69,7 @@ namespace WPEFramework {
             void frameRatePreChange();
             static void FrameRatePreChange(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
 
-            void frameRatePostChange();
+            void frameRatePostChange(char *displayFrameRate);
             static void FrameRatePostChange(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
 
 

--- a/WifiManager/impl/WifiManagerState.cpp
+++ b/WifiManager/impl/WifiManagerState.cpp
@@ -124,6 +124,11 @@ uint32_t WifiManagerState::setEnabled(const JsonObject &parameters, JsonObject &
         setWifiStateCache(true, WifiState::DISABLED);
     }
 
+    // Update wifi state cache if wifi interface was enabled
+    else if (retVal == IARM_RESULT_SUCCESS && param.isInterfaceEnabled == true) {
+        setWifiStateCache(true, WifiState::DISCONNECTED);
+    }
+
     returnResponse(retVal == IARM_RESULT_SUCCESS);
 }
 


### PR DESCRIPTION
…splayFrameRateChanged" if we setting org.rdk.FrameRate.2.setDisplayFrameRate

Reason for change: Added _dsSendDisplayFrameRateStatusPreChangeCall and _dsSendDisplayFrameRateStatusPreChangeCall to broadcast framerate prechange and postchange events

Test Procedure: Build and verify.

Risks: Low