### PR TITLE
XIONE-13388 : Increase the timeout for SystemAudioPlayer - For Realtek

### DIFF
--- a/SystemAudioPlayer/SystemAudioPlayer.cpp
+++ b/SystemAudioPlayer/SystemAudioPlayer.cpp
@@ -57,7 +57,7 @@ namespace Plugin {
 
         _service->Register(&_notification);
 
-        _sap = _service->Root<Exchange::ISystemAudioPlayer>(_connectionId, 5000, _T("SystemAudioPlayerImplementation"));
+        _sap = _service->Root<Exchange::ISystemAudioPlayer>(_connectionId, 15000, _T("SystemAudioPlayerImplementation"));
 
         std::string message;
         if(_sap != nullptr) {


### PR DESCRIPTION
In Thunder-R4, The SystemAudioPlayer is the first component to start activating and for some reason the activation takes more than 5sec and its timing out.

After sometime, If we manually activate, it activates successfully.

The issue is it happens only when you freshly flash the image. I suspected the gstreamer cache being wiped-out could be causing the issue as the next reboot works.  But at this point it is not clear; so just increasing the timeout and it fixes.