### PR TITLE
RDKCOM-3804: OMWAPPI-1077 introducing synchro utils

### DIFF
--- a/DisplaySettings/CHANGELOG.md
+++ b/DisplaySettings/CHANGELOG.md
@@ -15,6 +15,11 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+##[1.2.1] - 2023-07-19
+
+- Adding UtilsSynchro.hpp to provide tools for automatically synchronizing API calls for given plugin
+- Added UtilsSynchroIarm.hpp to additionally synchronize iarm event handlers.
+
 ## [1.2.0] - 2023-06-12
 ### Fixed
 - Added event for volume increase/decrease/mute/unmute events

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -52,6 +52,8 @@
 #include "UtilsisValidInt.h"
 #include "dsRpc.h"
 
+#include "UtilsSynchroIarm.hpp"
+
 using namespace std;
 
 #define HDMI_HOT_PLUG_EVENT_CONNECTED 0
@@ -83,7 +85,7 @@ using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 2
-#define API_VERSION_NUMBER_PATCH 0
+#define API_VERSION_NUMBER_PATCH 1
 
 static bool isCecEnabled = false;
 static int  hdmiArcPortId = -1;
@@ -148,6 +150,7 @@ namespace
 
 // TODO: remove this
 #define registerMethod(...) for (uint8_t i = 1; GetHandler(i); i++) GetHandler(i)->Register<JsonObject, JsonObject>(__VA_ARGS__)
+#define registerMethodLockedApi(...) for (uint8_t i = 1; GetHandler(i); i++) Utils::Synchro::RegisterLockedApiForHandler(GetHandler(i), __VA_ARGS__)
 
 namespace WPEFramework {
 
@@ -241,101 +244,102 @@ namespace WPEFramework {
 
             CreateHandler({ 2 });
 
-            registerMethod("getConnectedVideoDisplays", &DisplaySettings::getConnectedVideoDisplays, this);
-            registerMethod("getConnectedAudioPorts", &DisplaySettings::getConnectedAudioPorts, this);
-            registerMethod("setEnableAudioPort", &DisplaySettings::setEnableAudioPort, this);
-            registerMethod("getEnableAudioPort", &DisplaySettings::getEnableAudioPort, this);
-            registerMethod("getSupportedResolutions", &DisplaySettings::getSupportedResolutions, this);
-            registerMethod("getSupportedVideoDisplays", &DisplaySettings::getSupportedVideoDisplays, this);
-            registerMethod("getSupportedTvResolutions", &DisplaySettings::getSupportedTvResolutions, this);
-            registerMethod("getSupportedSettopResolutions", &DisplaySettings::getSupportedSettopResolutions, this);
-            registerMethod("getSupportedAudioPorts", &DisplaySettings::getSupportedAudioPorts, this);
-            registerMethod("getSupportedAudioModes", &DisplaySettings::getSupportedAudioModes, this);
-	    registerMethod("getAudioFormat", &DisplaySettings::getAudioFormat, this);
-            registerMethod("getZoomSetting", &DisplaySettings::getZoomSetting, this);
-            registerMethod("setZoomSetting", &DisplaySettings::setZoomSetting, this);
-            registerMethod("getCurrentResolution", &DisplaySettings::getCurrentResolution, this);
-            registerMethod("setCurrentResolution", &DisplaySettings::setCurrentResolution, this);
-            registerMethod("getSoundMode", &DisplaySettings::getSoundMode, this);
-            registerMethod("setSoundMode", &DisplaySettings::setSoundMode, this);
-            registerMethod("readEDID", &DisplaySettings::readEDID, this);
-            registerMethod("readHostEDID", &DisplaySettings::readHostEDID, this);
-            registerMethod("getActiveInput", &DisplaySettings::getActiveInput, this);
-            registerMethod("getTvHDRSupport", &DisplaySettings::getTvHDRSupport, this);
-            registerMethod("getSettopHDRSupport", &DisplaySettings::getSettopHDRSupport, this);
-            registerMethod("setVideoPortStatusInStandby", &DisplaySettings::setVideoPortStatusInStandby, this);
-            registerMethod("getVideoPortStatusInStandby", &DisplaySettings::getVideoPortStatusInStandby, this);
-            registerMethod("getCurrentOutputSettings", &DisplaySettings::getCurrentOutputSettings, this);
+            registerMethodLockedApi("getConnectedVideoDisplays", &DisplaySettings::getConnectedVideoDisplays, this);
+            registerMethodLockedApi("getConnectedAudioPorts", &DisplaySettings::getConnectedAudioPorts, this);
+            registerMethodLockedApi("setEnableAudioPort", &DisplaySettings::setEnableAudioPort, this);
+            registerMethodLockedApi("getEnableAudioPort", &DisplaySettings::getEnableAudioPort, this);
+            registerMethodLockedApi("getSupportedResolutions", &DisplaySettings::getSupportedResolutions, this);
+            registerMethodLockedApi("getSupportedVideoDisplays", &DisplaySettings::getSupportedVideoDisplays, this);
+            registerMethodLockedApi("getSupportedTvResolutions", &DisplaySettings::getSupportedTvResolutions, this);
+            registerMethodLockedApi("getSupportedSettopResolutions", &DisplaySettings::getSupportedSettopResolutions, this);
+            registerMethodLockedApi("getSupportedAudioPorts", &DisplaySettings::getSupportedAudioPorts, this);
+            registerMethodLockedApi("getSupportedAudioModes", &DisplaySettings::getSupportedAudioModes, this);
+            registerMethodLockedApi("getAudioFormat", &DisplaySettings::getAudioFormat, this);
+            registerMethodLockedApi("getZoomSetting", &DisplaySettings::getZoomSetting, this);
+            registerMethodLockedApi("setZoomSetting", &DisplaySettings::setZoomSetting, this);
+            registerMethodLockedApi("getCurrentResolution", &DisplaySettings::getCurrentResolution, this);
+            registerMethodLockedApi("setCurrentResolution", &DisplaySettings::setCurrentResolution, this);
+            registerMethodLockedApi("getSoundMode", &DisplaySettings::getSoundMode, this);
+            registerMethodLockedApi("setSoundMode", &DisplaySettings::setSoundMode, this);
+            registerMethodLockedApi("readEDID", &DisplaySettings::readEDID, this);
+            registerMethodLockedApi("readHostEDID", &DisplaySettings::readHostEDID, this);
+            registerMethodLockedApi("getActiveInput", &DisplaySettings::getActiveInput, this);
+            registerMethodLockedApi("getTvHDRSupport", &DisplaySettings::getTvHDRSupport, this);
+            registerMethodLockedApi("getSettopHDRSupport", &DisplaySettings::getSettopHDRSupport, this);
+            registerMethodLockedApi("setVideoPortStatusInStandby", &DisplaySettings::setVideoPortStatusInStandby, this);
+            registerMethodLockedApi("getVideoPortStatusInStandby", &DisplaySettings::getVideoPortStatusInStandby, this);
+            registerMethodLockedApi("getCurrentOutputSettings", &DisplaySettings::getCurrentOutputSettings, this);
 
-            Register("getVolumeLeveller", &DisplaySettings::getVolumeLeveller, this);
-            registerMethod("getBassEnhancer", &DisplaySettings::getBassEnhancer, this);
-            registerMethod("isSurroundDecoderEnabled", &DisplaySettings::isSurroundDecoderEnabled, this);
-            registerMethod("getDRCMode", &DisplaySettings::getDRCMode, this);
-            Register("getSurroundVirtualizer", &DisplaySettings::getSurroundVirtualizer, this);
-            Register("setVolumeLeveller", &DisplaySettings::setVolumeLeveller, this);
-            registerMethod("setBassEnhancer", &DisplaySettings::setBassEnhancer, this);
-            registerMethod("enableSurroundDecoder", &DisplaySettings::enableSurroundDecoder, this);
-            Register("setSurroundVirtualizer", &DisplaySettings::setSurroundVirtualizer, this);
-            registerMethod("setMISteering", &DisplaySettings::setMISteering, this);
-            registerMethod("setGain", &DisplaySettings::setGain, this);
-            registerMethod("getGain", &DisplaySettings::getGain, this);
-            registerMethod("setMuted", &DisplaySettings::setMuted, this);
-            registerMethod("getMuted", &DisplaySettings::getMuted, this);
-            registerMethod("setVolumeLevel", &DisplaySettings::setVolumeLevel, this);
-            registerMethod("getVolumeLevel", &DisplaySettings::getVolumeLevel, this);
-            registerMethod("setDRCMode", &DisplaySettings::setDRCMode, this);
-            registerMethod("getMISteering", &DisplaySettings::getMISteering, this);
-            registerMethod("setMS12AudioCompression", &DisplaySettings::setMS12AudioCompression, this);
-            registerMethod("getMS12AudioCompression", &DisplaySettings::getMS12AudioCompression, this);
-            registerMethod("setDolbyVolumeMode", &DisplaySettings::setDolbyVolumeMode, this);
-            registerMethod("getDolbyVolumeMode", &DisplaySettings::getDolbyVolumeMode, this);
-            registerMethod("setDialogEnhancement", &DisplaySettings::setDialogEnhancement, this);
-            registerMethod("getDialogEnhancement", &DisplaySettings::getDialogEnhancement, this);
-            registerMethod("setIntelligentEqualizerMode", &DisplaySettings::setIntelligentEqualizerMode, this);
-            registerMethod("getIntelligentEqualizerMode", &DisplaySettings::getIntelligentEqualizerMode, this);
-            registerMethod("setGraphicEqualizerMode", &DisplaySettings::setGraphicEqualizerMode, this);
-            registerMethod("getGraphicEqualizerMode", &DisplaySettings::getGraphicEqualizerMode, this);
-            registerMethod("setMS12AudioProfile", &DisplaySettings::setMS12AudioProfile, this);
-            registerMethod("getMS12AudioProfile", &DisplaySettings::getMS12AudioProfile, this);
-	    registerMethod("getSupportedMS12AudioProfiles", &DisplaySettings::getSupportedMS12AudioProfiles, this);
-            registerMethod("resetDialogEnhancement", &DisplaySettings::resetDialogEnhancement, this);
-            registerMethod("resetBassEnhancer", &DisplaySettings::resetBassEnhancer, this);
-            registerMethod("resetSurroundVirtualizer", &DisplaySettings::resetSurroundVirtualizer, this);
-            registerMethod("resetVolumeLeveller", &DisplaySettings::resetVolumeLeveller, this);
+            Utils::Synchro::RegisterLockedApi("getVolumeLeveller", &DisplaySettings::getVolumeLeveller, this);
+            registerMethodLockedApi("getBassEnhancer", &DisplaySettings::getBassEnhancer, this);
+            registerMethodLockedApi("isSurroundDecoderEnabled", &DisplaySettings::isSurroundDecoderEnabled, this);
+            registerMethodLockedApi("getDRCMode", &DisplaySettings::getDRCMode, this);
+            Utils::Synchro::RegisterLockedApi("getSurroundVirtualizer", &DisplaySettings::getSurroundVirtualizer, this);
+            Utils::Synchro::RegisterLockedApi("setVolumeLeveller", &DisplaySettings::setVolumeLeveller, this);
+            registerMethodLockedApi("setBassEnhancer", &DisplaySettings::setBassEnhancer, this);
+            registerMethodLockedApi("enableSurroundDecoder", &DisplaySettings::enableSurroundDecoder, this);
+            Utils::Synchro::RegisterLockedApi("setSurroundVirtualizer", &DisplaySettings::setSurroundVirtualizer, this);
+            registerMethodLockedApi("setMISteering", &DisplaySettings::setMISteering, this);
+            registerMethodLockedApi("setGain", &DisplaySettings::setGain, this);
+            registerMethodLockedApi("getGain", &DisplaySettings::getGain, this);
+            registerMethodLockedApi("setMuted", &DisplaySettings::setMuted, this);
+            registerMethodLockedApi("getMuted", &DisplaySettings::getMuted, this);
+            registerMethodLockedApi("setVolumeLevel", &DisplaySettings::setVolumeLevel, this);
+            registerMethodLockedApi("getVolumeLevel", &DisplaySettings::getVolumeLevel, this);
+            registerMethodLockedApi("setDRCMode", &DisplaySettings::setDRCMode, this);
+            registerMethodLockedApi("getMISteering", &DisplaySettings::getMISteering, this);
+            registerMethodLockedApi("setMS12AudioCompression", &DisplaySettings::setMS12AudioCompression, this);
+            registerMethodLockedApi("getMS12AudioCompression", &DisplaySettings::getMS12AudioCompression, this);
+            registerMethodLockedApi("setDolbyVolumeMode", &DisplaySettings::setDolbyVolumeMode, this);
+            registerMethodLockedApi("getDolbyVolumeMode", &DisplaySettings::getDolbyVolumeMode, this);
+            registerMethodLockedApi("setDialogEnhancement", &DisplaySettings::setDialogEnhancement, this);
+            registerMethodLockedApi("getDialogEnhancement", &DisplaySettings::getDialogEnhancement, this);
+            registerMethodLockedApi("setIntelligentEqualizerMode", &DisplaySettings::setIntelligentEqualizerMode, this);
+            registerMethodLockedApi("getIntelligentEqualizerMode", &DisplaySettings::getIntelligentEqualizerMode, this);
+            registerMethodLockedApi("setGraphicEqualizerMode", &DisplaySettings::setGraphicEqualizerMode, this);
+            registerMethodLockedApi("getGraphicEqualizerMode", &DisplaySettings::getGraphicEqualizerMode, this);
+            registerMethodLockedApi("setMS12AudioProfile", &DisplaySettings::setMS12AudioProfile, this);
+            registerMethodLockedApi("getMS12AudioProfile", &DisplaySettings::getMS12AudioProfile, this);
+            registerMethodLockedApi("getSupportedMS12AudioProfiles", &DisplaySettings::getSupportedMS12AudioProfiles, this);
+            registerMethodLockedApi("resetDialogEnhancement", &DisplaySettings::resetDialogEnhancement, this);
+            registerMethodLockedApi("resetBassEnhancer", &DisplaySettings::resetBassEnhancer, this);
+            registerMethodLockedApi("resetSurroundVirtualizer", &DisplaySettings::resetSurroundVirtualizer, this);
+            registerMethodLockedApi("resetVolumeLeveller", &DisplaySettings::resetVolumeLeveller, this);
 
-            registerMethod("setAssociatedAudioMixing", &DisplaySettings::setAssociatedAudioMixing, this);
-            registerMethod("getAssociatedAudioMixing", &DisplaySettings::getAssociatedAudioMixing, this);
-            registerMethod("setFaderControl", &DisplaySettings::setFaderControl, this);
-            registerMethod("getFaderControl", &DisplaySettings::getFaderControl, this);
-            registerMethod("setPrimaryLanguage", &DisplaySettings::setPrimaryLanguage, this);
-            registerMethod("getPrimaryLanguage", &DisplaySettings::getPrimaryLanguage, this);
-            registerMethod("setSecondaryLanguage", &DisplaySettings::setSecondaryLanguage, this);
-            registerMethod("getSecondaryLanguage", &DisplaySettings::getSecondaryLanguage, this);
+            registerMethodLockedApi("setAssociatedAudioMixing", &DisplaySettings::setAssociatedAudioMixing, this);
+            registerMethodLockedApi("getAssociatedAudioMixing", &DisplaySettings::getAssociatedAudioMixing, this);
+            registerMethodLockedApi("setFaderControl", &DisplaySettings::setFaderControl, this);
+            registerMethodLockedApi("getFaderControl", &DisplaySettings::getFaderControl, this);
+            registerMethodLockedApi("setPrimaryLanguage", &DisplaySettings::setPrimaryLanguage, this);
+            registerMethodLockedApi("getPrimaryLanguage", &DisplaySettings::getPrimaryLanguage, this);
+            registerMethodLockedApi("setSecondaryLanguage", &DisplaySettings::setSecondaryLanguage, this);
+            registerMethodLockedApi("getSecondaryLanguage", &DisplaySettings::getSecondaryLanguage, this);
 
-            registerMethod("getAudioDelay", &DisplaySettings::getAudioDelay, this);
-            registerMethod("setAudioDelay", &DisplaySettings::setAudioDelay, this);
-            registerMethod("getAudioDelayOffset", &DisplaySettings::getAudioDelayOffset, this);
-            registerMethod("setAudioDelayOffset", &DisplaySettings::setAudioDelayOffset, this);
-            registerMethod("getSinkAtmosCapability", &DisplaySettings::getSinkAtmosCapability, this);
-            registerMethod("setAudioAtmosOutputMode", &DisplaySettings::setAudioAtmosOutputMode, this);
-            registerMethod("setForceHDRMode", &DisplaySettings::setForceHDRMode, this);
-            registerMethod("getTVHDRCapabilities", &DisplaySettings::getTVHDRCapabilities, this);
-            registerMethod("isConnectedDeviceRepeater", &DisplaySettings::isConnectedDeviceRepeater, this);
-            registerMethod("getDefaultResolution", &DisplaySettings::getDefaultResolution, this);
-            registerMethod("setScartParameter", &DisplaySettings::setScartParameter, this);
-            registerMethod("getSettopMS12Capabilities", &DisplaySettings::getSettopMS12Capabilities, this);
-            registerMethod("getSettopAudioCapabilities", &DisplaySettings::getSettopAudioCapabilities, this);
-            registerMethod("setMS12ProfileSettingsOverride", &DisplaySettings::setMS12ProfileSettingsOverride,this);
+            registerMethodLockedApi("getAudioDelay", &DisplaySettings::getAudioDelay, this);
+            registerMethodLockedApi("setAudioDelay", &DisplaySettings::setAudioDelay, this);
+            registerMethodLockedApi("getAudioDelayOffset", &DisplaySettings::getAudioDelayOffset, this);
+            registerMethodLockedApi("setAudioDelayOffset", &DisplaySettings::setAudioDelayOffset, this);
+            registerMethodLockedApi("getSinkAtmosCapability", &DisplaySettings::getSinkAtmosCapability, this);
+            registerMethodLockedApi("setAudioAtmosOutputMode", &DisplaySettings::setAudioAtmosOutputMode, this);
+            registerMethodLockedApi("setForceHDRMode", &DisplaySettings::setForceHDRMode, this);
+            registerMethodLockedApi("getTVHDRCapabilities", &DisplaySettings::getTVHDRCapabilities, this);
+            registerMethodLockedApi("isConnectedDeviceRepeater", &DisplaySettings::isConnectedDeviceRepeater, this);
+            registerMethodLockedApi("getDefaultResolution", &DisplaySettings::getDefaultResolution, this);
+            registerMethodLockedApi("setScartParameter", &DisplaySettings::setScartParameter, this);
+            registerMethodLockedApi("getSettopMS12Capabilities", &DisplaySettings::getSettopMS12Capabilities, this);
+            registerMethodLockedApi("getSettopAudioCapabilities", &DisplaySettings::getSettopAudioCapabilities, this);
+            registerMethodLockedApi("setMS12ProfileSettingsOverride", &DisplaySettings::setMS12ProfileSettingsOverride,this);
 
-            GetHandler(2)->Register<JsonObject, JsonObject>("getVolumeLeveller", &DisplaySettings::getVolumeLeveller2, this);
-            GetHandler(2)->Register<JsonObject, JsonObject>("setVolumeLeveller", &DisplaySettings::setVolumeLeveller2, this);
-            GetHandler(2)->Register<JsonObject, JsonObject>("getSurroundVirtualizer", &DisplaySettings::getSurroundVirtualizer2, this);
-            GetHandler(2)->Register<JsonObject, JsonObject>("setSurroundVirtualizer", &DisplaySettings::setSurroundVirtualizer2, this);
-            registerMethod("getVideoFormat", &DisplaySettings::getVideoFormat, this);
+            Utils::Synchro::RegisterLockedApiForHandler(GetHandler(2), "getVolumeLeveller", &DisplaySettings::getVolumeLeveller2, this);
+            Utils::Synchro::RegisterLockedApiForHandler(GetHandler(2), "setVolumeLeveller", &DisplaySettings::setVolumeLeveller2, this);
+            Utils::Synchro::RegisterLockedApiForHandler(GetHandler(2), "getSurroundVirtualizer", &DisplaySettings::getSurroundVirtualizer2, this);
+            Utils::Synchro::RegisterLockedApiForHandler(GetHandler(2), "setSurroundVirtualizer", &DisplaySettings::setSurroundVirtualizer2, this);
 
-            registerMethod("setPreferredColorDepth", &DisplaySettings::setPreferredColorDepth, this);
-            registerMethod("getPreferredColorDepth", &DisplaySettings::getPreferredColorDepth, this);
-            registerMethod("getColorDepthCapabilities", &DisplaySettings::getColorDepthCapabilities, this);
+            registerMethodLockedApi("getVideoFormat", &DisplaySettings::getVideoFormat, this);
+
+            registerMethodLockedApi("setPreferredColorDepth", &DisplaySettings::setPreferredColorDepth, this);
+            registerMethodLockedApi("getPreferredColorDepth", &DisplaySettings::getPreferredColorDepth, this);
+            registerMethodLockedApi("getColorDepthCapabilities", &DisplaySettings::getColorDepthCapabilities, this);
             
 
 	    m_subscribed = false; //HdmiCecSink event subscription
@@ -583,24 +587,24 @@ namespace WPEFramework {
                 IARM_Result_t res;
                 IARM_Bus_PWRMgr_GetPowerState_Param_t param;
 
-                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_RX_SENSE, DisplResolutionHandler) );
-                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_ZOOM_SETTINGS, DisplResolutionHandler) );
+                // RegisterLockedIarmHandler(UsingClass *mutexOwner, const char *ownerName, IARM_EventId_t eventId, IARM_EventHandler_t handler)
+                IARM_CHECK( Utils::Synchro::RegisterLockedIarmEventHandler<DisplaySettings>(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_RX_SENSE, DisplResolutionHandler) );
+                IARM_CHECK( Utils::Synchro::RegisterLockedIarmEventHandler<DisplaySettings>(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_ZOOM_SETTINGS, DisplResolutionHandler) );
                 //TODO(MROLLINS) localinput.cpp has PreChange guarded with #if !defined(DISABLE_PRE_RES_CHANGE_EVENTS)
                 //Can we set it all the time from inside here and let localinput put guards around listening for our event?
-                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_RES_PRECHANGE,ResolutionPreChange) );
-                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_RES_POSTCHANGE, ResolutionPostChange) );
-                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_HOTPLUG, dsHdmiEventHandler) );
-		IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_IN_HOTPLUG, dsHdmiEventHandler) );
-                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_AUDIO_OUT_HOTPLUG, dsHdmiEventHandler) );
-		IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_AUDIO_FORMAT_UPDATE, formatUpdateEventHandler) );
-		IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_VIDEO_FORMAT_UPDATE, formatUpdateEventHandler) );
-                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_ATMOS_CAPS_CHANGED, checkAtmosCapsEventHandler) );
-                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_PWRMGR_NAME, IARM_BUS_PWRMGR_EVENT_MODECHANGED, powerEventHandler) );
-                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_AUDIO_PORT_STATE, audioPortStateEventHandler) );
-                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_AUDIO_ASSOCIATED_AUDIO_MIXING_CHANGED, dsSettingsChangeEventHandler) );
-                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_AUDIO_FADER_CONTROL_CHANGED, dsSettingsChangeEventHandler) );
-                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_AUDIO_PRIMARY_LANGUAGE_CHANGED, dsSettingsChangeEventHandler) );
-                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_AUDIO_SECONDARY_LANGUAGE_CHANGED, dsSettingsChangeEventHandler) );
+		IARM_CHECK( Utils::Synchro::RegisterLockedIarmEventHandler<DisplaySettings>(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_RES_PRECHANGE,ResolutionPreChange) );
+                IARM_CHECK( Utils::Synchro::RegisterLockedIarmEventHandler<DisplaySettings>(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_RES_POSTCHANGE, ResolutionPostChange) );
+                IARM_CHECK( Utils::Synchro::RegisterLockedIarmEventHandler<DisplaySettings>(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_HOTPLUG, dsHdmiEventHandler) );
+		IARM_CHECK( Utils::Synchro::RegisterLockedIarmEventHandler<DisplaySettings>(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_IN_HOTPLUG, dsHdmiEventHandler) );
+                IARM_CHECK( Utils::Synchro::RegisterLockedIarmEventHandler<DisplaySettings>(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_AUDIO_OUT_HOTPLUG, dsHdmiEventHandler) );
+		IARM_CHECK( Utils::Synchro::RegisterLockedIarmEventHandler<DisplaySettings>(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_AUDIO_FORMAT_UPDATE, formatUpdateEventHandler) );
+		IARM_CHECK( Utils::Synchro::RegisterLockedIarmEventHandler<DisplaySettings>(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_VIDEO_FORMAT_UPDATE, formatUpdateEventHandler) );
+                IARM_CHECK( Utils::Synchro::RegisterLockedIarmEventHandler<DisplaySettings>(IARM_BUS_PWRMGR_NAME, IARM_BUS_PWRMGR_EVENT_MODECHANGED, powerEventHandler) );
+                IARM_CHECK( Utils::Synchro::RegisterLockedIarmEventHandler<DisplaySettings>(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_AUDIO_PORT_STATE, audioPortStateEventHandler) );
+                IARM_CHECK( Utils::Synchro::RegisterLockedIarmEventHandler<DisplaySettings>(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_AUDIO_ASSOCIATED_AUDIO_MIXING_CHANGED, dsSettingsChangeEventHandler) );
+                IARM_CHECK( Utils::Synchro::RegisterLockedIarmEventHandler<DisplaySettings>(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_AUDIO_FADER_CONTROL_CHANGED, dsSettingsChangeEventHandler) );
+                IARM_CHECK( Utils::Synchro::RegisterLockedIarmEventHandler<DisplaySettings>(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_AUDIO_PRIMARY_LANGUAGE_CHANGED, dsSettingsChangeEventHandler) );
+                IARM_CHECK( Utils::Synchro::RegisterLockedIarmEventHandler<DisplaySettings>(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_AUDIO_SECONDARY_LANGUAGE_CHANGED, dsSettingsChangeEventHandler) ); 
  
                 res = IARM_Bus_Call(IARM_BUS_PWRMGR_NAME, IARM_BUS_PWRMGR_API_GetPowerState, (void *)&param, sizeof(param));
                 if (res == IARM_RESULT_SUCCESS)
@@ -633,21 +637,21 @@ namespace WPEFramework {
             {
                 IARM_Result_t res;
 
-                IARM_CHECK( IARM_Bus_RemoveEventHandler(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_RX_SENSE, DisplResolutionHandler) );
-                IARM_CHECK( IARM_Bus_RemoveEventHandler(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_ZOOM_SETTINGS, DisplResolutionHandler) );
-                IARM_CHECK( IARM_Bus_RemoveEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_RES_PRECHANGE, ResolutionPreChange) );
-                IARM_CHECK( IARM_Bus_RemoveEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_RES_POSTCHANGE, ResolutionPostChange) );
-                IARM_CHECK( IARM_Bus_RemoveEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_HOTPLUG, dsHdmiEventHandler) );
-                IARM_CHECK( IARM_Bus_RemoveEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_IN_HOTPLUG, dsHdmiEventHandler) );
-                IARM_CHECK( IARM_Bus_RemoveEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_AUDIO_OUT_HOTPLUG, dsHdmiEventHandler) );
-                IARM_CHECK( IARM_Bus_RemoveEventHandler(IARM_BUS_PWRMGR_NAME, IARM_BUS_DSMGR_EVENT_AUDIO_FORMAT_UPDATE, formatUpdateEventHandler) );
-                IARM_CHECK( IARM_Bus_RemoveEventHandler(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_VIDEO_FORMAT_UPDATE, formatUpdateEventHandler) );
-                IARM_CHECK( IARM_Bus_RemoveEventHandler(IARM_BUS_PWRMGR_NAME, IARM_BUS_PWRMGR_EVENT_MODECHANGED, powerEventHandler) );
-                IARM_CHECK( IARM_Bus_RemoveEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_AUDIO_PORT_STATE, audioPortStateEventHandler) );
-                IARM_CHECK( IARM_Bus_RemoveEventHandler(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_AUDIO_ASSOCIATED_AUDIO_MIXING_CHANGED, dsSettingsChangeEventHandler) );
-                IARM_CHECK( IARM_Bus_RemoveEventHandler(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_AUDIO_FADER_CONTROL_CHANGED, dsSettingsChangeEventHandler) );
-                IARM_CHECK( IARM_Bus_RemoveEventHandler(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_AUDIO_PRIMARY_LANGUAGE_CHANGED, dsSettingsChangeEventHandler) );
-                IARM_CHECK( IARM_Bus_RemoveEventHandler(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_AUDIO_SECONDARY_LANGUAGE_CHANGED, dsSettingsChangeEventHandler) );
+                IARM_CHECK( Utils::Synchro::RemoveLockedEventHandler<DisplaySettings>(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_RX_SENSE, DisplResolutionHandler) );
+                IARM_CHECK( Utils::Synchro::RemoveLockedEventHandler<DisplaySettings>(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_ZOOM_SETTINGS, DisplResolutionHandler) );
+                IARM_CHECK( Utils::Synchro::RemoveLockedEventHandler<DisplaySettings>(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_RES_PRECHANGE, ResolutionPreChange) );
+                IARM_CHECK( Utils::Synchro::RemoveLockedEventHandler<DisplaySettings>(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_RES_POSTCHANGE, ResolutionPostChange) );
+                IARM_CHECK( Utils::Synchro::RemoveLockedEventHandler<DisplaySettings>(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_HOTPLUG, dsHdmiEventHandler) );
+                IARM_CHECK( Utils::Synchro::RemoveLockedEventHandler<DisplaySettings>(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_IN_HOTPLUG, dsHdmiEventHandler) );
+                IARM_CHECK( Utils::Synchro::RemoveLockedEventHandler<DisplaySettings>(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_AUDIO_OUT_HOTPLUG, dsHdmiEventHandler) );
+                IARM_CHECK( Utils::Synchro::RemoveLockedEventHandler<DisplaySettings>(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_AUDIO_FORMAT_UPDATE, formatUpdateEventHandler) );
+                IARM_CHECK( Utils::Synchro::RemoveLockedEventHandler<DisplaySettings>(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_VIDEO_FORMAT_UPDATE, formatUpdateEventHandler) );
+                IARM_CHECK( Utils::Synchro::RemoveLockedEventHandler<DisplaySettings>(IARM_BUS_PWRMGR_NAME, IARM_BUS_PWRMGR_EVENT_MODECHANGED, powerEventHandler) );
+                IARM_CHECK( Utils::Synchro::RemoveLockedEventHandler<DisplaySettings>(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_AUDIO_PORT_STATE, audioPortStateEventHandler) );
+                IARM_CHECK( Utils::Synchro::RemoveLockedEventHandler<DisplaySettings>(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_AUDIO_ASSOCIATED_AUDIO_MIXING_CHANGED, dsSettingsChangeEventHandler) );
+                IARM_CHECK( Utils::Synchro::RemoveLockedEventHandler<DisplaySettings>(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_AUDIO_FADER_CONTROL_CHANGED, dsSettingsChangeEventHandler) );
+                IARM_CHECK( Utils::Synchro::RemoveLockedEventHandler<DisplaySettings>(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_AUDIO_PRIMARY_LANGUAGE_CHANGED, dsSettingsChangeEventHandler) );
+                IARM_CHECK( Utils::Synchro::RemoveLockedEventHandler<DisplaySettings>(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_EVENT_AUDIO_SECONDARY_LANGUAGE_CHANGED, dsSettingsChangeEventHandler) );
             }
 
             try
@@ -4055,7 +4059,10 @@ namespace WPEFramework {
                     }
 
                     LOGINFO("ARC Routing - %d \n", arcEnable);
-                    m_client->Invoke<JsonObject, JsonObject>(2000, "setupARCRouting", param, hdmiCecSinkResult);
+                    {
+                        Utils::Synchro::UnlockApiGuard<DisplaySettings> unlockApi;
+                        m_client->Invoke<JsonObject, JsonObject>(2000, "setupARCRouting", param, hdmiCecSinkResult);
+                    }
                     if (!hdmiCecSinkResult["success"].Boolean()) {
 			success = false;
                         LOGERR("HdmiCecSink Plugin returned error\n");
@@ -4085,8 +4092,10 @@ namespace WPEFramework {
                 else {
                     JsonObject hdmiCecSinkResult;
                     JsonObject param;
-
-                    m_client->Invoke<JsonObject, JsonObject>(2000, "getEnabled", param, hdmiCecSinkResult);
+                    {
+                        Utils::Synchro::UnlockApiGuard<DisplaySettings> unlockApi;
+                        m_client->Invoke<JsonObject, JsonObject>(2000, "getEnabled", param, hdmiCecSinkResult);
+                    }
 
 		    cecEnable = hdmiCecSinkResult["enabled"].Boolean();
 		    LOGINFO("get-cecEnabled [%d]\n",cecEnable);
@@ -4118,7 +4127,10 @@ namespace WPEFramework {
                     JsonObject hdmiCecSinkResult;
                     JsonObject param;
 
-                    m_client->Invoke<JsonObject, JsonObject>(2000, "getAudioDeviceConnectedStatus", param, hdmiCecSinkResult);
+                    {
+                        Utils::Synchro::UnlockApiGuard<DisplaySettings> unlockApi;
+                        m_client->Invoke<JsonObject, JsonObject>(2000, "getAudioDeviceConnectedStatus", param, hdmiCecSinkResult);
+                    }
 
                     hdmiAudioDeviceDetected = hdmiCecSinkResult["connected"].Boolean();
                     LOGINFO("getAudioDeviceConnectedStatus [%d]\n",hdmiAudioDeviceDetected);
@@ -4151,7 +4163,10 @@ namespace WPEFramework {
                     JsonObject param;
 
                     LOGINFO("Send Audio Device Power On !!!\n");
-                    m_client->Invoke<JsonObject, JsonObject>(2000, "sendAudioDevicePowerOnMessage", param, hdmiCecSinkResult);
+                    {
+                        Utils::Synchro::UnlockApiGuard<DisplaySettings> unlockApi;
+                        m_client->Invoke<JsonObject, JsonObject>(2000, "sendAudioDevicePowerOnMessage", param, hdmiCecSinkResult);
+                    }
                     if (!hdmiCecSinkResult["success"].Boolean()) {
                         success = false;
                         LOGERR("HdmiCecSink Plugin returned error\n");
@@ -4183,7 +4198,10 @@ namespace WPEFramework {
                     JsonObject param;
 
                     LOGINFO("Requesting Short Audio Descriptor \n");
-                    m_client->Invoke<JsonObject, JsonObject>(2000, "requestShortAudioDescriptor", param, hdmiCecSinkResult);
+                    {
+                        Utils::Synchro::UnlockApiGuard<DisplaySettings> unlockApi;
+                        m_client->Invoke<JsonObject, JsonObject>(2000, "requestShortAudioDescriptor", param, hdmiCecSinkResult);
+                    }
                     if (!hdmiCecSinkResult["success"].Boolean()) {
                         success = false;
                         LOGERR("HdmiCecSink Plugin returned error\n");
@@ -4215,7 +4233,10 @@ namespace WPEFramework {
                     JsonObject param;
 
                     LOGINFO("Requesting Audio Device power Status \n");
-                    m_client->Invoke<JsonObject, JsonObject>(2000, "requestAudioDevicePowerStatus", param, hdmiCecSinkResult);
+                    {
+                        Utils::Synchro::UnlockApiGuard<DisplaySettings> unlockApi;
+                        m_client->Invoke<JsonObject, JsonObject>(2000, "requestAudioDevicePowerStatus", param, hdmiCecSinkResult);
+                    }
                     if (!hdmiCecSinkResult["success"].Boolean()) {
                         success = false;
                         LOGERR("HdmiCecSink Plugin returned error\n");

--- a/HdmiCec/CHANGELOG.md
+++ b/HdmiCec/CHANGELOG.md
@@ -13,7 +13,10 @@ All notable changes to this RDK Service will be documented in this file.
     * **Security** in case of vulnerabilities.
 
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
-
+##[1.0.11] - 2023-07-19
+### Added
+-Adding UtilsSynchro.hpp to provide tools for automatically synchronizing API calls for given plugin
+-Adding UtilsSynchroIarm.hpp to additionally synchronize iarm event handlers.
 
 ## [1.0.10] - 2023-04-20
 ### Fixed

--- a/HdmiCec/HdmiCec.cpp
+++ b/HdmiCec/HdmiCec.cpp
@@ -38,6 +38,8 @@
 #include "UtilsJsonRpc.h"
 #include "UtilssyncPersistFile.h"
 
+#include "UtilsSynchroIarm.hpp"
+
 #define HDMICEC_METHOD_SET_ENABLED "setEnabled"
 #define HDMICEC_METHOD_GET_ENABLED "getEnabled"
 #define HDMICEC_METHOD_GET_CEC_ADDRESSES "getCECAddresses"
@@ -57,7 +59,7 @@
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 10
+#define API_VERSION_NUMBER_PATCH 11
 
 enum {
 	HDMICEC_EVENT_DEVICE_ADDED=0,
@@ -84,6 +86,8 @@ static bool isDeviceActiveSource = false;
 #endif
 
 #define CEC_SETTING_ENABLED "cecEnabled"
+
+static const timespec hundred_ms {.tv_sec = 0, .tv_nsec = int(1e8) };
 
 namespace WPEFramework
 {
@@ -179,12 +183,12 @@ namespace WPEFramework
             cecEnableStatus = false;
             HdmiCec::_instance = this;
 
-            Register(HDMICEC_METHOD_SET_ENABLED, &HdmiCec::setEnabledWrapper, this);
-            Register(HDMICEC_METHOD_GET_ENABLED, &HdmiCec::getEnabledWrapper, this);
-            Register(HDMICEC_METHOD_GET_CEC_ADDRESSES, &HdmiCec::getCECAddressesWrapper, this);
-            Register(HDMICEC_METHOD_SEND_MESSAGE, &HdmiCec::sendMessageWrapper, this);
-            Register(HDMICEC_METHOD_GET_ACTIVE_SOURCE_STATUS, &HdmiCec::getActiveSourceStatus, this);
-            Register("getDeviceList", &HdmiCec::getDeviceList, this);
+            Utils::Synchro::RegisterLockedApi(HDMICEC_METHOD_SET_ENABLED, &HdmiCec::setEnabledWrapper, this);
+            Utils::Synchro::RegisterLockedApi(HDMICEC_METHOD_GET_ENABLED, &HdmiCec::getEnabledWrapper, this);
+            Utils::Synchro::RegisterLockedApi(HDMICEC_METHOD_GET_CEC_ADDRESSES, &HdmiCec::getCECAddressesWrapper, this);
+            Utils::Synchro::RegisterLockedApi(HDMICEC_METHOD_SEND_MESSAGE, &HdmiCec::sendMessageWrapper, this);
+            Utils::Synchro::RegisterLockedApi(HDMICEC_METHOD_GET_ACTIVE_SOURCE_STATUS, &HdmiCec::getActiveSourceStatus, this);
+            Utils::Synchro::RegisterLockedApi("getDeviceList", &HdmiCec::getDeviceList, this);
 
             physicalAddress = 0x0F0F0F0F;
 
@@ -238,10 +242,10 @@ namespace WPEFramework
             if (Utils::IARM::init())
             {
                 IARM_Result_t res;
-                //IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_CECHOST_NAME, IARM_BUS_CECHost_EVENT_DEVICESTATUSCHANGE,cecDeviceStatusEventHandler) ); // It didn't do anything in original service
-                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_CECMGR_NAME, IARM_BUS_CECMGR_EVENT_DAEMON_INITIALIZED,cecMgrEventHandler) );
-                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_CECMGR_NAME, IARM_BUS_CECMGR_EVENT_STATUS_UPDATED,cecMgrEventHandler) );
-                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_HOTPLUG, dsHdmiEventHandler) );
+                //IARM_CHECK( Utils::Synchro::RegisterLockedIarmEventHandler<HdmiCec>(IARM_BUS_CECHOST_NAME, IARM_BUS_CECHost_EVENT_DEVICESTATUSCHANGE,cecDeviceStatusEventHandler) ); // It didn't do anything in original service
+                IARM_CHECK( Utils::Synchro::RegisterLockedIarmEventHandler<HdmiCec>(IARM_BUS_CECMGR_NAME, IARM_BUS_CECMGR_EVENT_DAEMON_INITIALIZED,cecMgrEventHandler) );
+                IARM_CHECK( Utils::Synchro::RegisterLockedIarmEventHandler<HdmiCec>(IARM_BUS_CECMGR_NAME, IARM_BUS_CECMGR_EVENT_STATUS_UPDATED,cecMgrEventHandler) );
+                IARM_CHECK( Utils::Synchro::RegisterLockedIarmEventHandler<HdmiCec>(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_HOTPLUG, dsHdmiEventHandler) );
             }
         }
 
@@ -250,10 +254,10 @@ namespace WPEFramework
             if (Utils::IARM::isConnected())
             {
                 IARM_Result_t res;
-                //IARM_CHECK( IARM_Bus_RemoveEventHandler(IARM_BUS_CECHOST_NAME, IARM_BUS_CECHost_EVENT_DEVICESTATUSCHANGE, cecDeviceStatusEventHandler) );
-                IARM_CHECK( IARM_Bus_RemoveEventHandler(IARM_BUS_CECMGR_NAME, IARM_BUS_CECMGR_EVENT_DAEMON_INITIALIZED, cecMgrEventHandler) );
-                IARM_CHECK( IARM_Bus_RemoveEventHandler(IARM_BUS_CECMGR_NAME, IARM_BUS_CECMGR_EVENT_STATUS_UPDATED, cecMgrEventHandler) );
-                IARM_CHECK( IARM_Bus_RemoveEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_HOTPLUG, dsHdmiEventHandler) );
+		//IARM_CHECK( Utils::Synchro::RemoveLockedEventHandler<HdmiCec>(IARM_BUS_CECHOST_NAME, IARM_BUS_CECHost_EVENT_DEVICESTATUSCHANGE, cecDeviceStatusEventHandler) );
+                IARM_CHECK( Utils::Synchro::RemoveLockedEventHandler<HdmiCec>(IARM_BUS_CECMGR_NAME, IARM_BUS_CECMGR_EVENT_DAEMON_INITIALIZED,cecMgrEventHandler) );
+                IARM_CHECK( Utils::Synchro::RemoveLockedEventHandler<HdmiCec>(IARM_BUS_CECMGR_NAME, IARM_BUS_CECMGR_EVENT_STATUS_UPDATED,cecMgrEventHandler) );
+                IARM_CHECK( Utils::Synchro::RemoveLockedEventHandler<HdmiCec>(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_HOTPLUG, dsHdmiEventHandler) );
             }
         }
 
@@ -543,6 +547,7 @@ namespace WPEFramework
                 if (m_UpdateThread.get().joinable()) {//Join thread to make sure it's deleted before moving on.
                     m_UpdateThread.get().join();
                 }
+
                 LOGWARN("Deleted update Thread %p", smConnection );
 
 
@@ -1050,7 +1055,7 @@ namespace WPEFramework
 			return;
 		if(!(_instance->smConnection))
 			return;
-		LOGINFO("Entering ThreadRun: _instance->m_pollThreadExit %d",_instance->m_pollThreadExit);
+		LOGINFO("Entering ThreadRun: _instance->m_pollThreadExit %d",_instance->m_pollThreadExit.load());
 		int i = 0;
 		pthread_mutex_lock(&(_instance->m_lock));//pthread_cond_wait should be mutex protected. //pthread_cond_wait will unlock the mutex and perfoms wait for the condition.
 		while (!_instance->m_pollThreadExit) {
@@ -1067,7 +1072,7 @@ namespace WPEFramework
 				pthread_cond_signal(&(_instance->m_condSigUpdate));
 			}
 			//Wait for mutex signal here to continue the worker thread again.
-			pthread_cond_wait(&(_instance->m_condSig), &(_instance->m_lock));
+			while (!_instance->m_pollThreadExit && ETIMEDOUT == pthread_cond_timedwait(&(_instance->m_condSig), &(_instance->m_lock), &hundred_ms));
 
 		}
 		pthread_mutex_unlock(&(_instance->m_lock));
@@ -1080,13 +1085,13 @@ namespace WPEFramework
 			return;
 		if(!(_instance->smConnection))
 			return;
-		LOGINFO("Entering ThreadUpdate: _instance->m_updateThreadExit %d",_instance->m_updateThreadExit);
+		LOGINFO("Entering ThreadUpdate: _instance->m_updateThreadExit %d",_instance->m_updateThreadExit.load());
 		int i = 0;
 		pthread_mutex_lock(&(_instance->m_lockUpdate));//pthread_cond_wait should be mutex protected. //pthread_cond_wait will unlock the mutex and perfoms wait for the condition.
 		while (!_instance->m_updateThreadExit) {
 			//Wait for mutex signal here to continue the worker thread again.
-			pthread_cond_wait(&(_instance->m_condSigUpdate), &(_instance->m_lockUpdate));
-
+			while (!_instance->m_updateThreadExit && ETIMEDOUT == pthread_cond_timedwait(&(_instance->m_condSigUpdate), &(_instance->m_lockUpdate), &hundred_ms));
+			if (_instance->m_updateThreadExit) break;
 			LOGINFO("Starting cec device update check");
 			for(i=0; ((i< LogicalAddress::UNREGISTERED)&&(!_instance->m_updateThreadExit)); i++ ) {
 				//If details are not updated. update now.
@@ -1103,7 +1108,6 @@ namespace WPEFramework
 								usleep (100 * 1000); //sleep for 100 milli sec
 								iCounter ++;
 							}
-
 							HdmiCec::_instance->requestOsdName (i);
 							retry = true;
 						}

--- a/HdmiCec/HdmiCec.h
+++ b/HdmiCec/HdmiCec.h
@@ -173,9 +173,9 @@ namespace WPEFramework {
             bool cecEnableStatus;
             Connection *smConnection;
             int m_numberOfDevices;
-            bool m_pollThreadExit;
+            std::atomic_bool m_pollThreadExit;
             Utils::ThreadRAII m_pollThread;
-            bool m_updateThreadExit;
+            std::atomic_bool m_updateThreadExit;
             Utils::ThreadRAII m_UpdateThread;
 
             const void InitializeIARM();

--- a/helpers/UtilsSynchro.hpp
+++ b/helpers/UtilsSynchro.hpp
@@ -1,0 +1,98 @@
+#pragma once
+
+#include <mutex>
+#include <plugins/plugins.h>
+#include <memory>
+#include "UtilsLogging.h"
+
+using namespace WPEFramework;
+
+namespace Utils {
+    namespace Synchro {
+
+        namespace {
+            // set when inside of getFunctionToCall wrapper (or locked IARM handler - see UtilsSynchroIarm.hpp)
+            thread_local bool isThreadUsingLockedApi = false;
+        }
+
+        // keeps API locks, one per specific class
+        template<class C>
+        struct ApiLocks {
+            static std::recursive_mutex mtx;
+        };
+
+        template <class C> std::recursive_mutex ApiLocks<C>::mtx;
+
+        template <typename METHOD, typename REALOBJECT>
+        std::function<uint32_t(REALOBJECT*, const WPEFramework::Core::JSON::VariantContainer&, WPEFramework::Core::JSON::VariantContainer&)>
+        getFunctionToCall(const std::string& debugname, const METHOD& method, REALOBJECT* objectPtr) {
+            return [debugname, method](REALOBJECT *obj, const WPEFramework::Core::JSON::VariantContainer& in, WPEFramework::Core::JSON::VariantContainer& out) -> uint32_t {
+                isThreadUsingLockedApi = true;
+                // printf("METHOD CALL, GETTING LOCK: REALOBJECT '%s', method: '%s' MUTEX:%p\n",typeid(REALOBJECT).name(), debugname.c_str(), &ApiLocks<REALOBJECT>::mtx); fflush(stdout);
+                std::lock_guard<std::recursive_mutex> lock(ApiLocks<REALOBJECT>::mtx);
+                LOGINFO("calling %s with lock: %p\n", debugname.c_str(), &ApiLocks<REALOBJECT>::mtx);
+                uint32_t ret;
+                try {
+                    ret = (obj->*method)(in, out);
+                } catch (...) {
+                    isThreadUsingLockedApi = false;
+                    throw;
+                }
+                isThreadUsingLockedApi = false;
+                return ret;
+            };
+        }
+
+        template <typename METHOD, typename REALOBJECT>
+        void RegisterLockedApi(const string& methodName, const METHOD& method, REALOBJECT* objectPtr)
+        {
+            using MethodType = decltype(getFunctionToCall(methodName, method, objectPtr));
+            objectPtr->PluginHost::JSONRPC::Register<Core::JSON::VariantContainer, Core::JSON::VariantContainer, MethodType, REALOBJECT>(methodName, getFunctionToCall(methodName, method, objectPtr), objectPtr);
+        }
+
+        template <typename METHOD, typename REALOBJECT>
+        void RegisterLockedApiForVersions(const string& methodName, const METHOD& method, REALOBJECT* objectPtr, const std::vector<uint8_t> versions)
+        {
+            objectPtr->PluginHost::JSONRPC::Register<METHOD,REALOBJECT>(methodName, getFunctionToCall(methodName, method, objectPtr), objectPtr, versions);
+        }
+
+        template <typename METHOD, typename REALOBJECT>
+        void RegisterLockedApiForHandler(Core::JSONRPC::Handler* handler, const string& methodName, const METHOD& method, REALOBJECT* objectPtr)
+        {
+            handler->Register<JsonObject, JsonObject>(methodName, getFunctionToCall(methodName, method, objectPtr), objectPtr);
+        }
+
+        /*
+            This guard can unlock & re-lock api mutex to prevent deadlock possible when calling other plugins via Invoke
+            (could deadlock in case when that other plugin called Invoke on this plugin at the same time, or tried to call
+            this plugin recursively, from the Invoke'd call).
+        */
+        template<class UsingClass>
+        struct UnlockApiGuard {
+            UnlockApiGuard() {
+                if (isThreadUsingLockedApi) {
+                    ApiLocks<UsingClass>::mtx.unlock();
+                }
+            }
+            ~UnlockApiGuard() {
+                if (isThreadUsingLockedApi) {
+                    ApiLocks<UsingClass>::mtx.lock();
+                }
+            }
+        };
+
+        template<class UsingClass>
+        struct LockApiGuard {
+            std::unique_lock<std::recursive_mutex> _lock;
+            LockApiGuard() : _lock(ApiLocks<UsingClass>::mtx) {}
+            void unlock() {
+                _lock.unlock();
+            }
+            void lock() {
+                _lock.lock();
+            }
+        };
+
+
+    } // Utils
+} // Synchro

--- a/helpers/UtilsSynchroIarm.hpp
+++ b/helpers/UtilsSynchroIarm.hpp
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <mutex>
+#include <libIBus.h>
+#include <UtilsSynchro.hpp>
+#include <map>
+#include <string>
+#include "UtilsLogging.h"
+
+using namespace WPEFramework;
+
+namespace Utils {
+
+    namespace Synchro {
+
+        // owner -> map( eventId -> real handler)
+        using HandlerMapType = std::map<std::string, std::map<IARM_EventId_t, IARM_EventHandler_t>>;
+
+        // maps evnt types to handlers, one per specific class
+        template<class UsingClass>
+        struct IarmHandlers {
+            static HandlerMapType _registered_iarm_handlers;
+        };
+
+        template<class UsingClass>
+        HandlerMapType IarmHandlers<UsingClass>::_registered_iarm_handlers;
+
+        // we need separate handler per class, so that when we call IARM_Bus_RemoveEventHandler, we will not
+        // remove _generic_iarm_handler registered by other classes/in-process plugins
+        template<class UsingClass>
+        static void _generic_iarm_handler(const char *owner, IARM_EventId_t eventId, void *data, size_t len) {
+            auto& handlers_map = IarmHandlers<UsingClass>::_registered_iarm_handlers;
+            isThreadUsingLockedApi = true;
+            std::lock_guard<std::recursive_mutex> lock(ApiLocks<UsingClass>::mtx);
+            LOGINFO("calling handler %s/%d with lock: %p\n", owner, eventId, &ApiLocks<UsingClass>::mtx);
+            try {
+                handlers_map[owner][eventId](owner, eventId, data, len);
+            } catch (...) {
+                isThreadUsingLockedApi = false;
+                throw;
+            }
+            isThreadUsingLockedApi = false;
+        }
+
+        template<class UsingClass>
+        static IARM_Result_t RegisterLockedIarmEventHandler(const char *ownerName, IARM_EventId_t eventId, IARM_EventHandler_t handler) {
+            auto generic_handler = _generic_iarm_handler<UsingClass>;
+            auto& handlers_map = IarmHandlers<UsingClass>::_registered_iarm_handlers;
+
+            std::lock_guard<std::recursive_mutex> lock(ApiLocks<UsingClass>::mtx);
+            handlers_map[ownerName][eventId] = handler;
+            return ::IARM_Bus_RegisterEventHandler(ownerName, eventId, generic_handler);
+        }
+
+        template<class UsingClass>
+        static IARM_Result_t UnregisterLockedEventHandler(const char *ownerName, IARM_EventId_t eventId) {
+            auto generic_handler = _generic_iarm_handler<UsingClass>;
+            auto& handlers_map = IarmHandlers<UsingClass>::_registered_iarm_handlers;
+
+            std::lock_guard<std::recursive_mutex> lock(ApiLocks<UsingClass>::mtx);
+            handlers_map[ownerName].erase(eventId);
+            return ::IARM_Bus_UnRegisterEventHandler(ownerName, eventId);
+        }
+
+        template<class UsingClass>
+        static IARM_Result_t RemoveLockedEventHandler(const char *ownerName, IARM_EventId_t eventId, IARM_EventHandler_t handler) {
+            auto& handlers_map = IarmHandlers<UsingClass>::_registered_iarm_handlers;
+
+            std::lock_guard<std::recursive_mutex> lock(ApiLocks<UsingClass>::mtx);
+            if (handler != handlers_map[ownerName][eventId]) {
+                LOGERR("class %s RemoveLockedEventHandler for ownerName: %s, event: %d passed handler: %p different than registered: %p\n", typeid(UsingClass).name(), ownerName, eventId, handler, handlers_map[ownerName][eventId]); fflush(stdout);
+            }
+            // still erase the event in any case
+            handlers_map[ownerName].erase(eventId);
+            return ::IARM_Bus_RemoveEventHandler(ownerName, eventId, _generic_iarm_handler<UsingClass>);
+        }
+    } // Synchro
+} // Utils


### PR DESCRIPTION
RDKCOM-3804: OMWAPPI-1077 introducing synchro utils
Adding UtilsSynchro.hpp to provide tools for
automatically synchronizing API calls for given
plugin, and UtilsSynchroIarm.hpp to additionally
synchronize iarm event handlers.

(cherry picked from commit baf32b375cc4f61910ccb05caad11e00837efcfd)

RDKCOM-3804: OMWAPPI-1077 locked API for DisplaySettings

(cherry picked from commit 85f0f4b456df3a48935f23d7b06af61b3b40b097)

RDKCOM-3804: OMWAPPI-1077 locked API for HdmiCec

also fixing problem where pthread signal
could've been skipped

(cherry picked from commit 024fd2d76b06528ee3e0e994fe75690643224b8b)

Signed-off-by: tomasz-karczewski-red <tomasz.karczewski@redembedded.com>
