### PR TITLE
RDKDEV-796: RDKCOM-4076: [RDKServices]: Failed to get Event "client.e…

### DIFF
--- a/FrameRate/CHANGELOG.md
+++ b/FrameRate/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.0.4] - 2023-09-12
+### Fixed
+- Sending FrameRate onDisplayFrameRateChanging and onDisplayFrameRateChanged events to wpeframework log with displayFrameRate params
+
 ## [1.0.3] - 2023-04-12
 ### Fixed
 - Fixed IARM_Bus_UnRegisterEventHandler  call to IARM_Bus_RemoveEventHandler

--- a/FrameRate/FrameRate.cpp
+++ b/FrameRate/FrameRate.cpp
@@ -51,7 +51,7 @@
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 3
+#define API_VERSION_NUMBER_PATCH 4
 
 namespace WPEFramework
 {
@@ -455,28 +455,54 @@ namespace WPEFramework
 
 	void FrameRate::FrameRatePreChange(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
         {
+	    char dispFrameRate[20] ={0};
+            if (strcmp(owner, IARM_BUS_DSMGR_NAME) == 0)
+            {
+                switch (eventId) {
+                    case IARM_BUS_DSMGR_EVENT_DISPLAY_FRAMRATE_PRECHANGE:
+                        IARM_Bus_DSMgr_EventData_t *eventData = (IARM_Bus_DSMgr_EventData_t *)data;
+                        strcpy(dispFrameRate,eventData->data.DisplayFrameRateChange.framerate);
+                        break;
+                }
+            }
+
             if(FrameRate::_instance)
             {
-                FrameRate::_instance->frameRatePreChange();
+                FrameRate::_instance->frameRatePreChange(dispFrameRate);
             }
         }
 
-        void FrameRate::frameRatePreChange()
+        void FrameRate::frameRatePreChange(char *displayFrameRate)
         {
-            sendNotify(EVENT_FRAMERATE_PRECHANGE, JsonObject());
+            JsonObject params;
+            params["displayFrameRate"] = std::string(displayFrameRate);
+            sendNotify(EVENT_FRAMERATE_PRECHANGE, params);
         }
 
         void FrameRate::FrameRatePostChange(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
         {
+	    char dispFrameRate[20] ={0};
+            if (strcmp(owner, IARM_BUS_DSMGR_NAME) == 0)
+            {
+                switch (eventId) {
+                    case IARM_BUS_DSMGR_EVENT_DISPLAY_FRAMRATE_POSTCHANGE:
+                        IARM_Bus_DSMgr_EventData_t *eventData = (IARM_Bus_DSMgr_EventData_t *)data;
+                        strcpy(dispFrameRate,eventData->data.DisplayFrameRateChange.framerate);
+                        break;
+                }
+            }
+
             if(FrameRate::_instance)
             {
-                FrameRate::_instance->frameRatePostChange();
+                FrameRate::_instance->frameRatePostChange(dispFrameRate);
             }
         }
 
-        void FrameRate::frameRatePostChange()
+        void FrameRate::frameRatePostChange(char *displayFrameRate)
         {
-            sendNotify(EVENT_FRAMERATE_POSTCHANGE, JsonObject());
+            JsonObject params;
+            params["displayFrameRate"] = std::string(displayFrameRate);
+            sendNotify(EVENT_FRAMERATE_POSTCHANGE, params);
         }
 
         

--- a/FrameRate/FrameRate.h
+++ b/FrameRate/FrameRate.h
@@ -66,10 +66,10 @@ namespace WPEFramework {
 	    void InitializeIARM();
             void DeinitializeIARM();
 
-            void frameRatePreChange();
+            void frameRatePreChange(char *displayFrameRate);
             static void FrameRatePreChange(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
 
-            void frameRatePostChange();
+            void frameRatePostChange(char *displayFrameRate);
             static void FrameRatePostChange(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
 
 


### PR DESCRIPTION
…vents.1.onDisplayFrameRateChanged" if we setting org.rdk.FrameRate.2.setDisplayFrameRate

Reason for change: Added _dsSendDisplayFrameRateStatusPreChangeCall and _dsSendDisplayFrameRateStatusPreChangeCall to broadcast framerate prechange and postchange events

Test Procedure: Build and verify.

Risks: Low