### PR TITLE
DELIA-63362: Implement cache logic for get internet state (#4434)

### DIFF
--- a/Network/CHANGELOG.md
+++ b/Network/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+## [1.2.1] - 2023-09-20
+### Fixed
+- Fixed multiple concurrent isConnectedToInternet() requests by using the cache
+
 ## [1.2.0] - 2023-08-16
 ### Added
 - Added new params in isConnectedToInternet for Query Internet Connectivity specific to Ipversion

--- a/Network/Network.cpp
+++ b/Network/Network.cpp
@@ -164,12 +164,24 @@ typedef struct _IARM_BUS_NetSrvMgr_Iface_EventData_t {
             m_useStbIPCache = false;
             m_stbIpCache = "";
             m_useDefInterfaceCache = false;
+            m_useIPv4InternetCache = false;
+            m_useIPv6InternetCache = false;
+            m_useInternetCache = false;
+            m_useIPv4ConnectionStateCache = false;
+            m_useIPv6ConnectionStateCache = false;
+            m_useConnectionStateCache = false;
             m_defInterfaceCache = "";
             m_defIpversionCache = "";
             m_ipv4WifiCache = {0};
             m_ipv6WifiCache = {0};
             m_ipv4EthCache = {0};
             m_ipv6EthCache = {0};
+            m_InternetCache = {};
+            m_ipv4InternetCache = {};
+            m_ipv6InternetCache = {};
+            m_ConnectionStateCache = {0};
+            m_ipv4ConnectionStateCache = {0};
+            m_ipv6ConnectionStateCache = {0};
         }
 
         Network::~Network()
@@ -1149,22 +1161,36 @@ typedef struct _IARM_BUS_NetSrvMgr_Iface_EventData_t {
             if(m_isPluginInited)
             {
                 IARM_BUS_NetSrvMgr_isConnectedtoInternet_t param;
+                IARM_Result_t retVal;
                 getDefaultStringParameter("ipversion", ipversion, "");
                 Utils::String::toUpper(ipversion);
-                if (ipversion == "IPV4")
-                    param.ipversion = NSM_IPRESOLVE_V4;
-                else if (ipversion == "IPV6")
-                    param.ipversion = NSM_IPRESOLVE_V6;
-                else
-                    param.ipversion = NSM_IPRESOLVE_WHATEVER;
-
-                param.isconnected = false;
-                if (IARM_RESULT_SUCCESS == IARM_Bus_Call(IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_NETSRVMGR_API_isConnectedToInternet, (void*) &param, sizeof(param)))
+                if ((ipversion == "IPV4") && m_useIPv4InternetCache)
                 {
-                    LOGINFO("%s :: isconnected = %d \n",__FUNCTION__, param.isconnected);
-                    response["connectedToInternet"] = param.isconnected;
-                    if(ipversion == "IPV4" || ipversion == "IPV6")
-                        response["ipversion"] = ipversion.c_str();
+                    memcpy(&param, &m_ipv4InternetCache, sizeof(m_ipv4InternetCache));
+                    retVal = IARM_RESULT_SUCCESS;
+                }
+                else if ((ipversion == "IPV6") && m_useIPv6InternetCache)
+                {
+                    memcpy(&param, &m_ipv6InternetCache, sizeof(m_ipv6InternetCache));
+                    retVal = IARM_RESULT_SUCCESS;
+                }
+                else if ((ipversion == "") && m_useInternetCache)
+                {
+                    memcpy(&param, &m_InternetCache, sizeof(m_InternetCache));
+                    retVal = IARM_RESULT_SUCCESS;
+                }
+                else
+                {
+                    if (ipversion == "IPV4")
+                        param.ipversion = NSM_IPRESOLVE_V4;
+                    else if (ipversion == "IPV6")
+                        param.ipversion = NSM_IPRESOLVE_V6;
+                    else
+                        param.ipversion = NSM_IPRESOLVE_WHATEVER;
+
+                    param.isconnected = false;
+                    retVal = IARM_Bus_Call(IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_NETSRVMGR_API_isConnectedToInternet, (void*) &param, sizeof(param));
+
                     if (param.isconnected)
                     {
                         PluginHost::ISubSystem* subSystem = m_service->SubSystems();
@@ -1200,6 +1226,30 @@ typedef struct _IARM_BUS_NetSrvMgr_Iface_EventData_t {
                             subSystem->Release();
                         }
                     }
+
+                    if (ipversion == "IPV4")
+                    {
+                        m_useIPv4InternetCache = true;
+                        memcpy(&m_ipv4InternetCache, &param, sizeof(param));
+                    }
+                    else if (ipversion == "IPV6")
+                    {
+                         m_useIPv6InternetCache = true;
+                         memcpy(&m_ipv6InternetCache, &param, sizeof(param));
+                    }
+                    else
+                    {
+                        m_useInternetCache = true;
+                        memcpy(&m_InternetCache, &param, sizeof(param));
+                    }
+                }
+
+                if (retVal == IARM_RESULT_SUCCESS)
+                {
+                    LOGINFO("%s :: isconnected = %d \n",__FUNCTION__, param.isconnected);
+                    response["connectedToInternet"] = param.isconnected;
+                    if(ipversion == "IPV4" || ipversion == "IPV6")
+                        response["ipversion"] = ipversion.c_str();
 
                     result = true;
                 }
@@ -1264,19 +1314,55 @@ typedef struct _IARM_BUS_NetSrvMgr_Iface_EventData_t {
             IARM_BUS_NetSrvMgr_Iface_InternetConnectivityStatus_t iarmData;
             bool result = false;
             std::string ipversion;
+	    IARM_Result_t retVal;
 
             if(m_isPluginInited)
             {
                 getDefaultStringParameter("ipversion", ipversion, "");
                 Utils::String::toUpper(ipversion);
-                if (ipversion == "IPV4")
-                    iarmData.ipversion = NSM_IPRESOLVE_V4;
-                else if (ipversion == "IPV6")
-                    iarmData.ipversion = NSM_IPRESOLVE_V6;
+                if ((ipversion == "IPV4") && m_useIPv4ConnectionStateCache)
+                {
+                    memcpy(&iarmData, &m_ipv4ConnectionStateCache, sizeof(m_ipv4ConnectionStateCache));
+                    retVal = IARM_RESULT_SUCCESS;
+                }
+                else if ((ipversion == "IPV6") && m_useIPv6ConnectionStateCache)
+                {
+                    memcpy(&iarmData, &m_ipv6ConnectionStateCache, sizeof(m_ipv6ConnectionStateCache));
+                    retVal = IARM_RESULT_SUCCESS;
+                }
+                else if ((ipversion == "") && m_useConnectionStateCache)
+                {
+                    memcpy(&iarmData, &m_ConnectionStateCache, sizeof(m_ConnectionStateCache));
+                    retVal = IARM_RESULT_SUCCESS;
+                }
                 else
-                    iarmData.ipversion = NSM_IPRESOLVE_WHATEVER;
+                {
+                    if (ipversion == "IPV4")
+                        iarmData.ipversion = NSM_IPRESOLVE_V4;
+                    else if (ipversion == "IPV6")
+                        iarmData.ipversion = NSM_IPRESOLVE_V6;
+                    else
+                        iarmData.ipversion = NSM_IPRESOLVE_WHATEVER;
+                    retVal = IARM_Bus_Call(IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_NETSRVMGR_API_getInternetConnectionState, (void*)&iarmData, sizeof(iarmData));
 
-                if (IARM_RESULT_SUCCESS == IARM_Bus_Call(IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_NETSRVMGR_API_getInternetConnectionState, (void*)&iarmData, sizeof(iarmData)))
+                    if (ipversion == "IPV4")
+                    {
+                        m_useIPv4ConnectionStateCache = true;
+                        memcpy(&m_ipv4ConnectionStateCache, &iarmData, sizeof(iarmData));
+                    }
+                    else if (ipversion == "IPV6")
+                    {
+                        m_useIPv6ConnectionStateCache = true;
+                        memcpy(&m_ipv6ConnectionStateCache, &iarmData, sizeof(iarmData));
+                    }
+                    else
+                    {
+                        m_useConnectionStateCache = true;
+                        memcpy(&m_ConnectionStateCache, &iarmData, sizeof(iarmData));
+                    }
+                }
+
+                if (retVal == IARM_RESULT_SUCCESS)
                 {
                     LOGINFO("InternetConnectionState = %d ",iarmData.connectivityState);
                     response["state"] = iarmData.connectivityState;
@@ -1287,6 +1373,7 @@ typedef struct _IARM_BUS_NetSrvMgr_Iface_EventData_t {
                         LOGINFO("Captive potal found URI = %s ", iarmData.captivePortalURI);
                         response["URI"] = string(iarmData.captivePortalURI, MAX_URI_LEN - 1);
                     }
+
                     result = true;
                 }
                 else
@@ -1525,12 +1612,25 @@ typedef struct _IARM_BUS_NetSrvMgr_Iface_EventData_t {
             m_useIpv6EthCache = false;
             m_defIpversionCache = "";
             m_defInterfaceCache = "";
+            m_useInternetCache = false;
+            m_useIPv4InternetCache = false;
+            m_useIPv6InternetCache = false;
+            m_useIPv4ConnectionStateCache = false;
+            m_useIPv6ConnectionStateCache = false;
+            m_useConnectionStateCache = false;
+
             sendNotify("onConnectionStatusChanged", params);
         }
 
         void Network::onInternetStatusChange(InternetConnectionState_t InternetConnectionState)
         {
             JsonObject params;
+            m_useInternetCache = false;
+            m_useConnectionStateCache = false;
+            m_useIPv4InternetCache = false;
+            m_useIPv4ConnectionStateCache = false;
+            m_useIPv6InternetCache = false;
+            m_useIPv6ConnectionStateCache = false;
             params["state"] = static_cast <int> (InternetConnectionState);
             switch (InternetConnectionState)
             {
@@ -1571,6 +1671,8 @@ typedef struct _IARM_BUS_NetSrvMgr_Iface_EventData_t {
                 {
                     m_useIpv6EthCache = false;
                 }
+                m_useIPv6InternetCache = false;
+                m_useIPv6ConnectionStateCache = false;
             }
             if (!ipv4Addr.empty())
             {
@@ -1583,7 +1685,11 @@ typedef struct _IARM_BUS_NetSrvMgr_Iface_EventData_t {
                 {
                     m_useIpv4EthCache = false;
                 }
+                m_useIPv4InternetCache = false;
+                m_useIPv4ConnectionStateCache = false;
             }
+            m_useInternetCache = false;
+            m_useConnectionStateCache = false;
             params["status"] = string (acquired ? "ACQUIRED" : "LOST");
             sendNotify("onIPAddressStatusChanged", params);
         }
@@ -1599,6 +1705,12 @@ typedef struct _IARM_BUS_NetSrvMgr_Iface_EventData_t {
             m_useIpv6WifiCache = false;
             m_useIpv4EthCache = false;
             m_useIpv6EthCache = false;
+            m_useInternetCache = false;
+            m_useIPv4InternetCache = false;
+            m_useIPv6InternetCache = false;
+            m_useIPv4ConnectionStateCache = false;
+            m_useIPv6ConnectionStateCache = false;
+            m_useConnectionStateCache = false;
             m_defIpversionCache = "";
             m_defaultInterface = ""; /* REFPLTV-1319 : Resetting when there is switch in interface, to get new value in getDefaultInterface() */
             m_gatewayInterface = "";

--- a/Network/Network.h
+++ b/Network/Network.h
@@ -301,10 +301,22 @@ namespace WPEFramework {
             std::atomic<bool> m_useIpv4EthCache;
             std::atomic<bool> m_useIpv6EthCache;
             std::atomic<bool> m_useStbIPCache;
+            std::atomic<bool> m_useIPv4InternetCache;
+            std::atomic<bool> m_useIPv6InternetCache;
+            std::atomic<bool> m_useInternetCache;
+            std::atomic<bool> m_useIPv4ConnectionStateCache;
+            std::atomic<bool> m_useIPv6ConnectionStateCache;
+            std::atomic<bool> m_useConnectionStateCache;
             string m_stbIpCache;
             std::atomic<bool> m_useDefInterfaceCache;
             string m_defInterfaceCache;
             string m_defIpversionCache;
+            IARM_BUS_NetSrvMgr_isConnectedtoInternet_t m_ipv4InternetCache;
+            IARM_BUS_NetSrvMgr_isConnectedtoInternet_t m_ipv6InternetCache;
+            IARM_BUS_NetSrvMgr_isConnectedtoInternet_t m_InternetCache;
+            IARM_BUS_NetSrvMgr_Iface_InternetConnectivityStatus_t m_ipv4ConnectionStateCache;
+            IARM_BUS_NetSrvMgr_Iface_InternetConnectivityStatus_t m_ipv6ConnectionStateCache;
+            IARM_BUS_NetSrvMgr_Iface_InternetConnectivityStatus_t m_ConnectionStateCache;
 
             IARM_BUS_NetSrvMgr_Iface_Settings_t m_ipv4WifiCache;
             IARM_BUS_NetSrvMgr_Iface_Settings_t m_ipv6WifiCache;

--- a/Tests/tests/test_Network.cpp
+++ b/Tests/tests/test_Network.cpp
@@ -379,7 +379,10 @@ TEST_F(NetworkTest, getInternetConnectionState)
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getInternetConnectionState"), _T("{}"), response));
 	EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"state\":1")));
 	EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"success\":true")));
+}
 
+TEST_F(NetworkTest, getInternetConnectionState2)
+{
     EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
     .Times(::testing::AnyNumber())
     .WillRepeatedly(

--- a/docs/api/NetworkPlugin.md
+++ b/docs/api/NetworkPlugin.md
@@ -2,7 +2,7 @@
 <a name="NetworkPlugin"></a>
 # NetworkPlugin
 
-**Version: [1.2.0](https://github.com/rdkcentral/rdkservices/blob/main/Network/CHANGELOG.md)**
+**Version: [1.2.1](https://github.com/rdkcentral/rdkservices/blob/main/Network/CHANGELOG.md)**
 
 A org.rdk.Network plugin for Thunder framework.
 


### PR DESCRIPTION
* DELIA-63362: Implement cache logic for get internet state

Reason for change: To handle isConnectedToInternet multiple calls.
Fix above issue: Implementing cache for isConnectedToInternet and getconnectionState API
Test Procedure: Build and verify.
Risks: High
Priority: P1
Signed-off-by: Kumar Santhanam <Kumar_Santhanam@comcast.com>

Co-authored-by: Karunakaran A <48997923+karuna2git@users.noreply.github.com>
(cherry picked from commit c0220970a3e81f09582cafa7a914f77181529ac4)

DELIA-63437:  Resetting interconnection, getconnectionstate value when state change (#4458)

* DELIA-63362: Implement cache logic for get internet state

Reason for change: To handle isConnectedToInternet multiple calls. Fix above issue: Implementing cache for isConnectedToInternet and getconnectionState API Test Procedure: Build and verify.
Risks: High
Priority: P1
Signed-off-by: Kumar Santhanam <Kumar_Santhanam@comcast.com>
(cherry picked from commit d3a563251cc33a401fa864bdbb9c897b9e5116d1)