### PR TITLE
RDKDEV-860: [RDK Services]: Display Framerate is not persist after re…

### DIFF
--- a/FrameRate/CHANGELOG.md
+++ b/FrameRate/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.0.6] - 2023-10-30
+### Added
+-  Added persist param for setDisplayFrameRate api to persist framerate after reboot other wise not persist framerate after reboot
+
 ## [1.0.5] - 2023-10-16
 ### Changed
 -  Sending FrameRate plugin onDisplayFrameRateChanging and onDisplayFrameRateChanged events to wpeframework log with displayFrameRate params

--- a/FrameRate/FrameRate.cpp
+++ b/FrameRate/FrameRate.cpp
@@ -51,7 +51,7 @@
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 5
+#define API_VERSION_NUMBER_PATCH 6
 
 namespace WPEFramework
 {
@@ -266,13 +266,17 @@ namespace WPEFramework
             LOGINFOMETHOD();
             returnIfParamNotFound(parameters, "framerate");
 
+	    bool hasPersist = parameters.HasLabel("persist");
+	    bool persist = hasPersist ? parameters["persist"].Boolean() : false;
+	    if (!hasPersist) LOGINFO("%s persist: false",__FUNCTION__); else LOGINFO("%s persist: true",__FUNCTION__);
+
             string sFramerate = parameters["framerate"].String();
 
             bool success = true;
             try
             {
                 device::VideoDevice &device = device::Host::getInstance().getVideoDevices().at(0);
-                device.setDisplayframerate(sFramerate.c_str());
+                device.setDisplayframerate(sFramerate.c_str(), persist);
             }
             catch (const device::Exception& err)
             {

--- a/FrameRate/FrameRate.json
+++ b/FrameRate/FrameRate.json
@@ -98,6 +98,11 @@
                 "properties": {
                     "framerate": {
                         "$ref": "#/definitions/framerate"
+                    },
+		    "persist": {
+                        "summary": "`true` to persist Display Framerate after reboot or `false` to not persist Display Framerate after reboot",
+                        "type": "boolean",
+                        "example": false
                     }
                 },
                 "required": [

--- a/Tests/mocks/devicesettings.h
+++ b/Tests/mocks/devicesettings.h
@@ -722,7 +722,7 @@ public:
     virtual int getFRFMode(int* frfmode) const = 0;
     virtual int setFRFMode(int frfmode) const = 0;
     virtual int getCurrentDisframerate(char* framerate) const = 0;
-    virtual int setDisplayframerate(const char* framerate) const = 0;
+    virtual int setDisplayframerate(const char* framerate, bool persist) const = 0;
 };
 
 class VideoDevice {
@@ -744,9 +744,9 @@ public:
         return impl->getCurrentDisframerate(framerate);
     }
 
-    int setDisplayframerate(const char* framerate) const
+    int setDisplayframerate(const char* framerate, bool persist) const
     {
-        return impl->setDisplayframerate(framerate);
+        return impl->setDisplayframerate(framerate, persist);
     }
 };
 

--- a/Tests/tests/test_FrameRate.cpp
+++ b/Tests/tests/test_FrameRate.cpp
@@ -177,7 +177,7 @@ TEST_F(FrameRateDsTest, DISABLED_setDisplayFrameRate)
                 return 0;
             }));
 
-    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("setDisplayFrameRate"), _T("{\"framerate\":\"3840x2160px48\"}"), response));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("setDisplayFrameRate"), _T("{\"framerate\":\"3840x2160px48\", \"persist\": false}"), response));
     EXPECT_EQ(response, string("{\"success\":true}"));
 }
 

--- a/docs/api/FrameRatePlugin.md
+++ b/docs/api/FrameRatePlugin.md
@@ -2,7 +2,7 @@
 <a name="FrameRate_Plugin"></a>
 # FrameRate Plugin
 
-**Version: [1.0.5](https://github.com/rdkcentral/rdkservices/blob/main/FrameRate/CHANGELOG.md)**
+**Version: [1.0.6](https://github.com/rdkcentral/rdkservices/blob/main/FrameRate/CHANGELOG.md)**
 
 A org.rdk.FrameRate plugin for Thunder framework.
 
@@ -216,6 +216,7 @@ Sets the display framerate values.
 | :-------- | :-------- | :-------- |
 | params | object |  |
 | params.framerate | string | The display framerate setting (width x height x framerate) |
+| params.persist | boolean | persist set as `true` means display framerate persist after reboot, persist set as `false` means display framerate not persist after reboot |
 
 ### Result
 
@@ -234,7 +235,8 @@ Sets the display framerate values.
     "id": 42,
     "method": "org.rdk.FrameRate.setDisplayFrameRate",
     "params": {
-        "framerate": "3840x2160px48"
+        "framerate": "3840x2160px48",
+	"persist": false
     }
 }
 ```


### PR DESCRIPTION
…boot using org.rdk.FrameRate.2.setDisplayFrameRate api

Reason for change: Added persist variable for setDisplayFrameRate API to persist display framerate if we pass persist as true other wise display framerate not persist

Test Procedure: Build and verify.

Risks: Low