### PR TITLE
RDKTV-24907: AVinput startinput Stint parameter for portID

### DIFF
--- a/AVInput/AVInput.cpp
+++ b/AVInput/AVInput.cpp
@@ -508,11 +508,12 @@ uint32_t AVInput::writeEDIDWrapper(const JsonObject& parameters, JsonObject& res
 {
     LOGINFOMETHOD();
 
-    int portId;
+    string sPortId = parameters["portId"].String();
+    int portId = 0;
     std::string message;
 
     if (parameters.HasLabel("portId") && parameters.HasLabel("message")) {
-        portId = parameters["portId"].Number();
+        portId = stoi(sPortId);
         message = parameters["message"].String();
     }
     else {
@@ -528,9 +529,10 @@ uint32_t AVInput::readEDIDWrapper(const JsonObject& parameters, JsonObject& resp
 {
     LOGINFOMETHOD();
 
+    string sPortId = parameters["portId"].String();
     int portId = 0;
     try {
-        portId = parameters["portId"].Number();
+        portId = stoi(sPortId);
     }catch (...) {
             LOGWARN("Invalid Arguments");
             returnResponse(false);
@@ -968,13 +970,14 @@ uint32_t AVInput::getSupportedGameFeatures(const JsonObject& parameters, JsonObj
 uint32_t AVInput::getGameFeatureStatusWrapper(const JsonObject& parameters, JsonObject& response)
 {
     string sGameFeature = "";
+    string sPortId = parameters["portId"].String();
     int portId = 0;
 
     LOGINFOMETHOD();
     if (parameters.HasLabel("portId") && parameters.HasLabel("gameFeature"))
     {
         try {
-            portId = parameters["portId"].Number();
+            portId = stoi(sPortId);
             sGameFeature = parameters["gameFeature"].String();
         }catch (...) {
             LOGWARN("Invalid Arguments");
@@ -1020,11 +1023,12 @@ uint32_t AVInput::getRawSPDWrapper(const JsonObject& parameters, JsonObject& res
 {
     LOGINFOMETHOD();
 
+    string sPortId = parameters["portId"].String();
     int portId = 0;
     if (parameters.HasLabel("portId"))
     {
         try {
-            portId = parameters["portId"].Number();
+            portId = stoi(sPortId);
         }catch (...) {
             LOGWARN("Invalid Arguments");
             returnResponse(false);
@@ -1049,11 +1053,12 @@ uint32_t AVInput::getSPDWrapper(const JsonObject& parameters, JsonObject& respon
 {
     LOGINFOMETHOD();
 
+    string sPortId = parameters["portId"].String();
     int portId = 0;
     if (parameters.HasLabel("portId"))
     {
         try {
-        portId = parameters["portId"].Number();
+            portId = stoi(sPortId);
         }catch (...) {
             LOGWARN("Invalid Arguments");
             returnResponse(false);
@@ -1151,12 +1156,13 @@ std::string AVInput::getSPD(int iPort)
 uint32_t AVInput::setEdidVersionWrapper(const JsonObject& parameters, JsonObject& response)
 {
     LOGINFOMETHOD();
+    string sPortId = parameters["portId"].String();
     int portId = 0;
     string sVersion = "";
     if (parameters.HasLabel("portId") && parameters.HasLabel("edidVersion"))
     {
         try {
-            portId = parameters["portId"].Number();
+            portId = stoi(sPortId);
             sVersion = parameters["edidVersion"].String();
         }catch (...) {
             LOGWARN("Invalid Arguments");
@@ -1204,13 +1210,14 @@ int AVInput::setEdidVersion(int iPort, int iEdidVer)
 
 uint32_t AVInput::getEdidVersionWrapper(const JsonObject& parameters, JsonObject& response)
 {
+    string sPortId = parameters["portId"].String();
     int portId = 0;
 
     LOGINFOMETHOD();
     if (parameters.HasLabel("portId"))
     {
         try {
-            portId = parameters["portId"].Number();
+            portId = stoi(sPortId);
         }
         catch (...) {
             LOGWARN("Invalid Arguments");

--- a/AVInput/AVInput.cpp
+++ b/AVInput/AVInput.cpp
@@ -325,7 +325,8 @@ string AVInput::currentVideoMode(bool &success)
 uint32_t AVInput::startInput(const JsonObject& parameters, JsonObject& response)
 {
     LOGINFOMETHOD();
-
+    
+    string sPortId = parameters["portId"].String();
     string sType = parameters["typeOfInput"].String();
     int portId = 0;
     int iType = 0;
@@ -333,7 +334,7 @@ uint32_t AVInput::startInput(const JsonObject& parameters, JsonObject& response)
     if (parameters.HasLabel("portId") && parameters.HasLabel("typeOfInput"))
     {
         try {
-            portId = parameters["portId"].Number();
+            portId = stoi(sPortId);
             iType = getTypeOfInput (sType);
         }catch (...) {
             LOGWARN("Invalid Arguments");

--- a/AVInput/AVInput.json
+++ b/AVInput/AVInput.json
@@ -50,7 +50,7 @@
         },
         "portId":{
             "summary": "An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method",
-            "type": "number",
+            "type": "string",
             "example": "0"
         },
         "typeOfInput":{

--- a/docs/api/AVInputPlugin.md
+++ b/docs/api/AVInputPlugin.md
@@ -295,7 +295,7 @@ No Events
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
 | params | object |  |
-| params?.portId | number | <sup>*(optional)*</sup> An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method |
+| params?.portId | string | <sup>*(optional)*</sup> An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method |
 
 ### Result
 
@@ -352,7 +352,7 @@ No Events
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
 | params | object |  |
-| params?.portId | number | <sup>*(optional)*</sup> An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method |
+| params?.portId | string | <sup>*(optional)*</sup> An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method |
 
 ### Result
 
@@ -409,7 +409,7 @@ No Events
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
 | params | object |  |
-| params.portId | number | An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method |
+| params.portId | string | An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method |
 
 ### Result
 
@@ -466,7 +466,7 @@ No Events
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
 | params | object |  |
-| params.portId | number | An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method |
+| params.portId | string | An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method |
 
 ### Result
 
@@ -525,7 +525,7 @@ Activates the specified HDMI/Composite Input port as the primary video source.
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
 | params | object |  |
-| params?.portId | number | <sup>*(optional)*</sup> An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method |
+| params?.portId | string | <sup>*(optional)*</sup> An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method |
 | params.typeOfInput | string | The type of Input - HDMI/COMPOSITE |
 
 ### Result
@@ -636,7 +636,7 @@ No Events
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
 | params | object |  |
-| params.portId | number | An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method |
+| params.portId | string | An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method |
 | params.edidVersion | string | The EDID version |
 
 ### Result
@@ -754,7 +754,7 @@ No Events
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
 | params | object |  |
-| params.portId | number | An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method |
+| params.portId | string | An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method |
 | params.message | string | A new EDID value |
 
 ### Result
@@ -862,7 +862,7 @@ No Events
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
 | params | object |  |
-| params?.portId | number | <sup>*(optional)*</sup> An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method |
+| params?.portId | string | <sup>*(optional)*</sup> An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method |
 | params.gameFeature | string | Game Feature to which current status requested |
 
 ### Result

--- a/docs/api/AVInputPlugin.md
+++ b/docs/api/AVInputPlugin.md
@@ -295,7 +295,7 @@ No Events
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
 | params | object |  |
-| params?.portId | string | <sup>*(optional)*</sup> An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method |
+| params?.portId | number | <sup>*(optional)*</sup> An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method |
 
 ### Result
 
@@ -352,7 +352,7 @@ No Events
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
 | params | object |  |
-| params?.portId | string | <sup>*(optional)*</sup> An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method |
+| params?.portId | number | <sup>*(optional)*</sup> An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method |
 
 ### Result
 
@@ -409,7 +409,7 @@ No Events
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
 | params | object |  |
-| params.portId | string | An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method |
+| params.portId | number | An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method |
 
 ### Result
 
@@ -466,7 +466,7 @@ No Events
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
 | params | object |  |
-| params.portId | string | An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method |
+| params.portId | number | An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method |
 
 ### Result
 
@@ -525,7 +525,7 @@ Activates the specified HDMI/Composite Input port as the primary video source.
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
 | params | object |  |
-| params?.portId | string | <sup>*(optional)*</sup> An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method |
+| params?.portId | number | <sup>*(optional)*</sup> An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method |
 | params.typeOfInput | string | The type of Input - HDMI/COMPOSITE |
 
 ### Result
@@ -636,7 +636,7 @@ No Events
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
 | params | object |  |
-| params.portId | string | An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method |
+| params.portId | number | An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method |
 | params.edidVersion | string | The EDID version |
 
 ### Result
@@ -754,7 +754,7 @@ No Events
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
 | params | object |  |
-| params.portId | string | An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method |
+| params.portId | number | An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method |
 | params.message | string | A new EDID value |
 
 ### Result
@@ -862,7 +862,7 @@ No Events
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
 | params | object |  |
-| params?.portId | string | <sup>*(optional)*</sup> An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method |
+| params?.portId | number | <sup>*(optional)*</sup> An ID of an HDMI/Composite Input port as returned by the `getInputDevices` method |
 | params.gameFeature | string | Game Feature to which current status requested |
 
 ### Result


### PR DESCRIPTION
Reason for change:string arugument as portID
Test Procedure: Refer the ticket for test procedure 
Risks: Low
Priority: P1
Signed-off-by: bp-tdora114 <dautapankumar.dora@sky.uk>