### PR TITLE
RDKTV-25173 - adding rawDeviceType parameter in getDiscoveredDevices

### DIFF
--- a/Bluetooth/Bluetooth.cpp
+++ b/Bluetooth/Bluetooth.cpp
@@ -40,7 +40,7 @@
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 1
+#define API_VERSION_NUMBER_PATCH 3
 
 const string WPEFramework::Plugin::Bluetooth::SERVICE_NAME = "org.rdk.Bluetooth";
 const string WPEFramework::Plugin::Bluetooth::METHOD_START_SCAN = "startScan";
@@ -396,6 +396,7 @@ namespace WPEFramework
                     deviceDetails["deviceType"] = string(BTRMGR_GetDeviceTypeAsString(discoveredDevices.m_deviceProperty[i].m_deviceType));
                     deviceDetails["connected"] = discoveredDevices.m_deviceProperty[i].m_isConnected?true:false;
                     deviceDetails["paired"] = discoveredDevices.m_deviceProperty[i].m_isPairedDevice?true:false;
+                    deviceDetails["rawDeviceType"] = std::to_string(discoveredDevices.m_deviceProperty[i].m_ui32DevClassBtSpec);    
                     deviceArray.Add(deviceDetails);
                 }
             }

--- a/Bluetooth/CHANGELOG.md
+++ b/Bluetooth/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+## [1.0.3] - 2023-09-12
+### Added
+- added rawDeviceType parameter in getDiscoveredDevices
 
 ## [1.0.2] - 2022-11-21
 ### Fixed

--- a/docs/api/BluetoothPlugin.md
+++ b/docs/api/BluetoothPlugin.md
@@ -2,7 +2,7 @@
 <a name="Bluetooth_Plugin"></a>
 # Bluetooth Plugin
 
-**Version: [1.0.2](https://github.com/rdkcentral/rdkservices/blob/main/Bluetooth/CHANGELOG.md)**
+**Version: [1.0.3](https://github.com/rdkcentral/rdkservices/blob/main/Bluetooth/CHANGELOG.md)**
 
 A org.rdk.Bluetooth plugin for Thunder framework.
 
@@ -1381,7 +1381,7 @@ Triggered during device discovery when a new device is discovered or a discovere
 | params.discoveryType | string | either `DISCOVERED` or `LOST` |
 | params.name | string | Name of the Bluetooth Device |
 | params.deviceType | string | Device class (for example: `headset`, `speakers`, etc.) |
-| params.rawDeviceType | string | Bluetooth device class as hex code |
+| params.rawDeviceType | string | Bluetooth device class as decimal |
 | params.lastConnectedState | boolean | Whether the device was last to connect. Only the last connected device has a value of `true` |
 | params.paired | boolean | Whether the device is paired. 1. `true` if the device is paired when the PAIRING_CHANGE status is sent 2. `false` if the device is unpaired. **Note** The set-top box does not retain/store all paired devices across previous power cycles. In addition, if the device is unpaired as part of a previous operation and the same device gets detected in a new discovery cycle, the device will not be a paired device |
 
@@ -1396,7 +1396,7 @@ Triggered during device discovery when a new device is discovered or a discovere
         "discoveryType": "DISCOVERED",
         "name": "[TV] UE32J5530",
         "deviceType": "TV",
-        "rawDeviceType": "0x060104",
+        "rawDeviceType": "2360344",
         "lastConnectedState": true,
         "paired": true
     }
@@ -1587,7 +1587,7 @@ Triggered when the previous request to pair or connect failed. In absence of a f
 | params.deviceID | string | ID that is derived from the Bluetooth MAC address. 6 byte MAC value is packed into 8 byte with leading zeros for first 2 bytes |
 | params.name | string | Name of the Bluetooth Device |
 | params.deviceType | string | Device class (for example: `headset`, `speakers`, etc.) |
-| params.rawDeviceType | string | Bluetooth device class as hex code |
+| params.rawDeviceType | string | Bluetooth device class as decimal |
 | params.lastConnectedState | boolean | Whether the device was last to connect. Only the last connected device has a value of `true` |
 | params.paired | boolean | Whether paired or not |
 | params.connected | boolean | Whether the device is connected. `true` if the device is connected when the `CONNECTION_CHANGE` status is sent. `false` if the device is disconnected |
@@ -1603,7 +1603,7 @@ Triggered when the previous request to pair or connect failed. In absence of a f
         "deviceID": "61579454946360",
         "name": "[TV] UE32J5530",
         "deviceType": "TV",
-        "rawDeviceType": "0x060104",
+        "rawDeviceType": "2360344",
         "lastConnectedState": true,
         "paired": true,
         "connected": true
@@ -1629,7 +1629,7 @@ Triggered when the Bluetooth functionality status changes. Supported statuses ar
 | params.deviceID | string | ID that is derived from the Bluetooth MAC address. 6 byte MAC value is packed into 8 byte with leading zeros for first 2 bytes |
 | params.name | string | Name of the Bluetooth Device |
 | params.deviceType | string | Device class (for example: `headset`, `speakers`, etc.) |
-| params.rawDeviceType | string | Bluetooth device class as hex code |
+| params.rawDeviceType | string | Bluetooth device class as decimal |
 | params.lastConnectedState | boolean | Whether the device was last to connect. Only the last connected device has a value of `true` |
 | params.paired | boolean | Whether paired or not |
 | params.connected | boolean | Whether device connected or not |
@@ -1645,7 +1645,7 @@ Triggered when the Bluetooth functionality status changes. Supported statuses ar
         "deviceID": "61579454946360",
         "name": "[TV] UE32J5530",
         "deviceType": "TV",
-        "rawDeviceType": "0x060104",
+        "rawDeviceType": "2360344",
         "lastConnectedState": true,
         "paired": true,
         "connected": false
@@ -1666,7 +1666,7 @@ Triggered when the new device got discovered.
 | params.deviceID | string | ID that is derived from the Bluetooth MAC address. 6 byte MAC value is packed into 8 byte with leading zeros for first 2 bytes |
 | params.name | string | Name of the Bluetooth Device |
 | params.deviceType | string | Device class (for example: `headset`, `speakers`, etc.) |
-| params.rawDeviceType | string | Bluetooth device class as hex code |
+| params.rawDeviceType | string | Bluetooth device class as decimal |
 | params.lastConnectedState | boolean | Whether the device was last to connect. Only the last connected device has a value of `true` |
 
 ### Example
@@ -1679,7 +1679,7 @@ Triggered when the new device got discovered.
         "deviceID": "61579454946360",
         "name": "[TV] UE32J5530",
         "deviceType": "TV",
-        "rawDeviceType": "0x060104",
+        "rawDeviceType": "2360344",
         "lastConnectedState": true
     }
 }
@@ -1698,7 +1698,7 @@ Triggered when any discovered device lost or out of range.
 | params.deviceID | string | ID that is derived from the Bluetooth MAC address. 6 byte MAC value is packed into 8 byte with leading zeros for first 2 bytes |
 | params.name | string | Name of the Bluetooth Device |
 | params.deviceType | string | Device class (for example: `headset`, `speakers`, etc.) |
-| params.rawDeviceType | string | Bluetooth device class as hex code |
+| params.rawDeviceType | string | Bluetooth device class as decimal |
 | params.lastConnectedState | boolean | Whether the device was last to connect. Only the last connected device has a value of `true` |
 
 ### Example
@@ -1711,7 +1711,7 @@ Triggered when any discovered device lost or out of range.
         "deviceID": "61579454946360",
         "name": "[TV] UE32J5530",
         "deviceType": "TV",
-        "rawDeviceType": "0x060104",
+        "rawDeviceType": "2360344",
         "lastConnectedState": true
     }
 }


### PR DESCRIPTION
Reason for change: AS team are asking if rawDeviceType parameter as appears in  onDiscoveredDevice event
can also be added to getDiscoveredDevices method

Test Procedure: getDiscoveredDevices should return rawDeviceType

Risks: Low
Priority: P1