### PR TITLE
DELIA-62821, RDK-41086: Consolidate F/W download to use swupdate_util…

### DIFF
--- a/SystemServices/CHANGELOG.md
+++ b/SystemServices/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.7.0] - 2023-05-15
+### Changed
+- Changed references to deviceInitiatedFWDnld.sh to swupdate_utility.sh
+
 ## [1.6.0] - 2023-07-05
 ### Added
 - Added API to get and set friendly name of the device

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -66,7 +66,7 @@
 using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 1
-#define API_VERSION_NUMBER_MINOR 6
+#define API_VERSION_NUMBER_MINOR 7
 #define API_VERSION_NUMBER_PATCH 0
 
 #define MAX_REBOOT_DELAY 86400 /* 24Hr = 86400 sec */
@@ -1235,7 +1235,7 @@ namespace WPEFramework {
                 JsonObject& response)
         {
             LOGWARN("SystemService updatingFirmware\n");
-            string command("/lib/rdk/deviceInitiatedFWDnld.sh 0 4 >> /opt/logs/swupdate.log &");
+            string command("/lib/rdk/swupdate_utility.sh 0 4 >> /opt/logs/swupdate.log &");
             Utils::cRunScript(command.c_str());
             returnResponse(true);
         }

--- a/Tests/tests/test_SystemServices.cpp
+++ b/Tests/tests/test_SystemServices.cpp
@@ -605,7 +605,7 @@ TEST_F(SystemServicesTest, updateFirmware)
         .Times(::testing::AnyNumber())
         .WillRepeatedly(::testing::Invoke(
             [&](const char* command, const char* type) {
-                EXPECT_EQ(string(command), string(_T("/lib/rdk/deviceInitiatedFWDnld.sh 0 4 >> /opt/logs/swupdate.log &")));
+                EXPECT_EQ(string(command), string(_T("/lib/rdk/swupdate_utility.sh 0 4 >> /opt/logs/swupdate.log &")));
                 return nullptr;
             }));
 


### PR DESCRIPTION
…ity.sh

Reason for change: Ensure entry point for firmware download is swupdate_utility.sh. github changes were missed in sprint/23Q3 and main.

Test Procedure: Ensure firmware downloads work successfully with both rdkvfwupgrader enabled and disabled.

Risks: Low

Priority: P1

Signed-off-by: Kirk Davis <kirk_davis@cable.comcast.com>
(cherry picked from commit 7fd7429c67df8f4e2332d44ca838dd4ec4091e41)