### PR TITLE
RDKTV-25836 : Removed redundant connectivity check call.

### DIFF
--- a/Network/CHANGELOG.md
+++ b/Network/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+## [1.2.1] - 2023-10-23
+### Fixed
+- Fixed the isConnectedToInternet method to not to call getPublicIP; as they are independent RPCs.
+
 ## [1.2.0] - 2023-08-16
 ### Added
 - Added new params in isConnectedToInternet for Query Internet Connectivity specific to Ipversion

--- a/Network/Network.cpp
+++ b/Network/Network.cpp
@@ -34,7 +34,7 @@ using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 2
-#define API_VERSION_NUMBER_PATCH 0
+#define API_VERSION_NUMBER_PATCH 1
 
 /* Netsrvmgr Based Macros & Structures */
 #define IARM_BUS_NM_SRV_MGR_NAME "NET_SRV_MGR"
@@ -1200,6 +1200,7 @@ typedef struct _IARM_BUS_NetSrvMgr_Iface_EventData_t {
                     response["connectedToInternet"] = param.isconnected;
                     if(ipversion == "IPV4" || ipversion == "IPV6")
                         response["ipversion"] = ipversion.c_str();
+
                     if (param.isconnected)
                     {
                         PluginHost::ISubSystem* subSystem = m_service->SubSystems();
@@ -1209,27 +1210,8 @@ typedef struct _IARM_BUS_NetSrvMgr_Iface_EventData_t {
                             const PluginHost::ISubSystem::IInternet* internet(subSystem->Get<PluginHost::ISubSystem::IInternet>());
                             if (nullptr == internet)
                             {
-                                if (m_ipversion.empty())
-                                {
-                                    JsonObject p, r;
-                                    getIPSettings(p, r);
-                                }
-
-                                if (m_publicIPAddress.empty())
-                                {
-                                    JsonObject p2, r2;
-                                    if (m_ipversion == "IPV6")
-                                        p2["ipv6"] = true;
-                                    getPublicIP(p2, r2);
-                                }
-
-                                if (!m_publicIPAddress.empty())
-                                {
                                     subSystem->Set(PluginHost::ISubSystem::INTERNET, this);
                                     LOGWARN("Set INTERNET ISubSystem");
-                                }
-                                else
-                                    LOGERR("Connected to Internet, but no publicIP");
                             }
  
                             subSystem->Release();

--- a/docs/api/NetworkPlugin.md
+++ b/docs/api/NetworkPlugin.md
@@ -2,7 +2,7 @@
 <a name="head.NetworkPlugin"></a>
 # NetworkPlugin
 
-**Version: [1.2.0](https://github.com/rdkcentral/rdkservices/blob/main/Network/CHANGELOG.md)**
+**Version: [1.2.1](https://github.com/rdkcentral/rdkservices/blob/main/Network/CHANGELOG.md)**
 
 A org.rdk.Network plugin for Thunder framework.
 


### PR DESCRIPTION
The Network Service Manager reports ConnectedToInternet as TRUE only after reaching out to external public endpoint. So no need to call getPublicIP to notify Thunder about Internet Subsystem.