### PR TITLE
RDK-42620,RDK-42827:Cherry Video Plane/AudioMixing

### DIFF
--- a/HdmiInput/HdmiInput.cpp
+++ b/HdmiInput/HdmiInput.cpp
@@ -229,9 +229,16 @@ namespace WPEFramework
             returnIfParamNotFound(parameters, "portId");
 
             string sPortId = parameters["portId"].String();
-            int portId = 0;
-            try {
+            bool audioMix = parameters["requestAudioMix"].Boolean();
+	    int portId = 0;
+	    //planeType = 0 -  primary, 1 - secondary video plane type
+	    int planeType = 0;
+	    try {
                 portId = stoi(sPortId);
+		if (parameters.HasLabel("plane")){
+                        string sPlaneType = parameters["plane"].String();
+                        planeType = stoi(sPlaneType);
+                }
             }catch (const std::exception& err) {
 		    LOGWARN("sPortId invalid paramater: %s ", sPortId.c_str());
 		    returnResponse(false);
@@ -239,7 +246,7 @@ namespace WPEFramework
             bool success = true;
             try
             {
-                device::HdmiInput::getInstance().selectPort(portId);
+                device::HdmiInput::getInstance().selectPort(portId,audioMix,planeType);
             }
             catch (const device::Exception& err)
             {

--- a/HdmiInput/HdmiInput.json
+++ b/HdmiInput/HdmiInput.json
@@ -222,6 +222,16 @@
                 "properties": {
                     "portId":{
                         "$ref": "#/definitions/portId"
+                    },
+		    "audioMix":{
+                        "summary": "Defines whether the Audio mixing is true or false",
+                        "type": "boolean",
+                        "example": "true"
+                    },
+                    "planeType":{
+                        "summary": "Defines whether the video plane type, 0 - Primary video plane, 1 - Secondary Video Plane, Other values - Invalid ",
+                        "type": "integer",
+                        "example": "0"
                     }
                 },
                 "required": [

--- a/Tests/mocks/devicesettings.h
+++ b/Tests/mocks/devicesettings.h
@@ -582,7 +582,7 @@ public:
     virtual uint8_t getNumberOfInputs() const = 0;
     virtual bool isPortConnected(int8_t Port) const = 0;
     virtual std::string getCurrentVideoMode() const = 0;
-    virtual void selectPort(int8_t Port) const = 0;
+    virtual void selectPort(int8_t Port,bool audioMix = false, int videoPlane = 0) const = 0;
     virtual void scaleVideo(int32_t x, int32_t y, int32_t width, int32_t height) const = 0;
 
     virtual void getEDIDBytesInfo(int iHdmiPort, std::vector<uint8_t>& edid) const = 0;
@@ -616,9 +616,9 @@ public:
     {
         return impl->getCurrentVideoMode();
     }
-    void selectPort(int8_t Port) const
+    void selectPort(int8_t Port,bool audioMix = false,int videoPlane = 0) const
     {
-        return impl->selectPort(Port);
+        return impl->selectPort(Port,audioMix,videoPlane);
     }
     void scaleVideo(int32_t x, int32_t y, int32_t width, int32_t height) const
     {

--- a/Tests/mocks/devicesettings/HdmiInputMock.h
+++ b/Tests/mocks/devicesettings/HdmiInputMock.h
@@ -11,7 +11,7 @@ public:
     MOCK_METHOD(uint8_t, getNumberOfInputs, (), (const, override));
     MOCK_METHOD(bool, isPortConnected, (int8_t Port), (const, override));
     MOCK_METHOD(std::string, getCurrentVideoMode, (), (const, override));
-    MOCK_METHOD(void, selectPort, (int8_t Port), (const, override));
+    MOCK_METHOD(void, selectPort, (int8_t Port,bool audioMix, int videoPlane), (const, override));
     MOCK_METHOD(void, scaleVideo, (int32_t x, int32_t y, int32_t width, int32_t height), (const, override));
     MOCK_METHOD(void, getEDIDBytesInfo, (int iHdmiPort, std::vector<uint8_t> &edid), (const, override));
     MOCK_METHOD(void, getHDMISPDInfo, (int iHdmiPort, std::vector<uint8_t> &data), (const, override));


### PR DESCRIPTION
Reason for change: changes done in thunder layer for secondary video plane and audio mixing
Test Procedure: Build and Verify.
Risks: Low
Signed-off-by: Aishwariya B aishwariya.bhaskar@sky.uk