### PR TITLE
RDK-42993:Replace System commands -popen()

### DIFF
--- a/Network/Network.cpp
+++ b/Network/Network.cpp
@@ -26,6 +26,7 @@
 #include "UtilsString.h"
 #include "UtilscRunScript.h"
 #include "UtilsgetRFCConfig.h"
+#include "UtilsgetFileContent.h"
 
 using namespace std;
 
@@ -142,9 +143,20 @@ typedef struct _IARM_BUS_NetSrvMgr_Iface_EventData_t {
             registerMethod("getPublicIP", &Network::getPublicIP, this);
             registerMethod("setStunEndPoint", &Network::setStunEndPoint, this);
 
-            const char * script1 = R"(grep DEVICE_TYPE /etc/device.properties | cut -d "=" -f2 | tr -d '\n')";
-            m_isHybridDevice = Utils::cRunScript(script1).substr();
-            LOGWARN("script1 '%s' result: '%s'", script1, m_isHybridDevice.c_str());
+            const char* filename = "/etc/device.properties";
+            std::string propertyName = "DEVICE_TYPE";
+            std::string deviceType;
+
+            if (Utils::readPropertyFromFile(filename, propertyName, deviceType))
+            {
+                m_isHybridDevice = deviceType;
+                LOGINFO("DEVICE_TYPE '%s' ", m_isHybridDevice.c_str());
+            }
+            else
+            {
+                LOGERR("deviceType is empty");
+            }
+
             m_defaultInterface = "";
             m_gatewayInterface = "";
 

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -62,6 +62,7 @@
 #include "UtilsString.h"
 #include "UtilscRunScript.h"
 #include "UtilsfileExists.h"
+#include "UtilsgetFileContent.h"
 
 using namespace std;
 
@@ -1537,9 +1538,13 @@ namespace WPEFramework {
             std::system("/lib/rdk/xconfImageCheck.sh  >> /opt/logs/wpeframework.log");
 
             //get xconf http code
-            string httpCodeStr = Utils::cRunScript("cat /tmp/xconf_httpcode_thunder.txt");
-            if(!httpCodeStr.empty())
+            string httpCodeStr ="";
+            const char* httpCodeFile = "/tmp/xconf_httpcode_thunder.txt";
+            bool httpCodeReadSuccess =  Utils::readFileContent(httpCodeFile, httpCodeStr);
+
+            if(httpCodeReadSuccess)
             {
+			    LOGINFO("xconf httpCodeStr '%s'\n", httpCodeStr.c_str());
                 try
                 {
                     _fwUpdate.httpStatus = std::stoi(httpCodeStr);
@@ -1552,10 +1557,10 @@ namespace WPEFramework {
 
             LOGINFO("xconf http code %d\n", _fwUpdate.httpStatus);
 
-            response = Utils::cRunScript("cat /tmp/xconf_response_thunder.txt");
-            LOGINFO("xconf response '%s'\n", response.c_str());
-            
-            if(!response.empty()) 
+            const char* responseFile = "/tmp/xconf_response_thunder.txt";
+            bool responseReadSuccess = Utils::readFileContent(responseFile, response);
+
+            if(responseReadSuccess)
             {
                 JsonObject httpResp;
                 if(httpResp.FromString(response))

--- a/Warehouse/Warehouse.cpp
+++ b/Warehouse/Warehouse.cpp
@@ -23,6 +23,7 @@
 #include <fstream>
 
 #include <regex.h>
+#include <regex>
 #include <time.h>
 
 #if defined(USE_IARMBUS) || defined(USE_IARM_BUS)
@@ -36,6 +37,7 @@
 #include "UtilsString.h"
 #include "UtilscRunScript.h"
 #include "UtilsfileExists.h"
+#include "UtilsgetFileContent.h"
 
 #include "frontpanel.h"
 
@@ -703,16 +705,34 @@ namespace WPEFramework
                 if (path.find('$') != std::string::npos)
                 {
                     std::string variable;
-                    std::string script = "echo '" + path + "' | sed -r \"s/([^$]*)([$\\{]*)([^$\\{\\}\\/]*)(.*)/\\3/\"";
-                    variable = Utils::cRunScript(script.c_str());
-                    Utils::String::trim(variable);
+                    std::regex pattern("\\$([^$\\{\\}\\/]*)");
+                    std::smatch matches;
+
+                    if (std::regex_search(path, matches, pattern))
+                    {
+                        variable = matches[1].str();
+                        LOGINFO("Extracted variable '%s' ", variable.c_str());
+                        Utils::String::trim(variable);
+                    }
+                    else
+                    {
+                         LOGERR("Variable extraction failed");
+                    }
 
                     std::string value;
                     if (variable.length() > 0)
                     {
-                        script = ". /etc/device.properties; echo \"$" + variable + "\"";
-                        value = Utils::cRunScript(script.c_str());
-                        Utils::String::trim(value);
+                        const char* filename = "/etc/device.properties";
+                        std::string propertyName = variable;
+
+                        if (Utils::readPropertyFromFile(filename, propertyName, value))
+                        {
+                            Utils::String::trim(value);
+                        }
+                        else
+                        {
+                            LOGERR("Property value is empty");
+                        }
                     }
 
                     if (value.length() == 0)

--- a/helpers/UtilsgetFileContent.h
+++ b/helpers/UtilsgetFileContent.h
@@ -1,0 +1,110 @@
+#pragma once
+
+#include <fstream>
+#include <iostream>
+#define READ_BUFFER_SIZE 1024
+namespace Utils {
+
+/**
+ * @brief           Read the property value from the given file based on the provided property name.
+ * @param filename  [in]  The name of the file from which to read the properties.
+ * @param property  [in]  The name of the property to search for in the file.
+ * @param propertyValue [out] The value of the property will be stored in this string.
+ * @return          bool  True if the property is found and successfully read, false otherwise.
+ */
+bool readPropertyFromFile(const char* filename, const std::string& property, std::string& propertyValue)
+{
+    std::string line = "";
+    bool found = false;
+    std::ifstream file(filename);
+    propertyValue = "";
+    if (file.is_open())
+    {
+        while (std::getline(file, line))
+        {
+            // Skip lines that start with '#' (single-line comments)
+            if (!line.empty() && line[0] == '#')
+            {
+                continue;
+            }
+            if (line.find(property + " ") == 0 || line.find(property + "=") == 0)
+            {
+                std::string propertyContent = line.substr(line.find("=") + 1);
+
+                // If the property value starts with '$', recursively expand it
+                if (!propertyContent.empty() && propertyContent[0] == '$')
+                {
+                    std::string expandedProperty = propertyContent.substr(1);
+                    if (readPropertyFromFile(filename, expandedProperty, propertyValue))
+                    {
+                        found = true;
+                        break;
+                    }
+                    else
+                    {
+                        LOGERR("Failed to find expanded property: %s", expandedProperty.c_str());
+                    }
+                }
+                else
+                {
+                    // If it does not start with '$', set propertyValue directly
+                    propertyValue = propertyContent;
+                    if (!propertyValue.empty())
+                    {
+                        // Remove new line character from end of the string if it exists
+                        if ((propertyValue.back() == '\r') || (propertyValue.back() == '\n'))
+                        {
+                            propertyValue.pop_back();
+                        }
+                    }
+                    found = true;
+                    break;
+                }
+            }
+        }
+    }
+    else
+    {
+        LOGERR("File is not open");
+    }
+
+    // If the property was not found, set the propertyValue to an empty string
+    if (!found)
+    {
+       LOGERR("Variable value is empty");
+    }
+
+    return found;
+}
+
+/**
+ * @brief           Read the content of a file and store it in the provided string.
+ * @param filename  [in]  The name of the file to read.
+ * @param content   [out] The content of the file will be stored in this string.
+ * @return          bool  True if the file is successfully read and its content is stored in 'content', false otherwise.
+ */
+
+bool readFileContent(const char* filename, std::string& content)
+{
+    char buffer[READ_BUFFER_SIZE];
+    FILE* file = fopen(filename, "r");
+    bool found = false;
+
+    if (file)
+    {
+        while (fgets(buffer, sizeof(buffer), file) != NULL)
+        {
+            content += buffer;
+        }
+        fclose(file);
+        found = true;
+    }
+    else
+    {
+        LOGERR("Failed to open the file");
+    }
+
+    return found;
+}
+
+}

--- a/helpers/UtilsgetFileContent.h
+++ b/helpers/UtilsgetFileContent.h
@@ -31,7 +31,7 @@ bool readPropertyFromFile(const char* filename, const std::string& property, std
             {
                 std::string propertyContent = line.substr(line.find("=") + 1);
 
-                // If the property value starts with '$', recursively expand it
+                // If the property value starts with '$',recursively expand it
                 if (!propertyContent.empty() && propertyContent[0] == '$')
                 {
                     std::string expandedProperty = propertyContent.substr(1);


### PR DESCRIPTION
Changes Done:
(i) Added util functions in Warehouse and Network Plugins to get file content, replacing popen.
(ii) Added util function in SystemService Plugin to read file property, replacing popen.
(iii) Used regular expressions in Warehouse plugin and util function to read property, instead of popen.

Reason for change: Trying to make RDK-E lean, as part of this gerrit, updating the popen call in Rdkservices
Test Procedure: Basic sanity