### PR TITLE
RDKTV-22976, RDKTV-22849, RDKTV-22676: Audio mute issue from AVR

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -86,8 +86,6 @@ using namespace std;
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 2
 #define API_VERSION_NUMBER_PATCH 1
-#define API_VERSION_NUMBER_MINOR 1
-#define API_VERSION_NUMBER_PATCH 1
 
 static bool isCecEnabled = false;
 static int  hdmiArcPortId = -1;


### PR DESCRIPTION
Reason for change: Fixed patch error
Test Procedure: None
Risks: Low