### PR TITLE
RDKTV-24789: Pioneer Failed to establish connection

### DIFF
--- a/XCast/XCast.cpp
+++ b/XCast/XCast.cpp
@@ -666,6 +666,7 @@ void XCast::updateDynamicAppCache(string strApps)
             }
 
             jProperties = cJSON_GetObjectItem(itrApp, "properties");
+	    int  allowStop = 0;
             if (!cJSON_IsObject(jProperties)) {
                 LOGINFO ("Invalid property format at application index %d", iIndex);
             }
@@ -676,10 +677,11 @@ void XCast::updateDynamicAppCache(string strApps)
                 }
                 else {
                     LOGINFO("allowStop: %d", jAllowStop->valueint);
-                    for (DynamicAppConfig* pDynamicAppConfig : appConfigListTemp) {
-                        pDynamicAppConfig->allowStop = jAllowStop->valueint;
-                    }
+		    allowStop = jAllowStop->valueint;
                 }
+            }
+            for (DynamicAppConfig* pDynamicAppConfig : appConfigListTemp) {
+                pDynamicAppConfig->allowStop = allowStop;
             }
 
             jLaunchParam = cJSON_GetObjectItem(itrApp, "launchParameters");


### PR DESCRIPTION
Reason for change:
Null check for payload and query added in json parsing defaul value added for AllowStop
Test Procedure: None
Risks: Low

Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>