### PR TITLE
RDK-43800: Query Internet Connectivity specific to Ipversion

### DIFF
--- a/Network/CHANGELOG.md
+++ b/Network/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+## [1.2.0] - 2023-08-16
+### Added
+- Added new params in isConnectedToInternet for Query Internet Connectivity specific to Ipversion
+
 ## [1.1.1] - 2023-08-16
 ### Fixed
 - Remove the Cache Logic for getInterface Network Plugin api

--- a/Network/Network.cpp
+++ b/Network/Network.cpp
@@ -33,7 +33,7 @@ using namespace std;
 #define CIDR_NETMASK_IP_LEN 32
 
 #define API_VERSION_NUMBER_MAJOR 1
-#define API_VERSION_NUMBER_MINOR 1
+#define API_VERSION_NUMBER_MINOR 2
 #define API_VERSION_NUMBER_PATCH 0
 
 /* Netsrvmgr Based Macros & Structures */
@@ -1144,16 +1144,28 @@ typedef struct _IARM_BUS_NetSrvMgr_Iface_EventData_t {
         uint32_t Network::isConnectedToInternet (const JsonObject &parameters, JsonObject &response)
         {
             bool result = false;
-            bool isconnected = false;
+            std::string ipversion;
 
             if(m_isPluginInited)
             {
-                if (IARM_RESULT_SUCCESS == IARM_Bus_Call(IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_NETSRVMGR_API_isConnectedToInternet, (void*) &isconnected, sizeof(isconnected)))
-                {
-                    LOGINFO("%s :: isconnected = %d \n",__FUNCTION__,isconnected);
-                    response["connectedToInternet"] = isconnected;
+                IARM_BUS_NetSrvMgr_isConnectedtoInternet_t param;
+                getDefaultStringParameter("ipversion", ipversion, "");
+                Utils::String::toUpper(ipversion);
+                if (ipversion == "IPV4")
+                    param.ipversion = NSM_IPRESOLVE_V4;
+                else if (ipversion == "IPV6")
+                    param.ipversion = NSM_IPRESOLVE_V6;
+                else
+                    param.ipversion = NSM_IPRESOLVE_WHATEVER;
 
-                    if (isconnected)
+                param.isconnected = false;
+                if (IARM_RESULT_SUCCESS == IARM_Bus_Call(IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_NETSRVMGR_API_isConnectedToInternet, (void*) &param, sizeof(param)))
+                {
+                    LOGINFO("%s :: isconnected = %d \n",__FUNCTION__, param.isconnected);
+                    response["connectedToInternet"] = param.isconnected;
+                    if(ipversion == "IPV4" || ipversion == "IPV6")
+                        response["ipversion"] = ipversion.c_str();
+                    if (param.isconnected)
                     {
                         PluginHost::ISubSystem* subSystem = m_service->SubSystems();
 
@@ -1184,7 +1196,7 @@ typedef struct _IARM_BUS_NetSrvMgr_Iface_EventData_t {
                                 else
                                     LOGERR("Connected to Internet, but no publicIP");
                             }
-    
+ 
                             subSystem->Release();
                         }
                     }
@@ -1251,14 +1263,26 @@ typedef struct _IARM_BUS_NetSrvMgr_Iface_EventData_t {
         {
             IARM_BUS_NetSrvMgr_Iface_InternetConnectivityStatus_t iarmData;
             bool result = false;
+            std::string ipversion;
 
             if(m_isPluginInited)
             {
+                getDefaultStringParameter("ipversion", ipversion, "");
+                Utils::String::toUpper(ipversion);
+                if (ipversion == "IPV4")
+                    iarmData.ipversion = NSM_IPRESOLVE_V4;
+                else if (ipversion == "IPV6")
+                    iarmData.ipversion = NSM_IPRESOLVE_V6;
+                else
+                    iarmData.ipversion = NSM_IPRESOLVE_WHATEVER;
+
                 if (IARM_RESULT_SUCCESS == IARM_Bus_Call(IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_NETSRVMGR_API_getInternetConnectionState, (void*)&iarmData, sizeof(iarmData)))
                 {
                     LOGINFO("InternetConnectionState = %d ",iarmData.connectivityState);
                     response["state"] = iarmData.connectivityState;
-                    if (iarmData.connectivityState == CAPTIVE_PORTAL)
+                    if(ipversion == "IPV4" || ipversion == "IPV6")
+                        response["ipversion"] = ipversion.c_str();
+		    if (iarmData.connectivityState == CAPTIVE_PORTAL)
                     {
                         LOGINFO("Captive potal found URI = %s ", iarmData.captivePortalURI);
                         response["URI"] = string(iarmData.captivePortalURI, MAX_URI_LEN - 1);

--- a/Network/Network.h
+++ b/Network/Network.h
@@ -98,12 +98,20 @@ typedef enum _InternetConnectionState_t {
     FULLY_CONNECTED
 }InternetConnectionState_t;
 
+typedef enum _NetworkManager_IPRESOLVE_ErrorCode_t
+{
+  NSM_IPRESOLVE_WHATEVER=0,
+  NSM_IPRESOLVE_V4,
+  NSM_IPRESOLVE_V6
+} NetworkManager_IPRESOLVE_t;
+
 typedef struct
 {
     int connectivityState;
     int monitorInterval;
     bool monitorConnectivity;
     char captivePortalURI[MAX_URI_LEN];
+    NetworkManager_IPRESOLVE_t ipversion;
 } IARM_BUS_NetSrvMgr_Iface_InternetConnectivityStatus_t;
 
 typedef struct {
@@ -118,6 +126,12 @@ typedef struct {
 
 typedef IARM_BUS_NetSrvMgr_Iface_EventInterfaceStatus_t IARM_BUS_NetSrvMgr_Iface_EventInterfaceEnabledStatus_t;
 typedef IARM_BUS_NetSrvMgr_Iface_EventInterfaceStatus_t IARM_BUS_NetSrvMgr_Iface_EventInterfaceConnectionStatus_t;
+
+typedef struct
+{
+    NetworkManager_IPRESOLVE_t ipversion;
+    bool isconnected;
+} IARM_BUS_NetSrvMgr_isConnectedtoInternet_t;
 
 typedef struct {
     char interface[16];

--- a/Tests/tests/test_Network.cpp
+++ b/Tests/tests/test_Network.cpp
@@ -266,8 +266,8 @@ TEST_F(NetworkTest, isConnectedToInternet)
                 EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
                 EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_isConnectedToInternet)));
                 *((bool*) arg) = true;
-
-                EXPECT_EQ(*((bool*) arg), true);
+                auto param = static_cast<IARM_BUS_NetSrvMgr_isConnectedtoInternet_t *>(arg);
+                param->isconnected = true;
 
                 return IARM_RESULT_SUCCESS;
             });

--- a/docs/api/NetworkPlugin.md
+++ b/docs/api/NetworkPlugin.md
@@ -511,8 +511,8 @@ No Events
 
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
-| params | object |  |
-| params.ipversion | string | Ipversion to query |
+| params | object | <sup>*(optional)*</sup> |
+| params?.ipversion | string | <sup>*(optional)*</sup> Either IPv4 or IPv6 |
 
 ### Result
 
@@ -520,7 +520,7 @@ No Events
 | :-------- | :-------- | :-------- |
 | result | object |  |
 | result.connectedToInternet | boolean | `true` if internet connectivity is detected, otherwise `false` |
-| result.ipversion | string | The IPVersion |
+| result?.ipversion | string | <sup>*(optional)*</sup> If the request is specific to IPv4 or IPv6 |
 | result.success | boolean | Whether the request succeeded |
 
 ### Example
@@ -569,15 +569,15 @@ No Events
 
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
-| params | object |  |
-| params.ipversion | string | Ipversion to query |
+| params | object | <sup>*(optional)*</sup>  |
+| params?.ipversion | string | <sup>*(optional)*</sup> Either IPv4 or IPv6 |
 
 ### Result
 
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
 | result | object |  |
-| result.ipversion | string | The Ipversion |
+| result?.ipversion | string | <sup>*(optional)*</sup> If the request is specific to IPv4 or IPv6 |
 | result.state | integer | Internet Connection state |
 | result?.URI | string | <sup>*(optional)*</sup> Captive portal URI |
 | result.success | boolean | Whether the request succeeded |

--- a/docs/api/NetworkPlugin.md
+++ b/docs/api/NetworkPlugin.md
@@ -2,7 +2,7 @@
 <a name="head.NetworkPlugin"></a>
 # NetworkPlugin
 
-**Version: [1.0.10](https://github.com/rdkcentral/rdkservices/blob/main/Network/CHANGELOG.md)**
+**Version: [1.2.0](https://github.com/rdkcentral/rdkservices/blob/main/Network/CHANGELOG.md)**
 
 A org.rdk.Network plugin for Thunder framework.
 
@@ -422,7 +422,7 @@ No Events
     "id": 42,
     "method": "org.rdk.Network.getSTBIPFamily",
     "params": {
-        "family": "AF_INET"
+        "family": "IPv4"
     }
 }
 ```
@@ -509,7 +509,10 @@ No Events
 
 ### Parameters
 
-This method takes no parameters.
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.ipversion | string | Ipversion to query |
 
 ### Result
 
@@ -517,6 +520,7 @@ This method takes no parameters.
 | :-------- | :-------- | :-------- |
 | result | object |  |
 | result.connectedToInternet | boolean | `true` if internet connectivity is detected, otherwise `false` |
+| result.ipversion | string | The IPVersion |
 | result.success | boolean | Whether the request succeeded |
 
 ### Example
@@ -528,6 +532,9 @@ This method takes no parameters.
     "jsonrpc": "2.0",
     "id": 42,
     "method": "org.rdk.Network.isConnectedToInternet"
+    "params": {
+        "ipversion": "IPv4"
+    }
 }
 ```
 
@@ -538,6 +545,7 @@ This method takes no parameters.
     "jsonrpc": "2.0",
     "id": 42,
     "result": {
+        "ipversion": "IPv4",
         "connectedToInternet": true,
         "success": true
     }
@@ -559,13 +567,17 @@ No Events
 
 ### Parameters
 
-This method takes no parameters.
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.ipversion | string | Ipversion to query |
 
 ### Result
 
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
 | result | object |  |
+| result.ipversion | string | The Ipversion |
 | result.state | integer | Internet Connection state |
 | result?.URI | string | <sup>*(optional)*</sup> Captive portal URI |
 | result.success | boolean | Whether the request succeeded |
@@ -578,7 +590,10 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Network.getInternetConnectionState"
+    "method": "org.rdk.Network.getInternetConnectionState",
+    "params": {
+        "ipversion": "IPv4"
+    }
 }
 ```
 
@@ -589,6 +604,7 @@ This method takes no parameters.
     "jsonrpc": "2.0",
     "id": 42,
     "result": {
+        "ipversion": "IPv4",
         "state": 2,
         "URI": "http://10.0.0.1/captiveportal.jst",
         "success": true
@@ -1092,7 +1108,7 @@ Sets the IP settings.All the inputs are mandatory for v1. But for v2, the interf
     "params": {
         "interface": "WIFI",
         "ipversion": "IPv4",
-        "autoconfig": true,
+        "autoconfig": false,
         "ipaddr": "192.168.1.101",
         "netmask": "255.255.255.0",
         "gateway": "192.168.1.1",


### PR DESCRIPTION
Reason for change:
Extending the isConnectedToInternet() and getConn() APIs to suport individual address space. Fix above issue: Send IPRESOLVE value in curl request Test Procedure: Build and verify.
Risks: High
Priority: P1
Signed-off-by: Kumar Santhanam <Kumar_Santhanam@comcast.com>