### PR TITLE
RDK-45136: RDK Z-Order Changes

### DIFF
--- a/AVInput/AVInput.cpp
+++ b/AVInput/AVInput.cpp
@@ -336,6 +336,8 @@ uint32_t AVInput::startInput(const JsonObject& parameters, JsonObject& response)
     int portId = 0;
     int iType = 0;
     int planeType = 0; //planeType = 0 -  primary, 1 - secondary video plane type
+    bool topMostPlane = parameters["topMost"].Boolean();
+    LOGINFO("topMost value in thunder: %d\n",topMostPlane);
     if (parameters.HasLabel("portId") && parameters.HasLabel("typeOfInput"))
     {
         try {
@@ -363,7 +365,7 @@ uint32_t AVInput::startInput(const JsonObject& parameters, JsonObject& response)
     try
     {
         if (iType == HDMI) {
-           device::HdmiInput::getInstance().selectPort(portId,audioMix,planeType);
+           device::HdmiInput::getInstance().selectPort(portId,audioMix,planeType,topMostPlane);
     }
     else if(iType == COMPOSITE) {
             device::CompositeInput::getInstance().selectPort(portId);

--- a/AVInput/AVInput.json
+++ b/AVInput/AVInput.json
@@ -63,7 +63,12 @@
              "type": "integer",
              "example": "0"
 	 },
-        "typeOfInput":{
+         "topMost":{
+             "summary": "Defines whether the Hdmi Input should be over or under the other video plane",
+             "type": "boolean",
+             "example": "true"
+         },
+	 "typeOfInput":{
             "summary": "The type of Input - HDMI/COMPOSITE",
             "type": "string",
             "example": "HDMI"
@@ -380,7 +385,16 @@
                     },
                     "typeOfInput":{
                         "$ref": "#/definitions/typeOfInput"
-                    }
+		    },
+		    "audioMix":{
+			    "$ref": "#/definitions/audioMix"
+	            },
+		    "planeType":{
+			    "$ref": "#/definitions/planeType"
+		    },
+		    "topMost":{
+			    "$ref": "#/definitions/topMost"
+		    }
                 },
                 "required": [
                     "portid",

--- a/HdmiInput/HdmiInput.cpp
+++ b/HdmiInput/HdmiInput.cpp
@@ -231,7 +231,8 @@ namespace WPEFramework
 	    string sPortId = parameters["portId"].String();
             bool audioMix = parameters["requestAudioMix"].Boolean();
 	    int portId = 0;    
-	    
+	    bool topMostPlane = parameters["topMost"].Boolean();
+	    LOGINFO("topMost value in thunder: %d\n",topMostPlane);
 	    //planeType = 0 -  primary, 1 - secondary video plane type
 	    int planeType = 0;
 	    try {
@@ -252,7 +253,7 @@ namespace WPEFramework
             bool success = true;
             try
             {
-                device::HdmiInput::getInstance().selectPort(portId,audioMix,planeType);
+                device::HdmiInput::getInstance().selectPort(portId,audioMix,planeType,topMostPlane);
             }
 	    catch (const device::Exception& err)
             {

--- a/HdmiInput/HdmiInput.json
+++ b/HdmiInput/HdmiInput.json
@@ -232,6 +232,11 @@
                         "summary": "Defines whether the video plane type, 0 - Primary video plane, 1 - Secondary Video Plane, Other values - Invalid - This is an optional argument ",
                         "type": "integer",
                         "example": "0"
+	            },
+		    "topMost":{
+                        "summary": "Defines whether the Hdmi Input should be over or under the other video plane",
+                        "type": "boolean",
+                        "example": "true"
                     }
                 },
                 "required": [

--- a/Tests/mocks/devicesettings.h
+++ b/Tests/mocks/devicesettings.h
@@ -585,7 +585,7 @@ public:
     virtual uint8_t getNumberOfInputs() const = 0;
     virtual bool isPortConnected(int8_t Port) const = 0;
     virtual std::string getCurrentVideoMode() const = 0;
-    virtual void selectPort(int8_t Port,bool audioMix = false, int videoPlane = 0) const = 0;
+    virtual void selectPort(int8_t Port,bool audioMix = false, int videoPlane = 0,,bool topMost = false) const = 0;
     virtual void scaleVideo(int32_t x, int32_t y, int32_t width, int32_t height) const = 0;
 
     virtual void getEDIDBytesInfo(int iHdmiPort, std::vector<uint8_t>& edid) const = 0;
@@ -621,9 +621,9 @@ public:
     {
         return impl->getCurrentVideoMode();
     }
-    void selectPort(int8_t Port,bool audioMix = false,int videoPlane = 0) const
+    void selectPort(int8_t Port,bool audioMix = false,int videoPlane = 0,bool topMost = false) const
     {
-        return impl->selectPort(Port,audioMix,videoPlane);
+        return impl->selectPort(Port,audioMix,videoPlane,topMost);
     }
     void scaleVideo(int32_t x, int32_t y, int32_t width, int32_t height) const
     {

--- a/Tests/mocks/devicesettings/HdmiInputMock.h
+++ b/Tests/mocks/devicesettings/HdmiInputMock.h
@@ -11,7 +11,7 @@ public:
     MOCK_METHOD(uint8_t, getNumberOfInputs, (), (const, override));
     MOCK_METHOD(bool, isPortConnected, (int8_t Port), (const, override));
     MOCK_METHOD(std::string, getCurrentVideoMode, (), (const, override));
-    MOCK_METHOD(void, selectPort, (int8_t Port,bool audioMix, int videoPlane), (const, override));
+    MOCK_METHOD(void, selectPort, (int8_t Port,bool audioMix, int videoPlane,bool topMost), (const, override));
     MOCK_METHOD(void, scaleVideo, (int32_t x, int32_t y, int32_t width, int32_t height), (const, override));
     MOCK_METHOD(void, getEDIDBytesInfo, (int iHdmiPort, std::vector<uint8_t> &edid), (const, override));
     MOCK_METHOD(void, getHDMISPDInfo, (int iHdmiPort, std::vector<uint8_t> &data), (const, override));


### PR DESCRIPTION
Reason for change: Support for SecondaryVideoplane and Audio mixing & Zorder control
Test Procedure: as per jira
Risks: None
Priority: P1
Signed-off-by: Aishwariya B <aishwariya.bhaskar@sky.uk>