### PR TITLE
RDK-44808: Default R4.2 Thunder release to Realtek Devices

### DIFF
--- a/HdmiCec_2/HdmiCec_2.conf.in
+++ b/HdmiCec_2/HdmiCec_2.conf.in
@@ -1,0 +1,4 @@
+precondition = ["Platform"]
+callsign = "org.rdk.HdmiCec_2"
+autostart = "false"
+startuporder = "@PLUGIN_HDMICEC2_STARTUPORDER@"


### PR DESCRIPTION
Reason for change: updated the HdmiCec_2 conf.in based on latest config generator in R4.2
Test Procedure: Verify in Jenkin Build
Risks: High
Signed-off-by: Thamim  Razith <tabbas651@cable.comcast.com>