### PR TITLE
Update DeviceInfo.json file to support make and modelid properties for RPI

### DIFF
--- a/DeviceInfo/CHANGELOG.md
+++ b/DeviceInfo/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.0.7] - 2023-08-28
+### Fixed 
+- Added valid values for modelid and make property of DeviceInfo plugin for RPI
+
 ## [1.0.6] - 2023-06-05
 ### Added 
 - Added Support to build the plugin to both R4 & R2

--- a/DeviceInfo/DeviceInfo.cpp
+++ b/DeviceInfo/DeviceInfo.cpp
@@ -21,7 +21,7 @@
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 5
+#define API_VERSION_NUMBER_PATCH 7
 
 namespace WPEFramework {
 namespace {

--- a/DeviceInfo/DeviceInfo.json
+++ b/DeviceInfo/DeviceInfo.json
@@ -142,7 +142,8 @@
         "pace",
         "samsung",
         "technicolor",
-        "Amlogic_Inc"
+        "Amlogic_Inc",
+        "raspberrypi_org"
       ],
       "description": "Device manufacturer",
       "example": "pace"
@@ -176,7 +177,8 @@
         "PX051AEI",
         "PXD01ANI",
         "SX022AN",
-        "TX061AEI"
+        "TX061AEI",
+        "PI"
       ],
       "description": "Device model number or SKU",
       "example": "PX051AEI"


### PR DESCRIPTION
REFPLTV-1561 RDKServices: Some of the APIs in DeviceInfo plugin are returning ERROR_GENERAL message

Reason for change: Support is added for RPI.
Test Procedure: Ensure the DeviceInfo plugin functionality for make and modelid property.
Risks: low.
Signed-off-by: [SajjadMusa_Shaikh@comcast.com](mailto:SajjadMusa_Shaikh@comcast.com)