### PR TITLE
Reverted the RDKSEC-289 WebProcess crashed while launching WebKitBrowser with "type": "HtmlApp" changes

### DIFF
--- a/RDKShell/CHANGELOG.md
+++ b/RDKShell/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+## [1.4.4] - 2023-08-14
+### Fixed
+- Reverted the RDKSEC-289 WebProcess crashed while launching WebKitBrowser with "type": "HtmlApp" changes.
+
 ## [1.4.3] - 2023-07-12
 ### Fixed
 - Gracefull exit on failures

--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -52,7 +52,7 @@
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 4
-#define API_VERSION_NUMBER_PATCH 3
+#define API_VERSION_NUMBER_PATCH 4
 
 const string WPEFramework::Plugin::RDKShell::SERVICE_NAME = "org.rdk.RDKShell";
 //methods

--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -3551,10 +3551,6 @@ namespace WPEFramework {
                     std::cout << "new launch count loc1: 0\n";
                     returnResponse(false);
                 }
-                else if ((true == newPluginFound) && (type != callsign))
-                {
-                    type = callsign;
-                }
                 else if (!newPluginFound)
                 {
                     std::cout << "attempting to clone type: " << type << " into " << callsign << std::endl;


### PR DESCRIPTION
Reason for change: This is not a valid test case. It will affect the other complications.
Test Procedure: Ensure the application loading with container and non-container mode.
Risks: low.
Signed-off-by: Dineshkumar_Periyasamy@comcast.com