### PR TITLE
RDKDEV-851/AMLS905X4-792 : onApplicationConnected event not triggered in RDK shell.

### DIFF
--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -1122,7 +1122,7 @@ namespace WPEFramework {
                            sem_wait(&request->mSemaphore);
                        }
                        gRdkShellMutex.lock();
-                       RdkShell::CompositorController::addListener(clientidentifier, mShell.mEventListener);
+                       RdkShell::CompositorController::addListener(service->Callsign(), mShell.mEventListener);
                        gRdkShellMutex.unlock();
                        gPluginDataMutex.lock();
                        std::string className = service->ClassName();
@@ -1219,7 +1219,7 @@ namespace WPEFramework {
                         gRdkShellMutex.unlock();
                         sem_wait(&request->mSemaphore);
                         gRdkShellMutex.lock();
-                        RdkShell::CompositorController::removeListener(clientidentifier, mShell.mEventListener);
+                        RdkShell::CompositorController::removeListener(service->Callsign(), mShell.mEventListener);
                         gRdkShellMutex.unlock();
                     }
                     


### PR DESCRIPTION
RDKDEV-851/AMLS905X4-792 : onApplicationConnected event not triggered in RDK shell.

Reason for change: event not triggered in rdkshell.
Test Procedure: Build and run RDKSHELL test cases.
Risks: LOW

Signed-off-by: Fasil KV <fasil_KV@comcast.com>