### PR TITLE
RDK-42949 - [PoC] Removal of code to deprecate DeviceSettings related RFCs

### DIFF
--- a/PlayerInfo/DeviceSettings/PlatformImplementation.cpp
+++ b/PlayerInfo/DeviceSettings/PlatformImplementation.cpp
@@ -188,6 +188,13 @@ public:
         return (Core::ERROR_NONE);
     }
 
+    uint32_t IsAudioEquivalenceEnabled(bool& isEnbaled /* @out */) const override
+    {
+        isEnbaled = false;
+
+        return (Core::ERROR_NONE);
+    }
+
     uint32_t Register(Exchange::Dolby::IOutput::INotification* notification) override
     {
         _adminLock.Lock();

--- a/PlayerInfo/DeviceSettings/PlatformImplementation.cpp
+++ b/PlayerInfo/DeviceSettings/PlatformImplementation.cpp
@@ -188,41 +188,6 @@ public:
         return (Core::ERROR_NONE);
     }
 
-    uint32_t IsAudioEquivalenceEnabled(bool& isEnbaled /* @out */) const override
-    {
-        isEnbaled = false;
-        try
-        {
-            if (device::Host::getInstance().isHDMIOutPortPresent())
-            {
-                device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort("HDMI0");
-                if (aPort.isConnected()) {
-                    isEnbaled = aPort.GetLEConfig();
-                    LOGINFO("IsAudioEquivalenceEnabled = %s", isEnbaled? "Enabled":"Disabled");
-                }
-                else
-                {
-                    TRACE(Trace::Information, (_T("IsAudioEquivalenceEnabled failure: HDMI0 not connected!")));
-
-                    LOGERR("IsAudioEquivalenceEnabled failure: HDMI0 not connected!");
-                }
-            }
-            else {
-                device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort("SPEAKER0");
-                isEnbaled = aPort.GetLEConfig();
-                LOGINFO("IsAudioEquivalenceEnabled = %s", isEnbaled? "Enabled":"Disabled");
-            }
-        }
-        catch(const device::Exception& err)
-        {
-            TRACE(Trace::Error, (_T("Exception during DeviceSetting library call. code = %d message = %s"), err.getCode(), err.what()));
-        }
-        TRACE(Trace::Information, (_T("Audio Equivalence = %d"), isEnbaled? "Enabled":"Disabled"));
-
-
-        return (Core::ERROR_NONE);
-    }
-
     uint32_t Register(Exchange::Dolby::IOutput::INotification* notification) override
     {
         _adminLock.Lock();


### PR DESCRIPTION
Reason for change:
Removing unneeded GetLEConfig call from Player info.
Test Procedure: None
Risks: Low
Priority: P1

Signed-off-by:Hayden Gfeller <Hayden_Gfeller@comcast.com>