### PR TITLE
RDK-43314:Hdmi EDID Allm support

### DIFF
--- a/HdmiInput/HdmiInput.cpp
+++ b/HdmiInput/HdmiInput.cpp
@@ -54,6 +54,8 @@
 #define HDMIINPUT_EVENT_ON_AVI_CONTENT_TYPE_CHANGED "hdmiContentTypeUpdate"
 #define HDMIINPUT_METHOD_GET_LOW_LATENCY_MODE "getTVLowLatencyMode"
 #define HDMIINPUT_METHOD_GET_AV_LATENCY "getAVLatency"
+#define HDMIINPUT_METHOD_SET_EDID_2_ALLM_SUPPORT "setEdid2AllmSupport" 
+#define HDMIINPUT_METHOD_GET_EDID_2_ALLM_SUPPORT "getEdid2AllmSupport"
 
 #define HDMICECSINK_CALLSIGN "org.rdk.HdmiCecSink"
 #define HDMICECSINK_CALLSIGN_VER HDMICECSINK_CALLSIGN".1"
@@ -123,7 +125,9 @@ namespace WPEFramework
             registerMethod(HDMIINPUT_METHOD_GAME_FEATURE_STATUS, &HdmiInput::getHdmiGameFeatureStatusWrapper, this);
 	    registerMethod(HDMIINPUT_METHOD_GET_AV_LATENCY, &HdmiInput::getAVLatency, this);
             registerMethod(HDMIINPUT_METHOD_GET_LOW_LATENCY_MODE, &HdmiInput::getTVLowLatencyMode, this);
-        }
+            registerMethod(HDMIINPUT_METHOD_SET_EDID_2_ALLM_SUPPORT, &HdmiInput::setEdid2AllmSupportWrapper, this);
+            registerMethod(HDMIINPUT_METHOD_GET_EDID_2_ALLM_SUPPORT, &HdmiInput::getEdid2AllmSupportWrapper, this);
+	}
 
         HdmiInput::~HdmiInput()
         {
@@ -1240,7 +1244,87 @@ namespace WPEFramework
             returnResponse(true);
        }
 
-        int HdmiInput::setEdidVersion(int iPort, int iEdidVer)
+        	int setEdid2AllmSupport(int portId, bool allmSupport)
+	{
+	    bool ret = true;
+    	    try
+	    {
+		device::HdmiInput::getInstance().setEdid2AllmSupport (portId, allmSupport);
+    		LOGWARN("HdmiInput::setEdid2AllmSupport allmsupport:%d", allmSupport);
+	    }
+            catch (const device::Exception& err)
+            {
+                LOG_DEVICE_EXCEPTION1(std::to_string(portId));
+                ret = false;
+            }
+	    return ret;
+	}
+
+	uint32_t HdmiInput::setEdid2AllmSupportWrapper(const JsonObject& parameters, JsonObject& response)
+	{
+	    LOGINFOMETHOD();
+
+	    returnIfParamNotFound(parameters, "portId");
+            returnIfParamNotFound(parameters, "allmSupport");
+
+	    int portId = 0;
+	    string sPortId = parameters["portId"].String();
+	    bool allmSupport = parameters["allmSupport"].Boolean();
+
+	    try {
+                portId = stoi(sPortId);
+            }catch (const std::exception& err) {
+                    LOGWARN("sPortId invalid paramater: %s ", sPortId.c_str());
+		    returnResponse(false);
+            }
+
+	   bool result = setEdid2AllmSupport(portId, allmSupport);   
+	   if(result == true)
+	   {
+		 returnResponse(true);
+	   }
+	   else
+	   {
+		   returnResponse(false);
+	   }
+
+	}
+
+	int getEdid2AllmSupport(int portId)
+	{
+		bool allmSupportValue = true;
+		try
+            	{
+			device::HdmiInput::getInstance().getEdid2AllmSupport (portId, &allmSupportValue);
+			LOGWARN("HdmiInput::getEdid2AllmSupport:%d", allmSupportValue);
+		}
+	        catch (const device::Exception& err)
+            	{
+                	LOG_DEVICE_EXCEPTION1(std::to_string(portId));
+            	}
+		return allmSupportValue;
+	}
+
+	uint32_t HdmiInput::getEdid2AllmSupportWrapper(const JsonObject& parameters, JsonObject& response)
+	{
+	    LOGINFOMETHOD();
+	    string sPortId = parameters["portId"].String();
+            int portId = 0;
+	    returnIfParamNotFound(parameters, "portId");
+
+	    try {
+                portId = stoi(sPortId);
+            }catch (const std::exception& err) {
+		    LOGWARN("sPortId invalid paramater: %s ", sPortId.c_str());
+		    returnResponse(false);
+            }
+
+	    bool allmSupport = getEdid2AllmSupport(portId);
+	    response["allmSupport"] = allmSupport;	
+	    returnResponse(true);
+	 }
+
+	int HdmiInput::setEdidVersion(int iPort, int iEdidVer)
         {
             bool ret = true;
             try

--- a/HdmiInput/HdmiInput.h
+++ b/HdmiInput/HdmiInput.h
@@ -66,6 +66,8 @@ namespace WPEFramework {
             uint32_t getHdmiGameFeatureStatusWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t getAVLatency(const JsonObject& parameters, JsonObject& response);
 	    uint32_t getTVLowLatencyMode(const JsonObject& parameters, JsonObject& response);
+	    uint32_t setEdid2AllmSupportWrapper(const JsonObject& parameters, JsonObject& response);
+	    uint32_t getEdid2AllmSupportWrapper(const JsonObject& parameters, JsonObject& response);
 	    //End methods
 
             JsonArray getHDMIInputDevices();

--- a/Tests/mocks/devicesettings.h
+++ b/Tests/mocks/devicesettings.h
@@ -592,6 +592,8 @@ public:
     virtual void getHdmiALLMStatus(int iHdmiPort, bool* allmStatus) const = 0;
     virtual void getSupportedGameFeatures(std::vector<std::string>& featureList) const = 0;
     virtual void getAVLatency(int *audio_output_delay, int *video_latency) const = 0;
+    virtual void setEdid2AllmSupport(int iHdmiPort, bool allmsupport) const = 0;
+    virtual void getEdid2AllmSupport(int iHdmiPort, bool *allmsupport) const = 0;
 };
 
 class HdmiInput {
@@ -652,6 +654,14 @@ public:
     void getAVLatency(int *audio_output_delay, int *video_latency) const
     {
         return impl->getAVLatency(audio_output_delay,video_latency);
+    }
+    void setEdid2AllmSupport(int iport, bool allmSupport) const
+    {
+        return impl->setEdid2AllmSupport(iport,allmSupport);
+    }
+    void getEdid2AllmSupport(int iport, bool *allmSupport) const
+    {
+        return impl->getEdid2AllmSupport(iport,allmSupport);
     }
 };
 

--- a/Tests/mocks/devicesettings/HdmiInputMock.h
+++ b/Tests/mocks/devicesettings/HdmiInputMock.h
@@ -17,6 +17,8 @@ public:
     MOCK_METHOD(void, getHDMISPDInfo, (int iHdmiPort, std::vector<uint8_t> &data), (const, override));
     MOCK_METHOD(void, setEdidVersion, (int iHdmiPort, int iEdidVersion), (const, override));
     MOCK_METHOD(void, getEdidVersion, (int iHdmiPort, int *iEdidVersion), (const, override));
+    MOCK_METHOD(void, setEdid2AllmSupport, (int iHdmiPort, bool allmSupport), (const, override));
+    MOCK_METHOD(void, getEdid2AllmSupport, (int iHdmiPort, bool *allmSupport), (const, override));
     MOCK_METHOD(void, getHdmiALLMStatus, (int iHdmiPort, bool *allmStatus), (const, override));
     MOCK_METHOD(void, getSupportedGameFeatures, (std::vector<std::string> &featureList), (const, override));
     MOCK_METHOD(void, getAVLatency, (int *audio_output_delay,int *video_latency), (const, override));


### PR DESCRIPTION
Reason for change:Added the Wpeframework and the devicesettings Changes Test Procedure: NA
Risks: None
Signed-off-by: Aishwariya B <aishwariya.bhaskar@sky.uk>