### PR TITLE
RDKCOM-3960: onApplicationLaunched event and proper error messages are not triggering for DAC apps

### DIFF
--- a/RDKShell/CHANGELOG.md
+++ b/RDKShell/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.4.11] - 2023-11-15
+### Added
+- onApplicationLaunched event and proper error messages are not triggering for DAC apps
+
 ## [1.4.10] - 2023-10-23
 ### Added
 - RDKShell changes for ignoring factoryMode


### PR DESCRIPTION
RDKCOM-3960: onApplicationLaunched event and proper error messages are not triggering for DAC apps

(cherry picked from commit 703e84c6d1f64c59d91c603431777b315a586830)

Signed-off-by: evelum102 <Ezhilarasi_Velumani@comcast.com>
