### PR TITLE
DELIA-63161: Thunder Services - Unsafe string Functions - Phase 6

### DIFF
--- a/ControlService/ControlService.cpp
+++ b/ControlService/ControlService.cpp
@@ -1897,7 +1897,7 @@ namespace WPEFramework {
             }
 
             // Store the STB-based information from the RF4CE network
-            sprintf(strMACAddress, "0x%016llX", netStatus.status.rf4ce.ieee_address);
+            snprintf(strMACAddress, sizeof(strMACAddress), "0x%016llX", netStatus.status.rf4ce.ieee_address);
             stbData["stbRf4ceMACAddress"]   = std::string(strMACAddress);
             stbData["stbRf4ceSocMfr"]       = std::string(netStatus.status.rf4ce.chipset);
             stbData["stbHALVersion"]        = std::string(netStatus.status.rf4ce.version_hal);
@@ -2010,7 +2010,7 @@ namespace WPEFramework {
 
             // Load the remoteInfo object with the data from the ctrlm_controller_status_t.
             remoteInfo["remoteId"]                  = JsonValue((int)ctrlStatus.controller_id);
-            sprintf(strMACAddress, "0x%016llX", ctrlStatus.status.ieee_address);
+            snprintf(strMACAddress, sizeof(strMACAddress), "0x%016llX", ctrlStatus.status.ieee_address);
             remoteInfo["remoteMACAddress"]          = std::string(strMACAddress);
             remoteInfo["remoteModel"]               = std::string(getRemoteModel(ctrlStatus.status.type));
             remoteInfo["remoteModelVersion"]        = std::string(getRemoteModelVersion(ctrlStatus.status.type));

--- a/OCIContainer/OCIContainer.cpp
+++ b/OCIContainer/OCIContainer.cpp
@@ -629,7 +629,7 @@ const int OCIContainer::GetContainerDescriptorFromId(const std::string& containe
     for (const std::pair<int32_t, std::string>& container : containers)
     {
         char strDescriptor[32];
-        sprintf(strDescriptor, "%d", container.first);
+        snprintf(strDescriptor, sizeof(strDescriptor), "%d", container.first);
 
         if ((containerId == strDescriptor) || (containerId == container.second))
         {

--- a/SystemAudioPlayer/impl/logger.cpp
+++ b/SystemAudioPlayer/impl/logger.cpp
@@ -131,7 +131,7 @@ namespace SAP {
         gmtime_r(&spec.tv_sec, &tm);
         long ms = spec.tv_nsec / 1.0e6;
 
-        sprintf(timestamp, "%02d%02d%02d-%02d:%02d:%02d.%03ld",
+        snprintf(timestamp, sizeof(timestamp), "%02d%02d%02d-%02d:%02d:%02d.%03ld",
                 tm.tm_year % 100,
                 tm.tm_mon + 1,
                 tm.tm_mday,

--- a/TextToSpeech/impl/logger.cpp
+++ b/TextToSpeech/impl/logger.cpp
@@ -131,7 +131,7 @@ namespace TTS {
         gmtime_r(&spec.tv_sec, &tm);
         long ms = spec.tv_nsec / 1.0e6;
 
-        sprintf(timestamp, "%02d%02d%02d-%02d:%02d:%02d.%03ld",
+        snprintf(timestamp, sizeof(timestamp), "%02d%02d%02d-%02d:%02d:%02d.%03ld",
                 tm.tm_year % 100,
                 tm.tm_mon + 1,
                 tm.tm_mday,


### PR DESCRIPTION
Convert string functions to safer versions and making sure there is a null terminator at the end after string function call Plugins: ControlService, OCIContainer, SystemAudioPlayer, TextToSpeech