### PR TITLE
RDKTV-24690: AAMP is scaling up the HDMI window in FHD platforms

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -1344,6 +1344,7 @@ namespace WPEFramework {
                 device::VideoOutputPort &vPort = device::Host::getInstance().getVideoOutputPort(videoDisplay);
 		int width = 0;
 		int height = 0;
+		bool progressive = false;
 		string res = vPort.getResolution().getName();
 		if(res.rfind("480", 0) == 0)
                 {
@@ -1386,9 +1387,14 @@ namespace WPEFramework {
                     height = 720;
                 }
 		
+		if(res.find('p') != std::string::npos) {
+                    progressive = true;
+                }
+
 		response["resolution"] = res;
 		response["w"] = width;
 		response["h"] = height;
+		response["progressive"] = progressive;
             }
             catch(const device::Exception& err)
             {

--- a/DisplaySettings/DisplaySettings.json
+++ b/DisplaySettings/DisplaySettings.json
@@ -135,6 +135,21 @@
             "type": "string",
             "example": "1080p"
         },
+	"w":{
+            "summary":"The width",
+            "type": "number",
+            "example": 1920
+        },
+        "h":{
+            "summary":"The height",
+            "type": "number",
+            "example": 1080
+        },
+	"progressive":{
+            "summary":"The type of scan signal",
+            "type": "boolean",
+            "example": true
+        },
         "soundMode": {
             "summary": "Sound mode. Possible values: `AUTO (Dolby Digital Plus)`, `AUTO (Dolby Digital 5.1)`, `AUTO (Stereo)`, `MONO`, `STEREO`, `SURROUND`, PASSTHRU.",
             "type":"string",
@@ -475,6 +490,9 @@
                     },
                     "h":{
                         "$ref": "#/definitions/h"
+                    },
+		    "progressive":{
+                        "$ref": "#/definitions/progressive"
                     },
                     "success": {
                         "$ref": "#/common/success"


### PR DESCRIPTION
Reason for change:getCurrentResolution api progressive field
Test Procedure: Refer the ticket for test procedure
Risks: Low
Priority: P1
Signed-off-by: bp-tdora114 dautapankumar.dora@sky.uk