### PR TITLE
RDKTV-25106: RDKShell to use Initialize() and DeInitialize() function

### DIFF
--- a/RDKShell/RDKShell.h
+++ b/RDKShell/RDKShell.h
@@ -414,12 +414,16 @@ namespace WPEFramework {
 
               private:
                   virtual void StateChange(PluginHost::IShell* shell);
+		  void handleInitialize(PluginHost::IShell* shell);
+                  void handleActivated(PluginHost::IShell* shell);
                   void handleDeactivated(PluginHost::IShell* shell);
 #ifdef USE_THUNDER_R4
+		  virtual void Initialize(VARIABLE_IS_NOT_USED const string& callsign, VARIABLE_IS_NOT_USED PluginHost::IShell* plugin);
                   virtual void Activation(const string& name, PluginHost::IShell* plugin);
                   virtual void Deactivation(const string& name, PluginHost::IShell* plugin);
                   virtual void  Activated(const string& callSign,  PluginHost::IShell* plugin);
                   virtual void  Deactivated(const string& callSign,  PluginHost::IShell* plugin);
+		  virtual void Deinitialized(VARIABLE_IS_NOT_USED const string& callsign, VARIABLE_IS_NOT_USED PluginHost::IShell* plugin);
                   virtual void  Unavailable(const string& callSign,  PluginHost::IShell* plugin);
 #endif /* USE_THUNDER_R4 */
               private:


### PR DESCRIPTION
Reason for change:removing activation patch from thunder Fix above issue: plugin statechange will happen correctly Test Procedure: Build and verify.
Risks: High
Priority: P1
Signed-off-by: Ezhilarasi Velumani Ezhilarasi_Velumani@comcast.com