### PR TITLE
AMLS905X4-1094  - Verify Containers on latest cmf stack with Thunder4 distro enabled

### DIFF
--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -3676,7 +3676,7 @@ namespace WPEFramework {
 #endif
                 }
 
-                if (type == "Cobalt")
+                if (type == "Cobalt" || type == "YouTube" || type == "YouTubeTV" || type == "YouTubeKids")
                 {
                     if (configuration.find("\"preload\"") == std::string::npos)
                     {


### PR DESCRIPTION
Reason for change: YouTube instances are not launching in container mode.

Test Procedure: Build and verify

Risks: Low

Signed-off-by: Hridhya Narayanan <hridhya_narayanan@comcast.com>