### PR TITLE
RDK-43786: Implement Thunder Plugin Configuration for CMake-3.20 & above

### DIFF
--- a/ControlService/ControlService.conf.in
+++ b/ControlService/ControlService.conf.in
@@ -1,0 +1,6 @@
+precondition = ["Platform"]
+callsign = "org.rdk.ControlService"
+autostart = "false"
+
+if boolean("@PLUGIN_CONTROLSERVICE_STARTUPORDER@"):
+    startuporder = "@PLUGIN_CONTROLSERVICE_STARTUPORDER@"

--- a/HdmiCec/HdmiCec.conf.in
+++ b/HdmiCec/HdmiCec.conf.in
@@ -1,0 +1,6 @@
+precondition = ["Platform"]
+callsign = "org.rdk.HdmiCec"
+autostart = "@PLUGIN_HDMICEC_AUTOSTART@"
+
+if boolean("@PLUGIN_HDMICEC_STARTUPORDER@"):
+    startuporder = "@PLUGIN_HDMICEC_STARTUPORDER@"

--- a/HdmiCecSource/HdmiCecSource.conf.in
+++ b/HdmiCecSource/HdmiCecSource.conf.in
@@ -1,0 +1,6 @@
+precondition = ["Platform"]
+callsign = "org.rdk.HdmiCecSource"
+autostart = "false"
+
+if boolean("@PLUGIN_HDMICECSOURCE_STARTUPORDER@"):
+    startuporder = "@PLUGIN_HDMICECSOURCE_STARTUPORDER@"

--- a/RemoteActionMapping/RemoteActionMapping.conf.in
+++ b/RemoteActionMapping/RemoteActionMapping.conf.in
@@ -1,0 +1,6 @@
+precondition = ["Platform"]
+callsign = "org.rdk.RemoteActionMapping"
+autostart = "false"
+
+if boolean("@PLUGIN_REMOTEACTIONMAPPING_STARTUPORDER@"):
+    startuporder = "@PLUGIN_REMOTEACTIONMAPPING_STARTUPORDER@"

--- a/ResourceManager/ResourceManager.conf.in
+++ b/ResourceManager/ResourceManager.conf.in
@@ -1,0 +1,6 @@
+precondition = ["Platform"]
+callsign = "org.rdk.ResourceManager"
+autostart = "true"
+
+if boolean("@PLUGIN_RESOURCE_MANAGER_STARTUPORDER@"):
+    startuporder = "@PLUGIN_RESOURCE_MANAGER_STARTUPORDER@"

--- a/SystemAudioPlayer/SystemAudioPlayer.conf.in
+++ b/SystemAudioPlayer/SystemAudioPlayer.conf.in
@@ -1,0 +1,8 @@
+precondition = ["Platform"]
+callsign = "org.rdk.SystemAudioPlayer"
+startuporder = "@PLUGIN_SYSTEMAUDIOPLAYER_STARTUPORDER@"
+autostart = "@PLUGIN_SYSTEMAUDIOPLAYER_AUTOSTART@"
+
+rootobject = JSON()
+rootobject.add("mode", "@PLUGIN_SYSTEMAUDIOPLAYER_MODE@")
+configuration.add("root", rootobject)


### PR DESCRIPTION
Reason for change: updated this <plugins>.conf.in to avoid the SerComm Flex2.0 Devices Compilation error
Test Procedure: Verify in Jenkin Build
Risks: High
Signed-off-by: Thamim  Razith <tabbas651@cable.comcast.com>