### PR TITLE
Reverted the RDKSEC-289 WebProcess crashed while launching WebKitBrowser with "type": "HtmlApp" changes

### DIFF
--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -3563,10 +3563,6 @@ namespace WPEFramework {
                     std::cout << "new launch count loc1: 0\n";
                     returnResponse(false);
                 }
-                else if ((true == newPluginFound) && (type != callsign))
-                {
-                    type = callsign;
-                }
                 else if (!newPluginFound)
                 {
                     std::cout << "attempting to clone type: " << type << " into " << callsign << std::endl;


### PR DESCRIPTION
Reason for change: This is not a valid test case. It will affect the other complications.
Test Procedure: Ensure the application loading with container and non-container mode.
Risks: low.
Signed-off-by: Dineshkumar_Periyasamy@comcast.com
