### PR TITLE
RDKTV-25836 : Removed redundant connectivity check call

### DIFF
--- a/Network/CHANGELOG.md
+++ b/Network/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.2.3] - 2023-10-23
+### Fixed
+- Fixed the isConnectedToInternet method to not to call getPublicIP; as they are independent RPCs.
+
 ## [1.2.2] - 2023-09-29
 ### Added
 - Implement Thunder Plugin Configuration for Kirkstone builds(CMake-3.20 & above)

--- a/Network/Network.cpp
+++ b/Network/Network.cpp
@@ -1158,9 +1158,6 @@ typedef struct _IARM_BUS_NetSrvMgr_Iface_EventData_t {
             bool result = false;
             std::string ipversion;
 
-            if(!m_isPluginInited)
-                EnsureNetSrvMgrRunning();
-
             if(m_isPluginInited)
             {
                 IARM_BUS_NetSrvMgr_isConnectedtoInternet_t param;

--- a/docs/api/NetworkPlugin.md
+++ b/docs/api/NetworkPlugin.md
@@ -2,7 +2,7 @@
 <a name="NetworkPlugin"></a>
 # NetworkPlugin
 
-**Version: [1.2.1](https://github.com/rdkcentral/rdkservices/blob/main/Network/CHANGELOG.md)**
+**Version: [1.2.3](https://github.com/rdkcentral/rdkservices/blob/main/Network/CHANGELOG.md)**
 
 A org.rdk.Network plugin for Thunder framework.
 


### PR DESCRIPTION
Reason for change: Removed GetPublicIP() within IsConnectedToInternet()
Test Procedure: As per [RDKTV-25836](https://ccp.sys.comcast.net/browse/RDKTV-25836)
Risks: Medium
Signed-off-by:  Thamim  Razith <tabbas651@cable.comcast.com>