### PR TITLE
RMFMEDIART- 60: Include tune params in the mediaengine RMF thunder pl…

### DIFF
--- a/MediaEngineRMF/MediaEngineRMF.cpp
+++ b/MediaEngineRMF/MediaEngineRMF.cpp
@@ -252,7 +252,7 @@ namespace WPEFramework {
                 if("qam" == source_type)
                 {
                     //Process for qam mediaplayer.
-                    if(std::string::npos != identifier.find("ocap://0x"))
+                    if((std::string::npos != identifier.find("ocap://0x")|| (std::string::npos != identifier.find("tune://")) )
                     {
                         m_player = std::unique_ptr <mediaplayer> (mediaplayer::createMediaPlayer(QAM, identifier));
                         if(nullptr == m_player)


### PR DESCRIPTION
…ugin

Reason for change: Support for tune:// added
Test Procedure: Build should pass
Risks: Low
Signed-off-by: Lakshmipriya_Purushan@comcast.com