### PR TITLE
DELIA-62843: TTS thunder plugin missing "speechrate" attribute

### DIFF
--- a/TextToSpeech/TextToSpeechImplementation.cpp
+++ b/TextToSpeech/TextToSpeechImplementation.cpp
@@ -176,6 +176,7 @@ namespace Plugin {
         config.ttsEndPointSecured = object.ttsEndPointSecured;
         config.language =  object.language;
         config.voice =  object.voice;
+        config.speechRate = object.speechRate;
         config.volume = (double) object.volume;
         config.rate =  object.rate;
         _adminLock.Lock();
@@ -190,6 +191,7 @@ namespace Plugin {
         TTSLOG_INFO("Voice : %s", config.voice.c_str());
         TTSLOG_INFO("Volume : %lf",config.volume);
         TTSLOG_INFO("Rate : %u", config.rate);
+        TTSLOG_INFO("SpeechRate : %s", config.speechRate.c_str());
         logResponse(status);
         return (status == TTS::TTS_OK) ? (Core::ERROR_NONE) : (Core::ERROR_GENERAL);
     }
@@ -225,15 +227,6 @@ namespace Plugin {
         return (Core::ERROR_NONE);
     }
     
-    uint32_t TextToSpeechImplementation::SetSpeechRate(const string speechRate)
-    {
-        _adminLock.Lock();
-        _ttsManager->setSpeechRate(speechRate);
-        _adminLock.Unlock();
-        TTSLOG_INFO("speechrate updated %s\n",speechRate.c_str());
-        return (Core::ERROR_NONE);
-    }
-
     uint32_t TextToSpeechImplementation::GetConfiguration(Exchange::ITextToSpeech::Configuration &exchangeConfig) const
     {
         _adminLock.Lock();
@@ -246,6 +239,7 @@ namespace Plugin {
             exchangeConfig.ttsEndPointSecured = ttsConfig.ttsEndPointSecured;
             exchangeConfig.language           = ttsConfig.language;
             exchangeConfig.voice              = ttsConfig.voice;
+            exchangeConfig.speechRate         = ttsConfig.speechRate;
             exchangeConfig.rate               = (uint8_t) ttsConfig.rate;
             exchangeConfig.volume             = (uint8_t) ttsConfig.volume;
         }
@@ -256,6 +250,7 @@ namespace Plugin {
         TTSLOG_INFO("Voice : %s",  ttsConfig.voice.c_str());
         TTSLOG_INFO("Volume : %lf", ttsConfig.volume);
         TTSLOG_INFO("Rate : %u",  ttsConfig.rate);
+        TTSLOG_INFO("SpeechRate : %s",  ttsConfig.speechRate.c_str());
         logResponse(status);
         return (status == TTS::TTS_OK) ? (Core::ERROR_NONE) : (Core::ERROR_GENERAL);
     }

--- a/TextToSpeech/TextToSpeechImplementation.h
+++ b/TextToSpeech/TextToSpeechImplementation.h
@@ -108,7 +108,6 @@ namespace Plugin {
         virtual uint32_t SetFallbackText(const string scenario,const string value) override ;
         virtual uint32_t SetAPIKey(const string apikey) override ;
         virtual uint32_t SetPrimaryVolDuck(const uint8_t prim) override ;
-        virtual uint32_t SetSpeechRate(const string speechRate) override ;
         virtual uint32_t GetConfiguration(Exchange::ITextToSpeech::Configuration &object/* @out */) const override;
         virtual uint32_t Speak(const string text,uint32_t &speechid/* @out */,Exchange::ITextToSpeech::TTSErrorDetail &status/* @out */) override;
         virtual uint32_t Cancel(const uint32_t speechid) override;

--- a/TextToSpeech/TextToSpeechJsonRpc.cpp
+++ b/TextToSpeech/TextToSpeechJsonRpc.cpp
@@ -152,6 +152,7 @@ namespace Plugin {
             response["ttsendpointsecured"]  = ttsConfig.ttsEndPointSecured;
             response["language"]            = ttsConfig.language;
             response["voice"]               = ttsConfig.voice;
+            response["speechrate"]          = ttsConfig.speechRate;
             response["rate"]                = (int) ttsConfig.rate;
             response["volume"]              = std::to_string(ttsConfig.volume);
             response["TTS_Status"] = static_cast<uint32_t> (TTS::TTS_OK);
@@ -169,6 +170,7 @@ namespace Plugin {
         config.ttsEndPointSecured = GET_STR(parameters, "ttsendpointsecured", "");
         config.language = GET_STR(parameters, "language", "");
         config.voice = GET_STR(parameters, "voice", "");
+        config.speechRate = GET_STR(parameters, "speechrate", "");
         config.volume = (uint8_t) std::stod(GET_STR(parameters, "volume", "0.0"));
 
         if(parameters.HasLabel("rate")) {
@@ -189,12 +191,6 @@ namespace Plugin {
                 apikey = GET_STR(auth,"value", "");
                 _tts->SetAPIKey(apikey);
             }
-        }
-
-        if(parameters.HasLabel("speechrate")) {
-            string speechrate;         
-            speechrate = parameters["speechrate"].String();
-            _tts->SetSpeechRate(speechrate);
         }
 
         if(parameters.HasLabel("fallbacktext")) {

--- a/TextToSpeech/impl/TTSManager.cpp
+++ b/TextToSpeech/impl/TTSManager.cpp
@@ -141,14 +141,16 @@ TTS_Error TTSManager::setConfiguration(Configuration &configuration) {
 
     m_needsConfigStoreUpdate |= m_defaultConfiguration.setVolume(configuration.volume);
     m_needsConfigStoreUpdate |= m_defaultConfiguration.setRate(configuration.rate);
+    m_needsConfigStoreUpdate |= m_defaultConfiguration.setSpeechRate(configuration.speechRate);
 
-    TTSLOG_INFO("Default config updated, endPoint=%s, secureEndPoint=%s, lang=%s, voice=%s, vol=%lf, rate=%u",
+    TTSLOG_INFO("Default config updated, endPoint=%s, secureEndPoint=%s, lang=%s, voice=%s, vol=%lf, rate=%u ,speechrate=%s",
             m_defaultConfiguration.endPoint().c_str(),
             m_defaultConfiguration.secureEndPoint().c_str(),
             m_defaultConfiguration.language().c_str(),
             m_defaultConfiguration.voice().c_str(),
             m_defaultConfiguration.volume(),
-            m_defaultConfiguration.rate());
+            m_defaultConfiguration.rate(),
+            m_defaultConfiguration.speechRate().c_str());
 
     if(v !=  m_defaultConfiguration.voice())
         m_callback->onVoiceChanged(m_defaultConfiguration.voice());
@@ -189,12 +191,6 @@ TTS_Error TTSManager::setAPIKey(string apikey)
     return TTS_OK;
 }
 
-TTS_Error TTSManager::setSpeechRate(const string speechrate)
-{
-    m_needsConfigStoreUpdate |= m_defaultConfiguration.setSpeechRate(speechrate);
-    return TTS_OK;
-}
-
 TTS_Error TTSManager::getConfiguration(Configuration &configuration) {
     TTSLOG_TRACE("Getting Default Configuration");
 
@@ -202,6 +198,7 @@ TTS_Error TTSManager::getConfiguration(Configuration &configuration) {
     configuration.ttsEndPointSecured = m_defaultConfiguration.secureEndPoint();
     configuration.language = m_defaultConfiguration.language();
     configuration.voice = m_defaultConfiguration.voice();
+    configuration.speechRate = m_defaultConfiguration.speechRate();
     configuration.volume = m_defaultConfiguration.volume();
     configuration.rate = m_defaultConfiguration.rate();
 

--- a/TextToSpeech/impl/TTSManager.h
+++ b/TextToSpeech/impl/TTSManager.h
@@ -37,6 +37,7 @@ struct Configuration {
     std::string ttsEndPointSecured;
     std::string language;
     std::string voice;
+    std::string speechRate;
     double volume;
     uint8_t rate;
 };
@@ -75,7 +76,6 @@ public:
     TTS_Error setFallbackText(FallbackData &data);
     TTS_Error setPrimaryVolDuck(const uint8_t prim);
     TTS_Error setAPIKey(string apikey);
-    TTS_Error setSpeechRate(string speechrate);
 
     //Speak APIs
     TTS_Error speak(int speechId, std::string text);


### PR DESCRIPTION
Reason for change:TTS thunder plugin missing "speechrate" Test Procedure: Mentioned in Ticket
Risks: Low