### PR TITLE
DELIA-63302 : RDKServices: In HdmiCecSink plugin osdName is not retur…

### DIFF
--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -2684,6 +2684,7 @@ namespace WPEFramework
 						_instance->deviceList[_instance->m_logicalAddressAllocated].m_vendorID = appVendorId;
 						_instance->deviceList[_instance->m_logicalAddressAllocated].m_powerStatus = PowerStatus(powerState);
 						_instance->deviceList[_instance->m_logicalAddressAllocated].m_currentLanguage = defaultLanguage;
+						_instance->deviceList[_instance->m_logicalAddressAllocated].m_osdName = osdName.toString().c_str();
 						if(cecVersion == 2.0) {
 						    _instance->deviceList[_instance->m_logicalAddressAllocated].m_cecVersion = Version::V_2_0;
 						    _instance->smConnection->sendTo(LogicalAddress(LogicalAddress::BROADCAST),


### PR DESCRIPTION
…ning proper result returning empty string

Reason for change: Modified the osdName reading value from osdName.toString().c_str()

Test Procedure: Verified and its returning TV Box

Risks: Low