### PR TITLE
Revert "DELIA-63401:xione UK doesn't show gamecontroller (#4594)"

### DIFF
--- a/Bluetooth/Bluetooth.cpp
+++ b/Bluetooth/Bluetooth.cpp
@@ -40,7 +40,7 @@
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 5
+#define API_VERSION_NUMBER_PATCH 6
 
 const string WPEFramework::Plugin::Bluetooth::SERVICE_NAME = "org.rdk.Bluetooth";
 const string WPEFramework::Plugin::Bluetooth::METHOD_START_SCAN = "startScan";
@@ -282,7 +282,7 @@ namespace WPEFramework
                     LOGERR("Failed to get the number of adapters..!");
 
                 if (numOfAdapters) {
-                    BTRMGR_DeviceOperationType_t lenDevOpDiscType = BTRMGR_DEVICE_OP_TYPE_UNKNOWN;
+                    BTRMGR_DeviceOperationType_t lenDevOpDiscType = BTRMGR_DEVICE_OP_TYPE_AUDIO_OUTPUT;
 
                     if (Utils::String::contains(discProfile, "LOUDSPEAKER") ||
                         Utils::String::contains(discProfile, "HEADPHONES") ||

--- a/Bluetooth/Bluetooth.h
+++ b/Bluetooth/Bluetooth.h
@@ -102,7 +102,7 @@ namespace WPEFramework {
         private: /*internal methods*/
             void getStatusSupport(string& status);
             bool isAdapterDiscoverable();
-            string startDeviceDiscovery(int timeout, const string &discProfile = "DEFAULT");
+            string startDeviceDiscovery(int timeout, const string &discProfile = "LOUDSPEAKER, HEADPHONES, WEARABLE HEADSET, HIFI AUDIO DEVICE");
             bool stopDeviceDiscovery();
             void startDiscoveryTimer(int msec);
             void stopDiscoveryTimer();

--- a/Bluetooth/CHANGELOG.md
+++ b/Bluetooth/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+## [1.0.6] - 2023-11-07
+### Added
+- revert change 1.0.4 so bluetooth scan without specified profile only shows audio devices
+
 ## [1.0.5] - 2023-10-30
 ### Added
 - added batteryLevel parameter in getDeviceInfo

--- a/docs/api/BluetoothPlugin.md
+++ b/docs/api/BluetoothPlugin.md
@@ -2,7 +2,7 @@
 <a name="Bluetooth_Plugin"></a>
 # Bluetooth Plugin
 
-**Version: [1.0.5](https://github.com/rdkcentral/rdkservices/blob/main/Bluetooth/CHANGELOG.md)**
+**Version: [1.0.6](https://github.com/rdkcentral/rdkservices/blob/main/Bluetooth/CHANGELOG.md)**
 
 A org.rdk.Bluetooth plugin for Thunder framework.
 


### PR DESCRIPTION
RDKTV-26264(https://ccp.sys.comcast.net/browse/RDKTV-26264): Unable to Pair the BT head phones

Reason for change: scanning all devices in noisy environments causes
several different issues

Test Procedure: You should be able to pair bluetooth headphones

Change-Id: I2f3860bac577261bd48a17cd3d3b959f718f61c6
Risks: Low
Priority: P0
Signed-off-by: Jack O'Gorman <jack.ogorman@sky.uk>