### PR TITLE
RDK-62688 - [Coverity] New issues identified in devicesettings

### DIFF
--- a/DisplayInfo/DeviceSettings/Amlogic/SoC_abstraction.cpp
+++ b/DisplayInfo/DeviceSettings/Amlogic/SoC_abstraction.cpp
@@ -113,7 +113,7 @@ static void getGraphicSize(uint32_t &w, uint32_t &h)
 
         /* Setup KMS */
         kms = kms_setup(drm_fd);
-        if( !kms->crtc ) {
+        if(!kms || !kms->crtc ) {
             cout << "[Amlogic] kms_setup fail" << endl;
             break;
         }
@@ -153,7 +153,9 @@ static void getGraphicSize(uint32_t &w, uint32_t &h)
 
     cout << "[getGraphicSize] width : " << w << endl;
     cout << "[getGraphicSize] height : " << h << endl;
-    close(drm_fd);
+    if(drm_fd >= 0){
+        close(drm_fd);
+    }
 }
 
 

--- a/DisplayInfo/DeviceSettings/Amlogic/kms.c
+++ b/DisplayInfo/DeviceSettings/Amlogic/kms.c
@@ -29,7 +29,11 @@ void kms_setup_encoder( int fd, kms_ctx *kms )
 
         kms->encoder = drmModeGetEncoder(fd,kms->res->encoders[i]);
 
-        if ( kms->encoder && ( kms->encoder->encoder_id == kms->connector->encoder_id ) ) {
+        if(!kms->encoder){
+            return;
+        }
+
+        if ( kms->encoder->encoder_id == kms->connector->encoder_id ) {
 
             kms->encoder_id = kms->encoder->encoder_id;
             return;

--- a/DisplayInfo/DeviceSettings/PlatformImplementation.cpp
+++ b/DisplayInfo/DeviceSettings/PlatformImplementation.cpp
@@ -230,7 +230,7 @@ public:
                 TRACE(Trace::Information, (_T("EDID Verification failed")));
                 ret = Core::ERROR_GENERAL;
             }
-            delete edidbytes;
+            delete[] edidbytes;
         }
         else
         {
@@ -605,7 +605,7 @@ public:
                 TRACE(Trace::Error, (_T("EDID Verification failed")));
                 ret = Core::ERROR_GENERAL;
             }
-            delete edidbytes;
+            delete[] edidbytes;
         }
         else
         {

--- a/DisplayInfo/DeviceSettings/Realtek/SoC_abstraction.cpp
+++ b/DisplayInfo/DeviceSettings/Realtek/SoC_abstraction.cpp
@@ -112,7 +112,7 @@ static void getGraphicSize(uint32_t &w, uint32_t &h)
 
         /* Setup KMS */
         kms = kms_setup(drm_fd);
-        if( !kms->crtc ) {
+        if(!kms || !kms->crtc ) {
             cout << "[Realtek] kms_setup fail" << endl;
             break;
         }

--- a/DisplayInfo/DeviceSettings/Realtek/kms.c
+++ b/DisplayInfo/DeviceSettings/Realtek/kms.c
@@ -30,8 +30,11 @@ void kms_setup_encoder( int fd, kms_ctx *kms )
     for( int i = 0; i < kms->res->count_encoders; i++ ) {
 
         kms->encoder = drmModeGetEncoder(fd,kms->res->encoders[i]);
+        if(!kms->encoder){
+            return;
+        }
 
-        if ( kms->encoder && ( kms->encoder->encoder_id == kms->connector->encoder_id ) ) {
+        if ( kms->encoder->encoder_id == kms->connector->encoder_id ) {
 
             kms->encoder_id = kms->encoder->encoder_id;
             return;


### PR DESCRIPTION
Reason for change:
Fixing Coverity issues in devicesettings.
Test Procedure: None
Risks: Low
Priority: P1

Signed-off-by:Hayden Gfeller Hayden_Gfeller@comcast.com