### PR TITLE
DELIA-62842:org.rdk.System.getSystemVersions API has wrong stbTimestamp

### DIFF
--- a/SystemServices/SystemServicesHelper.cpp
+++ b/SystemServices/SystemServicesHelper.cpp
@@ -546,7 +546,7 @@ std::string stringTodate(char *pBuffer)
     } else {
         char tempBuff[128] = {'\0'};
 
-        strftime(tempBuff, sizeof(tempBuff), "%a %d %b %Y %H:%M:%S AP UTC", &result);
+        strftime(tempBuff, sizeof(tempBuff), "%a %d %b %Y %H:%M:%S %p UTC", &result);
         str = tempBuff;
     }
     return str;

--- a/Tests/tests/test_SystemServices.cpp
+++ b/Tests/tests/test_SystemServices.cpp
@@ -572,7 +572,7 @@ TEST_F(SystemServicesTest, SystemVersions)
     file.close();
 
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getSystemVersions"), _T("{}"), response));
-    EXPECT_EQ(response, string("{\"stbVersion\":\"PX051AEI_VBN_2203_sprint_20220331225312sdy_NG\",\"receiverVersion\":\"000.36.0.0\",\"stbTimestamp\":\"Fri 05 Aug 2022 16:14:54 AP UTC\",\"success\":true}"));
+    EXPECT_EQ(response, string("{\"stbVersion\":\"PX051AEI_VBN_2203_sprint_20220331225312sdy_NG\",\"receiverVersion\":\"000.36.0.0\",\"stbTimestamp\":\"Fri 05 Aug 2022 16:14:54 PM UTC\",\"success\":true}"));
 }
 
 TEST_F(SystemServicesTest, MocaStatus)


### PR DESCRIPTION
Reason for change: The timestamp is not showing as AM/PM
Test Procedure: Test api org.rdk.System.getSystemVersions
Risks: Low
Priority: P1