### PR TITLE
RDKCOM-4342 AMLS905X4-945 - Verify that deviceType property is functional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,11 @@ if(PLUGIN_REMOTEACTIONMAPPING)
     add_subdirectory(RemoteActionMapping)
 endif()
 
+if(ENABLE_COMMUNITY_DEVICE_TYPE)
+   add_definitions(-DENABLE_COMMUNITY_DEVICE_TYPE)
+endif()
+
+
 if(PLUGIN_CONTROLSERVICE)
     add_subdirectory(ControlService)
 endif()

--- a/DeviceInfo/CHANGELOG.md
+++ b/DeviceInfo/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.0.11] - 2023-10-20
+### Fixed
+- Verify that deviceType property is functional
+
 ## [1.0.10] - 2023-10-04
 ### Added
 - Implement Thunder Plugin Configuration for Kirkstone builds(CMake-3.20 & above)

--- a/DeviceInfo/DeviceInfo.cpp
+++ b/DeviceInfo/DeviceInfo.cpp
@@ -21,7 +21,7 @@
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 5
+#define API_VERSION_NUMBER_PATCH 6
 
 namespace WPEFramework {
 namespace {

--- a/DeviceInfo/DeviceInfo.cpp
+++ b/DeviceInfo/DeviceInfo.cpp
@@ -21,7 +21,7 @@
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 6
+#define API_VERSION_NUMBER_PATCH 11
 
 namespace WPEFramework {
 namespace {

--- a/DeviceInfo/Implementation/DeviceInfo.cpp
+++ b/DeviceInfo/Implementation/DeviceInfo.cpp
@@ -119,8 +119,19 @@ namespace Plugin {
 
     uint32_t DeviceInfoImplementation::DeviceType(string& deviceType) const
     {
-        return GetFileRegex(_T("/etc/authService.conf"),
-            std::regex("^deviceType(?:\\s*)=(?:\\s*)(?:\"{0,1})([^\"\\n]+)(?:\"{0,1})(?:\\s*)$"), deviceType);
+#ifndef ENABLE_COMMUNITY_DEVICE_TYPE
+        return GetFileRegex(_T("/etc/authService.conf"),std::regex("^deviceType(?:\\s*)=(?:\\s*)(?:\"{0,1})([^\"\\n]+)(?:\"{0,1})(?:\\s*)$"), deviceType);
+#else
+        const char* device_type;
+        uint32_t result = GetFileRegex(_T("/etc/authService.conf"),
+            std::regex("^deviceType(?:\\s*)=(?:\\s*)(?:\"{0,1})([^\"\\n]+)(?:\"{0,1})(?:\\s*)$"), deviceType)
+            == Core::ERROR_NONE ? Core::ERROR_NONE
+            : GetFileRegex(_T("/etc/device.properties"),
+                                        std::regex("^DEVICE_TYPE(?:\\s*)=(?:\\s*)(?:\"{0,1})([^\"\\n]+)(?:\"{0,1})(?:\\s*)$"), deviceType);
+        device_type = deviceType.c_str();
+        deviceType = (strcmp("mediaclient",device_type)==0)?("IpStb"):((strcmp("hybrid",device_type)==0)?("QamIpStb"):("TV"));
+        return result;
+#endif
     }
 
     uint32_t DeviceInfoImplementation::DistributorId(string& distributorId) const


### PR DESCRIPTION
RDKCOM-4342 AMLS905X4-945 - Verify that deviceType property is functional

Reason for change: Reading existing device_type and assigning based on value , mediaclient->IpStb / hybrid->QamIpStb / tv->tv

Test Procedure: Build and verify.

Risks: Low
Signed-off-by: <arikrishnan_g@comcast.com>
(cherry picked from commit 869ae57a8aee267c13ff9e13e134c27d1fa63e34)