### PR TITLE
RDKDEV-854: RDKServices: VolumeLevelChanged event is not triggering f…

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -2958,7 +2958,7 @@ namespace WPEFramework {
                 {
                         device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
                         aPort.setLevel(level);
-                        if(cache_volumelevel != (int)level)
+                        if((0 == (int)level) || (cache_volumelevel != (int)level))
                         {
                             cache_volumelevel = (int)level;
                             JsonObject params;


### PR DESCRIPTION
…or the zero volume level

Reason for change: Added a condition check in setVolumeLevel api for volume level Zero

Test Procedure: Build and verify volumeLevelChanged event for Zero and other volume levels

Risks: Low