### PR TITLE
(Cherrypick 4370)SERXIONE-2617: WPEProcess crash with TTS::TTSManager::interrupted

### DIFF
--- a/TextToSpeech/impl/TTSManager.cpp
+++ b/TextToSpeech/impl/TTSManager.cpp
@@ -41,7 +41,8 @@ TTSManager::TTSManager(TTSEventCallback *callback) :
 
 TTSManager::~TTSManager() {
     TTSLOG_TRACE("TTSManager::~TTSManager");
-    m_callback = NULL;
+    TTSEventCallback dummyCallback;
+    m_callback = &dummyCallback;
 
     // Clear Speaker Instance
     if(m_speaker) {


### PR DESCRIPTION
Reason for change: During Destruction Process of TTSSpeaker m_callback is set to NULL and it accessed by GstremerThreadFuc which leads to crash
Signed-off-by: Chockalingam Murugan <Chockalingam_Murugan@comcast.com>
Test Procedure: Sanity Testing in apps
Priority: P1
Risks: None

Cherrypick of [4370](https://github.com/rdkcentral/rdkservices/pull/4370)