### PR TITLE
RDK-42995 SystemServices - Replace System Commands with C Library

### DIFF
--- a/SystemServices/CMakeLists.txt
+++ b/SystemServices/CMakeLists.txt
@@ -21,6 +21,7 @@ set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
 set(PLUGIN_SYSTEMSERVICE_STARTUPORDER "" CACHE STRING "To configure startup order of SystemServices plugin")
 
 find_package(${NAMESPACE}Plugins REQUIRED)
+find_library(PROCPS_LIBRARIES NAMES procps)
 
 if(BUILD_TESTS)
     add_subdirectory(TestClient)
@@ -60,6 +61,10 @@ else (IARMBus_FOUND)
     target_include_directories(${MODULE_NAME} PRIVATE ${IARMBUS_INCLUDE_DIRS})
     target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins ${IARMBUS_LIBRARIES})
 endif(IARMBus_FOUND)
+
+if(PROCPS_LIBRARIES)
+    target_link_libraries(${MODULE_NAME} PRIVATE ${PROCPS_LIBRARIES})
+endif(PROCPS_LIBRARIES)
 
 find_package(DS)
 if (DS_FOUND)

--- a/SystemServices/SystemServicesHelper.h
+++ b/SystemServices/SystemServicesHelper.h
@@ -68,7 +68,7 @@
 #define OPT_DCM_PROPERTIES                      "/opt/dcm.properties"
 #define ETC_DCM_PROPERTIES                      "/etc/dcm.properties"
 #define TMP_DCM_SETTINGS                        "/tmp/DCMSettings.conf"
-
+#define DOWNLOAD_PROGRESS_FILE                  "/opt/curl_progress"
 
 #define MODE_TIMER_UPDATE_INTERVAL	1000
 #define CURL_BUFFER_SIZE	(64 * 1024) /* 256kB */
@@ -84,8 +84,6 @@
 #define TZ_ACCURACY_INITIAL "INITIAL"
 #define TZ_ACCURACY_INTERIM "INTERIM"
 #define TZ_ACCURACY_FINAL   "FINAL"
-
-#define CAT_DWNLDPROGRESSFILE_AND_GET_INFO "cat /opt/curl_progress | tr -s '\r' '\n' | tail -n 1 | sed 's/^ *//g' | sed '/^[^M/G]*$/d' | tr -s ' ' | cut -d ' ' -f3"
 
 enum eRetval { E_NOK = -1,
     E_OK };
@@ -186,6 +184,13 @@ void setJSONResponseArray(JsonObject& response, const char* key,
         const vector<string>& items);
 
 /***
+ * @brief  : Get the download progress from DOWNLOAD_PROGRESS_FILE file.
+ * @param1[out] :  Download percent from the DOWNLOAD_PROGRESS_FILE file.
+ * @return : <bool>; TRUE if succesfully get the download percent.
+ */
+bool getDownloadProgress(int& downloadPercent);
+
+/***
  * @brief	: Used to read file contents into a string
  * @param1[in]	: Complete file name with path
  * @param2[out]	: Destination string object filled with file contents
@@ -200,14 +205,6 @@ bool getFileContent(std::string fileName, std::string& fileContent);
  * @return : <bool>; TRUE if operation success; else FALSE.
  */
 bool getFileContent(std::string fileName, std::vector<std::string> & vecOfStrs);
-
-/***
- * @brief	: Used to search for files in the given directory
- * @param1[in]	: Directory on which the search has to be performed
- * @param2[in]	: Filter for the search command
- * @return	: <vector<std::string>>; Vector of file names.
- */
-std::vector<std::string> searchAndGetFilesList(std::string path, std::string filter);
 
 /***
  * @brief  : compare two C string case insensitively

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -35,7 +35,8 @@ add_executable(${PROJECT_NAME}
         mocks/thunder/Module.cpp
         mocks/Wraps.cpp
         mocks/Dobby.cpp
-	mocks/rdkshell.cpp
+        mocks/rdkshell.cpp
+        mocks/readprocMock.cpp
         )
 
 set_source_files_properties(

--- a/Tests/mocks/readprocMock.cpp
+++ b/Tests/mocks/readprocMock.cpp
@@ -1,5 +1,5 @@
 #include "readprocMock.h"
-#include "readproc_Mock.h"
+#include "readprocMockInterface.h"
 
 readprocImplMock* impl = new readprocImplMock;
 

--- a/Tests/mocks/readprocMock.cpp
+++ b/Tests/mocks/readprocMock.cpp
@@ -1,0 +1,21 @@
+#include "readprocMock.h"
+#include "readproc_Mock.h"
+
+readprocImplMock* impl = new readprocImplMock;
+
+
+PROCTAB* openproc(int flags, ... /* pid_t*|uid_t*|dev_t*|char* [, int n] */ )
+{
+    return impl->openproc(flags);
+}
+
+void closeproc(PROCTAB* PT)
+{
+    return impl->closeproc(PT);
+}
+
+proc_t* readproc(PROCTAB *__restrict const PT, proc_t *__restrict p)
+{
+    return impl->readproc(PT,p);
+}
+

--- a/Tests/mocks/readprocMock.h
+++ b/Tests/mocks/readprocMock.h
@@ -24,11 +24,11 @@ typedef struct PROCTAB {
 } PROCTAB;
 
 // Initialize a PROCTAB structure holding needed call-to-call persistent data
-extern PROCTAB* openproc(int flags, ... /* pid_t*|uid_t*|dev_t*|char* [, int n] */ );
+PROCTAB* openproc(int flags, ... /* pid_t*|uid_t*|dev_t*|char* [, int n] */ );
 
 // Clean-up open files, etc from the openproc()
-extern void closeproc(PROCTAB* PT);
+void closeproc(PROCTAB* PT);
 
-extern proc_t* readproc(PROCTAB *__restrict const PT, proc_t *__restrict p);
+proc_t* readproc(PROCTAB *__restrict const PT, proc_t *__restrict p);
 
 #endif

--- a/Tests/mocks/readprocMock.h
+++ b/Tests/mocks/readprocMock.h
@@ -1,34 +1,13 @@
-#ifndef PROCPS_PROC_READPROC_H
-#define PROCPS_PROC_READPROC_H
+#pragma once
 
-#include <sys/types.h>
-#include <dirent.h>
-#include <unistd.h>
+#include <gmock/gmock.h>
+#include "readprocMock.h"
 
-#define PROC_FILLSTATUS      0x0020 // read status
-#define PROC_FILLMEM         0x0001 // read statm
-#define PROC_FILLSTAT        0x0040 // read stat
+class readprocImplMock : public readprocImpl {
+public:
+    virtual ~readprocImplMock() = default;
 
-typedef struct proc_t {
-// 1st 16 bytes
-    int
-        tid,		// (special)       task id, the POSIX thread ID (see also: tgid)
-    	ppid;		// stat,status     pid of parent process
-    char
-        cmd[16];	// stat,status     basename of executable file in call to exec(2)
-	
-} proc_t;
-
-typedef struct PROCTAB {
-    DIR*	procfs;
-} PROCTAB;
-
-// Initialize a PROCTAB structure holding needed call-to-call persistent data
-PROCTAB* openproc(int flags, ... /* pid_t*|uid_t*|dev_t*|char* [, int n] */ );
-
-// Clean-up open files, etc from the openproc()
-void closeproc(PROCTAB* PT);
-
-proc_t* readproc(PROCTAB *__restrict const PT, proc_t *__restrict p);
-
-#endif
+    MOCK_METHOD(PROCTAB*, openproc, (int flags), (override));
+    MOCK_METHOD(void, closeproc, (PROCTAB* PT), (override));
+    MOCK_METHOD(proc_t*, readproc, (PROCTAB *__restrict const PT, proc_t *__restrict p), (override));
+};

--- a/Tests/mocks/readprocMock.h
+++ b/Tests/mocks/readprocMock.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <gmock/gmock.h>
-#include "readprocMock.h"
+#include "readprocMockInterface.h"
 
 class readprocImplMock : public readprocImpl {
 public:

--- a/Tests/mocks/readprocMock.h
+++ b/Tests/mocks/readprocMock.h
@@ -1,0 +1,34 @@
+#ifndef PROCPS_PROC_READPROC_H
+#define PROCPS_PROC_READPROC_H
+
+#include <sys/types.h>
+#include <dirent.h>
+#include <unistd.h>
+
+#define PROC_FILLSTATUS      0x0020 // read status
+#define PROC_FILLMEM         0x0001 // read statm
+#define PROC_FILLSTAT        0x0040 // read stat
+
+typedef struct proc_t {
+// 1st 16 bytes
+    int
+        tid,		// (special)       task id, the POSIX thread ID (see also: tgid)
+    	ppid;		// stat,status     pid of parent process
+    char
+        cmd[16];	// stat,status     basename of executable file in call to exec(2)
+	
+} proc_t;
+
+typedef struct PROCTAB {
+    DIR*	procfs;
+} PROCTAB;
+
+// Initialize a PROCTAB structure holding needed call-to-call persistent data
+extern PROCTAB* openproc(int flags, ... /* pid_t*|uid_t*|dev_t*|char* [, int n] */ );
+
+// Clean-up open files, etc from the openproc()
+extern void closeproc(PROCTAB* PT);
+
+extern proc_t* readproc(PROCTAB *__restrict const PT, proc_t *__restrict p);
+
+#endif

--- a/Tests/mocks/readprocMockInterface.h
+++ b/Tests/mocks/readprocMockInterface.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <sys/types.h>
+#include <dirent.h>
+#include <unistd.h>
+
+#define PROC_FILLSTATUS      0x0020 // read status
+#define PROC_FILLMEM         0x0001 // read statm
+#define PROC_FILLSTAT        0x0040 // read stat
+
+typedef struct proc_t {
+// 1st 16 bytes
+int
+	tid,		// (special)       task id, the POSIX thread ID (see also: tgid)
+	ppid;		// stat,status     pid of parent process
+char
+	cmd[16];	// stat,status     basename of executable file in call to exec(2)
+
+} proc_t;
+
+typedef struct PROCTAB {
+DIR*	procfs;
+} PROCTAB;
+
+class readprocImpl {
+public:
+    virtual ~readprocImpl() = default;
+
+    virtual PROCTAB* openproc(int flags) = 0;
+    virtual void closeproc(PROCTAB* PT) = 0;
+    virtual proc_t* readproc(PROCTAB *__restrict const PT, proc_t *__restrict p) = 0;
+ 
+};
+
+PROCTAB* openproc(int flags, ... /* pid_t*|uid_t*|dev_t*|char* [, int n] */ );
+void closeproc(PROCTAB* PT);
+proc_t* readproc(PROCTAB *__restrict const PT, proc_t *__restrict p);
+
+
+
+

--- a/Tests/tests/test_SystemServices.cpp
+++ b/Tests/tests/test_SystemServices.cpp
@@ -28,7 +28,7 @@
 #include "ServiceMock.h"
 #include "SleepModeMock.h"
 #include "WrapsMock.h"
-#include "readprocMock.h"
+#include "readprocMockInterface.h"
 
 #include "deepSleepMgr.h"
 #include "exception.hpp"

--- a/Tests/tests/test_SystemServices.cpp
+++ b/Tests/tests/test_SystemServices.cpp
@@ -28,6 +28,7 @@
 #include "ServiceMock.h"
 #include "SleepModeMock.h"
 #include "WrapsMock.h"
+#include "readprocMock.h"
 
 #include "deepSleepMgr.h"
 #include "exception.hpp"

--- a/helpers/UtilsString.h
+++ b/helpers/UtilsString.h
@@ -140,7 +140,7 @@ namespace String {
                                         "0123456789+/";
 
 
-    void imageEncoder(const uint8_t object[], const uint32_t length, const bool padding, string& result)
+    inline void imageEncoder(const uint8_t object[], const uint32_t length, const bool padding, string& result)
     {
         uint8_t state = 0;
         uint32_t index = 0;
@@ -182,7 +182,7 @@ namespace String {
 * @param[out] out_str - The output string (equals input_string with extra spaces removed)
 * @return true if the input string is a valid string
 */
-    bool removeExtraWhitespaces(string& in_str, string& out_str)
+    inline bool removeExtraWhitespaces(string& in_str, string& out_str)
     {
         bool ret_status = false;
         int idx = 0;

--- a/helpers/UtilsgetFileContent.h
+++ b/helpers/UtilsgetFileContent.h
@@ -12,7 +12,7 @@ namespace Utils {
  * @param[out] propertyValue - The value of the property will be stored in this string.
  * @return          bool  True if the property is found and successfully read, false otherwise.
  */
-bool readPropertyFromFile(const char* filename, const std::string& property, std::string& propertyValue)
+inline bool readPropertyFromFile(const char* filename, const std::string& property, std::string& propertyValue)
 {
     std::string line = "";
     bool found = false;
@@ -84,7 +84,7 @@ bool readPropertyFromFile(const char* filename, const std::string& property, std
  * @return  bool  True if the file is successfully read and its content is stored in 'content', false otherwise.
  */
 
-bool readFileContent(const char* filename, std::string& content)
+inline bool readFileContent(const char* filename, std::string& content)
 {
     char buffer[READ_BUFFER_SIZE];
     FILE* file = fopen(filename, "r");
@@ -113,7 +113,7 @@ bool readFileContent(const char* filename, std::string& content)
  * @param[in] path - The path to check.
  * @return bool - True if the path corresponds to a regular file, false otherwise.
  */
-bool isRegularFile(const std::string& path)
+inline bool isRegularFile(const std::string& path)
 {
     struct stat st;
     if (stat(path.c_str(), &st) == 0)
@@ -132,7 +132,7 @@ bool isRegularFile(const std::string& path)
  * @param[out] result - The search results will be stored in this string.Results are capped at 10.
  * @return bool - True if the search operation is successful, false otherwise.
  */
-bool searchFiles(std::string& inputPath, int maxDepth, int minDepth, const std::list<std::string>& exclusions, std::string& result)
+inline bool searchFiles(std::string& inputPath, int maxDepth, int minDepth, const std::list<std::string>& exclusions, std::string& result)
 {
     int count = 0;
     if (minDepth <= 0)
@@ -237,7 +237,7 @@ bool searchFiles(std::string& inputPath, int maxDepth, int minDepth, const std::
  * @param[out] expandedString - The string with variables replaced by values.
  * @return bool - True if the processing and replacement are successful, false otherwise.
  */
-bool ExpandPropertiesInString(const char* input, const char* filePath, std::string & expandedString)
+inline bool ExpandPropertiesInString(const char* input, const char* filePath, std::string & expandedString)
 {
     const char* variablePos = strchr(input, '$');
     while (variablePos)

--- a/tests.cmake
+++ b/tests.cmake
@@ -144,7 +144,7 @@ set(FAKE_HEADERS
         ${BASEDIR}/RdkLoggerMilestone.h
         ${BASEDIR}/wpa_ctrl_mock.h
         ${BASEDIR}/secure_wrappermock.h
-        ${BASEDIR}/readprocMock.h
+        ${BASEDIR}/readprocMockInterface.h
         )
 
 foreach (file ${FAKE_HEADERS})

--- a/tests.cmake
+++ b/tests.cmake
@@ -18,9 +18,11 @@ set(EMPTY_HEADERS_DIRS
         ${BASEDIR}/Dobby/Public/Dobby
         ${BASEDIR}/Dobby/IpcService
         ${BASEDIR}/websocket
-	      ${BASEDIR}/rdk/control
+        ${BASEDIR}/rdk/control
         ${BASEDIR}/rdk/iarmmgrs
         ${BASEDIR}/rdkshell
+        ${BASEDIR}/systemservices
+        ${BASEDIR}/systemservices/proc
         )
 
 set(EMPTY_HEADERS
@@ -107,6 +109,7 @@ set(EMPTY_HEADERS
         ${BASEDIR}/rdk/control/ctrlm_ipc_rcu.h
         ${BASEDIR}/rdk/control/ctrlm_ipc_key_codes.h
         ${BASEDIR}/rdk_logger_milestone.h
+        ${BASEDIR}/systemservices/proc/readproc.h
         )
 
 file(MAKE_DIRECTORY ${EMPTY_HEADERS_DIRS})
@@ -141,6 +144,7 @@ set(FAKE_HEADERS
         ${BASEDIR}/RdkLoggerMilestone.h
         ${BASEDIR}/wpa_ctrl_mock.h
         ${BASEDIR}/secure_wrappermock.h
+        ${BASEDIR}/readprocMock.h
         )
 
 foreach (file ${FAKE_HEADERS})


### PR DESCRIPTION
As part of this gerrit removed below system commands from SystemServices.cpp file.

1. pgrep <processname>
2. pkill <processname>
3. pgrep -P <PPID>
4. Added new function getDownloadProgress() as a replacement for below system command. "cat /opt/curl_progress | tr -s '\r' '\n' | tail -n 1 | sed 's/^ *//g' | sed '/^[^M/G]*$/d' | tr -s ' ' | cut -d ' ' -f3"

-> To avoid "multiple definition of same functions" error, added "inline" keyword in UtilsString.h & UtilsgetFileContent.h files.

-> Removed searchAndGetFilesList() api from SystemServicesHelper.cpp file as this api is not calling from anywhere in rdkservices. 'find' system command is using in searchAndGetFilesList().