### PR TITLE
Update DeviceInfo.json file to provide support for modelid and make p…

### DIFF
--- a/DeviceInfo/DeviceInfo.json
+++ b/DeviceInfo/DeviceInfo.json
@@ -142,7 +142,8 @@
         "pace",
         "samsung",
         "technicolor",
-        "Amlogic_Inc"
+        "Amlogic_Inc",
+        "raspberrypi_org"
       ],
       "description": "Device manufacturer",
       "example": "pace"
@@ -176,7 +177,8 @@
         "PX051AEI",
         "PXD01ANI",
         "SX022AN",
-        "TX061AEI"
+        "TX061AEI",
+        "PI"
       ],
       "description": "Device model number or SKU",
       "example": "PX051AEI"


### PR DESCRIPTION
…roperty for rpi

REFPLTV-1561 RDKServices: Some of the APIs in DeviceInfo plugin are returning ERROR_GENERAL message

Reason for change: Support is added for RPI for modelid and make property.
Test Procedure: Ensure the DeviceInfo plugin functionality for modelid and make properties.
Risks: low.
Signed-off-by: SajjadMusa_Shaikh@comcast.com