### PR TITLE
DELIA-63356: [RDK Services]: org.rdk.Wifi.1.getCurrentState API is no…

### DIFF
--- a/WifiManager/CHANGELOG.md
+++ b/WifiManager/CHANGELOG.md
@@ -15,6 +15,11 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+
+## [1.0.9] - 2023-09-21
+### Fixed
+- Fixed Update wifi state cache if wifi interface was enabled and added persist param in wifi setEnabled API to persist wifi state or not persist wifi state after reboot
+
 ## [1.0.8] - 2023-09-12
 ### Added
 - Implement Thunder Plugin Configuration for Kirkstone builds(CMake-3.20 & above)

--- a/WifiManager/Wifi.json
+++ b/WifiManager/Wifi.json
@@ -502,7 +502,12 @@
                         "summary": "`true` to enable or `false` to disable",
                         "type": "boolean",
                         "example": true
-                    }
+                    },
+		    "persist": {
+                        "summary": "`true` to persist Wifi state after reboot or `false` to not persist Wifi state after reboot",
+                        "type": "boolean",
+                        "example": false
+		    }
                 },
                 "required": [
                     "enable"

--- a/WifiManager/impl/WifiManagerState.cpp
+++ b/WifiManager/impl/WifiManagerState.cpp
@@ -115,6 +115,9 @@ uint32_t WifiManagerState::setEnabled(const JsonObject &parameters, JsonObject &
 
     strncpy(param.setInterface, "WIFI", INTERFACE_SIZE - 1);
     param.isInterfaceEnabled = parameters["enable"].Boolean();
+    bool persist_t = false;
+    getDefaultBoolParameter("persist", persist_t, false);
+    param.persist = persist_t;
 
     // disables wifi interface when ethernet interface is active
     IARM_Result_t retVal = IARM_Bus_Call(IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_NETSRVMGR_API_setInterfaceEnabled, (void *)&param, sizeof(param));
@@ -122,6 +125,11 @@ uint32_t WifiManagerState::setEnabled(const JsonObject &parameters, JsonObject &
     // Update wifi state cache if wifi interface was disabled
     if (retVal == IARM_RESULT_SUCCESS && !param.isInterfaceEnabled) {
         setWifiStateCache(true, WifiState::DISABLED);
+    }
+
+    // Update wifi state cache if wifi interface was enabled
+    else if (retVal == IARM_RESULT_SUCCESS && param.isInterfaceEnabled == true) {
+        setWifiStateCache(true, WifiState::DISCONNECTED);
     }
 
     returnResponse(retVal == IARM_RESULT_SUCCESS);

--- a/docs/api/WifiPlugin.md
+++ b/docs/api/WifiPlugin.md
@@ -770,6 +770,7 @@ No Events
 | :-------- | :-------- | :-------- |
 | params | object |  |
 | params.enable | boolean | `true` to enable or `false` to disable |
+| params.persist | boolean | `true` to persist Wifi state after reboot or `false` to not persist Wifi state after reboot |
 
 ### Result
 
@@ -788,7 +789,8 @@ No Events
     "id": 42,
     "method": "org.rdk.Wifi.setEnabled",
     "params": {
-        "enable": true
+        "enable": true,
+	"persist": false
     }
 }
 ```


### PR DESCRIPTION
…t returning the wifi states properly and added persist parameter in wifi setEnabled API

Reason for change: Fixed wifi state cache if wifi interface was enabled and added persist param to persist wifi state after reboot

Test Procedure: Build and verify.

Risks: Low