### PR TITLE
RDKDEV-796: RDKCOM-4076: [RDKServices]: Failed to get Event "client.e…

### DIFF
--- a/FrameRate/CHANGELOG.md
+++ b/FrameRate/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.0.5] - 2023-10-16
+### Changed
+-  Sending FrameRate plugin onDisplayFrameRateChanging and onDisplayFrameRateChanged events to wpeframework log with displayFrameRate params
+
 ## [1.0.4] - 2023-09-12
 ### Added
 - Implement Thunder Plugin Configuration for Kirkstone builds(CMake-3.20 & above)

--- a/FrameRate/CMakeLists.txt
+++ b/FrameRate/CMakeLists.txt
@@ -32,13 +32,34 @@ set_target_properties(${MODULE_NAME} PROPERTIES
 
 target_compile_definitions(${MODULE_NAME} PRIVATE MODULE_NAME=Plugin_${PLUGIN_NAME})
 
-find_package(DS)
+if (NOT RDK_SERVICES_TEST)
+    target_compile_options(${MODULE_NAME} PRIVATE -Wno-error)
+endif ()
+
+list(APPEND CMAKE_MODULE_PATH
+        "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")
+
 find_package(IARMBus)
+if (IARMBus_FOUND)
+    target_include_directories(${MODULE_NAME} PRIVATE ${IARMBUS_INCLUDE_DIRS})
+    target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins ${IARMBUS_LIBRARIES})
+else (IARMBus_FOUND)
+    message ("Module IARMBus required.")
+    target_include_directories(${MODULE_NAME} PRIVATE ${IARMBUS_INCLUDE_DIRS})
+    target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins ${IARMBUS_LIBRARIES})
+endif(IARMBus_FOUND)
 
-add_definitions(-DDS_FOUND)
+find_package(DS)
+if (DS_FOUND)
+        find_package(IARMBus)
+    add_definitions(-DDS_FOUND)
+    target_include_directories(${MODULE_NAME} PRIVATE ${IARMBUS_INCLUDE_DIRS})
+    target_include_directories(${MODULE_NAME} PRIVATE ${DS_INCLUDE_DIRS})
+    target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins ${IARMBUS_LIBRARIES} ${DS_LIBRARIES})
+else (DS_FOUND)
+    target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins)
+endif(DS_FOUND)
 
-target_include_directories(${MODULE_NAME} PRIVATE ${DS_INCLUDE_DIRS})
-target_include_directories(${MODULE_NAME} PRIVATE ${IARMBUS_INCLUDE_DIRS})
 target_include_directories(${MODULE_NAME} PRIVATE ../helpers)
 
 set_source_files_properties(FrameRate.cpp PROPERTIES COMPILE_FLAGS "-fexceptions")

--- a/FrameRate/FrameRate.cpp
+++ b/FrameRate/FrameRate.cpp
@@ -51,7 +51,7 @@
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 3
+#define API_VERSION_NUMBER_PATCH 5
 
 namespace WPEFramework
 {
@@ -455,28 +455,54 @@ namespace WPEFramework
 
 	void FrameRate::FrameRatePreChange(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
         {
+	    char dispFrameRate[20] ={0};
+            if (strcmp(owner, IARM_BUS_DSMGR_NAME) == 0)
+            {
+                switch (eventId) {
+                    case IARM_BUS_DSMGR_EVENT_DISPLAY_FRAMRATE_PRECHANGE:
+                        IARM_Bus_DSMgr_EventData_t *eventData = (IARM_Bus_DSMgr_EventData_t *)data;
+                        strcpy(dispFrameRate,eventData->data.DisplayFrameRateChange.framerate);
+                        break;
+                }
+            }
+
             if(FrameRate::_instance)
             {
-                FrameRate::_instance->frameRatePreChange();
+                FrameRate::_instance->frameRatePreChange(dispFrameRate);
             }
         }
 
-        void FrameRate::frameRatePreChange()
+        void FrameRate::frameRatePreChange(char *displayFrameRate)
         {
-            sendNotify(EVENT_FRAMERATE_PRECHANGE, JsonObject());
+            JsonObject params;
+            params["displayFrameRate"] = std::string(displayFrameRate);
+            sendNotify(EVENT_FRAMERATE_PRECHANGE, params);
         }
 
         void FrameRate::FrameRatePostChange(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
         {
+	    char dispFrameRate[20] ={0};
+            if (strcmp(owner, IARM_BUS_DSMGR_NAME) == 0)
+            {
+                switch (eventId) {
+                    case IARM_BUS_DSMGR_EVENT_DISPLAY_FRAMRATE_POSTCHANGE:
+                        IARM_Bus_DSMgr_EventData_t *eventData = (IARM_Bus_DSMgr_EventData_t *)data;
+                        strcpy(dispFrameRate,eventData->data.DisplayFrameRateChange.framerate);
+                        break;
+                }
+            }
+
             if(FrameRate::_instance)
             {
-                FrameRate::_instance->frameRatePostChange();
+                FrameRate::_instance->frameRatePostChange(dispFrameRate);
             }
         }
 
-        void FrameRate::frameRatePostChange()
+        void FrameRate::frameRatePostChange(char *displayFrameRate)
         {
-            sendNotify(EVENT_FRAMERATE_POSTCHANGE, JsonObject());
+            JsonObject params;
+            params["displayFrameRate"] = std::string(displayFrameRate);
+            sendNotify(EVENT_FRAMERATE_POSTCHANGE, params);
         }
 
         

--- a/FrameRate/FrameRate.h
+++ b/FrameRate/FrameRate.h
@@ -66,10 +66,10 @@ namespace WPEFramework {
 	    void InitializeIARM();
             void DeinitializeIARM();
 
-            void frameRatePreChange();
+            void frameRatePreChange(char *displayFrameRate);
             static void FrameRatePreChange(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
 
-            void frameRatePostChange();
+            void frameRatePostChange(char *displayFrameRate);
             static void FrameRatePostChange(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
 
 

--- a/FrameRate/FrameRate.json
+++ b/FrameRate/FrameRate.json
@@ -163,10 +163,30 @@
     },
     "events":{
         "onDisplayFrameRateChanging":{
-            "summary": "Triggered when the framerate changes started"
+            "summary": "Triggered when the framerate changes started",
+	    "params": {
+                "type":"object",
+                "properties": {
+                    "displayFrameRate": {
+                        "summary": "Video Display FrameRate changing",
+                        "type": "string",
+                        "example": "1920x1080x60"
+                    }
+                }
+            }
         },
         "onDisplayFrameRateChanged":{
-            "summary": "Triggered when the framerate changed"
+            "summary": "Triggered when the framerate changed",
+	    "params": {
+                "type":"object",
+                "properties": {
+                    "displayFrameRate": {
+                        "summary": "Video Display FrameRate changed",
+                        "type": "string",
+                        "example": "1920x1080x60"
+                    }
+                }
+            }
         },
         "onFpsEvent":{
             "summary": "Triggered at the end of each interval as defined by the `setCollectionFrequency` method and once after the `stopFpsCollection` method is invoked.",

--- a/FrameRate/cmake/FindDS.cmake
+++ b/FrameRate/cmake/FindDS.cmake
@@ -1,0 +1,51 @@
+# If not stated otherwise in this file or this component's license file the
+# following copyright and licenses apply:
+#
+# Copyright 2020 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# - Try to find Display Settings library
+# Once done this will define
+#  DS_FOUND - System has DS
+#  DS_INCLUDE_DIRS - The DS include directories
+#  DS_LIBRARIES - The libraries needed to use DS
+#  DS_FLAGS - The flags needed to use DS
+#
+
+find_package(PkgConfig)
+
+find_library(DS_LIBRARIES NAMES ds)
+find_library(DSHAL_LIBRARIES NAMES dshalcli)
+find_library(OEMHAL_LIBRARIES NAMES ds-hal)
+find_library(IARMBUS_LIBRARIES NAMES IARMBus)
+find_path(DS_INCLUDE_DIRS NAMES manager.hpp PATH_SUFFIXES rdk/ds)
+find_path(DSHAL_INCLUDE_DIRS NAMES dsTypes.h PATH_SUFFIXES rdk/ds-hal)
+find_path(DSRPC_INCLUDE_DIRS NAMES dsMgr.h PATH_SUFFIXES rdk/ds-rpc)
+
+set(DS_LIBRARIES ${DS_LIBRARIES} ${DSHAL_LIBRARIES})
+set(DS_LIBRARIES ${DS_LIBRARIES} CACHE PATH "Path to DS library")
+set(DS_INCLUDE_DIRS ${DS_INCLUDE_DIRS} ${DSHAL_INCLUDE_DIRS} ${DSRPC_INCLUDE_DIRS})
+set(DS_INCLUDE_DIRS ${DS_INCLUDE_DIRS} CACHE PATH "Path to DS include")
+
+
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(DS DEFAULT_MSG DS_INCLUDE_DIRS DS_LIBRARIES)
+
+mark_as_advanced(
+    DS_FOUND
+    DS_INCLUDE_DIRS
+    DS_LIBRARIES
+    DS_LIBRARY_DIRS
+    DS_FLAGS)

--- a/FrameRate/cmake/FindIARMBus.cmake
+++ b/FrameRate/cmake/FindIARMBus.cmake
@@ -1,0 +1,46 @@
+# If not stated otherwise in this file or this component's license file the
+# following copyright and licenses apply:
+#
+# Copyright 2020 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# - Try to find IARMBus
+# Once done this will define
+#  IARMBUS_FOUND - System has IARMBus
+#  IARMBUS_INCLUDE_DIRS - The IARMBus include directories
+#  IARMBUS_LIBRARIES - The libraries needed to use IARMBus
+#  IARMBUS_FLAGS - The flags needed to use IARMBus
+#
+
+find_package(PkgConfig)
+
+find_library(IARMBUS_LIBRARIES NAMES IARMBus)
+find_path(IARMBUS_INCLUDE_DIRS NAMES libIARM.h PATH_SUFFIXES rdk/iarmbus)
+find_path(IARMIR_INCLUDE_DIRS NAMES irMgr.h PATH_SUFFIXES rdk/iarmmgrs/ir)
+find_path(IARMRECEIVER_INCLUDE_DIRS NAMES receiverMgr.h PATH_SUFFIXES rdk/iarmmgrs/receiver)
+find_path(IARMPWR_INCLUDE_DIRS NAMES pwrMgr.h PATH_SUFFIXES rdk/iarmmgrs-hal)
+
+set(IARMBUS_LIBRARIES ${IARMBUS_LIBRARIES} CACHE PATH "Path to IARMBus library")
+set(IARMBUS_INCLUDE_DIRS ${IARMBUS_INCLUDE_DIRS} ${IARMIR_INCLUDE_DIRS} ${IARMRECEIVER_INCLUDE_DIRS} ${IARMPWR_INCLUDE_DIRS})
+set(IARMBUS_INCLUDE_DIRS ${IARMBUS_INCLUDE_DIRS} ${IARMIR_INCLUDE_DIRS} ${IARMRECEIVER_INCLUDE_DIRS} ${IARMPWR_INCLUDE_DIRS} CACHE PATH "Path to IARMBus include")
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(IARMBUS DEFAULT_MSG IARMBUS_INCLUDE_DIRS IARMBUS_LIBRARIES)
+
+mark_as_advanced(
+    IARMBUS_FOUND
+    IARMBUS_INCLUDE_DIRS
+    IARMBUS_LIBRARIES
+    IARMBUS_LIBRARY_DIRS
+    IARMBUS_FLAGS)

--- a/Tests/mocks/devicesettings.h
+++ b/Tests/mocks/devicesettings.h
@@ -424,6 +424,9 @@ typedef struct _DSMgr_EventData_t {
                int audio_output_delay;
                int video_latency;
         }hdmi_in_av_latency; /*HDMI in AVLatency change*/
+	struct _DISPLAY_FRAMERATE_CHANGE {
+            char framerate[20];
+        }DisplayFrameRateChange;
     } data;
 } IARM_Bus_DSMgr_EventData_t;
 

--- a/docs/api/FrameRatePlugin.md
+++ b/docs/api/FrameRatePlugin.md
@@ -2,7 +2,7 @@
 <a name="FrameRate_Plugin"></a>
 # FrameRate Plugin
 
-**Version: [1.0.4](https://github.com/rdkcentral/rdkservices/blob/main/FrameRate/CHANGELOG.md)**
+**Version: [1.0.5](https://github.com/rdkcentral/rdkservices/blob/main/FrameRate/CHANGELOG.md)**
 
 A org.rdk.FrameRate plugin for Thunder framework.
 
@@ -464,14 +464,20 @@ Triggered when the framerate changes started.
 
 ### Parameters
 
-This event carries no parameters.
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.displayFrameRate | string | video display framerate |
 
 ### Example
 
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.onDisplayFrameRateChanging"
+    "method": "client.events.onDisplayFrameRateChanging",
+    "params": {
+        "displayFrameRate": "1920x1080x60"
+    }
 }
 ```
 
@@ -482,14 +488,20 @@ Triggered when the framerate changed.
 
 ### Parameters
 
-This event carries no parameters.
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.displayFrameRate | string | video display framerate |
 
 ### Example
 
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.onDisplayFrameRateChanged"
+    "method": "client.events.onDisplayFrameRateChanged",
+    "params": {
+        "displayFrameRate": "1920x1080x60"
+    }
 }
 ```
 


### PR DESCRIPTION
…vents.1.onDisplayFrameRateChanged" if we setting org.rdk.FrameRate.2.setDisplayFrameRate

Reason for change: Added _dsSendDisplayFrameRateStatusPreChangeCall and _dsSendDisplayFrameRateStatusPreChangeCall to broadcast framerate prechange and postchange events

Test Procedure: Build and verify.

Risks: Low