### PR TITLE
RDKTV-25044:Remove the Cache Logic for getInterface Network Plugin api

### DIFF
--- a/Network/CHANGELOG.md
+++ b/Network/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+## [1.1.1] - 2023-08-16
+### Fixed
+- Remove the Cache Logic for getInterface Network Plugin api
+
 ## [1.1.0] - 2023-08-16
 ### Added
 - Added new method to configure PNI settings

--- a/Network/Network.cpp
+++ b/Network/Network.cpp
@@ -166,8 +166,6 @@ typedef struct _IARM_BUS_NetSrvMgr_Iface_EventData_t {
             m_useDefInterfaceCache = false;
             m_defInterfaceCache = "";
             m_defIpversionCache = "";
-            m_useInterfacesCache = false;
-            m_interfacesCache = {0};
             m_ipv4WifiCache = {0};
             m_ipv6WifiCache = {0};
             m_ipv4EthCache = {0};
@@ -385,23 +383,7 @@ typedef struct _IARM_BUS_NetSrvMgr_Iface_EventData_t {
 
             if(m_isPluginInited)
             {
-                if (m_useInterfacesCache)
-                {
-                    memcpy(&list, &m_interfacesCache, sizeof(m_interfacesCache));
-                    result = true;
-                }
-                else if (IARM_RESULT_SUCCESS == IARM_Bus_Call(IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_NETSRVMGR_API_getInterfaceList, (void*)&list, sizeof(list)))
-                {
-                    memcpy(&m_interfacesCache, &list, sizeof(list));
-                    m_useInterfacesCache = true;
-                    result = true;
-                }
-                else
-                {
-                    LOGWARN ("Call to %s for %s failed", IARM_BUS_NM_SRV_MGR_NAME, __FUNCTION__);
-                }
-
-                if (result == true)
+                if (IARM_RESULT_SUCCESS == IARM_Bus_Call(IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_NETSRVMGR_API_getInterfaceList, (void*)&list, sizeof(list)))
                 {
                     JsonArray networkInterfaces;
 
@@ -422,8 +404,12 @@ typedef struct _IARM_BUS_NetSrvMgr_Iface_EventData_t {
                     }
 
                     response["interfaces"] = networkInterfaces;
+                    result = true;
                 }
-
+                else
+                {
+                    LOGWARN ("Call to %s for %s failed", IARM_BUS_NM_SRV_MGR_NAME, __FUNCTION__);
+                }
             }
             else
             {
@@ -1499,7 +1485,6 @@ typedef struct _IARM_BUS_NetSrvMgr_Iface_EventData_t {
             JsonObject params;
             params["interface"] = m_netUtils.getInterfaceDescription(interface);
             params["enabled"] = enabled;
-            m_useInterfacesCache = false;
             sendNotify("onInterfaceStatusChanged", params);
         }
 
@@ -1508,7 +1493,6 @@ typedef struct _IARM_BUS_NetSrvMgr_Iface_EventData_t {
             JsonObject params;
             params["interface"] = m_netUtils.getInterfaceDescription(interface);
             params["status"] = string (connected ? "CONNECTED" : "DISCONNECTED");
-            m_useInterfacesCache = false;
             m_useStbIPCache = false;
             m_useDefInterfaceCache = false;
             m_useIpv4WifiCache = false;

--- a/Network/Network.h
+++ b/Network/Network.h
@@ -291,8 +291,6 @@ namespace WPEFramework {
             std::atomic<bool> m_useDefInterfaceCache;
             string m_defInterfaceCache;
             string m_defIpversionCache;
-            std::atomic<bool> m_useInterfacesCache;
-            IARM_BUS_NetSrvMgr_InterfaceList_t m_interfacesCache;
 
             IARM_BUS_NetSrvMgr_Iface_Settings_t m_ipv4WifiCache;
             IARM_BUS_NetSrvMgr_Iface_Settings_t m_ipv6WifiCache;


### PR DESCRIPTION
Reason for change: incase , nlmon return mac address Null at first iteration, getInterface cache variable will take those Null value for further iterations it will overall impact getInterfaces macaddress as NULL in response. for this use case , we are reverting the cache mechanism for getInterface apis Test Procedure: Verify in Jenkin Build
Risks: High
Signed-off-by: Thamim  Razith <tabbas651@cable.comcast.com>