### PR TITLE
DELIA-61880: cannot disable ledcontrol plugin

### DIFF
--- a/services.cmake
+++ b/services.cmake
@@ -270,8 +270,3 @@ if(BUILD_ENABLE_ERM)
 endif()
 
 add_definitions(-DRDK_LOG_MILESTONE)
-
-
-add_definitions (-DPLUGIN_LEDCONTROL)
-option(PLUGIN_LEDCONTROL "PLUGIN_LEDCONTROL" ON)
-


### PR DESCRIPTION
Reason for change: remove some stupid code
Test Procedure: None
Risks: None
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>