### PR TITLE
RDK-45551: return modalias and firmware version for game controllers

### DIFF
--- a/Bluetooth/Bluetooth.cpp
+++ b/Bluetooth/Bluetooth.cpp
@@ -40,7 +40,7 @@
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 6
+#define API_VERSION_NUMBER_PATCH 7
 
 const string WPEFramework::Plugin::Bluetooth::SERVICE_NAME = "org.rdk.Bluetooth";
 const string WPEFramework::Plugin::Bluetooth::METHOD_START_SCAN = "startScan";
@@ -809,6 +809,9 @@ namespace WPEFramework
                 deviceDetails["signalStrength"] = std::to_string(deviceProperty.m_signalLevel);
                 deviceDetails["rssi"] =  std::to_string(deviceProperty.m_rssi);
                 deviceDetails["batteryLevel"] =  std::to_string(deviceProperty.m_batteryLevel);
+                deviceDetails["modalias"] = string(deviceProperty.m_modalias);
+                deviceDetails["firmwareRevision"] = string(deviceProperty.m_firmwareRevision);
+
                 for (int i = 0; i < deviceProperty.m_serviceInfo.m_numOfService; i++)
                 {
                     profileInfo += string(deviceProperty.m_serviceInfo.m_profileInfo[i].m_profile);

--- a/Bluetooth/Bluetooth.json
+++ b/Bluetooth/Bluetooth.json
@@ -155,6 +155,16 @@
             "type":"string",
             "example": "53"
         },
+        "modalias": {
+            "summary":"The modalias for the device - if no modalias is present it will be an empty string",
+            "type":"string",
+            "example": "v:0B13p:045Ed:0517"
+        },
+        "firmwareRevision": {
+            "summary":"The firmware revision for a particular device creaded from the modalias - if no modalias is present it will be an empty string",
+            "type":"string",
+            "example": "5.1.7"
+        },
         "eventType":{
             "summary": "Name of a request-time event (for example, `onPairingRequest`, `onConnectionRequest`, `onPlaybackRequest`)",
             "type":"string",
@@ -446,6 +456,12 @@
                             },
                             "batteryLevel": {
                                 "$ref": "#/definitions/batteryLevel"
+                            },
+                            "modalias": {
+                                "$ref": "#/definitions/modalias"
+                            },
+                            "firmwareRevision": {
+                                "$ref": "#/definitions/firmwareRevision"
                             }
                         },
                         "required": [

--- a/Bluetooth/CHANGELOG.md
+++ b/Bluetooth/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+## [1.0.7] - 2023-11-21
+### Added
+- add modalias and firmware revision string (derived from modalias) to device info
+
 ## [1.0.6] - 2023-11-07
 ### Added
 - revert change 1.0.4 so bluetooth scan without specified profile only shows audio devices

--- a/Bluetooth/README.md
+++ b/Bluetooth/README.md
@@ -84,7 +84,7 @@ setAudioStream:
 {"jsonrpc":"2.0","id":3,"result":{"success":true}}
 
 getDeviceInfo:
-{"jsonrpc":"2.0","id":3,"result":{"deviceInfo":{"deviceID":"256168644324480","name":"Eleven","deviceType":"SMARTPHONE","manufacturer":"640","MAC":"E8:FB:E9:0C:2C:80","signalStrength":"0","rssi":"0","batteryLevel":"53","supportedProfile":"Not Identified;Not Identified;Audio Source;AV Remote Target;AV Remote;Not Identified;Handsfree - Audio Gateway;Not Identified;Not Identified;PnP Information;Generic Attribute;Not Identified"},"success":true}}
+{"jsonrpc":"2.0","id":3,"result":{"deviceInfo":{"deviceID":"256168644324480","name":"Eleven","deviceType":"SMARTPHONE","manufacturer":"640","MAC":"E8:FB:E9:0C:2C:80","signalStrength":"0","rssi":"0","batteryLevel":"53","modalias":"v:0B13, p:045E, d:0517","firmwareRevision":"5.1.7","supportedProfile":"Not Identified;Not Identified;Audio Source;AV Remote Target;AV Remote;Not Identified;Handsfree - Audio Gateway;Not Identified;Not Identified;PnP Information;Generic Attribute;Not Identified"},"success":true}}
 
 getAudioInfo:
 {"jsonrpc":"2.0","id":3,"result":{"trackInfo":{"album":"Spacebound Apes","genre":"Jazz","title":"Grace","artist":"Neil Cowley Trio","ui32Duration":"217292","ui32TrackNumber":"1","ui32NumberOfTracks":"73"},"success":true}}

--- a/docs/api/BluetoothPlugin.md
+++ b/docs/api/BluetoothPlugin.md
@@ -2,7 +2,7 @@
 <a name="Bluetooth_Plugin"></a>
 # Bluetooth Plugin
 
-**Version: [1.0.6](https://github.com/rdkcentral/rdkservices/blob/main/Bluetooth/CHANGELOG.md)**
+**Version: [1.0.7](https://github.com/rdkcentral/rdkservices/blob/main/Bluetooth/CHANGELOG.md)**
 
 A org.rdk.Bluetooth plugin for Thunder framework.
 
@@ -424,6 +424,8 @@ No Events
 | result.deviceInfo.rssi | string | Received signal strength of the device |
 | result.deviceInfo.signalStrength | string | Bluetooth signal strength |
 | result.deviceInfo.batteryLevel | string | Bluetooth battery level |
+| result.deviceInfo.modalias | string | Bluetooth device modalias |
+| result.deviceInfo.firmwareRevision | string | Bluetooth device firmware revision | 
 | result.success | boolean | Whether the request succeeded |
 
 ### Example


### PR DESCRIPTION
Reason for change: return the modalias and firmware version string from rdkservices

Test Procedure: use curl command to get device properties from rdkservices and you should be able to see the modalias and firmware parameters

Risks: Low