### PR TITLE
RDKDEV-796: RDKCOM-4076: [RDKServices]: Failed to get Event "client.e…

### DIFF
--- a/FrameRate/CHANGELOG.md
+++ b/FrameRate/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.0.5] - 2023-09-13
+### Changed
+-  FrameRate onDisplayFrameRateChanging and onDisplayFrameRateChanged events to wpeframework log with displayFrameRate params
+
 ## [1.0.4] - 2023-09-12
 ### Added
 - Implement Thunder Plugin Configuration for Kirkstone builds(CMake-3.20 & above)

--- a/FrameRate/FrameRate.cpp
+++ b/FrameRate/FrameRate.cpp
@@ -455,28 +455,54 @@ namespace WPEFramework
 
 	void FrameRate::FrameRatePreChange(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
         {
+	    char dispFrameRate[20] ={0};
+            if (strcmp(owner, IARM_BUS_DSMGR_NAME) == 0)
+            {
+                switch (eventId) {
+                    case IARM_BUS_DSMGR_EVENT_DISPLAY_FRAMRATE_PRECHANGE:
+                        IARM_Bus_DSMgr_EventData_t *eventData = (IARM_Bus_DSMgr_EventData_t *)data;
+                        strcpy(dispFrameRate,eventData->data.DisplayFrameRateChange.framerate);
+                        break;
+                }
+            }
+
             if(FrameRate::_instance)
             {
-                FrameRate::_instance->frameRatePreChange();
+                FrameRate::_instance->frameRatePreChange(dispFrameRate);
             }
         }
 
-        void FrameRate::frameRatePreChange()
+        void FrameRate::frameRatePreChange(char *displayFrameRate)
         {
-            sendNotify(EVENT_FRAMERATE_PRECHANGE, JsonObject());
+            JsonObject params;
+            params["displayFrameRate"] = std::string(displayFrameRate);
+            sendNotify(EVENT_FRAMERATE_PRECHANGE, params);
         }
 
         void FrameRate::FrameRatePostChange(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
         {
+	    char dispFrameRate[20] ={0};
+            if (strcmp(owner, IARM_BUS_DSMGR_NAME) == 0)
+            {
+                switch (eventId) {
+                    case IARM_BUS_DSMGR_EVENT_DISPLAY_FRAMRATE_POSTCHANGE:
+                        IARM_Bus_DSMgr_EventData_t *eventData = (IARM_Bus_DSMgr_EventData_t *)data;
+                        strcpy(dispFrameRate,eventData->data.DisplayFrameRateChange.framerate);
+                        break;
+                }
+            }
+
             if(FrameRate::_instance)
             {
-                FrameRate::_instance->frameRatePostChange();
+                FrameRate::_instance->frameRatePostChange(dispFrameRate);
             }
         }
 
-        void FrameRate::frameRatePostChange()
+        void FrameRate::frameRatePostChange(char *displayFrameRate)
         {
-            sendNotify(EVENT_FRAMERATE_POSTCHANGE, JsonObject());
+            JsonObject params;
+            params["displayFrameRate"] = std::string(displayFrameRate);
+            sendNotify(EVENT_FRAMERATE_POSTCHANGE, params);
         }
 
         

--- a/FrameRate/FrameRate.h
+++ b/FrameRate/FrameRate.h
@@ -66,10 +66,10 @@ namespace WPEFramework {
 	    void InitializeIARM();
             void DeinitializeIARM();
 
-            void frameRatePreChange();
+            void frameRatePreChange(char *displayFrameRate);
             static void FrameRatePreChange(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
 
-            void frameRatePostChange();
+            void frameRatePostChange(char *displayFrameRate);
             static void FrameRatePostChange(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
 
 

--- a/FrameRate/FrameRate.json
+++ b/FrameRate/FrameRate.json
@@ -163,10 +163,30 @@
     },
     "events":{
         "onDisplayFrameRateChanging":{
-            "summary": "Triggered when the framerate changes started"
+            "summary": "Triggered when the framerate changes started",
+	    "params": {
+                "type":"object",
+                "properties": {
+                    "displayFrameRate": {
+                        "summary": "Display FrameRate changing",
+                        "type": "string",
+                        "example": "1920x1080x60"
+                    }
+                }
+            }
         },
         "onDisplayFrameRateChanged":{
-            "summary": "Triggered when the framerate changed"
+            "summary": "Triggered when the framerate changed",
+	    "params": {
+                "type":"object",
+                "properties": {
+                    "displayFrameRate": {
+                        "summary": "Display FrameRate changed",
+                        "type": "string",
+                        "example": "1920x1080x60"
+                    }
+                }
+            }
         },
         "onFpsEvent":{
             "summary": "Triggered at the end of each interval as defined by the `setCollectionFrequency` method and once after the `stopFpsCollection` method is invoked.",

--- a/SystemServices/CHANGELOG.md
+++ b/SystemServices/CHANGELOG.md
@@ -15,9 +15,9 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
-## [1.7.1] - 2023-09-12
+## [1.7.2] - 2023-09-19
 ### Fixed
-- Based on System document updated onRebootRequest event with requestedApp and rebootReason
+- Based on System document updated onRebootRequest event with requestedApp and rebootReason parameters
 
 ## [1.7.1] - 2023-09-12
 ### Added

--- a/SystemServices/CHANGELOG.md
+++ b/SystemServices/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+## [1.7.1] - 2023-09-12
+### Fixed
+- Based on System document updated onRebootRequest event with requestedApp and rebootReason
 
 ## [1.7.1] - 2023-09-12
 ### Added

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -660,6 +660,7 @@ namespace WPEFramework {
             if(IARM_RESULT_SUCCESS != iarmcallstatus) {
                 LOGWARN("requestSystemReboot: IARM_BUS_PWRMGR_API_Reboot failed with code %d.\n", iarmcallstatus); 
             }
+	    onRebootRequest(rebootParam.requestor,rebootParam.reboot_reason_other);
             response["IARM_Bus_Call_STATUS"] = static_cast <int32_t> (iarmcallstatus);
             result = true;
             returnResponse(result);
@@ -857,13 +858,13 @@ namespace WPEFramework {
             sendNotify(EVT_ONSYSTEMPOWERSTATECHANGED, params);
         }
 
-        void SystemServices::onPwrMgrReboot(string requestedApp, string rebootReason)
+        void SystemServices::onPwrMgrRebootRequest(string requestedApp, string rebootReason)
         {
             JsonObject params;
             params["requestedApp"] = requestedApp;
             params["rebootReason"] = rebootReason;
-
-            sendNotify(EVT_ONREBOOTREQUEST, params);
+	    LOGINFO("Notifying onPwrMgrRebootRequest\n");
+            sendNotify(EVT_ONPWRMGRREBOOTREQUEST, params);
         }
 
         void SystemServices::onNetorkModeChanged(bool bNetworkStandbyMode)
@@ -4213,7 +4214,7 @@ namespace WPEFramework {
                         IARM_Bus_PWRMgr_RebootParam_t *eventData = (IARM_Bus_PWRMgr_RebootParam_t *)data;
 
                         if (SystemServices::_instance) {
-                            SystemServices::_instance->onPwrMgrReboot(eventData->requestor, eventData->reboot_reason_other);
+                            SystemServices::_instance->onPwrMgrRebootRequest(eventData->requestor, eventData->reboot_reason_other);
                         } else {
                             LOGERR("SystemServices::_instance is NULL.\n");
                         }
@@ -4438,10 +4439,11 @@ namespace WPEFramework {
          * @param2[in]  : string; reboot reason
          * @Event [out] : {"rebootReason": <string_ReasonForReboot>}
          */
-        void SystemServices::onRebootRequest(string reason)
+        void SystemServices::onRebootRequest(string requestedApp, string rebootReason)
         {
             JsonObject params;
-            params["rebootReason"] = reason;
+	    params["requestedApp"] = requestedApp;
+            params["rebootReason"] = rebootReason;
             LOGINFO("Notifying onRebootRequest\n");
             sendNotify(EVT_ONREBOOTREQUEST, params);
         }

--- a/SystemServices/SystemServices.h
+++ b/SystemServices/SystemServices.h
@@ -63,7 +63,7 @@ using std::ofstream;
 #define EVT_ONREBOOTREQUEST               "onRebootRequest"
 #define EVT_ON_SYSTEM_CLOCK_SET           "onSystemClockSet"
 #define EVT_ONFWPENDINGREBOOT             "onFirmwarePendingReboot" /* Auto Reboot notifier */
-#define EVT_ONREBOOTREQUEST               "onRebootRequest"
+#define EVT_ONPWRMGRREBOOTREQUEST         "onPwrMgrRebootRequest"
 #define EVT_ONTERRITORYCHANGED            "onTerritoryChanged"
 #define EVT_ONTIMEZONEDSTCHANGED          "onTimeZoneDSTChanged"
 #define EVT_FRIENDLYNAMECHANGED           "onFriendlyNameChanged"
@@ -190,7 +190,7 @@ namespace WPEFramework {
                 /* Events : Begin */
                 void onFirmwareUpdateInfoRecieved(string CallGUID);
                 void onSystemPowerStateChanged(string currentPowerState, string powerState);
-                void onPwrMgrReboot(string requestedApp, string rebootReason);
+                void onPwrMgrRebootRequest(string requestedApp, string rebootReason);
                 void onNetorkModeChanged(bool betworkStandbyMode);
                 void onSystemModeChanged(string mode);
                 void onFirmwareUpdateStateChange(int state);
@@ -198,7 +198,7 @@ namespace WPEFramework {
                 void onLogUpload(int newState);
                 void onTemperatureThresholdChanged(string thresholdType,
                         bool exceed, float temperature);
-                void onRebootRequest(string reason);
+                void onRebootRequest(string requestedApp, string rebootReason);
                 void onFirmwarePendingReboot(int seconds); /* Event handler for Pending Reboot */
 		void onTerritoryChanged(string oldTerritory, string newTerritory, string oldRegion="", string newRegion="");
 		void onTimeZoneDSTChanged(string oldTimeZone, string newTimeZone, string oldAccuracy, string newAccuracy);

--- a/WifiManager/CHANGELOG.md
+++ b/WifiManager/CHANGELOG.md
@@ -15,6 +15,11 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+
+## [1.0.9] - 2023-09-20
+### Fixed
+- Fixed Update wifi state cache if wifi interface was enabled and added persist param in wifi setEnabled API to persist wifi state after reboot
+
 ## [1.0.8] - 2023-09-12
 ### Added
 - Implement Thunder Plugin Configuration for Kirkstone builds(CMake-3.20 & above)

--- a/WifiManager/Wifi.json
+++ b/WifiManager/Wifi.json
@@ -502,10 +502,16 @@
                         "summary": "`true` to enable or `false` to disable",
                         "type": "boolean",
                         "example": true
+                    },
+		    "persist": {
+                        "summary": "`true` to persist after reboot or `false` to not persist after reboot",
+                        "type": "boolean",
+                        "example": true
                     }
                 },
                 "required": [
-                    "enable"
+                    "enable",
+		    "persist"
                 ]
             },
             "result": {


### PR DESCRIPTION
…vents.1.onDisplayFrameRateChanged" if we setting org.rdk.FrameRate.2.setDisplayFrameRate

Reason for change: Added _dsSendDisplayFrameRateStatusPreChangeCall and _dsSendDisplayFrameRateStatusPreChangeCall to broadcast framerate prechange and postchange events

Test Procedure: Build and verify.

Risks: Low