### PR TITLE
RDK-42996 - Warehouse-Replace system commands

### DIFF
--- a/Tests/tests/test_Warehouse.cpp
+++ b/Tests/tests/test_Warehouse.cpp
@@ -335,7 +335,7 @@ TEST_F(WarehouseResetDeviceTest, ColdFactoryResetDevicePwrMgr2RFCEnabled)
     plugin->m_isPwrMgr2RFCEnabled = true;
 
     EXPECT_CALL(wrapsImplMock, system(::testing::_))
-        .Times(4)
+        .Times(2)
         .WillOnce(::testing::Invoke(
             [](const char* command) {
                 EXPECT_EQ(string(command), string("sh /lib/rdk/deviceReset.sh coldfactory"));
@@ -357,7 +357,7 @@ TEST_F(WarehouseResetDeviceTest, FactoryResetDevicePwrMgr2RFCEnabled)
     plugin->m_isPwrMgr2RFCEnabled = true;
 
     EXPECT_CALL(wrapsImplMock, system(::testing::_))
-        .Times(3)
+        .Times(1)
         .WillOnce(::testing::Invoke(
             [](const char* command) {
                 EXPECT_EQ(string(command), string("sh /lib/rdk/deviceReset.sh factory"));
@@ -379,9 +379,7 @@ TEST_F(WarehouseResetDeviceTest, UserFactoryResetDevicePwrMgr2RFCEnabled)
     plugin->m_isPwrMgr2RFCEnabled = true;
 
     EXPECT_CALL(wrapsImplMock, system(::testing::_))
-        .Times(3)
-        .WillOnce(::testing::Return(Core::ERROR_NONE))
-        .WillOnce(::testing::Return(Core::ERROR_NONE))
+        .Times(1)
         .WillOnce(::testing::Invoke(
             [](const char* command) {
                 EXPECT_EQ(string(command), string("sh /lib/rdk/deviceReset.sh userfactory"));
@@ -402,10 +400,7 @@ TEST_F(WarehouseResetDeviceTest, WarehouseClearResetDevicePwrMgr2RFCEnabled)
     plugin->m_isPwrMgr2RFCEnabled = true;
 
     EXPECT_CALL(wrapsImplMock, system(::testing::_))
-        .Times(4)
-        .WillOnce(::testing::Return(Core::ERROR_NONE))
-        .WillOnce(::testing::Return(Core::ERROR_NONE))
-        .WillOnce(::testing::Return(Core::ERROR_NONE))
+        .Times(1)
         .WillOnce(::testing::Invoke(
             [](const char* command) {
                 EXPECT_EQ(string(command), string("sh /lib/rdk/deviceReset.sh WAREHOUSE_CLEAR"));
@@ -427,8 +422,7 @@ TEST_F(WarehouseInitializedTest, WarehouseClearResetDeviceNoResponsePwrMgr2RFCEn
     plugin->m_isPwrMgr2RFCEnabled = true;
 
     EXPECT_CALL(wrapsImplMock, system(::testing::_))
-        .Times(2)
-        .WillOnce(::testing::Return(Core::ERROR_NONE))
+        .Times(1)
         .WillOnce(::testing::Invoke(
             [&](const char* command) {
                 EXPECT_EQ(string(command), string("sh /lib/rdk/deviceReset.sh WAREHOUSE_CLEAR --suppressReboot"));
@@ -450,10 +444,7 @@ TEST_F(WarehouseResetDeviceTest, GenericResetDevicePwrMgr2RFCEnabled)
     plugin->m_isPwrMgr2RFCEnabled = true;
 
     EXPECT_CALL(wrapsImplMock, system(::testing::_))
-        .Times(4)
-        .WillOnce(::testing::Return(Core::ERROR_NONE))
-        .WillOnce(::testing::Return(Core::ERROR_NONE))
-        .WillOnce(::testing::Return(Core::ERROR_NONE))
+        .Times(1)
         .WillOnce(::testing::Invoke(
             [](const char* command) {
                 EXPECT_EQ(string(command), string("sh /lib/rdk/deviceReset.sh warehouse"));
@@ -475,8 +466,7 @@ TEST_F(WarehouseInitializedTest, GenericResetDeviceNoResponsePwrMgr2RFCEnabled)
     plugin->m_isPwrMgr2RFCEnabled = true;
 
     EXPECT_CALL(wrapsImplMock, system(::testing::_))
-        .Times(2)
-        .WillOnce(::testing::Return(Core::ERROR_NONE))
+        .Times(1)
         .WillOnce(::testing::Invoke(
             [&](const char* command) {
                 EXPECT_EQ(string(command), string("sh /lib/rdk/deviceReset.sh warehouse --suppressReboot &"));
@@ -498,8 +488,7 @@ TEST_F(WarehouseResetDeviceFailureTest, UserFactoryResetDeviceFailurePwrMgr2RFCE
     plugin->m_isPwrMgr2RFCEnabled = true;
 
     EXPECT_CALL(wrapsImplMock, system(::testing::_))
-        .Times(2)
-        .WillOnce(::testing::Return(Core::ERROR_NONE))
+        .Times(1)
         .WillOnce(::testing::Invoke(
             [](const char* command) {
                 EXPECT_EQ(string(command), string("sh /lib/rdk/deviceReset.sh warehouse --suppressReboot &"));

--- a/Warehouse/Warehouse.cpp
+++ b/Warehouse/Warehouse.cpp
@@ -1118,7 +1118,7 @@ namespace WPEFramework
             return;
         }
 
-        void Warehouse::addLogToFile(char *log, const char *file_name)
+        void Warehouse::addLogToFile(const char *log, const char *file_name)
         {
             char logWithTimeStamp[MAX_LOG_SIZE] = {0};
             string utcDateTime = "";

--- a/Warehouse/Warehouse.h
+++ b/Warehouse/Warehouse.h
@@ -116,6 +116,14 @@ namespace WPEFramework {
             END_INTERFACE_MAP
 
         private:
+            /*returns the UTC date and time in format DD.MM.YYYY_HH.MM.SS format eg : 11.08.2023_18:47:47*/
+            void getDateAndTime(string& utcDateTime);
+            /*Adds the given null terminated string to the given file*/
+            void addLogToFile(char *log, const char *file_name);
+            /*gets the SD card mount path by reading /proc/mounts, returns true on success, false otherwise*/
+            bool getSDCardMountPath(string&);
+            /*Adds 0 to file /opt/.rebootFlag*/
+            void resetWarehouseRebootFlag();
             void InitializeIARM();
             void DeinitializeIARM();
 

--- a/Warehouse/Warehouse.h
+++ b/Warehouse/Warehouse.h
@@ -119,7 +119,7 @@ namespace WPEFramework {
             /*returns the UTC date and time in format DD.MM.YYYY_HH.MM.SS format eg : 11.08.2023_18:47:47*/
             void getDateAndTime(string& utcDateTime);
             /*Adds the given null terminated string to the given file*/
-            void addLogToFile(char *log, const char *file_name);
+            void addLogToFile(const char *log, const char *file_name);
             /*gets the SD card mount path by reading /proc/mounts, returns true on success, false otherwise*/
             bool getSDCardMountPath(string&);
             /*Adds 0 to file /opt/.rebootFlag*/


### PR DESCRIPTION
RDK-42996-WareHouse - Replace System Commands

Replaced system() and popen() commands in Warehouse plugin as part of this gerrit

Affected areas: Cold reset, factory reset, warehouse reset, warehouse clear, light reset, userfactory reset

Testing: Please refer Jira ticket, dev testing details updated there