### PR TITLE
Avoid DCM functionality from maintenance manager module

### DIFF
--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -124,7 +124,7 @@ string moduleStatusToString(IARM_Maint_module_status_t &status)
 {
     string ret_status="";
     switch(status){
-#ifndef DCM_REMOVAL_MM
+#ifndef DCM_TASK_REMOVAL
         case MAINT_DCM_COMPLETE:
             ret_status="MAINTENANCE_DCM_COMPLETE";
             break;
@@ -219,7 +219,7 @@ namespace WPEFramework {
         cSettings MaintenanceManager::m_setting(MAINTENANCE_MGR_RECORD_FILE);
 
         string task_names_foreground[]={
-#ifndef DCM_REMOVAL_MM
+#ifndef DCM_TASK_REMOVAL
             "/lib/rdk/StartDCM_maintaince.sh",
 #endif
             "/lib/rdk/RFCbase.sh",
@@ -230,7 +230,7 @@ namespace WPEFramework {
         vector<string> tasks;
 
         string script_names[]={
-#ifndef DCM_REMOVAL_MM
+#ifndef DCM_TASK_REMOVAL
             "DCMscript_maintaince.sh",
 #endif
 		"RFCbase.sh",
@@ -269,7 +269,7 @@ namespace WPEFramework {
             MaintenanceManager::m_task_map[task_names_foreground[0].c_str()]=false;
             MaintenanceManager::m_task_map[task_names_foreground[1].c_str()]=false;
             MaintenanceManager::m_task_map[task_names_foreground[2].c_str()]=false;
-#ifndef DCM_REMOVAL_MM
+#ifndef DCM_TASK_REMOVAL
             MaintenanceManager::m_task_map[task_names_foreground[3].c_str()]=false;
 #endif
             MaintenanceManager::m_param_map[deviceInitializationContext[0].c_str()] = TR181_PARTNER_ID;
@@ -340,7 +340,7 @@ namespace WPEFramework {
 
             if (UNSOLICITED_MAINTENANCE == g_maintenance_type){
                 LOGINFO("---------------UNSOLICITED_MAINTENANCE--------------");
-#ifndef DCM_REMOVAL_MM
+#ifndef DCM_TASK_REMOVAL
 #ifndef ENABLE_WHOAMI
                 tasks.push_back(task_names_foreground[0].c_str());
 #endif
@@ -350,7 +350,7 @@ namespace WPEFramework {
                 LOGINFO("=============SOLICITED_MAINTENANCE===============");
             }
 
-#ifndef DCM_REMOVAL_MM 
+#ifndef DCM_TASK_REMOVAL
 #if defined(ENABLE_WHOAMI)
             if (UNSOLICITED_MAINTENANCE == g_maintenance_type) {
                 tasks.push_back(task_names_foreground[1].c_str());
@@ -866,7 +866,7 @@ namespace WPEFramework {
             IARM_Maint_module_status_t module_status;
             time_t successfulTime;
             string str_successfulTime="";
-#ifndef DCM_REMOVAL_MM
+#ifndef DCM_TASK_REMOVAL
             auto task_status_DCM=m_task_map.find(task_names_foreground[0].c_str());
             auto task_status_RFC=m_task_map.find(task_names_foreground[1].c_str());
             auto task_status_FWDLD=m_task_map.find(task_names_foreground[2].c_str());
@@ -907,7 +907,7 @@ namespace WPEFramework {
                                  m_task_map[task_names_foreground[1].c_str()]=false;
                             }
                             break;
-#ifndef DCM_REMOVAL_MM
+#ifndef DCM_TASK_REMOVAL
                         case MAINT_DCM_COMPLETE :
                             if(task_status_DCM->second != true) {
                                  LOGINFO("Ignoring Event DCM_COMPLETE");
@@ -961,7 +961,7 @@ namespace WPEFramework {
                             m_task_map[task_names_foreground[2].c_str()]=false;
                             LOGINFO("FW Download task aborted \n");
                             break;
-#ifndef DCM_REMOVAL_MM
+#ifndef DCM_TASK_REMOVAL
                         case MAINT_DCM_ERROR:
                             if(task_status_DCM->second != true) {
                                  LOGINFO("Ignoring Event DCM_ERROR");
@@ -1013,7 +1013,7 @@ namespace WPEFramework {
                                 m_task_map[task_names_foreground[2].c_str()]=false;
                             }
                             break;
-#ifndef DCM_REMOVAL_MM
+#ifndef DCM_TASK_REMOVAL
                        case MAINT_DCM_INPROGRESS:
                             m_task_map[task_names_foreground[0].c_str()]=true;
                             /*will be set to false once COMEPLETE/ERROR received for DCM*/
@@ -1451,7 +1451,7 @@ namespace WPEFramework {
 
                         m_abort_flag=false;
 
-#ifndef DCM_REMOVAL_MM
+#ifndef DCM_TASK_REMOVAL
                         /* we dont touch the dcm so
                          * we say DCM is success and complete */
                         SET_STATUS(g_task_status,DCM_SUCCESS);
@@ -1507,7 +1507,7 @@ namespace WPEFramework {
 	        string codeDLtask;
             int k_ret=EINVAL;
             int i=0;
-#ifndef DCM_REMOVAL_MM
+#ifndef DCM_TASK_REMOVAL
             bool task_status[4]={false};
 #else
 			bool task_status[3]={false};
@@ -1522,7 +1522,7 @@ namespace WPEFramework {
                 // Set the condition flag m_abort_flag to true
                 m_abort_flag = true;
 
-#ifndef DCM_REMOVAL_MM
+#ifndef DCM_TASK_REMOVAL
                 auto task_status_DCM=m_task_map.find(task_names_foreground[0].c_str());
                 auto task_status_RFC=m_task_map.find(task_names_foreground[1].c_str());
                 auto task_status_FWDLD=m_task_map.find(task_names_foreground[2].c_str());

--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -872,7 +872,7 @@ namespace WPEFramework {
             auto task_status_FWDLD=m_task_map.find(task_names_foreground[2].c_str());
             auto task_status_LOGUPLD=m_task_map.find(task_names_foreground[3].c_str());
 #else
-			auto task_status_RFC=m_task_map.find(task_names_foreground[0].c_str());
+	    auto task_status_RFC=m_task_map.find(task_names_foreground[0].c_str());
             auto task_status_FWDLD=m_task_map.find(task_names_foreground[1].c_str());
             auto task_status_LOGUPLD=m_task_map.find(task_names_foreground[2].c_str());
 #endif
@@ -904,7 +904,11 @@ namespace WPEFramework {
                                  SET_STATUS(g_task_status,RFC_SUCCESS);
                                  SET_STATUS(g_task_status,RFC_COMPLETE);
                                  task_thread.notify_one();
+#ifndef DCM_TASK_REMOVAL
                                  m_task_map[task_names_foreground[1].c_str()]=false;
+#else
+                                 m_task_map[task_names_foreground[0].c_str()]=false;
+#endif
                             }
                             break;
 #ifndef DCM_TASK_REMOVAL
@@ -930,7 +934,11 @@ namespace WPEFramework {
                                 SET_STATUS(g_task_status,DIFD_SUCCESS);
                                 SET_STATUS(g_task_status,DIFD_COMPLETE);
                                 task_thread.notify_one();
+#ifndef DCM_TASK_REMOVAL
                                 m_task_map[task_names_foreground[2].c_str()]=false;
+#else
+                                m_task_map[task_names_foreground[1].c_str()]=false;
+#endif
                             }
                             break;
                        case MAINT_LOGUPLOAD_COMPLETE :
@@ -942,7 +950,11 @@ namespace WPEFramework {
                                 SET_STATUS(g_task_status,LOGUPLOAD_SUCCESS);
                                 SET_STATUS(g_task_status,LOGUPLOAD_COMPLETE);
                                 task_thread.notify_one();
+#ifndef DCM_TASK_REMOVAL
                                 m_task_map[task_names_foreground[3].c_str()]=false;
+#else
+                                m_task_map[task_names_foreground[2].c_str()]=false;
+#endif
                             }
 
                             break;
@@ -958,7 +970,11 @@ namespace WPEFramework {
                             /* we say FW update task complete */
                             SET_STATUS(g_task_status,DIFD_COMPLETE);
                             task_thread.notify_one();
+#ifndef DCM_TASK_REMOVAL
                             m_task_map[task_names_foreground[2].c_str()]=false;
+#else
+			    m_task_map[task_names_foreground[1].c_str()]=false;
+#endif
                             LOGINFO("FW Download task aborted \n");
                             break;
 #ifndef DCM_TASK_REMOVAL
@@ -984,7 +1000,11 @@ namespace WPEFramework {
                                  SET_STATUS(g_task_status,RFC_COMPLETE);
                                  task_thread.notify_one();
                                  LOGINFO("Error encountered in RFC script task \n");
+#ifndef DCM_TASK_REMOVAL
                                  m_task_map[task_names_foreground[1].c_str()]=false;
+#else
+                                 m_task_map[task_names_foreground[0].c_str()]=false;
+#endif
                             }
 
                             break;
@@ -997,9 +1017,12 @@ namespace WPEFramework {
                                 SET_STATUS(g_task_status,LOGUPLOAD_COMPLETE);
                                 task_thread.notify_one();
                                 LOGINFO("Error encountered in LOGUPLOAD script task \n");
+#ifndef DCM_TASK_REMOVAL
                                 m_task_map[task_names_foreground[3].c_str()]=false;
+#else
+                                m_task_map[task_names_foreground[2].c_str()]=false;
+#endif			    
                             }
-
                             break;
                        case MAINT_FWDOWNLOAD_ERROR:
                             if(task_status_FWDLD->second != true) {
@@ -1010,7 +1033,11 @@ namespace WPEFramework {
                                 SET_STATUS(g_task_status,DIFD_COMPLETE);
                                 task_thread.notify_one();
                                 LOGINFO("Error encountered in SWUPDATE script task \n");
+#ifndef DCM_TASK_REMOVAL
                                 m_task_map[task_names_foreground[2].c_str()]=false;
+#else
+                                m_task_map[task_names_foreground[1].c_str()]=false;
+#endif
                             }
                             break;
 #ifndef DCM_TASK_REMOVAL
@@ -1021,17 +1048,29 @@ namespace WPEFramework {
                             break;
 #endif
                        case MAINT_RFC_INPROGRESS:
+#ifndef DCM_TASK_REMOVAL
                             m_task_map[task_names_foreground[1].c_str()]=true;
+#else
+                            m_task_map[task_names_foreground[0].c_str()]=true;
+#endif
                             /*will be set to false once COMEPLETE/ERROR received for RFC*/
                             LOGINFO(" RFC already IN PROGRESS -> setting m_task_map of RFC to true \n");
                             break;
                        case MAINT_FWDOWNLOAD_INPROGRESS:
+#ifndef DCM_TASK_REMOVAL
                             m_task_map[task_names_foreground[2].c_str()]=true;
+#else
+                            m_task_map[task_names_foreground[1].c_str()]=true;
+#endif
                             /*will be set to false once COMEPLETE/ERROR received for FWDOWNLOAD*/
                             LOGINFO(" FWDOWNLOAD already IN PROGRESS -> setting m_task_map of FWDOWNLOAD to true \n");
                             break;
                        case MAINT_LOGUPLOAD_INPROGRESS:
+#ifndef DCM_TASK_REMOVAL
                             m_task_map[task_names_foreground[3].c_str()]=true;
+#else
+                            m_task_map[task_names_foreground[2].c_str()]=true;
+#endif
                             /*will be set to false once COMEPLETE/ERROR received for LOGUPLOAD*/
                             LOGINFO(" LOGUPLOAD already IN PROGRESS -> setting m_task_map of LOGUPLOAD to true \n");
                             break;

--- a/MaintenanceManager/MaintenanceManager.h
+++ b/MaintenanceManager/MaintenanceManager.h
@@ -68,7 +68,7 @@ typedef enum{
 #define FOREGROUND_MODE "FOREGROUND"
 #define BACKGROUND_MODE "BACKGROUND"
 
-#ifndef DCM_REMOVAL_MM
+#ifndef DCM_TASK_REMOVAL
 
 #define TASKS_COMPLETED                0xAA
 #define ALL_TASKS_SUCCESS              0xFF

--- a/MaintenanceManager/MaintenanceManager.h
+++ b/MaintenanceManager/MaintenanceManager.h
@@ -68,13 +68,10 @@ typedef enum{
 #define FOREGROUND_MODE "FOREGROUND"
 #define BACKGROUND_MODE "BACKGROUND"
 
+#ifndef DCM_REMOVAL_MM
+
 #define TASKS_COMPLETED                0xAA
 #define ALL_TASKS_SUCCESS              0xFF
-#define MAINTENANCE_TASK_SKIPPED       0x200
-
-#define MAX_NETWORK_RETRIES             4
-#define MAX_ACTIVATION_RETRIES          4
-
 #define DCM_SUCCESS                     0
 #define DCM_COMPLETE                    1
 #define RFC_SUCCESS                     2
@@ -86,6 +83,27 @@ typedef enum{
 #define REBOOT_REQUIRED                 8
 #define TASK_SKIPPED                    9
 #define TASKS_STARTED                   10
+
+#else
+
+#define TASKS_COMPLETED                0x2A
+#define ALL_TASKS_SUCCESS              0x3F
+#define RFC_SUCCESS                     0
+#define RFC_COMPLETE                    1
+#define LOGUPLOAD_SUCCESS               2
+#define LOGUPLOAD_COMPLETE              3
+#define DIFD_SUCCESS                    4
+#define DIFD_COMPLETE                   5
+#define REBOOT_REQUIRED                 6
+#define TASK_SKIPPED                    7
+#define TASKS_STARTED                   8
+
+#endif
+
+#define MAINTENANCE_TASK_SKIPPED       0x200
+
+#define MAX_NETWORK_RETRIES             4
+#define MAX_ACTIVATION_RETRIES          4
 
 #define SET_STATUS(VALUE,N)     ((VALUE) |=  (1<<(N)))
 #define CLEAR_STATUS(VALUE,N)   ((VALUE) &= ~(1<<(N)))

--- a/amlogic.cmake
+++ b/amlogic.cmake
@@ -166,4 +166,4 @@ if(BUILD_ENABLE_APP_CONTROL_AUDIOPORT_INIT)
    add_definitions (-DAPP_CONTROL_AUDIOPORT_INIT)
 endif()
 
-add_definitions (-DDCM_REMOVAL)
+add_definitions (-DDCM_TASK_REMOVAL)

--- a/amlogic.cmake
+++ b/amlogic.cmake
@@ -165,3 +165,5 @@ endif()
 if(BUILD_ENABLE_APP_CONTROL_AUDIOPORT_INIT)
    add_definitions (-DAPP_CONTROL_AUDIOPORT_INIT)
 endif()
+
+add_definitions (-DDCM_REMOVAL)

--- a/broadcom.cmake
+++ b/broadcom.cmake
@@ -319,7 +319,7 @@ if(DEFINES,USE_COMMON_XG1_XI3)
     add_definitions (-DENABLE_GET_SET_APIVERSION)   
 endif()
 
-add_definitions (-DDCM_REMOVAL_MM)
+add_definitions (-DDCM_TASK_REMOVAL)
 
 	# Front panel support
 #if(HAS_FRONT_PANEL)

--- a/broadcom.cmake
+++ b/broadcom.cmake
@@ -319,6 +319,7 @@ if(DEFINES,USE_COMMON_XG1_XI3)
     add_definitions (-DENABLE_GET_SET_APIVERSION)   
 endif()
 
+add_definitions (-DDCM_REMOVAL_MM)
 
 	# Front panel support
 #if(HAS_FRONT_PANEL)

--- a/realtek.cmake
+++ b/realtek.cmake
@@ -167,4 +167,5 @@ if(DEFINES,USE_XI1_MORE_DEFINITIONS)
     add_definitions (-DENABLE_GET_SET_APIVERSION)   
 endif()
 
+add_definitions (-DDCM_REMOVAL_MM)
 

--- a/realtek.cmake
+++ b/realtek.cmake
@@ -167,5 +167,5 @@ if(DEFINES,USE_XI1_MORE_DEFINITIONS)
     add_definitions (-DENABLE_GET_SET_APIVERSION)   
 endif()
 
-add_definitions (-DDCM_REMOVAL_MM)
+add_definitions (-DDCM_TASK_REMOVAL)
 


### PR DESCRIPTION
Reason for change: DCM exectution removed from MM as DCM is starting from service seperately
Test Procedure: NA
Risks: None
Priority: P2