### PR TITLE
RDK-41938: Remove unwanted test scripts

### DIFF
--- a/RemoteControl/CMakeLists.txt
+++ b/RemoteControl/CMakeLists.txt
@@ -22,7 +22,9 @@ set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
 
 find_package(${NAMESPACE}Plugins REQUIRED)
 
-add_subdirectory(test)
+if (BUILD_REMOTECONTROLTESTCLIENT)
+    add_subdirectory(test)
+endif ()
 
 add_library(${MODULE_NAME} SHARED
         RemoteControl.cpp

--- a/SystemAudioPlayer/CMakeLists.txt
+++ b/SystemAudioPlayer/CMakeLists.txt
@@ -15,7 +15,9 @@ find_package(Boost COMPONENTS system filesystem REQUIRED)
 find_package(websocketpp REQUIRED)
 find_package(OpenSSL REQUIRED)
 
-add_subdirectory(test)
+if (BUILD_SYSTEMAUDIOPLAYERAPITEST)
+    add_subdirectory(test)
+endif ()
 
 add_library(${MODULE_NAME} SHARED
         Module.cpp

--- a/TextToSpeech/CMakeLists.txt
+++ b/TextToSpeech/CMakeLists.txt
@@ -7,7 +7,9 @@ set(PLUGIN_TEXTTOSPEECH_MODE "Local" CACHE STRING "Controls if the plugin should
 
 find_package(${NAMESPACE}Plugins REQUIRED)
 
-add_subdirectory(test)
+if (BUILD_TTSTHUNDERAPITEST)
+    add_subdirectory(test)
+endif ()
 
 add_library(${MODULE_NAME} SHARED
         Module.cpp


### PR DESCRIPTION
Reason for change: Remove unwanted test scripts
Test Procedure: build succeeds
Risks: None
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>