### PR TITLE
SERXIONE-3290: Unable to play content/launch major apps

### DIFF
--- a/OpenCDMi/OCDM.conf.in
+++ b/OpenCDMi/OCDM.conf.in
@@ -11,7 +11,6 @@ if boolean("@PLUGIN_OCDM_STARTUPORDER@"):
 
 configuration = JSON()
 configuration.add("sharepath", "/tmp/OCDM")
-configuration.add("connector", "/tmp/OCDM/ocdm")
 if ("@PLUGIN_OPENCDMI_MODE@" == "off"):
     configuration.add("outofprocess", "@PLUGIN_OPENCDMI_OOP@")
 


### PR DESCRIPTION
Reason for change: OCDM socket path was done only for Platco/Hisense platform , we need to remove the connector socket
Test Procedure: Verify in Jenkin Build
Risks: High
Signed-off-by: Thamim  Razith <tabbas651@cable.comcast.com>