### PR TITLE
RDK-43753: Default R4.2 Thunder release to Skyllama Devices

### DIFF
--- a/MotionDetection/MotionDetection.conf.in
+++ b/MotionDetection/MotionDetection.conf.in
@@ -1,0 +1,4 @@
+precondition = ["Platform"]
+callsign = "org.rdk.MotionDetection"
+autostart = "false"
+startuporder = "@PLUGIN_MOTIONDETECTION_STARTUPORDER@"


### PR DESCRIPTION
Reason for change:  MotionDetection.conf.in changes is neeeded for Modern Config generator 
Test Procedure: Verify in Jenkin Build
Risks: High
Signed-off-by: Thamim  Razith <tabbas651@cable.comcast.com>