### PR TITLE
RDK-41474: Documentation for New Plugins not reflected on the wiki(ht…

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -25,6 +25,7 @@
   - [HdmiCec](api/HdmiCecPlugin.md)
   - [HdmiCecSink](api/HdmiCecSinkPlugin.md)
   - [HdmiInput](api/HdmiInputPlugin.md)
+  - [LEDControl](api/LEDControlPlugin.md)
   - [LinearPlaybackControl](api/LinearPlaybackControlPlugin.md)
   - [LocationSync](api/LocationSyncPlugin.md)
   - [LoggingPreferences](api/LoggingPreferencesPlugin.md)


### PR DESCRIPTION
…tps://rdkcentral.github.io/rdkservices/#/README)

Reason for change:Adding new plugin md file
Error:Documentation for New Plugins not reflected on the wiki Test Procedure: None
Risks: Low
Signed-off-by:AkshayKumar_Gampa <AkshayKumar_Gampa@comcast.com