### PR TITLE
[RDKShell] RDKTV-26298: Split part of Deactivated into Deinitialized

### DIFF
--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -1059,7 +1059,13 @@ namespace WPEFramework {
                     gApplicationsExitReason[service->Callsign()] = AppLastExitReason::CRASH;
                 }
                 gExitReasonMutex.unlock();
+            }
+        }
 
+        void RDKShell::MonitorClients::handleDeinitialized(PluginHost::IShell* service)
+        {
+            if (service)
+            {
                 std::string configLine = service->ConfigLine();
                 if (configLine.empty())
                 {
@@ -1106,6 +1112,7 @@ namespace WPEFramework {
                 gLaunchDestroyMutex.unlock();
             }
         }
+
 
         void RDKShell::MonitorClients::StateChange(PluginHost::IShell* service)
         {
@@ -1304,7 +1311,9 @@ namespace WPEFramework {
             handleDeactivated(service);
        }
         void RDKShell::MonitorClients::Deinitialized(VARIABLE_IS_NOT_USED const string& callsign, VARIABLE_IS_NOT_USED PluginHost::IShell* service)
-       {}
+        {
+            handleDeinitialized(service);
+        }
        void RDKShell::MonitorClients::Unavailable(const string& callsign, PluginHost::IShell* service)
        {}
 #endif /* USE_THUNDER_R4 */

--- a/RDKShell/RDKShell.h
+++ b/RDKShell/RDKShell.h
@@ -417,6 +417,7 @@ namespace WPEFramework {
 		  void handleInitialize(PluginHost::IShell* shell);
                   void handleActivated(PluginHost::IShell* shell);
                   void handleDeactivated(PluginHost::IShell* shell);
+                  void handleDeinitialized(PluginHost::IShell* shell);
 #ifdef USE_THUNDER_R4
 		  virtual void Initialize(VARIABLE_IS_NOT_USED const string& callsign, VARIABLE_IS_NOT_USED PluginHost::IShell* plugin);
                   virtual void Activation(const string& name, PluginHost::IShell* plugin);


### PR DESCRIPTION
With Thunder R4 Deactivated notification comes very early, before plugin destruction (Deactivation state in R2). As a result RDKShell destroys compositor for running plugin (like WebKit browser).
This change moves previous "Deactivated" state handling code into Deinitialized that is called after plugin destruction.