### PR TITLE
RDKTV-25106: RDKShell to use Initialize() and DeInitialize() function

### DIFF
--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -906,10 +906,115 @@ namespace WPEFramework {
 	    return ignoreLaunch;
 	}
 
+        void RDKShell::MonitorClients::handleInitialize(PluginHost::IShell* service)
+        {
+                if(service)
+                {
+                   std::string configLine = service->ConfigLine();
+                   if (configLine.empty())
+                   {
+                       return;
+                   }
+                   JsonObject serviceConfig = JsonObject(configLine.c_str());
+                   if (serviceConfig.HasLabel("clientidentifier"))
+                   {
+                       std::string clientidentifier = serviceConfig["clientidentifier"].String();
+                      std::string serviceCallsign = service->Callsign();
+                       if ((serviceCallsign == RESIDENTAPP_CALLSIGN) && ignoreResidentAppLaunch())
+                       {
+                           std::cout << "Resident app activation early !!! " << std::endl;
+                           return;
+                       }
+                       if (!isClientExists(serviceCallsign))
+                       {
+                           std::shared_ptr<CreateDisplayRequest> request = std::make_shared<CreateDisplayRequest>(serviceCallsign, clientidentifier);
+                           gRdkShellMutex.lock();
+                           gCreateDisplayRequests.push_back(request);
+                           gRdkShellMutex.unlock();
+                           sem_wait(&request->mSemaphore);
+                       }
+                       gRdkShellMutex.lock();
+                       RdkShell::CompositorController::addListener(clientidentifier, mShell.mEventListener);
+                       gRdkShellMutex.unlock();
+                       gPluginDataMutex.lock();
+                       std::string className = service->ClassName();
+                       PluginData pluginData;
+                       pluginData.mClassName = className;
+                       if (gActivePluginsData.find(serviceCallsign) == gActivePluginsData.end())
+                       {
+                           gActivePluginsData[serviceCallsign] = pluginData;
+                       }
+                       gPluginDataMutex.unlock();
+                   }
+                }
+           }
+
+        void  RDKShell::MonitorClients::handleActivated(PluginHost::IShell* service)
+        {
+                if(service)
+                {
+                        if(service->Callsign() == RESIDENTAPP_CALLSIGN)
+                        {
+                                bool ignoreLaunch = ignoreResidentAppLaunch(true);
+                                if (ignoreLaunch)
+                                {
+                                  std::cout << "deactivating resident app as factory mode is set" << std::endl;
+                                  JsonObject destroyRequest;
+                                 destroyRequest["callsign"] = "ResidentApp";
+                                  RDKShellApiRequest apiRequest;
+                                  apiRequest.mName = "destroy";
+                                  apiRequest.mRequest = destroyRequest;
+                                  RDKShell* rdkshellPlugin = RDKShell::_instance;
+                                   rdkshellPlugin->launchRequestThread(apiRequest);
+                                }
+                        }
+                        else if(service->Callsign() == PERSISTENT_STORE_CALLSIGN && !sPersistentStoreFirstActivated)
+                        {
+                                std::cout << "persistent store activated\n";
+                                gRdkShellMutex.lock();
+                                sPersistentStoreFirstActivated = true;
+                                gRdkShellMutex.unlock();
+                        }
+                        else if(service->Callsign() == SYSTEM_SERVICE_CALLSIGN)
+                        {
+                                RDKShellApiRequest apiRequest;
+                        apiRequest.mName = "susbscribeSystemEvent";
+                        RDKShell* rdkshellPlugin = RDKShell::_instance;
+                        rdkshellPlugin->launchRequestThread(apiRequest);
+                        }
+                }
+        }
+
+
         void RDKShell::MonitorClients::handleDeactivated(PluginHost::IShell* service)
         {
             if (service)
             {
+		gLaunchDestroyMutex.lock();
+                if (gDestroyApplications.find(service->Callsign()) == gDestroyApplications.end())
+                {
+                     gExternalDestroyApplications[service->Callsign()] = true;
+                }
+                    gLaunchDestroyMutex.unlock();
+                    StateControlNotification* notification = nullptr;
+                    gPluginDataMutex.lock();
+                    auto notificationIt = gStateNotifications.find(service->Callsign());
+                    if (notificationIt != gStateNotifications.end())
+                    {
+                        notification = notificationIt->second;
+                        gStateNotifications.erase(notificationIt);
+                    }
+                    gPluginDataMutex.unlock();
+                    if (notification)
+                    {
+                        PluginHost::IStateControl* stateControl(service->QueryInterface<PluginHost::IStateControl>());
+                        if (stateControl != nullptr)
+                        {
+                            stateControl->Unregister(notification);
+                            stateControl->Release();
+                        }
+                        notification->Release();
+                    }
                 gExitReasonMutex.lock();
                 gApplicationsExitReason[service->Callsign()] = AppLastExitReason::DEACTIVATED;
 #ifdef HIBERNATE_NATIVE_APPS_ON_SUSPENDED
@@ -1149,23 +1254,24 @@ namespace WPEFramework {
         }
 
 #ifdef USE_THUNDER_R4
-       void RDKShell::MonitorClients::Activation(const string& callsign, PluginHost::IShell* service)
+       void RDKShell::MonitorClients::Initialize(VARIABLE_IS_NOT_USED const string& callsign, VARIABLE_IS_NOT_USED PluginHost::IShell* service)
        {
-           StateChange(service);
+             handleInitialize(service);
        }
+       void RDKShell::MonitorClients::Activation(const string& callsign, PluginHost::IShell* service)
+       {}
        void RDKShell::MonitorClients::Activated(const string& callsign, PluginHost::IShell* service)
        {
-            StateChange(service);
+            handleActivated(service);
        }
        void RDKShell::MonitorClients::Deactivation(const string& callsign, PluginHost::IShell* service)
-       {
-           StateChange(service);
-       }
+       {}
        void RDKShell::MonitorClients::Deactivated(const string& callsign, PluginHost::IShell* service)
        {
-            //StateChange(service);
             handleDeactivated(service);
        }
+       void RDKShell::MonitorClients::Deinitialized(VARIABLE_IS_NOT_USED const string& callsign, VARIABLE_IS_NOT_USED PluginHost::IShell* service)
+       {}
        void RDKShell::MonitorClients::Unavailable(const string& callsign, PluginHost::IShell* service)
        {}
 #endif /* USE_THUNDER_R4 */

--- a/RDKShell/RDKShell.h
+++ b/RDKShell/RDKShell.h
@@ -414,12 +414,16 @@ namespace WPEFramework {
 
               private:
                   virtual void StateChange(PluginHost::IShell* shell);
+		  void handleInitialize(PluginHost::IShell* shell);
+                  void handleActivated(PluginHost::IShell* shell);
                   void handleDeactivated(PluginHost::IShell* shell);
 #ifdef USE_THUNDER_R4
+		  virtual void Initialize(VARIABLE_IS_NOT_USED const string& callsign, VARIABLE_IS_NOT_USED PluginHost::IShell* plugin);
                   virtual void Activation(const string& name, PluginHost::IShell* plugin);
                   virtual void Deactivation(const string& name, PluginHost::IShell* plugin);
                   virtual void  Activated(const string& callSign,  PluginHost::IShell* plugin);
                   virtual void  Deactivated(const string& callSign,  PluginHost::IShell* plugin);
+		  virtual void Deinitialized(VARIABLE_IS_NOT_USED const string& callsign, VARIABLE_IS_NOT_USED PluginHost::IShell* plugin);
                   virtual void  Unavailable(const string& callSign,  PluginHost::IShell* plugin);
 #endif /* USE_THUNDER_R4 */
               private:


### PR DESCRIPTION
Reason for change:removing activation patch from thunder Fix above issue: plugin statechange will happen correctly Test Procedure: Build and verify.
Risks: High
Priority: P1
Signed-off-by: Ezhilarasi Velumani <Ezhilarasi_Velumani@comcast.com>