### PR TITLE
RDKTV-24279: HDMI AVI Content type Signalling -FMM -AVInput

### DIFF
--- a/AVInput/AVInput.cpp
+++ b/AVInput/AVInput.cpp
@@ -30,8 +30,8 @@
 #include <algorithm>
 
 #define API_VERSION_NUMBER_MAJOR 1
-#define API_VERSION_NUMBER_MINOR 1
-#define API_VERSION_NUMBER_PATCH 1
+#define API_VERSION_NUMBER_MINOR 2
+#define API_VERSION_NUMBER_PATCH 0
 
 #define HDMI 0
 #define COMPOSITE 1
@@ -58,6 +58,7 @@
 #define AVINPUT_EVENT_ON_STATUS_CHANGED "onInputStatusChanged"
 #define AVINPUT_EVENT_ON_VIDEO_MODE_UPDATED "videoStreamInfoUpdate"
 #define AVINPUT_EVENT_ON_GAME_FEATURE_STATUS_CHANGED "gameFeatureStatusUpdate"
+#define AVINPUT_EVENT_ON_AVI_CONTENT_TYPE_CHANGED "aviContentTypeUpdate"
 
 using namespace std;
 int getTypeOfInput(string sType)
@@ -159,6 +160,10 @@ void AVInput::InitializeIARM()
             IARM_BUS_DSMGR_NAME,
             IARM_BUS_DSMGR_EVENT_COMPOSITE_IN_STATUS,
             dsAVStatusEventHandler));
+        IARM_CHECK(IARM_Bus_RegisterEventHandler(
+            IARM_BUS_DSMGR_NAME,
+            IARM_BUS_DSMGR_EVENT_HDMI_IN_AVI_CONTENT_TYPE,
+            dsAviContentTypeEventHandler));
     }
 }
 
@@ -190,6 +195,9 @@ void AVInput::DeinitializeIARM()
         IARM_CHECK(IARM_Bus_RemoveEventHandler(
             IARM_BUS_DSMGR_NAME,
             IARM_BUS_DSMGR_EVENT_COMPOSITE_IN_STATUS, dsAVStatusEventHandler));
+    	IARM_CHECK(IARM_Bus_RemoveEventHandler(
+            IARM_BUS_DSMGR_NAME,
+            IARM_BUS_DSMGR_EVENT_HDMI_IN_AVI_CONTENT_TYPE, dsAviContentTypeEventHandler));
     }
 }
 
@@ -803,6 +811,29 @@ void AVInput::AVInputVideoModeUpdate( int port , dsVideoPortResolution_t resolut
     }
 
     sendNotify(AVINPUT_EVENT_ON_VIDEO_MODE_UPDATED, params);
+}
+
+void AVInput::dsAviContentTypeEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
+{
+	if(!AVInput::_instance)
+		return;
+
+	if (IARM_BUS_DSMGR_EVENT_HDMI_IN_AVI_CONTENT_TYPE == eventId)
+	{
+		IARM_Bus_DSMgr_EventData_t *eventData = (IARM_Bus_DSMgr_EventData_t *)data;
+		int hdmi_in_port = eventData->data.hdmi_in_content_type.port;
+		int avi_content_type = eventData->data.hdmi_in_content_type.aviContentType;
+		LOGINFO("Received IARM_BUS_DSMGR_EVENT_HDMI_IN_AVI_CONTENT_TYPE  event  port: %d, Content Type : %d", hdmi_in_port,avi_content_type);
+AVInput::_instance->hdmiInputAviContentTypeChange(hdmi_in_port, avi_content_type);
+	}
+}
+
+void AVInput::hdmiInputAviContentTypeChange( int port , int content_type)
+{
+	JsonObject params;
+	params["id"] = port;
+	params["aviContentType"] = content_type;
+	sendNotify(AVINPUT_EVENT_ON_AVI_CONTENT_TYPE_CHANGED, params);
 }
 
 void AVInput::dsAVEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len)

--- a/AVInput/AVInput.h
+++ b/AVInput/AVInput.h
@@ -103,6 +103,8 @@ private:
     void AVInputALLMChange( int port , bool allmMode);
     static void dsAVGameFeatureStatusEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
 
+    void hdmiInputAviContentTypeChange(int port, int content_type);
+    static void dsAviContentTypeEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
 public:
     static AVInput* _instance;
 };

--- a/AVInput/AVInput.json
+++ b/AVInput/AVInput.json
@@ -702,6 +702,30 @@
                     "mode"
                 ]
             }
-        }
+        },
+    	"hdmiContentTypeUpdate": {
+            "deprecated" : true,
+            "referenceUrl" : "https://rdkcentral.github.io/rdkservices/#/api/AVInputPlugin?id=hdmiContentTypeUpdate",
+            "summary": "Triggered whenever AV Infoframe content type changes for an HDMI Input",
+            "params": {
+                "type": "object",
+                "properties": {
+                   "id": {
+                        "summary": "Hdmi Input port ID for which content type change event received and possible values are port id 0, 1 and 2 for three Hdmi Input ports",
+                        "type": "integer",
+                        "example": 1
+		   },
+                   "aviContentType": {
+                        "summary": "new Content type received for the active hdmi input port and the possible integer values indicates following accordingly 0 - Graphics, 1 - Photo, 2 - Cinema, 3 - Game, 4 - Invalid data",
+                        "type": "integer",
+                        "example": 1
+		   }
+                },
+                "required": [
+                    "id",
+                    "aviContentType"
+                ]
+            }
+	}
     }
 }

--- a/AVInput/CHANGELOG.md
+++ b/AVInput/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.2.0] - 2023-08-08
+### Added
+- Added Event for AV Content Type update
+
 ## [1.1.1] - 2023-04-12
 ### Fixed
 - Fixed IARM_Bus_UnRegisterEventHandler  call to IARM_Bus_RemoveEventHandler

--- a/Tests/mocks/Iarm.h
+++ b/Tests/mocks/Iarm.h
@@ -665,5 +665,6 @@ typedef enum _DSMgr_EventId_t {
     IARM_BUS_DSMGR_EVENT_DISPLAY_FRAMRATE_POSTCHANGE, /*!< Frame rate post change */
     IARM_BUS_DSMGR_EVENT_AUDIO_PORT_STATE, /*!< Audio Port Init State */
     IARM_BUS_DSMGR_EVENT_SLEEP_MODE_CHANGED, /*!< Sleep Mode Change Event*/
+    IARM_BUS_DSMGR_EVENT_HDMI_IN_AVI_CONTENT_TYPE, /*<HDMI IN content type event */
     IARM_BUS_DSMGR_EVENT_MAX, /*!< Max Event  */
 } IARM_Bus_DSMgr_EventId_t;

--- a/Tests/mocks/devicesettings.h
+++ b/Tests/mocks/devicesettings.h
@@ -219,6 +219,14 @@ typedef enum _dsHdmiInSignalStatus_t {
     dsHDMI_IN_SIGNAL_STATUS_MAX
 } dsHdmiInSignalStatus_t;
 
+typedef enum dsAviContentType {
+  dsAVICONTENT_TYPE_GRAPHICS,
+  dsAVICONTENT_TYPE_PHOTO,
+  dsAVICONTENT_TYPE_CINEMA,
+  dsAVICONTENT_TYPE_GAME,
+  dsAVICONTENT_TYPE_INVALID,
+}dsAviContentType_t;
+
 struct dsSpd_infoframe_st {
     uint8_t pkttype;
     uint8_t version;
@@ -408,6 +416,10 @@ typedef struct _DSMgr_EventData_t {
             dsHdmiInPort_t port;
             bool allm_mode;
         } hdmi_in_allm_mode; /*HDMI in ALLM Mode change*/
+	struct _HDMI_IN_CONTENT_TYPE_DATA{
+            dsHdmiInPort_t port;
+            dsAviContentType_t aviContentType;
+        }hdmi_in_content_type;
 
     } data;
 } IARM_Bus_DSMgr_EventData_t;


### PR DESCRIPTION
Reason for change: Added the events for sending the content type in AVInput Thunder plugin.
Test Procedure: Build and Verify.
Risks: Low
Signed-off-by: Aishwariya B aishwariya.bhaskar@sky.uk