### PR TITLE
RDKCOM-4353 RDKDEV-852 CLONE - RDKServices: VolumeLevelChanged event is not triggering for the zero volume level

### DIFF
--- a/DisplaySettings/CHANGELOG.md
+++ b/DisplaySettings/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+## [1.3.7] - 2023-11-08
+### Fixed
+- RDKServices:Event not triggering for Volume level 'zero'
 
 ## [1.3.6] - 2023-10-04
 ### Added

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -85,7 +85,7 @@ using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 3
-#define API_VERSION_NUMBER_PATCH 6
+#define API_VERSION_NUMBER_PATCH 7
 
 static bool isCecEnabled = false;
 static int  hdmiArcPortId = -1;

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -85,7 +85,7 @@ using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 3
-#define API_VERSION_NUMBER_PATCH 5
+#define API_VERSION_NUMBER_PATCH 6
 
 static bool isCecEnabled = false;
 static int  hdmiArcPortId = -1;
@@ -2944,7 +2944,7 @@ namespace WPEFramework {
                 returnIfParamNotFound(parameters, "volumeLevel");
                 string sLevel = parameters["volumeLevel"].String();
                 float level = 0;
-                int cache_volumelevel = 0;
+                int current_volumelevel = 0;
                 try {
                         level = stof(sLevel);
                 }catch (const device::Exception& err) {
@@ -2957,10 +2957,10 @@ namespace WPEFramework {
                 try
                 {
                         device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
+			current_volumelevel = (int)aPort.getLevel();
                         aPort.setLevel(level);
-                        if(cache_volumelevel != (int)level)
+                        if(current_volumelevel != (int)level)
                         {
-                            cache_volumelevel = (int)level;
                             JsonObject params;
                             params["volumeLevel"] = (int)level;
                             sendNotify("volumeLevelChanged", params);


### PR DESCRIPTION
RDKCOM-4353 RDKDEV-852 CLONE - RDKServices: VolumeLevelChanged event is not triggering for the zero volume level

Event not triggering for Volume level 'zero'

RDKServices:Event not triggering for Volume level 'zero'

Signed-off-by: arunl2910 <148241489+arunl2910@users.noreply.github.com>