### PR TITLE
RDKCMF-8920 : Fix OCDM issue for wpeframework R4

### DIFF
--- a/OpenCDMi/CHANGELOG.md
+++ b/OpenCDMi/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.0.2] - 2023-07-19
+### Change
+- Updated the name of the method as per R4 fixes
+
 ## [1.0.1] - 2023-06-05
 ### Added 
 - Added Support to build the plugin to both R4 & R2

--- a/OpenCDMi/FrameworkRPC.cpp
+++ b/OpenCDMi/FrameworkRPC.cpp
@@ -123,7 +123,11 @@ namespace Plugin {
             }
 
         private:
+#ifndef USE_THUNDER_R4
             virtual void* Aquire(const string& className, const uint32_t interfaceId, const uint32_t versionId)
+#else
+            virtual void* Acquire(const string& className, const uint32_t interfaceId, const uint32_t versionId)
+#endif /* USE_THUNDER_R4 */
             {
                 void* result = nullptr;
 
@@ -131,7 +135,7 @@ namespace Plugin {
                 if (((versionId == 1) || (versionId == static_cast<uint32_t>(~0))) && ((interfaceId == ::OCDM::IAccessorOCDM::ID) || (interfaceId == Core::IUnknown::ID))) {
                     // Reference count our parent
                     _parentInterface->AddRef();
-                    TRACE(Trace::Information, ("OCDM interface aquired => %p", this));
+                    TRACE(Trace::Information, ("OCDM interface acquired => %p", this));
                     // Allright, respond with the interface.
                     result = _parentInterface;
                 }


### PR DESCRIPTION
Reason for change : OCDM not working on R4
Due to the below change.
[TYPE] Aquire -> Acquire is fixed in: https://github.com/rdkcentral/Thunder/commit/11c82babf09926357024085518f1f5535c7e98b3
Test Procedure : test OCDM on R4 build
Risks: Low
Signed-off-by: Peter Trekels <ptrekels.contractor@libertyglobal.com>
Signed-off-by: Karunakaran A <karunakaran_amirthalingam@cable.comcast.com>