### PR TITLE
RDKCOM-4267 REFPLTV-1925: mfgserialnumber not obtained for org.rdk.System.1.getMfgSerialNumber API

### DIFF
--- a/raspberrypi.cmake
+++ b/raspberrypi.cmake
@@ -77,5 +77,11 @@ if (BUILD_DBUS)
     option(IARM_USE_DBUS "IARM_USE_DBUS" ON)
 endif()
 
+if (BUILD_ENABLE_DEVICE_MANUFACTURER_INFO)
+    message("Building with device manufacturer info")
+    add_definitions (-DENABLE_DEVICE_MANUFACTURER_INFO)
+endif()
+
+
 
 


### PR DESCRIPTION
RDKCOM-4267 REFPLTV-1925: mfgserialnumber not obtained for org.rdk.System.1.getMfgSerialNumber API

Reason for change: Added the getMfgSerialNumber support for RPI. Test Procedure: Build and verify.
Risks: Low
Signed-off-by: Dineshkumar_Periyasamy@comcast.com
(cherry picked from commit 7c968b03ef58a10cc4b0348bc75c50cb690b9e0f)