### PR TITLE
RDKTV-24690: AAMP is scaling up the HDMI window in FHD platforms

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -1339,10 +1339,55 @@ namespace WPEFramework {
             std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
             string videoDisplay = parameters.HasLabel("videoDisplay") ? parameters["videoDisplay"].String() : strVideoPort;
             bool success = true;
+	    int width = 0;
+	    int height = 0;
             try
             {
                 device::VideoOutputPort &vPort = device::Host::getInstance().getVideoOutputPort(videoDisplay);
-                response["resolution"] = vPort.getResolution().getName();
+                switch(vPort.getResolution().getName()) {
+		    case "480i":
+		    case "480p":
+			width =  720;
+			height = 480;
+		    break;
+		    case "576p50":
+        		width =  720;
+        		height = 576;
+		    break;
+		    case "720p":
+		    case "720p50":
+			width =  1280;
+			height = 720;
+		    break;
+		    case "1080p24":
+		    case "1080p":
+		    case "1080i50":
+		    case "1080i":
+			width =  1920;
+			height = 1080;
+		    break;
+		    case "2160p30":
+		    case "2160p60":
+			width =  3840;
+			height = 2160;
+		    break;
+		    case "4096x2160p24":
+		    case "4096x2160p25":
+		    case "4096x2160p30":
+		    case "4096x2160p50":
+		    case "4096x2160p60":
+			width =  4096;
+			height = 2160;
+		    break;
+		    default:
+			width =  1280;
+			height = 720;
+		    break;
+		    }
+
+		    response["resolution"] = vPort.getResolution().getName();
+		    response["w"] = width;
+		    response["h"] = height;
             }
             catch(const device::Exception& err)
             {

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -1344,50 +1344,46 @@ namespace WPEFramework {
             try
             {
                 device::VideoOutputPort &vPort = device::Host::getInstance().getVideoOutputPort(videoDisplay);
-                switch(vPort.getResolution().getName()) {
-		    case "480i":
-		    case "480p":
-			width =  720;
-			height = 480;
-		    break;
-		    case "576p50":
-        		width =  720;
-        		height = 576;
-		    break;
-		    case "720p":
-		    case "720p50":
-			width =  1280;
-			height = 720;
-		    break;
-		    case "1080p24":
-		    case "1080p":
-		    case "1080i50":
-		    case "1080i":
-			width =  1920;
-			height = 1080;
-		    break;
-		    case "2160p30":
-		    case "2160p60":
-			width =  3840;
-			height = 2160;
-		    break;
-		    case "4096x2160p24":
-		    case "4096x2160p25":
-		    case "4096x2160p30":
-		    case "4096x2160p50":
-		    case "4096x2160p60":
-			width =  4096;
-			height = 2160;
-		    break;
-		    default:
-			width =  1280;
-			height = 720;
-		    break;
-		    }
+		string resolution = vPort.getResolution().getName();
+		if(strcmp(resolution,"480i")== 0 || strcmp(resolution,"480p")== 0)
+		{
+		    width =  720;
+		    height = 480;
+		}
+		else if(strcmp(resolution,"576p50")== 0)
+		{
+		    width =  720;
+		    height = 576;
+		}
+		else if(strcmp(resolution,"720p")== 0 || strcmp(resolution,"720p50")== 0)
+		{
+		    width =  1280;
+		    height = 720;
+		}
+		else if(strcmp(resolution,"1080p24")== 0 || strcmp(resolution,"1080p")== 0 || strcmp(resolution,"1080i50")== 0 || strcmp(resolution,"1080i")== 0)
+		{
+		    width =  1920;
+		    height = 1080;
+		}
+		else if(strcmp(resolution,"2160p30")== 0 || strcmp(resolution,"2160p60")== 0)
+		{
+		    width =  3840;
+		    height = 2160;
+		}
+		else if(strcmp(resolution,"4096x2160p24")== 0 || strcmp(resolution,"4096x2160p25")== 0 || strcmp(resolution,"4096x2160p30")== 0 || strcmp(resolution,"4096x2160p50")== 0 || strcmp(resolution,"4096x2160p60")== 0)
+		{
+		    width =  4096;
+		    height = 2160;
+		}
+		else
+		{
+		    width =  1280;
+		    height = 720;
+		}
 
-		    response["resolution"] = vPort.getResolution().getName();
-		    response["w"] = width;
-		    response["h"] = height;
+		response["resolution"] = vPort.getResolution().getName();
+		response["w"] = width;
+		response["h"] = height;
             }
             catch(const device::Exception& err)
             {

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -1344,33 +1344,33 @@ namespace WPEFramework {
             try
             {
                 device::VideoOutputPort &vPort = device::Host::getInstance().getVideoOutputPort(videoDisplay);
-		string resolution = vPort.getResolution().getName();
-		if(strcmp(resolution,"480i")== 0 || strcmp(resolution,"480p")== 0)
+		string resolution = vPort.getresolution.().getName();
+		if(strcmp(resolution.c_str(),"480i")== 0 || strcmp(resolution.c_str(),"480p")== 0)
 		{
 		    width =  720;
 		    height = 480;
 		}
-		else if(strcmp(resolution,"576p50")== 0)
+		else if(strcmp(resolution.c_str(),"576p50")== 0)
 		{
 		    width =  720;
 		    height = 576;
 		}
-		else if(strcmp(resolution,"720p")== 0 || strcmp(resolution,"720p50")== 0)
+		else if(strcmp(resolution.c_str(),"720p")== 0 || strcmp(resolution.c_str(),"720p50")== 0)
 		{
 		    width =  1280;
 		    height = 720;
 		}
-		else if(strcmp(resolution,"1080p24")== 0 || strcmp(resolution,"1080p")== 0 || strcmp(resolution,"1080i50")== 0 || strcmp(resolution,"1080i")== 0)
+		else if(strcmp(resolution.c_str(),"1080p24")== 0 || strcmp(resolution.c_str(),"1080p")== 0 || strcmp(resolution.c_str(),"1080i50")== 0 || strcmp(resolution.c_str(),"1080i")== 0)
 		{
 		    width =  1920;
 		    height = 1080;
 		}
-		else if(strcmp(resolution,"2160p30")== 0 || strcmp(resolution,"2160p60")== 0)
+		else if(strcmp(resolution.c_str(),"2160p30")== 0 || strcmp(resolution.c_str(),"2160p60")== 0)
 		{
 		    width =  3840;
 		    height = 2160;
 		}
-		else if(strcmp(resolution,"4096x2160p24")== 0 || strcmp(resolution,"4096x2160p25")== 0 || strcmp(resolution,"4096x2160p30")== 0 || strcmp(resolution,"4096x2160p50")== 0 || strcmp(resolution,"4096x2160p60")== 0)
+		else if(strcmp(resolution.c_str(),"4096x2160p24")== 0 || strcmp(resolution.c_str(),"4096x2160p25")== 0 || strcmp(resolution.c_str(),"4096x2160p30")== 0 || strcmp(resolution.c_str(),"4096x2160p50")== 0 || strcmp(resolution.c_str(),"4096x2160p60")== 0)
 		{
 		    width =  4096;
 		    height = 2160;
@@ -1381,7 +1381,7 @@ namespace WPEFramework {
 		    height = 720;
 		}
 
-		response["resolution"] = vPort.getResolution().getName();
+		response["resolution"] = vPort.getresolution().getName();
 		response["w"] = width;
 		response["h"] = height;
             }

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -1339,38 +1339,38 @@ namespace WPEFramework {
             std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
             string videoDisplay = parameters.HasLabel("videoDisplay") ? parameters["videoDisplay"].String() : strVideoPort;
             bool success = true;
-	    int width = 0;
-	    int height = 0;
             try
             {
                 device::VideoOutputPort &vPort = device::Host::getInstance().getVideoOutputPort(videoDisplay);
-		string resolution = vPort.getresolution.().getName();
-		if(strcmp(resolution.c_str(),"480i")== 0 || strcmp(resolution.c_str(),"480p")== 0)
+		int width = 0;
+		int height = 0;
+		string res = vPort.getResolution().getName();
+		if(strcmp(res.c_str(),"480i")== 0 || strcmp(res.c_str(),"480p")== 0)
 		{
 		    width =  720;
 		    height = 480;
 		}
-		else if(strcmp(resolution.c_str(),"576p50")== 0)
+		else if(strcmp(res.c_str(),"576p50")== 0)
 		{
 		    width =  720;
 		    height = 576;
 		}
-		else if(strcmp(resolution.c_str(),"720p")== 0 || strcmp(resolution.c_str(),"720p50")== 0)
+		else if(strcmp(res.c_str(),"720p")== 0 || strcmp(res.c_str(),"720p50")== 0)
 		{
 		    width =  1280;
 		    height = 720;
 		}
-		else if(strcmp(resolution.c_str(),"1080p24")== 0 || strcmp(resolution.c_str(),"1080p")== 0 || strcmp(resolution.c_str(),"1080i50")== 0 || strcmp(resolution.c_str(),"1080i")== 0)
+		else if(strcmp(res.c_str(),"1080p24")== 0 || strcmp(res.c_str(),"1080p")== 0 || strcmp(res.c_str(),"1080i50")== 0 || strcmp(res.c_str(),"1080i")== 0)
 		{
 		    width =  1920;
 		    height = 1080;
 		}
-		else if(strcmp(resolution.c_str(),"2160p30")== 0 || strcmp(resolution.c_str(),"2160p60")== 0)
+		else if(strcmp(res.c_str(),"2160p30")== 0 || strcmp(res.c_str(),"2160p60")== 0)
 		{
 		    width =  3840;
 		    height = 2160;
 		}
-		else if(strcmp(resolution.c_str(),"4096x2160p24")== 0 || strcmp(resolution.c_str(),"4096x2160p25")== 0 || strcmp(resolution.c_str(),"4096x2160p30")== 0 || strcmp(resolution.c_str(),"4096x2160p50")== 0 || strcmp(resolution.c_str(),"4096x2160p60")== 0)
+		else if(strcmp(res.c_str(),"4096x2160p24")== 0 || strcmp(res.c_str(),"4096x2160p25")== 0 || strcmp(res.c_str(),"4096x2160p30")== 0 || strcmp(res.c_str(),"4096x2160p50")== 0 || strcmp(res.c_str(),"4096x2160p60")== 0)
 		{
 		    width =  4096;
 		    height = 2160;
@@ -1381,7 +1381,7 @@ namespace WPEFramework {
 		    height = 720;
 		}
 
-		response["resolution"] = vPort.getresolution().getName();
+		response["resolution"] = vPort.getResolution().getName();
 		response["w"] = width;
 		response["h"] = height;
             }

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -1345,48 +1345,48 @@ namespace WPEFramework {
 		int width = 0;
 		int height = 0;
 		string res = vPort.getResolution().getName();
-		if(strcmp(res.c_str(),"480i")== 0 || strcmp(res.c_str(),"480p")== 0)
-		{
-		    width =  720;
-		    height = 480;
-		}
-		else if(strcmp(res.c_str(),"576p50")== 0)
-		{
-		    width =  720;
-		    height = 576;
-		}
-		else if(strcmp(res.c_str(),"720p")== 0 || strcmp(res.c_str(),"720p50")== 0)
-		{
-		    width =  1280;
-		    height = 720;
-		}
-		else if(strcmp(res.c_str(),"768p")== 0)
-		{
-		    width =  1366;
-		    height = 768;
-		}
-		else if(strcmp(res.c_str(),"1080p24")== 0 || strcmp(res.c_str(),"1080p")== 0 || strcmp(res.c_str(),"1080i50")== 0 || strcmp(res.c_str(),"1080i")== 0)
-		{
-		    width =  1920;
-		    height = 1080;
-		}
-		else if(strcmp(res.c_str(),"2160p30")== 0 || strcmp(res.c_str(),"2160p60")== 0)
-		{
-		    width =  3840;
-		    height = 2160;
-		}
-		else if(strcmp(res.c_str(),"4096x2160p24")== 0 || strcmp(res.c_str(),"4096x2160p25")== 0 || strcmp(res.c_str(),"4096x2160p30")== 0 || strcmp(res.c_str(),"4096x2160p50")== 0 || strcmp(res.c_str(),"4096x2160p60")== 0)
-		{
-		    width =  4096;
-		    height = 2160;
-		}
-		else
-		{
-		    width =  1280;
-		    height = 720;
-		}
-
-		response["resolution"] = vPort.getResolution().getName();
+		if(res.rfind("480", 0) == 0)
+                {
+                    width =  720;
+                    height = 480;
+                }
+                else if(res.rfind("576", 0) == 0)
+                {
+                    width =  720;
+                    height = 576;
+                }
+                else if(res.rfind("720", 0) == 0)
+                {
+                    width =  1280;
+                    height = 720;
+                }
+                else if(res.rfind("768", 0) == 0)
+                {
+                    width =  1366;
+                    height = 768;
+                }
+		else if(res.rfind("1080", 0) == 0)
+                {
+                    width =  1920;
+                    height = 1080;
+                }
+                else if(res.rfind("2160", 0) == 0)
+                {
+                    width =  3840;
+                    height = 2160;
+                }
+                else if(res.rfind("4096x2160", 0) == 0)
+                {
+                    width =  4096;
+                    height = 2160;
+                }
+                else
+                {
+                    width =  1280;
+                    height = 720;
+                }
+		
+		response["resolution"] = res;
 		response["w"] = width;
 		response["h"] = height;
             }

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -1360,6 +1360,11 @@ namespace WPEFramework {
 		    width =  1280;
 		    height = 720;
 		}
+		else if(strcmp(res.c_str(),"768p")== 0)
+		{
+		    width =  1366;
+		    height = 768;
+		}
 		else if(strcmp(res.c_str(),"1080p24")== 0 || strcmp(res.c_str(),"1080p")== 0 || strcmp(res.c_str(),"1080i50")== 0 || strcmp(res.c_str(),"1080i")== 0)
 		{
 		    width =  1920;

--- a/DisplaySettings/DisplaySettings.json
+++ b/DisplaySettings/DisplaySettings.json
@@ -470,11 +470,20 @@
                     "resolution": {
                         "$ref": "#/definitions/resolution"
                     },
+		    "w":{
+                        "$ref": "#/definitions/w"
+                    },
+                    "h":{
+                        "$ref": "#/definitions/h"
+                    },
                     "success": {
                         "$ref": "#/common/success"
                     }
                 },
                 "required": [
+		    "resolution",
+		    "w",
+		    "h",
                     "success"
                 ]
             }


### PR DESCRIPTION

Reason for change:getCurrentResolution api changes
Test Procedure: Refer the ticket for test procedure
Risks: Low
Priority: P1
Signed-off-by: bp-tdora114 <dautapankumar.dora@sky.uk>