### PR TITLE
DELIA-63157: Thunder Services - Unsafe string Functions - Phase 5

### DIFF
--- a/Tests/tests/test_ControlService.cpp
+++ b/Tests/tests/test_ControlService.cpp
@@ -156,8 +156,8 @@ TEST_F(ControlServiceTest, getAllRemoteData)
                 auto param = static_cast<ctrlm_main_iarm_call_network_status_t*>(arg);
                 memset(param, 0, sizeof(ctrlm_main_iarm_call_network_status_t));
 
-                sprintf(param->status.rf4ce.version_hal,  "%s", "GPv2.6.3.514598");
-                sprintf(param->status.rf4ce.chipset,      "%s", "GP502KXBG");
+                snprintf(param->status.rf4ce.version_hal, sizeof(param->status.rf4ce.version_hal), "%s", "GPv2.6.3.514598");
+                snprintf(param->status.rf4ce.chipset, sizeof(param->status.rf4ce.chipset), "%s", "GP502KXBG");
 
                 param->status.rf4ce.ieee_address             = (uint64_t) 0x00155F00205E1789;
                 param->status.rf4ce.controller_qty           = 1;
@@ -172,8 +172,8 @@ TEST_F(ControlServiceTest, getAllRemoteData)
                 auto param = static_cast<ctrlm_main_iarm_call_pairing_metrics_t*>(arg);
                 memset(param, 0, sizeof(ctrlm_main_iarm_call_pairing_metrics_t));
 
-                sprintf(param->last_non_screenbind_remote_type, "%s", "...");
-                sprintf(param->last_screenbind_remote_type,     "%s", "...");
+                snprintf(param->last_non_screenbind_remote_type, sizeof(param->last_non_screenbind_remote_type), "%s", "...");
+                snprintf(param->last_screenbind_remote_type, sizeof(param->last_screenbind_remote_type), "%s", "...");
 
                 param->num_screenbind_failures                = 1;
                 param->last_screenbind_error_timestamp        = 1589356931;
@@ -199,16 +199,16 @@ TEST_F(ControlServiceTest, getAllRemoteData)
                 auto param = static_cast<ctrlm_rcu_iarm_call_controller_status_t*>(arg);
                 memset(param, 0, sizeof(ctrlm_rcu_iarm_call_controller_status_t));
 
-                sprintf(param->status.type,                   "%s", "XR15-2");
-                sprintf(param->status.ir_db_code_tv,          "%s", "12371");
-                sprintf(param->status.ir_db_code_avr,         "%s", "31360");
-                sprintf(param->status.manufacturer,           "%s", "RS");
-                sprintf(param->status.chipset,                "%s", "QORVO");
-                sprintf(param->status.version_software,       "%s", "2.0.1.2");
-                sprintf(param->status.version_hardware,       "%s", "2.3.1.0");
-                sprintf(param->status.version_irdb,           "%s", "4.3.2.0");
-                sprintf(param->status.irdb_entry_id_name_tv,  "%s", "...");
-                sprintf(param->status.irdb_entry_id_name_avr, "%s", "...");
+                snprintf(param->status.type, sizeof(param->status.type), "%s", "XR15-2");
+                snprintf(param->status.ir_db_code_tv, sizeof(param->status.ir_db_code_tv), "%s", "12371");
+                snprintf(param->status.ir_db_code_avr, sizeof(param->status.ir_db_code_avr), "%s", "31360");
+                snprintf(param->status.manufacturer, sizeof(param->status.manufacturer), "%s", "RS");
+                snprintf(param->status.chipset, sizeof(param->status.chipset), "%s", "QORVO");
+                snprintf(param->status.version_software, sizeof(param->status.version_software), "%s", "2.0.1.2");
+                snprintf(param->status.version_hardware, sizeof(param->status.version_hardware), "%s", "2.3.1.0");
+                snprintf(param->status.version_irdb, sizeof(param->status.version_irdb), "%s", "4.3.2.0");
+                snprintf(param->status.irdb_entry_id_name_tv, sizeof(param->status.irdb_entry_id_name_tv), "%s", "...");
+                snprintf(param->status.irdb_entry_id_name_avr, sizeof(param->status.irdb_entry_id_name_avr), "%s", "...");
 
                 param->controller_id                                               = 1;
                 param->status.ieee_address                                         = (uint64_t) 0x00155F011C7F7359;
@@ -377,16 +377,16 @@ TEST_F(ControlServiceTest, getSingleRemoteData)
                 auto param = static_cast<ctrlm_rcu_iarm_call_controller_status_t*>(arg);
                 memset(param, 0, sizeof(ctrlm_rcu_iarm_call_controller_status_t));
 
-                sprintf(param->status.type,                   "%s", "XR15-2");
-                sprintf(param->status.ir_db_code_tv,          "%s", "12371");
-                sprintf(param->status.ir_db_code_avr,         "%s", "31360");
-                sprintf(param->status.manufacturer,           "%s", "RS");
-                sprintf(param->status.chipset,                "%s", "QORVO");
-                sprintf(param->status.version_software,       "%s", "2.0.1.2");
-                sprintf(param->status.version_hardware,       "%s", "2.3.1.0");
-                sprintf(param->status.version_irdb,           "%s", "4.3.2.0");
-                sprintf(param->status.irdb_entry_id_name_tv,  "%s", "...");
-                sprintf(param->status.irdb_entry_id_name_avr, "%s", "...");
+                snprintf(param->status.type, sizeof(param->status.type), "%s", "XR15-2");
+                snprintf(param->status.ir_db_code_tv, sizeof(param->status.ir_db_code_tv), "%s", "12371");
+                snprintf(param->status.ir_db_code_avr, sizeof(param->status.ir_db_code_avr), "%s", "31360");
+                snprintf(param->status.manufacturer, sizeof(param->status.manufacturer), "%s", "RS");
+                snprintf(param->status.chipset, sizeof(param->status.chipset), "%s", "QORVO");
+                snprintf(param->status.version_software, sizeof(param->status.version_software), "%s", "2.0.1.2");
+                snprintf(param->status.version_hardware, sizeof(param->status.version_hardware), "%s", "2.3.1.0");
+                snprintf(param->status.version_irdb, sizeof(param->status.version_irdb), "%s", "4.3.2.0");
+                snprintf(param->status.irdb_entry_id_name_tv, sizeof(param->status.irdb_entry_id_name_tv), "%s", "...");
+                snprintf(param->status.irdb_entry_id_name_avr, sizeof(param->status.irdb_entry_id_name_avr), "%s", "...");
 
                 param->controller_id                                               = 1;
                 param->status.ieee_address                                         = (uint64_t) 0x00155F011C7F7359;
@@ -517,7 +517,7 @@ TEST_F(ControlServiceTest, getLastKeypressSource)
                 auto param = static_cast<ctrlm_main_iarm_call_last_key_info_t*>(arg);
                 memset(param, 0, sizeof(ctrlm_main_iarm_call_last_key_info_t));
 
-                sprintf(param->source_name, "%s", "XR15-10");
+                snprintf(param->source_name, sizeof(param->source_name), "%s", "XR15-10");
 
                 param->result               = CTRLM_IARM_CALL_RESULT_SUCCESS;
                 param->controller_id        = 1;
@@ -566,16 +566,16 @@ TEST_F(ControlServiceTest, getLastPairedRemoteData)
                 auto param = static_cast<ctrlm_rcu_iarm_call_controller_status_t*>(arg);
                 memset(param, 0, sizeof(ctrlm_rcu_iarm_call_controller_status_t));
 
-                sprintf(param->status.type,                   "%s", "XR15-2");
-                sprintf(param->status.ir_db_code_tv,          "%s", "12371");
-                sprintf(param->status.ir_db_code_avr,         "%s", "31360");
-                sprintf(param->status.manufacturer,           "%s", "RS");
-                sprintf(param->status.chipset,                "%s", "QORVO");
-                sprintf(param->status.version_software,       "%s", "2.0.1.2");
-                sprintf(param->status.version_hardware,       "%s", "2.3.1.0");
-                sprintf(param->status.version_irdb,           "%s", "4.3.2.0");
-                sprintf(param->status.irdb_entry_id_name_tv,  "%s", "...");
-                sprintf(param->status.irdb_entry_id_name_avr, "%s", "...");
+                snprintf(param->status.type, sizeof(param->status.type), "%s", "XR15-2");
+                snprintf(param->status.ir_db_code_tv, sizeof(param->status.ir_db_code_tv), "%s", "12371");
+                snprintf(param->status.ir_db_code_avr, sizeof(param->status.ir_db_code_avr), "%s", "31360");
+                snprintf(param->status.manufacturer, sizeof(param->status.manufacturer), "%s", "RS");
+                snprintf(param->status.chipset, sizeof(param->status.chipset), "%s", "QORVO");
+                snprintf(param->status.version_software, sizeof(param->status.version_software), "%s", "2.0.1.2");
+                snprintf(param->status.version_hardware, sizeof(param->status.version_hardware), "%s", "2.3.1.0");
+                snprintf(param->status.version_irdb, sizeof(param->status.version_irdb), "%s", "4.3.2.0");
+                snprintf(param->status.irdb_entry_id_name_tv, sizeof(param->status.irdb_entry_id_name_tv), "%s", "...");
+                snprintf(param->status.irdb_entry_id_name_avr, sizeof(param->status.irdb_entry_id_name_avr), "%s", "...");
 
                 param->controller_id                                               = 1;
                 param->status.ieee_address                                         = (uint64_t) 0x00155F011C7F7359;
@@ -914,7 +914,7 @@ TEST_F(ControlServiceInitializedEventTest, onXRConfigurationComplete)
     eventData.controller_id = 1;
     eventData.result        = CTRLM_RCU_CONFIGURATION_RESULT_SUCCESS;
     eventData.binding_type  = CTRLM_RCU_BINDING_TYPE_AUTOMATIC;
-    sprintf(eventData.controller_type, "%s", "XR11");
+    snprintf(eventData.controller_type, sizeof(eventData.controller_type), "%s", "XR11");
 
     handler_.Subscribe(0, _T("onXRConfigurationComplete"), _T("org.rdk.ControlService"), message_);
     controlEventHandler_(CTRLM_MAIN_IARM_BUS_NAME, CTRLM_RCU_IARM_EVENT_CONFIGURATION_COMPLETE, &eventData, sizeof(ctrlm_rcu_iarm_event_configuration_complete_t));
@@ -944,7 +944,7 @@ TEST_F(ControlServiceInitializedEventTest, onXRPairingStart)
     eventData.validation_keys[0] = CTRLM_KEY_CODE_DIGIT_1;
     eventData.validation_keys[1] = CTRLM_KEY_CODE_DIGIT_3;
     eventData.validation_keys[2] = CTRLM_KEY_CODE_DIGIT_5;
-    sprintf(eventData.controller_type, "%s", "XR11");
+    snprintf(eventData.controller_type, sizeof(eventData.controller_type), "%s", "XR11");
 
     handler_.Subscribe(0, _T("onXRPairingStart"), _T("org.rdk.ControlService"), message_);
     controlEventHandler_(CTRLM_MAIN_IARM_BUS_NAME, CTRLM_RCU_IARM_EVENT_VALIDATION_BEGIN, &eventData, sizeof(ctrlm_rcu_iarm_event_validation_begin_t));
@@ -971,7 +971,7 @@ TEST_F(ControlServiceInitializedEventTest, onXRValidationComplete)
     eventData.controller_id = 1;
     eventData.binding_type  = CTRLM_RCU_BINDING_TYPE_AUTOMATIC;
     eventData.result        = CTRLM_RCU_VALIDATION_RESULT_SUCCESS;
-    sprintf(eventData.controller_type, "%s", "XR11");
+    snprintf(eventData.controller_type, sizeof(eventData.controller_type), "%s", "XR11");
 
     handler_.Subscribe(0, _T("onXRValidationComplete"), _T("org.rdk.ControlService"), message_);
     controlEventHandler_(CTRLM_MAIN_IARM_BUS_NAME, CTRLM_RCU_IARM_EVENT_VALIDATION_END, &eventData, sizeof(ctrlm_rcu_iarm_event_validation_end_t));
@@ -1012,14 +1012,14 @@ TEST_F(ControlServiceInitializedEventTest, onXRValidationUpdate)
     beginData.validation_keys[0] = CTRLM_KEY_CODE_DIGIT_1;
     beginData.validation_keys[1] = CTRLM_KEY_CODE_DIGIT_3;
     beginData.validation_keys[2] = CTRLM_KEY_CODE_DIGIT_5;
-    sprintf(beginData.controller_type, "%s", "XR11");
+    snprintf(beginData.controller_type, sizeof(beginData.controller_type), "%s", "XR11");
 
     eventData.api_revision  = CTRLM_RCU_IARM_BUS_API_REVISION;
     eventData.controller_id = 1;
     eventData.binding_type  = CTRLM_RCU_BINDING_TYPE_INTERACTIVE;
     eventData.key_code      = CTRLM_KEY_CODE_DIGIT_1;
     eventData.key_status    = CTRLM_KEY_STATUS_DOWN;
-    sprintf(eventData.controller_type, "%s", "XR11");
+    snprintf(eventData.controller_type, sizeof(eventData.controller_type), "%s", "XR11");
 
     handler_.Subscribe(0, _T("onXRPairingStart"), _T("org.rdk.ControlService"), message_);
     controlEventHandler_(CTRLM_MAIN_IARM_BUS_NAME, CTRLM_RCU_IARM_EVENT_VALIDATION_BEGIN, &beginData, sizeof(ctrlm_rcu_iarm_event_validation_begin_t));

--- a/Tests/tests/test_MotionDetection.cpp
+++ b/Tests/tests/test_MotionDetection.cpp
@@ -82,16 +82,16 @@ TEST_F(MotionDetectionEventTest, getMotionDetectors)
                 
                 memset(pSensorStatus, 0, sizeof(MOTION_DETECTION_CurrentSensorSettings_t));
 
-                strcpy(pSensorStatus->m_sensorIndex, MOTION_DETECTOR);
-                strcpy(pSensorStatus->m_sensorDescription, MOTION_DETECTION_DESCRIPTION);
-                strcpy(pSensorStatus->m_sensorType, MOTION_DETECTOR_TYPE);
+                strncpy(pSensorStatus->m_sensorIndex, MOTION_DETECTOR, sizeof(pSensorStatus->m_sensorIndex) - 1);
+                strncpy(pSensorStatus->m_sensorDescription, MOTION_DETECTION_DESCRIPTION, sizeof(pSensorStatus->m_sensorDescription) - 1);
+                strncpy(pSensorStatus->m_sensorType, MOTION_DETECTOR_TYPE, sizeof(pSensorStatus->m_sensorType) - 1);
                 pSensorStatus->m_sensorDistance = MOTION_DETECTION_DISTANCE;
                 pSensorStatus->m_sensorAngle = MOTION_DETECTION_ANGLE;
                 pSensorStatus->m_sensitivityMode = 2;
                 
-                strcpy(pSensorStatus->m_sensitivity[SENSITIVITY_IDENTIFIER_1], STR_SENSITIVITY_LOW);
-                strcpy(pSensorStatus->m_sensitivity[SENSITIVITY_IDENTIFIER_2], STR_SENSITIVITY_MEDIUM);
-                strcpy(pSensorStatus->m_sensitivity[SENSITIVITY_IDENTIFIER_3], STR_SENSITIVITY_HIGH);
+                strncpy(pSensorStatus->m_sensitivity[SENSITIVITY_IDENTIFIER_1], STR_SENSITIVITY_LOW, sizeof(pSensorStatus->m_sensitivity[SENSITIVITY_IDENTIFIER_1]) - 1);
+                strncpy(pSensorStatus->m_sensitivity[SENSITIVITY_IDENTIFIER_2], STR_SENSITIVITY_MEDIUM, sizeof(pSensorStatus->m_sensitivity[SENSITIVITY_IDENTIFIER_2]) - 1);
+                strncpy(pSensorStatus->m_sensitivity[SENSITIVITY_IDENTIFIER_3], STR_SENSITIVITY_HIGH, sizeof(pSensorStatus->m_sensitivity[SENSITIVITY_IDENTIFIER_3]) - 1);
 
                 return MOTION_DETECTION_RESULT_SUCCESS;
             }));

--- a/Tests/tests/test_RemoteActionMapping.cpp
+++ b/Tests/tests/test_RemoteActionMapping.cpp
@@ -176,7 +176,7 @@ TEST_F(RemoteActionMappingTest, getLastUsedDeviceID)
                 auto param = static_cast<ctrlm_rcu_iarm_call_controller_status_t*>(arg);
                 memset(param, 0, sizeof(ctrlm_rcu_iarm_call_controller_status_t));
 
-                sprintf(param->status.type, "%s", "XR15-2");
+                snprintf(param->status.type, sizeof(param->status.type), "%s", "XR15-2");
                 param->status.time_last_key                 = 1580263335;
                 param->status.ir_db_code_download_supported = 1;
                 return IARM_RESULT_SUCCESS;

--- a/Tests/tests/test_SystemServices.cpp
+++ b/Tests/tests/test_SystemServices.cpp
@@ -2542,7 +2542,7 @@ TEST_F(SystemServicesTest, getDeviceInfoSuccess_onValidInput)
                   const char key_estb_mac[] = "12:34:56:78:90:AB";
                   char buffer[1024];
                   memset(buffer, 0, sizeof(buffer));
-                  strcpy(buffer, key_estb_mac);
+                  strncpy(buffer, key_estb_mac, sizeof(buffer) - 1);
                   FILE* pipe = fmemopen(buffer, strlen(buffer), "r");
                   return pipe;
                }));
@@ -3700,7 +3700,7 @@ TEST_F(SystemServicesEventTest, onMacAddressesRetrieved)
             if (valueToReturn != NULL) {
                   char buffer[1024];
                   memset(buffer, 0, sizeof(buffer));
-                  strcpy(buffer, valueToReturn);
+                  strncpy(buffer, valueToReturn, sizeof(buffer) - 1);
                   FILE* pipe = fmemopen(buffer, strlen(buffer), "r");
                   return pipe;
             } else {
@@ -3759,10 +3759,10 @@ TEST_F(SystemServicesEventTest, onFirmwareUpdateInfoReceived_WithHttpStatusCode4
                       memset(buffer, 0, sizeof(buffer));
                   if (string(command) == string("cat /tmp/xconf_httpcode_thunder.txt")) {
                       const char http_code_str[] = "460";
-                      strcpy(buffer, http_code_str);
+                      strncpy(buffer, http_code_str, sizeof(buffer) - 1);
                   } else if (string(command) == string("cat /tmp/xconf_response_thunder.txt")) {
                       const char response_str[] = "{\"firmwareVersion\":\"1234\"}";
-                      strcpy(buffer, response_str);
+                      strncpy(buffer, response_str, sizeof(buffer) - 1);
                   }
                  FILE* pipe = fmemopen(buffer, strlen(buffer), "r");
                  return pipe;
@@ -3808,10 +3808,10 @@ TEST_F(SystemServicesEventTest, onFirmwareUpdateInfoReceived_WithHttpStatusCode4
                       memset(buffer, 0, sizeof(buffer));
                   if (string(command) == string("cat /tmp/xconf_httpcode_thunder.txt")) {
                       const char http_code_str[] = "403";
-                      strcpy(buffer, http_code_str);
+                      strncpy(buffer, http_code_str, sizeof(buffer) - 1);
                   } else if (string(command) == string("cat /tmp/xconf_response_thunder.txt")) {
                       const char response_str[] = "{\"firmwareVersion\":\"1234\"}";
-                      strcpy(buffer, response_str);
+                      strncpy(buffer, response_str, sizeof(buffer) - 1);
                   }
                  FILE* pipe = fmemopen(buffer, strlen(buffer), "r");
                  return pipe;
@@ -3857,10 +3857,10 @@ TEST_F(SystemServicesEventTest, onFirmwareUpdateInfoReceived_WithHttpStatusCodeO
                       memset(buffer, 0, sizeof(buffer));
                   if (string(command) == string("cat /tmp/xconf_httpcode_thunder.txt")) {
                       const char http_code_str[] = "400";
-                      strcpy(buffer, http_code_str);
+                      strncpy(buffer, http_code_str, sizeof(buffer) - 1);
                   } else if (string(command) == string("cat /tmp/xconf_response_thunder.txt")) {
                       const char response_str[] = "{\"firmwareVersion\":\"1234\"}";
-                      strcpy(buffer, response_str);
+                      strncpy(buffer, response_str, sizeof(buffer) - 1);
                   }
                  FILE* pipe = fmemopen(buffer, strlen(buffer), "r");
                  return pipe;
@@ -3906,10 +3906,10 @@ TEST_F(SystemServicesEventTest, onFirmwareUpdateInfoReceived_WhenEnvPROD)
                       memset(buffer, 0, sizeof(buffer));
                   if (string(command) == string("cat /tmp/xconf_httpcode_thunder.txt")) {
                       const char http_code_str[] = "460";
-                      strcpy(buffer, http_code_str);
+                      strncpy(buffer, http_code_str, sizeof(buffer) - 1);
                   } else if (string(command) == string("cat /tmp/xconf_response_thunder.txt")) {
                       const char response_str[] = "{\"firmwareVersion\":\"1234\"}";
-                      strcpy(buffer, response_str);
+                      strncpy(buffer, response_str, sizeof(buffer) - 1);
                   }
                  FILE* pipe = fmemopen(buffer, strlen(buffer), "r");
                  return pipe;
@@ -3955,10 +3955,10 @@ TEST_F(SystemServicesEventTest, onFirmwareUpdateInfoReceived_WhenEnvDev)
                       memset(buffer, 0, sizeof(buffer));
                   if (string(command) == string("cat /tmp/xconf_httpcode_thunder.txt")) {
                       const char http_code_str[] = "460";
-                      strcpy(buffer, http_code_str);
+                      strncpy(buffer, http_code_str, sizeof(buffer) - 1);
                   } else if (string(command) == string("cat /tmp/xconf_response_thunder.txt")) {
                       const char response_str[] = "{\"firmwareVersion\":\"1234\"}";
-                      strcpy(buffer, response_str);
+                      strncpy(buffer, response_str, sizeof(buffer) - 1);
                   }
                  FILE* pipe = fmemopen(buffer, strlen(buffer), "r");
                  return pipe;
@@ -4005,10 +4005,10 @@ TEST_F(SystemServicesEventTest, onFirmwareUpdateInfoReceived_WhenEnvVBN)
                       memset(buffer, 0, sizeof(buffer));
                   if (string(command) == string("cat /tmp/xconf_httpcode_thunder.txt")) {
                       const char http_code_str[] = "460";
-                      strcpy(buffer, http_code_str);
+                      strncpy(buffer, http_code_str, sizeof(buffer) - 1);
                   } else if (string(command) == string("cat /tmp/xconf_response_thunder.txt")) {
                       const char response_str[] = "{\"firmwareVersion\":\"1234\"}";
-                      strcpy(buffer, response_str);
+                      strncpy(buffer, response_str, sizeof(buffer) - 1);
                   }
                  FILE* pipe = fmemopen(buffer, strlen(buffer), "r");
                  return pipe;
@@ -4055,10 +4055,10 @@ TEST_F(SystemServicesEventTest, onFirmwareUpdateInfoReceived_WhenEnvCqa)
                       memset(buffer, 0, sizeof(buffer));
                   if (string(command) == string("cat /tmp/xconf_httpcode_thunder.txt")) {
                       const char http_code_str[] = "460";
-                      strcpy(buffer, http_code_str);
+                      strncpy(buffer, http_code_str, sizeof(buffer) - 1);
                   } else if (string(command) == string("cat /tmp/xconf_response_thunder.txt")) {
                       const char response_str[] = "{\"firmwareVersion\":\"1234\"}";
-                      strcpy(buffer, response_str);
+                      strncpy(buffer, response_str, sizeof(buffer) - 1);
                   }
                  FILE* pipe = fmemopen(buffer, strlen(buffer), "r");
                  return pipe;
@@ -4105,10 +4105,10 @@ TEST_F(SystemServicesEventTest, onFirmwareUpdateInfoReceived_WhenEnvNotProdWitho
                       memset(buffer, 0, sizeof(buffer));
                   if (string(command) == string("cat /tmp/xconf_httpcode_thunder.txt")) {
                       const char http_code_str[] = "460";
-                      strcpy(buffer, http_code_str);
+                      strncpy(buffer, http_code_str, sizeof(buffer) - 1);
                   } else if (string(command) == string("cat /tmp/xconf_response_thunder.txt")) {
                       const char response_str[] = "{\"firmwareVersion\":\"1234\"}";
-                      strcpy(buffer, response_str);
+                      strncpy(buffer, response_str, sizeof(buffer) - 1);
                   }
                  FILE* pipe = fmemopen(buffer, strlen(buffer), "r");
                  return pipe;
@@ -4159,10 +4159,10 @@ TEST_F(SystemServicesEventTest, OnFirmwareUpdateInfoReceived_WhenEnvNotProdWithC
                       memset(buffer, 0, sizeof(buffer));
                   if (string(command) == string("cat /tmp/xconf_httpcode_thunder.txt")) {
                       const char http_code_str[] = "460";
-                      strcpy(buffer, http_code_str);
+                      strncpy(buffer, http_code_str, sizeof(buffer) - 1);
                   } else if (string(command) == string("cat /tmp/xconf_response_thunder.txt")) {
                       const char response_str[] = "{\"firmwareVersion\":\"1234\"}";
-                      strcpy(buffer, response_str);
+                      strncpy(buffer, response_str, sizeof(buffer) - 1);
                   }
                  FILE* pipe = fmemopen(buffer, strlen(buffer), "r");
                  return pipe;
@@ -4214,10 +4214,10 @@ TEST_F(SystemServicesEventTest, OnFirmwareUpdateInfoReceived_WhenEnvNotProdWithC
                       memset(buffer, 0, sizeof(buffer));
                   if (string(command) == string("cat /tmp/xconf_httpcode_thunder.txt")) {
                       const char http_code_str[] = "460";
-                      strcpy(buffer, http_code_str);
+                      strncpy(buffer, http_code_str, sizeof(buffer) - 1);
                   } else if (string(command) == string("cat /tmp/xconf_response_thunder.txt")) {
                       const char response_str[] = "{\"firmwareVersion\":\"1234\"}";
-                      strcpy(buffer, response_str);
+                      strncpy(buffer, response_str, sizeof(buffer) - 1);
                   }
                  FILE* pipe = fmemopen(buffer, strlen(buffer), "r");
                  return pipe;
@@ -4294,10 +4294,10 @@ TEST_F(SystemServicesEventTest, onFirmwareUpdateInfoReceived_WhenResponseEmpty)
                       memset(buffer, 0, sizeof(buffer));
                   if (string(command) == string("cat /tmp/xconf_httpcode_thunder.txt")) {
                       const char http_code_str[] = "460";
-                      strcpy(buffer, http_code_str);
+                      strncpy(buffer, http_code_str, sizeof(buffer) - 1);
                   } else if (string(command) == string("cat /tmp/xconf_response_thunder.txt")) {
                       const char response_str[] = "";
-                      strcpy(buffer, response_str);
+                      strncpy(buffer, response_str, sizeof(buffer) - 1);
                   }
                  FILE* pipe = fmemopen(buffer, strlen(buffer), "r");
                  return pipe;
@@ -4343,10 +4343,10 @@ TEST_F(SystemServicesEventTest, onFirmwareUpdateInfoReceived_WhenErrorInParsingR
                       memset(buffer, 0, sizeof(buffer));
                   if (string(command) == string("cat /tmp/xconf_httpcode_thunder.txt")) {
                       const char http_code_str[] = "460";
-                      strcpy(buffer, http_code_str);
+                      strncpy(buffer, http_code_str, sizeof(buffer) - 1);
                   } else if (string(command) == string("cat /tmp/xconf_response_thunder.txt")) {
                       const char response_str[] = "firmwareVersion:1234";
-                      strcpy(buffer, response_str);
+                      strncpy(buffer, response_str, sizeof(buffer) - 1);
                   }
                  FILE* pipe = fmemopen(buffer, strlen(buffer), "r");
                  return pipe;
@@ -4392,10 +4392,10 @@ TEST_F(SystemServicesEventTest, onFirmwareUpdateInfoReceived_WhenInvalidResponse
                       memset(buffer, 0, sizeof(buffer));
                   if (string(command) == string("cat /tmp/xconf_httpcode_thunder.txt")) {
                       const char http_code_str[] = "460";
-                      strcpy(buffer, http_code_str);
+                      strncpy(buffer, http_code_str, sizeof(buffer) - 1);
                   } else if (string(command) == string("cat /tmp/xconf_response_thunder.txt")) {
                       const char response_str[] = "{}";
-                      strcpy(buffer, response_str);
+                      strncpy(buffer, response_str, sizeof(buffer) - 1);
                   }
                  FILE* pipe = fmemopen(buffer, strlen(buffer), "r");
                  return pipe;
@@ -5452,7 +5452,7 @@ TEST_F(SystemServicesTest, uploadLogFailed_whenArchieveLogsFailed)
                       memset(buffer, 0, sizeof(buffer));
                   if (string(command) == string(". /lib/rdk/utils.sh && getMacAddressOnly")) {
                       const char mac_Addr[] = "test_mac";
-                      strcpy(buffer, mac_Addr);
+                      strncpy(buffer, mac_Addr, sizeof(buffer) - 1);
                   }
                  FILE* pipe = fmemopen(buffer, strlen(buffer), "r");
                  return pipe;
@@ -5484,7 +5484,7 @@ TEST_F(SystemServicesTest, uploadLogSuccess_withValidURL)
                       memset(buffer, 0, sizeof(buffer));
                   if (string(command) == string(". /lib/rdk/utils.sh && getMacAddressOnly")) {
                       const char mac_Addr[] = "test_mac";
-                      strcpy(buffer, mac_Addr);
+                      strncpy(buffer, mac_Addr, sizeof(buffer) - 1);
                   }
                  FILE* pipe = fmemopen(buffer, strlen(buffer), "r");
                  return pipe;
@@ -5517,7 +5517,7 @@ TEST_F(SystemServicesTest, uploadLogSuccess_WithDefaultURL)
                       memset(buffer, 0, sizeof(buffer));
                   if (string(command) == string(". /lib/rdk/utils.sh && getMacAddressOnly")) {
                       const char mac_Addr[] = "test_mac";
-                      strcpy(buffer, mac_Addr);
+                      strncpy(buffer, mac_Addr, sizeof(buffer) - 1);
                   }
                  FILE* pipe = fmemopen(buffer, strlen(buffer), "r");
                  return pipe;

--- a/Tests/tests/test_UsbAccess.cpp
+++ b/Tests/tests/test_UsbAccess.cpp
@@ -1444,7 +1444,7 @@ TEST_F(UsbAccessEventTest, archiveLogsSuccess_When_pathParamisEmpty)
             if (valueToReturn != NULL) {
                   char buffer[1024];
                   memset(buffer, 0, sizeof(buffer));
-                  strcpy(buffer, valueToReturn);
+                  strncpy(buffer, valueToReturn, sizeof(buffer) - 1);
                   FILE* pipe = fmemopen(buffer, strlen(buffer), "r");
                   return pipe;
             } else {
@@ -1524,7 +1524,7 @@ TEST_F(UsbAccessEventTest, archiveLogsSuccess_onValidPath)
             if (valueToReturn != NULL) {
                   char buffer[1024];
                   memset(buffer, 0, sizeof(buffer));
-                  strcpy(buffer, valueToReturn);
+                  strncpy(buffer, valueToReturn, sizeof(buffer) - 1);
                   FILE* pipe = fmemopen(buffer, strlen(buffer), "r");
                   return pipe;
             } else {
@@ -2168,7 +2168,8 @@ TEST_F(UsbAccessEventIarmTest, onUSBMountChangedSuccess)
 
     IARM_Bus_SYSMgr_EventData_t usbEventData;
     usbEventData.data.usbMountData.mounted= 1;
-    strcpy(usbEventData.data.usbMountData.dir, "/dev/sda1");
+    strncpy(usbEventData.data.usbMountData.dir, "/dev/sda1", sizeof(usbEventData.data.usbMountData.dir));
+    usbEventData.data.usbMountData.dir[sizeof(usbEventData.data.usbMountData.dir) - 1] = '\0';
     eventHandler(IARM_BUS_SYSMGR_NAME, IARM_BUS_SYSMGR_EVENT_USB_MOUNT_CHANGED, &usbEventData, 1);
 
     EXPECT_EQ(Core::ERROR_NONE, onUSBMountChanged.Lock());

--- a/Tests/tests/test_VoiceControl.cpp
+++ b/Tests/tests/test_VoiceControl.cpp
@@ -419,7 +419,7 @@ TEST_F(VoiceControlInitializedEventTest, onSessionEnd)
 
     memset(eventData, 0, len);
     eventData->api_revision = CTRLM_VOICE_IARM_BUS_API_REVISION;
-    sprintf(eventData->payload, "%s", onSessionEndParams.c_str());
+    snprintf(eventData->payload, len, "%s", onSessionEndParams.c_str());
 
     handler_.Subscribe(0, _T("onSessionEnd"), _T("org.rdk.VoiceControl"), message_);
     voiceEventHandler_(CTRLM_MAIN_IARM_BUS_NAME, CTRLM_VOICE_IARM_EVENT_JSON_SESSION_END, eventData, len);
@@ -449,7 +449,7 @@ TEST_F(VoiceControlInitializedEventTest, onStreamBegin)
 
     memset(eventData, 0, len);
     eventData->api_revision = CTRLM_VOICE_IARM_BUS_API_REVISION;
-    sprintf(eventData->payload, "%s", onStreamBeginParams.c_str());
+    snprintf(eventData->payload, len, "%s", onStreamBeginParams.c_str());
 
     handler_.Subscribe(0, _T("onStreamBegin"), _T("org.rdk.VoiceControl"), message_);
     voiceEventHandler_(CTRLM_MAIN_IARM_BUS_NAME, CTRLM_VOICE_IARM_EVENT_JSON_STREAM_BEGIN, eventData, len);
@@ -481,7 +481,7 @@ TEST_F(VoiceControlInitializedEventTest, onStreamEnd)
 
     memset(eventData, 0, len);
     eventData->api_revision = CTRLM_VOICE_IARM_BUS_API_REVISION;
-    sprintf(eventData->payload, "%s", onStreamEndParams.c_str());
+    snprintf(eventData->payload, len, "%s", onStreamEndParams.c_str());
 
     handler_.Subscribe(0, _T("onStreamEnd"), _T("org.rdk.VoiceControl"), message_);
     voiceEventHandler_(CTRLM_MAIN_IARM_BUS_NAME, CTRLM_VOICE_IARM_EVENT_JSON_STREAM_END, eventData, len);
@@ -515,7 +515,7 @@ TEST_F(VoiceControlInitializedEventTest, onServerMessage)
 
     memset(eventData, 0, len);
     eventData->api_revision = CTRLM_VOICE_IARM_BUS_API_REVISION;
-    sprintf(eventData->payload, "%s", onServerMessageParams.c_str());
+    snprintf(eventData->payload, len, "%s", onServerMessageParams.c_str());
 
     handler_.Subscribe(0, _T("onServerMessage"), _T("org.rdk.VoiceControl"), message_);
     voiceEventHandler_(CTRLM_MAIN_IARM_BUS_NAME, CTRLM_VOICE_IARM_EVENT_JSON_SERVER_MESSAGE, eventData, len);
@@ -547,7 +547,7 @@ TEST_F(VoiceControlInitializedEventTest, onKeywordVerification)
 
     memset(eventData, 0, len);
     eventData->api_revision = CTRLM_VOICE_IARM_BUS_API_REVISION;
-    sprintf(eventData->payload, "%s", onKeywordVerParams.c_str());
+    snprintf(eventData->payload, len, "%s", onKeywordVerParams.c_str());
 
     handler_.Subscribe(0, _T("onKeywordVerification"), _T("org.rdk.VoiceControl"), message_);
     voiceEventHandler_(CTRLM_MAIN_IARM_BUS_NAME, CTRLM_VOICE_IARM_EVENT_JSON_KEYWORD_VERIFICATION, eventData, len);


### PR DESCRIPTION
Convert string functions to safer versions and making sure there is a null terminator at the end after string function calls in RDKServices test files