### PR TITLE
 RDK-42620,RDK-42827: Cherry SecondaryVideoPlane/AudioMixing

### DIFF
--- a/HdmiInput/HdmiInput.cpp
+++ b/HdmiInput/HdmiInput.cpp
@@ -43,6 +43,7 @@
 #define HDMIINPUT_METHOD_START_HDMI_INPUT "startHdmiInput"
 #define HDMIINPUT_METHOD_STOP_HDMI_INPUT "stopHdmiInput"
 #define HDMIINPUT_METHOD_SCALE_HDMI_INPUT "setVideoRectangle"
+#define HDMIINPUT_METHOD_SET_PLANE_TOP_MOST "setPlaneTopMost"
 #define HDMIINPUT_METHOD_SUPPORTED_GAME_FEATURES "getSupportedGameFeatures"
 #define HDMIINPUT_METHOD_GAME_FEATURE_STATUS "getHdmiGameFeatureStatus"
 
@@ -123,6 +124,7 @@ namespace WPEFramework
             registerMethod(HDMIINPUT_METHOD_GAME_FEATURE_STATUS, &HdmiInput::getHdmiGameFeatureStatusWrapper, this);
 	    registerMethod(HDMIINPUT_METHOD_GET_AV_LATENCY, &HdmiInput::getAVLatency, this);
             registerMethod(HDMIINPUT_METHOD_GET_LOW_LATENCY_MODE, &HdmiInput::getTVLowLatencyMode, this);
+	    registerMethod(HDMIINPUT_METHOD_SET_PLANE_TOP_MOST, &HdmiInput::setPlaneTopMost, this);
         }
 
         HdmiInput::~HdmiInput()
@@ -229,9 +231,15 @@ namespace WPEFramework
             returnIfParamNotFound(parameters, "portId");
 
             string sPortId = parameters["portId"].String();
-            int portId = 0;
-            try {
+            bool audioMix = parameters["requestAudioMix"].Boolean();
+	    int portId = 0;
+	    int planeType = 0;
+	    try {
                 portId = stoi(sPortId);
+		if (parameters.HasLabel("plane")){
+                        string sPlaneType = parameters["plane"].String();
+                        planeType = stoi(sPlaneType);
+                }
             }catch (const std::exception& err) {
 		    LOGWARN("sPortId invalid paramater: %s ", sPortId.c_str());
 		    returnResponse(false);
@@ -239,7 +247,7 @@ namespace WPEFramework
             bool success = true;
             try
             {
-                device::HdmiInput::getInstance().selectPort(portId);
+                device::HdmiInput::getInstance().selectPort(portId,audioMix,planeType);
             }
             catch (const device::Exception& err)
             {
@@ -268,7 +276,27 @@ namespace WPEFramework
 
         }
 
-        uint32_t HdmiInput::setVideoRectangleWrapper(const JsonObject& parameters, JsonObject& response)
+        uint32_t HdmiInput::setPlaneTopMost(const JsonObject& parameters, JsonObject& response)
+        {
+            LOGINFOMETHOD();
+            returnIfParamNotFound(parameters, "topMost");
+
+	    bool topMostPlane = parameters["topMost"].Boolean();
+		// need to add the logic properly after amlogic implementation
+            bool success = true;
+            try
+            {
+                device::HdmiInput::getInstance().setPlaneTopMost(topMostPlane);
+            }
+            catch (const device::Exception& err)
+            {
+                LOGWARN("HdmiInputService::setPlaneTopMost Failed");
+                success = false;
+            }
+	     returnResponse(success);
+	}
+
+	uint32_t HdmiInput::setVideoRectangleWrapper(const JsonObject& parameters, JsonObject& response)
         {
             LOGINFOMETHOD();
 

--- a/HdmiInput/HdmiInput.h
+++ b/HdmiInput/HdmiInput.h
@@ -66,6 +66,7 @@ namespace WPEFramework {
             uint32_t getHdmiGameFeatureStatusWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t getAVLatency(const JsonObject& parameters, JsonObject& response);
 	    uint32_t getTVLowLatencyMode(const JsonObject& parameters, JsonObject& response);
+	     uint32_t setPlaneTopMost(const JsonObject& parameters, JsonObject& response);
 	    //End methods
 
             JsonArray getHDMIInputDevices();

--- a/Tests/mocks/devicesettings.h
+++ b/Tests/mocks/devicesettings.h
@@ -582,7 +582,7 @@ public:
     virtual uint8_t getNumberOfInputs() const = 0;
     virtual bool isPortConnected(int8_t Port) const = 0;
     virtual std::string getCurrentVideoMode() const = 0;
-    virtual void selectPort(int8_t Port) const = 0;
+    virtual void selectPort(int8_t Port,,bool audioMix = false, int videoPlane = 0) const = 0;
     virtual void scaleVideo(int32_t x, int32_t y, int32_t width, int32_t height) const = 0;
 
     virtual void getEDIDBytesInfo(int iHdmiPort, std::vector<uint8_t>& edid) const = 0;
@@ -592,6 +592,7 @@ public:
     virtual void getHdmiALLMStatus(int iHdmiPort, bool* allmStatus) const = 0;
     virtual void getSupportedGameFeatures(std::vector<std::string>& featureList) const = 0;
     virtual void getAVLatency(int *audio_output_delay, int *video_latency) const = 0;
+    virtual void setPlaneTopMost(bool topMostPlane) const = 0;
 };
 
 class HdmiInput {
@@ -616,9 +617,9 @@ public:
     {
         return impl->getCurrentVideoMode();
     }
-    void selectPort(int8_t Port) const
+    void selectPort(int8_t Port,bool audioMix = false,int videoPlane = 0) const
     {
-        return impl->selectPort(Port);
+        return impl->selectPort(Port,audioMix,videoPlane);
     }
     void scaleVideo(int32_t x, int32_t y, int32_t width, int32_t height) const
     {
@@ -652,6 +653,10 @@ public:
     void getAVLatency(int *audio_output_delay, int *video_latency) const
     {
         return impl->getAVLatency(audio_output_delay,video_latency);
+    }
+    void setPlaneTopMost(bool topMostPlane) const
+    {
+        return impl->setPlaneTopMost(topMostPlane);
     }
 };
 

--- a/Tests/mocks/devicesettings/HdmiInputMock.h
+++ b/Tests/mocks/devicesettings/HdmiInputMock.h
@@ -12,6 +12,7 @@ public:
     MOCK_METHOD(bool, isPortConnected, (int8_t Port), (const, override));
     MOCK_METHOD(std::string, getCurrentVideoMode, (), (const, override));
     MOCK_METHOD(void, selectPort, (int8_t Port), (const, override));
+    MOCK_METHOD(void, selectPort, (int8_t Port,bool audioMix, int videoPlane), (const, override));
     MOCK_METHOD(void, scaleVideo, (int32_t x, int32_t y, int32_t width, int32_t height), (const, override));
     MOCK_METHOD(void, getEDIDBytesInfo, (int iHdmiPort, std::vector<uint8_t> &edid), (const, override));
     MOCK_METHOD(void, getHDMISPDInfo, (int iHdmiPort, std::vector<uint8_t> &data), (const, override));
@@ -20,4 +21,5 @@ public:
     MOCK_METHOD(void, getHdmiALLMStatus, (int iHdmiPort, bool *allmStatus), (const, override));
     MOCK_METHOD(void, getSupportedGameFeatures, (std::vector<std::string> &featureList), (const, override));
     MOCK_METHOD(void, getAVLatency, (int *audio_output_delay,int *video_latency), (const, override));
+    MOCK_METHOD(void, setPlaneTopMost, (bool planeTopMost), (const, override));
 };


### PR DESCRIPTION
Reason for change: Support for SecondaryVideoplane and Audio mixing
Test Procedure: as per jira
Risks: None
Priority: P1
Signed-off-by: Aishwariya B <aishwariya.bhaskar@sky.uk>