### PR TITLE
RDKCOM-3963 RDKDEV-850 RDKServices: org.rdk.System.hasRebootBeenRequested API always returning false response

### DIFF
--- a/SystemServices/CHANGELOG.md
+++ b/SystemServices/CHANGELOG.md
@@ -16,9 +16,13 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
-## [1.7.2] - 2023-10-18
-### Fixed
-- Fix for onFirmwareUpdateStateChange events with the same data.
+## [3.0.0] - 2023-11-09
+### Removed
+- Removed hasRebootBeenRequested method fixes
+
+## [2.0.0] - 2023-10-12
+### Removed
+- Removed the hardcoded implementation of hasRebootBeenRequested
 
 ## [1.7.1] - 2023-10-04
 ### Added

--- a/SystemServices/CHANGELOG.md
+++ b/SystemServices/CHANGELOG.md
@@ -16,13 +16,9 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
-## [3.0.0] - 2023-11-09
+## [2.0.0] - 2023-11-15
 ### Removed
 - Removed hasRebootBeenRequested method fixes
-
-## [2.0.0] - 2023-10-12
-### Removed
-- Removed the hardcoded implementation of hasRebootBeenRequested
 
 ## [1.7.1] - 2023-10-04
 ### Added

--- a/SystemServices/CHANGELOG.md
+++ b/SystemServices/CHANGELOG.md
@@ -16,9 +16,9 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
-## [2.0.0] - 2023-11-15
+## [2.0.0] - 2023-10-12
 ### Removed
-- Removed hasRebootBeenRequested method fixes
+- Removed the hardcoded implementation of hasRebootBeenRequested
 
 ## [1.7.1] - 2023-10-04
 ### Added

--- a/SystemServices/System.json
+++ b/SystemServices/System.json
@@ -1444,26 +1444,6 @@
                 ]
             }
         },
-        "hasRebootBeenRequested":{
-            "summary": "Checks whether a reboot has been requested.",
-            "result": {
-                "type": "object",
-                "properties": {
-                    "rebootRequested": {
-                        "summary": "`true` if a reboot has been requested, otherwise `false`",
-                        "type": "boolean",
-                        "example": false
-                    },
-                    "success":{
-                        "$ref": "#/common/success"
-                    }
-                },
-                "required": [
-                    "rebootRequested",
-                    "success"
-                ]
-            }
-        },
         "isGzEnabled":{
 	    "deprecated" : true,
             "summary": "Checks whether GZ is enabled.",

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -65,7 +65,7 @@
 
 using namespace std;
 
-#define API_VERSION_NUMBER_MAJOR 3
+#define API_VERSION_NUMBER_MAJOR 2
 #define API_VERSION_NUMBER_MINOR 0
 #define API_VERSION_NUMBER_PATCH 0
 

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -65,9 +65,9 @@
 
 using namespace std;
 
-#define API_VERSION_NUMBER_MAJOR 1
-#define API_VERSION_NUMBER_MINOR 7
-#define API_VERSION_NUMBER_PATCH 2
+#define API_VERSION_NUMBER_MAJOR 3
+#define API_VERSION_NUMBER_MINOR 0
+#define API_VERSION_NUMBER_PATCH 0
 
 #define MAX_REBOOT_DELAY 86400 /* 24Hr = 86400 sec */
 #define TR181_FW_DELAY_REBOOT "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.AutoReboot.fwDelayReboot"
@@ -396,8 +396,6 @@ namespace WPEFramework {
 #endif /* HAS_API_SYSTEM && HAS_API_POWERSTATE */
             registerMethod("setGzEnabled", &SystemServices::setGZEnabled, this);
             registerMethod("isGzEnabled", &SystemServices::isGZEnabled, this);
-            registerMethod("hasRebootBeenRequested",
-                    &SystemServices::isRebootRequested, this);
             registerMethod("getMode", &SystemServices::getMode, this);
             registerMethod("updateFirmware", &SystemServices::updateFirmware, this);
             registerMethod("setMode", &SystemServices::setMode, this);
@@ -3695,20 +3693,6 @@ namespace WPEFramework {
 		returnResponse(retVal);
 	}//end of setPower State
 #endif /* HAS_API_SYSTEM && HAS_API_POWERSTATE */
-
-        /***
-         * @brief : To check if Reboot has been requested or not.
-         *
-         * @param1[in]  : query parameter.
-         * @param2[out] : {"result":{"rebootRequested":false,"success":<bool>}}
-         * @return      : Core::<StatusCode>
-         */
-        uint32_t SystemServices::isRebootRequested(const JsonObject& parameters,
-                JsonObject& response)
-        {
-            response["rebootRequested"] = false;
-            returnResponse(true);
-        }//end of isRebootRequested
 
         /***
          * @brief : To set GZ Status.

--- a/SystemServices/SystemServices.h
+++ b/SystemServices/SystemServices.h
@@ -218,8 +218,6 @@ namespace WPEFramework {
                 uint32_t getDevicePowerState(const JsonObject& parameters,JsonObject& response);
                 uint32_t setDevicePowerState(const JsonObject& parameters,JsonObject& response);
 #endif /* HAS_API_SYSTEM && HAS_API_POWERSTATE */
-
-                uint32_t isRebootRequested(const JsonObject& parameters,JsonObject& response);
                 uint32_t setGZEnabled(const JsonObject& parameters,JsonObject& response);
                 uint32_t isGZEnabled(const JsonObject& parameters,JsonObject& response);
                 uint32_t getSystemVersions(const JsonObject& parameters, JsonObject& response);

--- a/SystemServices/TestClient/systemServiceTestClient.cpp
+++ b/SystemServices/TestClient/systemServiceTestClient.cpp
@@ -95,7 +95,6 @@ typedef enum SME_t {
 	SME_getTemperatureThresholds,
 	SME_getTimeZoneDST,
 	SME_getXconfParams,
-	SME_hasRebootBeenRequested,
 	SME_isGzEnabled,
 	SME_queryMocaStatus,
 	SME_reboot,
@@ -149,7 +148,6 @@ std::map<SME_t, std::string> SMName = {
 	{SME_getTemperatureThresholds, "getTemperatureThresholds"},
 	{SME_getTimeZoneDST, "getTimeZoneDST"},
 	{SME_getXconfParams, "getXconfParams"},
-	{SME_hasRebootBeenRequested, "hasRebootBeenRequested"},
 	{SME_isGzEnabled, "isGzEnabled"},
 	{SME_queryMocaStatus, "queryMocaStatus"},
 	{SME_reboot, "reboot"},
@@ -608,19 +606,6 @@ void getXconfParams(std::string methodName, JSONRPC::LinkType<Core::JSON::IEleme
 	}
 }
 
-void hasRebootBeenRequested(std::string methodName, JSONRPC::LinkType<Core::JSON::IElement> *remoteObject)
-{
-	printf("[%llu] Inside (%s)\n", TimeStamp(), __FUNCTION__);
-
-	JsonObject parameters, response;
-	std::string result;
-
-	if (invokeJSONRPC(remoteObject, methodName, parameters, response)) {
-		response.ToString(result);
-		printf("\nResponse: '%s'\n", result.c_str());
-	}
-}
-
 void isGzEnabled(std::string methodName, JSONRPC::LinkType<Core::JSON::IElement> *remoteObject)
 {
 	printf("[%llu] Inside (%s)\n", TimeStamp(), __FUNCTION__);
@@ -1030,7 +1015,6 @@ int EvaluateMethods(JSONRPC::LinkType<Core::JSON::IElement>* remoteObject)
 			case SME_getTemperatureThresholds: getTemperatureThresholds(getMethodName((SME_t)retStatus), remoteObject); break;
 			case SME_getTimeZoneDST: getTimeZoneDST(getMethodName((SME_t)retStatus), remoteObject); break;
 			case SME_getXconfParams: getXconfParams(getMethodName((SME_t)retStatus), remoteObject); break;
-			case SME_hasRebootBeenRequested: hasRebootBeenRequested(getMethodName((SME_t)retStatus), remoteObject); break;
 			case SME_isGzEnabled: isGzEnabled(getMethodName((SME_t)retStatus), remoteObject); break;
 			case SME_queryMocaStatus: queryMocaStatus(getMethodName((SME_t)retStatus), remoteObject); break;
 			case SME_reboot: reboot(getMethodName((SME_t)retStatus), remoteObject); break;

--- a/docs/api/SystemPlugin.md
+++ b/docs/api/SystemPlugin.md
@@ -90,7 +90,6 @@ SystemServices interface methods:
 | [getTimeZoneDST](#getTimeZoneDST) | Get the configured time zone from the file referenced by `TZ_FILE` |
 | [getWakeupReason](#getWakeupReason) | Returns the reason for the device coming out of deep sleep |
 | [getXconfParams](#getXconfParams) | Returns XCONF configuration parameters for the device |
-| [hasRebootBeenRequested](#hasRebootBeenRequested) | Checks whether a reboot has been requested |
 | [isGzEnabled](#isGzEnabled) | Checks whether GZ is enabled |
 | [isOptOutTelemetry](#isOptOutTelemetry) | Checks the telemetry opt-out status |
 | [queryMocaStatus](#queryMocaStatus) | Checks whether MOCA is enabled |
@@ -2299,52 +2298,6 @@ This method takes no parameters.
             "model": "AX061AEI",
             "firmwareVersion": "AX061AEI_VBN_1911_sprint_20200109040424sdy"
         },
-        "success": true
-    }
-}
-```
-
-<a name="hasRebootBeenRequested"></a>
-## *hasRebootBeenRequested*
-
-Checks whether a reboot has been requested.
-
-### Events
-
-No Events
-
-### Parameters
-
-This method takes no parameters.
-
-### Result
-
-| Name | Type | Description |
-| :-------- | :-------- | :-------- |
-| result | object |  |
-| result.rebootRequested | boolean | `true` if a reboot has been requested, otherwise `false` |
-| result.success | boolean | Whether the request succeeded |
-
-### Example
-
-#### Request
-
-```json
-{
-    "jsonrpc": "2.0",
-    "id": 42,
-    "method": "org.rdk.System.hasRebootBeenRequested"
-}
-```
-
-#### Response
-
-```json
-{
-    "jsonrpc": "2.0",
-    "id": 42,
-    "result": {
-        "rebootRequested": false,
         "success": true
     }
 }


### PR DESCRIPTION
RDKCOM-3963 RDKDEV-850 RDKServices: org.rdk.System.hasRebootBeenRequested API always returning false response

Removed hasRebootBeenRequested method

(cherry picked from commit a361be9881fb27ff05335b5cca40172409f93975)

Reset to major version

(cherry picked from commit 19f2b331981db6ff7c9f01786eb166f0eee3c4f3)

Signed-off-by: jkuria217 josekutty_kuriakose@cable.comcast.com