### PR TITLE
RDK-43831 Move the Connectivity Monitoring to NetworkManager Thunder

### DIFF
--- a/Network/CHANGELOG.md
+++ b/Network/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.3.0] - 2023-11-25
+### Added 
+- added connectivity monitor class remove Connectivity related IARM Calls
+
 ## [1.2.3] - 2023-10-23
 ### Fixed
 - Fixed the isConnectedToInternet method to not to call getPublicIP; as they are independent RPCs.

--- a/Network/CMakeLists.txt
+++ b/Network/CMakeLists.txt
@@ -27,6 +27,7 @@ add_library(${MODULE_NAME} SHARED
         NetUtils.cpp
         NetUtilsNetlink.cpp
         NetworkTraceroute.cpp
+        NetworkConnectivity.cpp
         PingNotifier.cpp
         Module.cpp)
 
@@ -43,7 +44,7 @@ find_package(IARMBus)
 add_definitions (-DNET_DEFINED_INTERFACES_ONLY)
 target_include_directories(${MODULE_NAME} PRIVATE ${IARMBUS_INCLUDE_DIRS})
 target_include_directories(${MODULE_NAME} PRIVATE ../helpers)
-target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins ${IARMBUS_LIBRARIES})
+target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins ${IARMBUS_LIBRARIES} curl)
 
 install(TARGETS ${MODULE_NAME}
         DESTINATION lib/${STORAGE_DIRECTORY}/plugins)

--- a/Network/Network.json
+++ b/Network/Network.json
@@ -402,7 +402,7 @@
             }
         },
         "setConnectivityTestEndpoints":{
-            "summary": "Set the list of endpoints used for a connectivity test. Endpoint should return HTTP Status 204 (No Content) for successful connection and Maximum number of endpoints is 5 . \n\nDefault endpoints:-\n* http://clients3.google.com/generate_204 \n* http://edge-http.microsoft.com/captiveportal/generate_204 \n* http://gstatic.com/generate_204 ",
+            "summary": "Define up to 5 endpoints for a connectivity test. Successful connections are verified with HTTP Status code 204 (No Content). Priority is given to endpoints configured in /etc/netsrvmgr.conf. In case of errors or if not configured, the default endpoints are considered: `http://clients3.google.com/generate_204`.",
             "params": {
                 "type":"object",
                 "properties": {
@@ -425,6 +425,14 @@
         },
         "isConnectedToInternet":{
             "summary": "Whether the device has internet connectivity. This API might take up to 2s to validate internet connectivity.",
+            "params": {
+                "type":"object",
+                "properties": {
+                    "ipversion": {
+                        "$ref": "#/definitions/ipversion"
+                    }
+                }
+            },
             "result": {
                 "type": "object",
                 "properties": {
@@ -432,6 +440,9 @@
                         "summary": "`true` if internet connectivity is detected, otherwise `false`",
                         "type": "boolean",
                         "example": true
+                    },
+                    "ipversion": {
+                        "$ref": "#/definitions/ipversion"
                     },
                     "success": {
                         "$ref": "#/common/success"
@@ -445,6 +456,14 @@
         },
         "getInternetConnectionState":{
             "summary": "Returns the internet connection state. The possible internet connection state are as follows. \n* `0`: NO_INTERNET - No internet connection  \n* `1`: LIMITED_INTERNET - Internet connection limited  \n* `2`: CAPTIVE_PORTAL - Captive portal found  \n* `3`: FULLY_CONNECTED - Fully connected to internet",
+            "params": {
+                "type":"object",
+                "properties": {
+                    "ipversion": {
+                        "$ref": "#/definitions/ipversion"
+                    }
+                }
+            },
             "result": {
                 "type": "object",
                 "properties": {
@@ -455,6 +474,9 @@
                         "summary": "Captive portal URI",
                         "type": "string",
                         "example": "http://10.0.0.1/captiveportal.jst"
+                    },
+                    "ipversion": {
+                        "$ref": "#/definitions/ipversion"
                     },
                     "success":{
                         "$ref": "#/common/success"
@@ -495,7 +517,7 @@
                 "type":"object",
                 "properties": {
                     "interval": {
-                        "summary": "Interval in sec. Default value 600 sec and interval should be greater than 5 sec",
+                        "summary": "Interval in sec. Default value 60 sec and interval should be greater than 5 sec",
                         "type": "number",
                         "example": "30"
                     }

--- a/Network/NetworkConnectivity.cpp
+++ b/Network/NetworkConnectivity.cpp
@@ -1,0 +1,528 @@
+#include <unistd.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string>
+#include <fstream>
+#include <algorithm>
+#include <time.h>
+#include <vector>
+#include <thread>
+#include <chrono>
+#include <condition_variable>
+#include <atomic>
+#include <mutex>
+#include <curl/curl.h>
+
+#include "UtilsLogging.h"
+#include "Module.h"
+#include "Network.h"
+#include "NetworkConnectivity.h"
+
+namespace WPEFramework {
+    namespace Plugin {
+
+    bool EndpointCache::isEndpointCashFileExist()
+    {
+        std::ifstream fileStream(CachefilePath);
+        return fileStream.is_open();
+    }
+
+    void EndpointCache::writeEnpointsToFile(const std::vector<std::string>& endpoints)
+    {
+        std::ofstream outputFile(CachefilePath);
+        if (outputFile.is_open())
+        {
+            for (const std::string& str : endpoints)
+            {
+                outputFile << str << '\n';
+            }
+            outputFile.close();
+            LOGINFO("Connectivity endpoints successfully written to a file");
+        }
+        else
+        {
+            LOGERR("Connectivity endpoints file write error");
+        }
+    }
+
+    std::vector<std::string> EndpointCache::readEnpointsFromFile()
+    {
+        std::vector<std::string> readStrings;
+        std::ifstream inputFile(CachefilePath);
+        if (inputFile.is_open())
+        {
+            std::string line;
+            while (std::getline(inputFile, line))
+            {
+                readStrings.push_back(line);
+            }
+            inputFile.close();
+        }
+        else
+        {
+            LOGERR("Failed to open connectivity endpoint cache file");
+        }
+        return readStrings;
+    }
+
+    void Connectivity::loadConnectivityConfig(const std::string& configFilePath)
+    {
+        std::ifstream configFile(configFilePath);
+        if (!configFile.is_open()) 
+        {
+            LOGERR("Unable to open the configuration file: %s", configFilePath.c_str());
+            return;
+        }
+
+        bool ConnectivityConfigFound = false;
+
+        // load connectivity endpoint configuration
+        std::string line;
+        while (std::getline(configFile, line))
+        {
+            if (line == "[Connectivity_Config]")
+            {
+                ConnectivityConfigFound = true;
+                continue;
+            }
+
+            if (ConnectivityConfigFound)
+            {
+                size_t equalsPos = line.find('=');
+                if (equalsPos != std::string::npos)
+                {
+                    std::string key = line.substr(0, equalsPos);
+                    std::string value = line.substr(equalsPos + 1);
+                    configMap[key] = value;
+                }
+            }
+        }
+
+        configFile.close();
+
+        /* Parse the connectivity monitor interval and enable values */
+        configMonitorConnectivityEnabled = ((configMap["CONNECTIVITY_MONITOR_ENABLE"] == "1")? true:false);
+        std::string monitorIntervalStr = configMap["CONNECTIVITY_MONITOR_INTERVAL"];
+        if (!monitorIntervalStr.empty())
+        {
+            configMonitorInterval = std::stoi(monitorIntervalStr);
+        }
+
+        m_defaultEndpoints.clear();
+        for (int i = 1; i <= 5; ++i)
+        {
+            std::string endpointName = "CONNECTIVITY_ENDPOINT_" + std::to_string(i);
+            auto endpoint = configMap.find(endpointName);
+            if (endpoint != configMap.end() && endpoint->second.length() > 3)
+            {
+                m_defaultEndpoints.push_back(endpoint->second);
+            }
+        }
+
+        if(m_defaultEndpoints.empty())
+        {
+            LOGERR("Default endpoints are empty !!");
+        }
+        else
+        {
+            std::string endpoints_str;
+            for (const auto& endpoint : m_defaultEndpoints)
+                endpoints_str.append(endpoint).append(" ");
+            LOGINFO("default endpoints count %d and endpoints:- %s", static_cast<int>(m_defaultEndpoints.size()), endpoints_str.c_str());
+            LOGINFO("default monitor connectivity interval: %d and monitor connectivity auto start : %s", configMonitorInterval, configMonitorConnectivityEnabled?"true":"false");
+        }
+    }
+
+    bool ConnectivityMonitor::isConnectivityMonitorEndpointSet()
+    {
+        const std::lock_guard<std::mutex> lock(endpointMutex);
+        if(monitorEndpoints.size() > 0)
+        {
+            return true;
+        }
+        else if(endpointCache.isEndpointCashFileExist())
+        {
+            monitorEndpoints = endpointCache.readEnpointsFromFile();
+            std::string endpoints_str;
+            for (const auto& endpoint : monitorEndpoints)
+                endpoints_str.append(endpoint).append(" ");
+            LOGINFO("updated endpoints count %d and endpoints:- %s", static_cast<int>(monitorEndpoints.size()), endpoints_str.c_str());
+            if(monitorEndpoints.size() > 0)
+                return true;
+        }
+        return false;
+    }
+
+    bool ConnectivityMonitor::isConnectedToInternet(nsm_ipversion ipversion)
+    {
+        if (nsm_internetState::FULLY_CONNECTED == getInternetConnectionState(ipversion))
+        {
+            LOGINFO("isConnectedToInternet = true");
+            return true;
+        }
+
+        LOGWARN("isConnectedToInternet = false");
+        return false;
+    }
+
+    nsm_internetState ConnectivityMonitor::getInternetConnectionState(nsm_ipversion ipversion)
+    {
+
+        nsm_internetState internetState = nsm_internetState::UNKNOWN;
+
+        // If monitor connectivity is running take the cashe value
+        if ( isMonitorThreadRunning() && (ipversion == NSM_IPRESOLVE_WHATEVER) && (g_internetState != nsm_internetState::UNKNOWN) )
+        {
+            internetState = g_internetState;
+        }
+        else
+        {
+            if(isConnectivityMonitorEndpointSet())
+                internetState = testConnectivity(getConnectivityMonitorEndpoints(), 2000, ipversion);
+            else
+                internetState = testConnectivity(getConnectivityDefaultEndpoints(), 2000, ipversion);
+        }
+
+        return internetState;
+    }
+
+    std::string ConnectivityMonitor::getCaptivePortalURI()
+    {
+        if (g_internetState == nsm_internetState::CAPTIVE_PORTAL)
+        {
+            return getCaptivePortal();
+        }
+        else
+        {
+            std::string captivePortal;
+            if(getInternetConnectionState(NSM_IPRESOLVE_WHATEVER) == nsm_internetState::CAPTIVE_PORTAL)
+            {
+                return getCaptivePortal();
+            }
+            else
+                LOGWARN("No captive portal found !");
+        }
+        return std::string("");
+    }
+
+    void ConnectivityMonitor::setConnectivityMonitorEndpoints(const std::vector<std::string> &endpoints)
+    {
+        const std::lock_guard<std::mutex> lock(endpointMutex);
+        monitorEndpoints.clear();
+        for (auto endpoint : endpoints) {
+            if(!endpoint.empty() && endpoint.size() > 3)
+                monitorEndpoints.push_back(endpoint.c_str());
+            else
+                LOGINFO("endpoint not vallied = %s", endpoint.c_str());
+        }
+
+        // write the endpoints to a file
+        endpointCache.writeEnpointsToFile(monitorEndpoints);
+
+        std::string endpoints_str;
+        for (const auto& endpoint : monitorEndpoints)
+            endpoints_str.append(endpoint).append(" ");
+        LOGINFO("Connectivity monitor endpoints -: %d :- %s", static_cast<int>(monitorEndpoints.size()), endpoints_str.c_str());
+    }
+
+    std::vector<std::string> ConnectivityMonitor::getConnectivityMonitorEndpoints()
+    {
+        const std::lock_guard<std::mutex> lock(endpointMutex);
+        std::vector<std::string> endpoints;
+        for (auto endpoint : monitorEndpoints) {
+            endpoints.push_back(endpoint);
+        }
+        return endpoints;
+    }
+
+    static bool curlVerboseEnabled() {
+        std::ifstream fileStream("/tmp/network.plugin.debug");
+        return fileStream.is_open();
+    }
+
+    static long current_time ()
+    {
+        struct timespec ts;
+        clock_gettime (CLOCK_MONOTONIC, &ts);
+        return (ts.tv_sec * 1000) + (ts.tv_nsec / 1000000);
+    }
+    static size_t writeFunction(void* ptr, size_t size, size_t nmemb, std::string* data) {
+    #ifdef DBG_CURL_GET_RESPONSE
+        LOG_DBG("%s",(char*)ptr);
+    #endif
+        return size * nmemb;
+    }
+
+    nsm_internetState Connectivity::testConnectivity(const std::vector<std::string>& endpoints, long timeout_ms, nsm_ipversion ipversion)
+    {
+        long deadline = current_time() + timeout_ms, time_now = 0, time_earlier = 0;
+        if(endpoints.size() < 1) {
+            LOGERR("endpoints size error ! ");
+            return NO_INTERNET;
+        }
+
+        CURLM *curl_multi_handle = curl_multi_init();
+        if (!curl_multi_handle)
+        {
+            LOGERR("curl_multi_init returned NULL");
+            return NO_INTERNET;
+        }
+
+        CURLMcode mc;
+        std::vector<CURL*> curl_easy_handles;
+        std::vector<int> http_responses;
+        struct curl_slist *chunk = NULL;
+        chunk = curl_slist_append(chunk, "Cache-Control: no-cache, no-store");
+        for (const auto& endpoint : endpoints)
+        {
+            CURL *curl_easy_handle = curl_easy_init();
+            if (!curl_easy_handle)
+            {
+                LOGERR("endpoint = <%s> curl_easy_init returned NULL", endpoint.c_str());
+                continue;
+            }
+            curl_easy_setopt(curl_easy_handle, CURLOPT_URL, endpoint.c_str());
+            curl_easy_setopt(curl_easy_handle, CURLOPT_PRIVATE, endpoint.c_str());
+            /* set our custom set of headers */
+            curl_easy_setopt(curl_easy_handle, CURLOPT_HTTPHEADER, chunk);
+            curl_easy_setopt(curl_easy_handle, CURLOPT_USERAGENT, "RDKCaptiveCheck/1.0");
+            /* set CURLOPT_HTTPGET option insted of CURLOPT_CONNECT_ONLY bcause we need to get the captiveportal URI not just connection only */
+            curl_easy_setopt(curl_easy_handle, CURLOPT_HTTPGET, 1L);
+            curl_easy_setopt(curl_easy_handle, CURLOPT_WRITEFUNCTION, writeFunction);
+            curl_easy_setopt(curl_easy_handle, CURLOPT_TIMEOUT_MS, deadline - current_time());
+            if ((ipversion == CURL_IPRESOLVE_V4) || (ipversion == CURL_IPRESOLVE_V6))
+                curl_easy_setopt(curl_easy_handle, CURLOPT_IPRESOLVE, ipversion);
+            if(curlVerboseEnabled())
+                curl_easy_setopt(curl_easy_handle, CURLOPT_VERBOSE, 1L);
+            if (CURLM_OK != (mc = curl_multi_add_handle(curl_multi_handle, curl_easy_handle)))
+            {
+                LOGERR("endpoint = <%s> curl_multi_add_handle returned %d (%s)", endpoint.c_str(), mc, curl_multi_strerror(mc));
+                curl_easy_cleanup(curl_easy_handle);
+                continue;
+            }
+            curl_easy_handles.push_back(curl_easy_handle);
+        }
+        int handles, msgs_left;
+        char *url = nullptr;
+    #if LIBCURL_VERSION_NUM < 0x074200
+        int numfds, repeats = 0;
+    #endif
+        char *endpoint;
+        while (1)
+        {
+            if (CURLM_OK != (mc = curl_multi_perform(curl_multi_handle, &handles)))
+            {
+                LOGERR("curl_multi_perform returned %d (%s)", mc, curl_multi_strerror(mc));
+                break;
+            }
+            for (CURLMsg *msg; NULL != (msg = curl_multi_info_read(curl_multi_handle, &msgs_left)); )
+            {
+                long response_code = -1;
+                if (msg->msg != CURLMSG_DONE)
+                    continue;
+                if (CURLE_OK == msg->data.result) {
+                    curl_easy_getinfo(msg->easy_handle, CURLINFO_PRIVATE, &endpoint);
+                    if (curl_easy_getinfo(msg->easy_handle, CURLINFO_RESPONSE_CODE, &response_code) == CURLE_OK)  {
+                        if(curlVerboseEnabled())
+                            LOGINFO("endpoint = <%s> response code <%d>",endpoint, static_cast<int>(response_code));
+                        if (HttpStatus_302_Found == response_code) {
+                            if ( (curl_easy_getinfo(msg->easy_handle, CURLINFO_REDIRECT_URL, &url) == CURLE_OK) && url != nullptr) {
+                                //LOGWARN("captive portal found !!!");
+                                setCaptivePortal(url);
+                            }
+                        }
+                    }
+                }
+                //else
+                //    LOGERR("endpoint = <%s> error = %d (%s)", endpoint, msg->data.result, curl_easy_strerror(msg->data.result));
+                http_responses.push_back(response_code);
+            }
+            time_earlier = time_now;
+            time_now = current_time();
+            if (handles == 0 || time_now >= deadline)
+                break;
+    #if LIBCURL_VERSION_NUM < 0x074200
+            if (CURLM_OK != (mc = curl_multi_wait(curl_multi_handle, NULL, 0, deadline - time_now, &numfds)))
+            {
+                LOGERR("curl_multi_wait returned %d (%s)", mc, curl_multi_strerror(mc));
+                break;
+            }
+            if (numfds == 0)
+            {
+                repeats++;
+                if (repeats > 1)
+                    usleep(10*1000); /* sleep 10 ms */
+            }
+            else
+                repeats = 0;
+    #else
+            if (CURLM_OK != (mc = curl_multi_poll(curl_multi_handle, NULL, 0, deadline - time_now, NULL)))
+            {
+                LOGERR("curl_multi_poll returned %d (%s)", mc, curl_multi_strerror(mc));
+                break;
+            }
+    #endif
+        }
+        if(curlVerboseEnabled()) {
+            LOGINFO("endpoints count = %d response count %d, handles = %d, deadline = %ld, time_now = %ld, time_earlier = %ld",
+                static_cast<int>(endpoints.size()), static_cast<int>(http_responses.size()), handles, deadline, time_now, time_earlier);
+        }
+        for (const auto& curl_easy_handle : curl_easy_handles)
+        {
+            curl_easy_getinfo(curl_easy_handle, CURLINFO_PRIVATE, &endpoint);
+            //LOG_DBG("endpoint = <%s> terminating attempt", endpoint);
+            curl_multi_remove_handle(curl_multi_handle, curl_easy_handle);
+            curl_easy_cleanup(curl_easy_handle);
+        }
+        curl_multi_cleanup(curl_multi_handle);
+        /* free the custom headers */
+        curl_slist_free_all(chunk);
+        return checkInternetStateFromResponseCode(http_responses);
+    }
+
+    /*
+     * verifying Most occurred response code is 50 % or more
+     * Example 1 :
+     *      if we have 5 endpoints so response also 5 ( 204 302 204 204 200 ) . Here count is 204 :- 3, 302 :- 1, 200 :- 1
+     *      Return Internet State: FULLY_CONNECTED - 60 %
+     * Example 2 :
+     *      if we have 4 endpoints so response also 4 ( 204 204 200 200 ) . Here count is 204 :- 2, 200 :- 2
+     *      Return Internet State: FULLY_CONNECTED - 50 %
+     */
+
+    nsm_internetState Connectivity::checkInternetStateFromResponseCode(const std::vector<int>& responses)
+    {
+        nsm_internetState InternetConnectionState = NO_INTERNET;
+        nsm_connectivity_httpcode http_response_code = HttpStatus_response_error;
+
+        int max_count = 0;
+        for (int element : responses)
+        {
+            int element_count = count(responses.begin(), responses.end(), element);
+            if (element_count > max_count)
+            {
+                http_response_code = static_cast<nsm_connectivity_httpcode>(element);
+                max_count = element_count;
+            }
+        }
+
+        /* Calculate the percentage of the most frequent code occurrences */
+        float percentage = (static_cast<float>(max_count) / responses.size());
+
+        /* 50 % connectivity check */
+        if (percentage >= 0.5)
+        {
+            switch (http_response_code)
+            {
+                case HttpStatus_204_No_Content:
+                    InternetConnectionState = FULLY_CONNECTED;
+                    LOGINFO("Internet State: FULLY_CONNECTED - %.1f%%", (percentage*100));
+                break;
+                case HttpStatus_200_OK:
+                    InternetConnectionState = LIMITED_INTERNET;
+                    LOGINFO("Internet State: LIMITED_INTERNET - %.1f%%", (percentage*100));
+                break;
+                case HttpStatus_511_Authentication_Required:
+                case HttpStatus_302_Found:
+                    InternetConnectionState = CAPTIVE_PORTAL;
+                    LOGINFO("Internet State: CAPTIVE_PORTAL -%.1f%%", (percentage*100));
+                break;
+                default:
+                    InternetConnectionState = NO_INTERNET;
+                    LOGINFO("Internet State: NO_INTERNET Response code: <%d> %.1f%%", static_cast<int>(http_response_code), (percentage*100));
+            }
+        }
+
+        return InternetConnectionState;
+    }
+
+    bool ConnectivityMonitor::startConnectivityMonitor(int timeoutInSeconds)
+    {
+
+        if(!isConnectivityMonitorEndpointSet())
+        {
+            LOGINFO("Connectivity monitor endpoints are not set !");
+            return false;
+        }
+
+        timeout.store(timeoutInSeconds >= MONITOR_TIMEOUT_INTERVAL_MIN ? timeoutInSeconds:defaultTimeoutInSec);
+
+        if (!isMonitorThreadRunning())
+        {
+            stopFlag.store(false);
+            thread_ = std::thread(&ConnectivityMonitor::connectivityMonitorFunction, this);
+            threadRunning = true;
+            LOGINFO("Connectivity monitor started with %d", timeout.load());
+        }
+        else
+        {
+            cv_.notify_all();
+            LOGINFO("Connectivity monitor Restarted with %d", timeout.load());
+        }
+        return true;
+    }
+
+    bool ConnectivityMonitor::isMonitorThreadRunning()
+    {
+        return threadRunning.load();
+    }
+
+    bool ConnectivityMonitor::stopConnectivityMonitor()
+    {
+        if (isMonitorThreadRunning()) {
+            stopFlag.store(true);
+            cv_.notify_all();
+            if (thread_.joinable()) {
+                thread_.join();
+                threadRunning = false;
+                LOGINFO("Connectivity monitor stopped");
+                g_internetState.store(nsm_internetState::UNKNOWN);
+            }
+            return true;
+        }
+        else
+            LOGWARN("Connectivity monitor not running");
+        return false;
+    }
+
+    void ConnectivityMonitor::signalConnectivityMonitor()
+    {
+        if (isMonitorThreadRunning())
+        {
+            /* Reset the global value to UNKNOWN state*/
+            resetConnectivityCache();
+            cv_.notify_all();
+        }
+    }
+
+    void ConnectivityMonitor::connectivityMonitorFunction()
+    {
+        nsm_internetState InternetConnectionState = nsm_internetState::UNKNOWN;
+        while (!stopFlag)
+        {
+            InternetConnectionState = testConnectivity(getConnectivityMonitorEndpoints(), 2000, NSM_IPRESOLVE_WHATEVER);
+            if(g_internetState.load() != InternetConnectionState)
+            {
+                g_internetState.store(InternetConnectionState);
+                Network::notifyInternetStatusChange(g_internetState.load());
+            }
+
+            //wait for next timout or conditon signal
+            std::unique_lock<std::mutex> lock(mutex_);
+            if (cv_.wait_for(lock, std::chrono::seconds(timeout.load())) == std::cv_status::timeout)
+            {
+                LOGINFO("Connectivity monitor thread timeout");
+            }
+            else
+            {
+                if(!stopFlag)
+                {
+                    LOGINFO("Connectivity monitor received a trigger");
+                }
+            }
+        }
+        LOGWARN("Connectivity monitor exiting");
+    }
+
+    } // namespace Plugin
+} // namespace WPEFramework

--- a/Network/NetworkConnectivity.h
+++ b/Network/NetworkConnectivity.h
@@ -1,0 +1,148 @@
+#pragma once
+
+#include <string>
+#include <atomic>
+#include <vector>
+#include <map>
+#include <curl/curl.h>
+#include <condition_variable>
+#include <mutex>
+
+#include "Module.h"
+
+#define CAPTIVEPORTAL_MAX_LEN 512
+#define DEFAULT_MONITOR_TIMEOUT 60 // in seconds
+#define MONITOR_TIMEOUT_INTERVAL_MIN 5
+
+enum nsm_ipversion {
+    NSM_IPRESOLVE_WHATEVER  = 0, /* default, resolves addresses to all IP*/
+    NSM_IPRESOLVE_V4        = 1, /* resolve to IPv4 addresses */
+    NSM_IPRESOLVE_V6        = 2  /* resolve to IPv6 addresses */
+};
+
+enum nsm_internetState {
+    UNKNOWN = -1,
+    NO_INTERNET,
+    LIMITED_INTERNET,
+    CAPTIVE_PORTAL,
+    FULLY_CONNECTED
+};
+
+enum nsm_connectivity_httpcode {
+    HttpStatus_response_error               = 99,
+    HttpStatus_200_OK                      = 200,
+    HttpStatus_204_No_Content              = 204,
+    HttpStatus_301_Moved_Permanentl        = 301,
+    HttpStatus_302_Found                   = 302,     // captive portal
+    HttpStatus_307_Temporary_Redirect      = 307,
+    HttpStatus_308_Permanent_Redirect      = 308,
+    HttpStatus_403_Forbidden               = 403,
+    HttpStatus_404_Not_Found               = 404,
+    HttpStatus_511_Authentication_Required = 511      // captive portal RFC 6585
+};
+
+namespace WPEFramework {
+    namespace Plugin {
+
+        /* save user specific endponint in to a chache file and load form the file if monitorEndpoints are empty case wpeframework restared */
+        class EndpointCache {
+            public:
+                static EndpointCache& getInstance() {
+                    static EndpointCache instance;
+                    return instance;
+                }
+
+                bool isEndpointCashFileExist();
+                void writeEnpointsToFile(const std::vector<std::string>& endpoints);
+                std::vector<std::string> readEnpointsFromFile();
+
+            private:
+                EndpointCache() : CachefilePath("/tmp/network.plugin.endpoints") {}
+                ~EndpointCache(){}
+
+                std::string CachefilePath;
+        };
+
+        class Connectivity {
+
+            Connectivity(const Connectivity&) = delete;
+            const Connectivity& operator=(const Connectivity&) = delete;
+
+        public:
+            Connectivity(const std::string& configFilePath = "/etc/netsrvmgr.conf")
+            {
+                loadConnectivityConfig(configFilePath);
+                if(m_defaultEndpoints.empty())
+                {
+                    LOGERR("NETSRVMGR CONFIGURATION ERROR: CONNECTIVITY ENDPOINT EMPTY");
+                    m_defaultEndpoints.clear();
+                    m_defaultEndpoints.push_back("http://clients3.google.com/generate_204");
+                }
+            }
+            ~Connectivity(){}
+
+            nsm_internetState testConnectivity(const std::vector<std::string>& endpoints, long timeout_ms, nsm_ipversion ipversion);
+            std::vector<std::string> getConnectivityDefaultEndpoints() { return m_defaultEndpoints; };
+            std::string getCaptivePortal() { const std::lock_guard<std::mutex> lock(capitiveMutex); return g_captivePortal; }
+            void setCaptivePortal(const char* captivePortal) {const std::lock_guard<std::mutex> lock(capitiveMutex); g_captivePortal = captivePortal; }
+
+        private:
+            void loadConnectivityConfig(const std::string& configFilePath);
+            nsm_internetState checkInternetStateFromResponseCode(const std::vector<int>& responses);
+
+            std::vector<std::string> m_defaultEndpoints;
+            std::map<std::string, std::string> configMap;
+            std::mutex capitiveMutex;
+            std::string g_captivePortal;
+            bool configMonitorConnectivityEnabled = false;
+            int configMonitorInterval = DEFAULT_MONITOR_TIMEOUT;
+        };
+
+        class ConnectivityMonitor : public Connectivity {
+            public:
+                static ConnectivityMonitor& getInstance() {
+                    static ConnectivityMonitor instance;
+                    return instance;
+                }
+
+                bool isConnectedToInternet(nsm_ipversion ipversion);
+                nsm_internetState getInternetConnectionState(nsm_ipversion ipversion);
+                std::string getCaptivePortalURI();
+                void setConnectivityMonitorEndpoints(const std::vector<std::string> &endpoints);
+                bool startConnectivityMonitor(int timeoutInSeconds);
+                bool stopConnectivityMonitor();
+                bool isConnectivityMonitorEndpointSet();
+                bool isMonitorThreadRunning();
+                void signalConnectivityMonitor();
+                void resetConnectivityCache() { g_internetState = nsm_internetState::UNKNOWN;}
+
+            private:
+                ConnectivityMonitor() : stopFlag(false), threadRunning(false)
+                {
+                    setConnectivityMonitorEndpoints(getConnectivityDefaultEndpoints());
+                }
+
+                ~ConnectivityMonitor() {
+                    stopConnectivityMonitor();
+                }
+
+                std::vector<std::string> getConnectivityMonitorEndpoints();
+                ConnectivityMonitor(const ConnectivityMonitor&) = delete;
+                ConnectivityMonitor& operator=(const ConnectivityMonitor&) = delete;
+                void connectivityMonitorFunction();
+
+                EndpointCache& endpointCache = EndpointCache::getInstance();
+
+                std::thread thread_;
+                std::atomic<bool> stopFlag;
+                std::atomic<bool> threadRunning;
+                std::condition_variable cv_;
+                std::atomic<int> timeout;
+                std::vector<std::string> monitorEndpoints;
+                const int defaultTimeoutInSec = DEFAULT_MONITOR_TIMEOUT;
+                std::mutex mutex_;
+                std::mutex endpointMutex;
+                std::atomic<nsm_internetState> g_internetState = {nsm_internetState::UNKNOWN};
+        };
+    } // namespace Plugin
+} // namespace WPEFramework

--- a/Tests/tests/test_Network.cpp
+++ b/Tests/tests/test_Network.cpp
@@ -257,25 +257,6 @@ TEST_F(NetworkTest, getIPSettings)
     EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"success\":true")));
 }
 
-TEST_F(NetworkTest, isConnectedToInternet)
-{
-    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(
-            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
-                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
-                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_isConnectedToInternet)));
-                *((bool*) arg) = true;
-                auto param = static_cast<IARM_BUS_NetSrvMgr_isConnectedtoInternet_t *>(arg);
-                param->isconnected = true;
-
-                return IARM_RESULT_SUCCESS;
-            });
-    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("isConnectedToInternet"), _T("{}"), response));
-    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"connectedToInternet\":true")));
-    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"success\":true")));
-}
-
 TEST_F(NetworkTest, getPublicIP)
 {
     EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
@@ -346,129 +327,6 @@ TEST_F(NetworkTest, getSTBIPFamily)
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getSTBIPFamily"), _T("{\"family\": \"AF_INET\"}"), response));
     EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"ip\":\"192.168.1.101\"")));
 	EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"success\":true")));
-}
-
-TEST_F(NetworkTest, setConnectivityTestEndpoints)
-{
-    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(
-            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
-                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
-                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_setConnectivityTestEndpoints)));
-
-                return IARM_RESULT_SUCCESS;
-            });
-    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("setConnectivityTestEndpoints"), _T("{\"endpoints\": [\"http://clients3.google.com/generate_204\"]}"), response));
-    EXPECT_EQ(response, string("{\"success\":true}"));
-}
-
-TEST_F(NetworkTest, getInternetConnectionState)
-{
-    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(
-            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
-                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
-                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_getInternetConnectionState)));
-                auto param = static_cast<IARM_BUS_NetSrvMgr_Iface_InternetConnectivityStatus_t *>(arg);
-
-				param->connectivityState = LIMITED_INTERNET;
-                return IARM_RESULT_SUCCESS;
-            });
-    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getInternetConnectionState"), _T("{}"), response));
-	EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"state\":1")));
-	EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"success\":true")));
-
-}
-
-TEST_F(NetworkTest, getInternetConnectionState2)
-{
-    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
-    .Times(::testing::AnyNumber())
-    .WillRepeatedly(
-        [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
-            EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
-            EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_getInternetConnectionState)));
-            auto param = static_cast<IARM_BUS_NetSrvMgr_Iface_InternetConnectivityStatus_t *>(arg);
-
-			param->connectivityState = CAPTIVE_PORTAL;
-			memcpy(param->captivePortalURI, "http://10.0.0.1/captiveportal.jst", sizeof("http://10.0.0.1/captiveportal.jst"));
-            return IARM_RESULT_SUCCESS;
-        });
-    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getInternetConnectionState"), _T("{}"), response));
-	EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"state\":2")));
-
-	EXPECT_THAT(response, ::testing::ContainsRegex(_T("captiveportal.jst")));
-	EXPECT_THAT(response, ::testing::ContainsRegex(_T("10.0.0.1")));
-	EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"success\":true")));
-}
-
-TEST_F(NetworkTest, getCaptivePortalURI)
-{
-    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
-    .Times(::testing::AnyNumber())
-    .WillRepeatedly(
-        [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
-            EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
-            EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_getInternetConnectionState)));
-            auto param = static_cast<IARM_BUS_NetSrvMgr_Iface_InternetConnectivityStatus_t *>(arg);
-
-			param->connectivityState = LIMITED_INTERNET;
-            return IARM_RESULT_SUCCESS;
-        });
-
-    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getCaptivePortalURI"), _T("{}"), response));
-	EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"URI\":\"\"")));
-	EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"success\":true")));
-	EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
-    .Times(::testing::AnyNumber())
-    .WillRepeatedly(
-        [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
-            EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
-            EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_getInternetConnectionState)));
-            auto param = static_cast<IARM_BUS_NetSrvMgr_Iface_InternetConnectivityStatus_t *>(arg);
-
-			param->connectivityState = CAPTIVE_PORTAL;
-			memcpy(param->captivePortalURI, "http://10.0.0.1/captiveportal.jst", sizeof("http://10.0.0.1/captiveportal.jst"));
-            return IARM_RESULT_SUCCESS;
-        });
-    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getCaptivePortalURI"), _T("{}"), response));
-	EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"URI\"")));
-	EXPECT_THAT(response, ::testing::ContainsRegex(_T("captiveportal.jst")));
-	EXPECT_THAT(response, ::testing::ContainsRegex(_T("10.0.0.1")));
-	EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"success\":true")));
-}
-
-TEST_F(NetworkTest, startConnectivityMonitoring)
-{
-    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(
-            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
-                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
-                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_startConnectivityMonitoring)));
-                return IARM_RESULT_SUCCESS;
-            });
-    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("startConnectivityMonitoring"), _T("{\"interval\": 900}"), response));
-    EXPECT_EQ(response, string("{\"success\":true}"));
-    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("startConnectivityMonitoring"), _T("{}"), response));
-    EXPECT_THAT(response, ::testing::ContainsRegex(_T("")));
-}
-
-TEST_F(NetworkTest, stopConnectivityMonitoring)
-{
-    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly(
-            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
-                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
-                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_stopConnectivityMonitoring)));
-
-                return IARM_RESULT_SUCCESS;
-            });
-    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("stopConnectivityMonitoring"), _T("{}"), response));
-    EXPECT_EQ(response, string("{\"success\":true}"));
 }
 
 TEST_F(NetworkTest, setDefaultInterface)
@@ -602,4 +460,46 @@ TEST_F(NetworkTest, getQuirks)
 {
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getQuirks"), _T("{}"), response));
 	EXPECT_EQ(response, string("{\"quirks\":[\"RDK-20093\"],\"success\":true}"));
+}
+/*
+TEST_F(NetworkTest, getInternetConnectionState)
+{
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getInternetConnectionState"), _T("{\"ipversion\": \"IPV6\"}"), response));
+    EXPECT_EQ(response, string("{\"state\":0,\"ipversion\":\"IPV6\",\"success\":true}"));
+}
+
+TEST_F(NetworkTest, isConnectedToInternet)
+{
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("isConnectedToInternet"), _T("{\"ipversion\": \"IPV6\"}"), response));
+    EXPECT_EQ(response, string("{\"connectedToInternet\":false,\"ipversion\":\"IPV6\",\"success\":true}"));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("isConnectedToInternet"), _T("{\"ipversion\": \"IPV4\"}"), response));
+    EXPECT_EQ(response, string("{\"connectedToInternet\":false,\"ipversion\":\"IPV4\",\"success\":true}"));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("isConnectedToInternet"), _T("{}"), response));
+    EXPECT_EQ(response, string("{\"connectedToInternet\":false,\"success\":true}"));
+}
+*/
+TEST_F(NetworkTest, stopConnectivityMonitoring)
+{
+    EXPECT_NE(Core::ERROR_NONE, handler.Invoke(connection, _T("stopConnectivityMonitoring"), _T("{}"), response));
+    EXPECT_NE(response, string("{\"connectedToInternet\":false,\"ipversion\":\"IPV6\",\"success\":true}"));
+}
+
+TEST_F(NetworkTest, getCaptivePortalURI)
+{
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getCaptivePortalURI"), _T("{}"), response));
+    EXPECT_EQ(response, string("{\"URI\":\"\",\"success\":true}"));
+}
+/*
+TEST_F(NetworkTest, startConnectivityMonitoring)
+{
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("startConnectivityMonitoring"), _T("{}"), response));
+    EXPECT_EQ(response, string(""));
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("startConnectivityMonitoring"), _T("{\"interval\":6}"), response));
+    EXPECT_EQ(response, string(""));
+}
+*/
+TEST_F(NetworkTest, setConnectivityTestEndpoints)
+{
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("setConnectivityTestEndpoints"), _T("{\"endpoints\": [\"http://clients3.google.com/generate_204\"]}"), response));
+    EXPECT_EQ(response, string("{\"success\":true}"));
 }

--- a/docs/api/NetworkPlugin.md
+++ b/docs/api/NetworkPlugin.md
@@ -1,32 +1,32 @@
 <!-- Generated automatically, DO NOT EDIT! -->
-<a name="NetworkPlugin"></a>
+<a name="head.NetworkPlugin"></a>
 # NetworkPlugin
 
-**Version: [1.2.3](https://github.com/rdkcentral/rdkservices/blob/main/Network/CHANGELOG.md)**
+**Version: [1.3.0](https://github.com/rdkcentral/rdkservices/blob/main/Network/CHANGELOG.md)**
 
 A org.rdk.Network plugin for Thunder framework.
 
 ### Table of Contents
 
-- [Abbreviation, Acronyms and Terms](#Abbreviation,_Acronyms_and_Terms)
-- [Description](#Description)
-- [Configuration](#Configuration)
-- [Methods](#Methods)
-- [Notifications](#Notifications)
+- [Abbreviation, Acronyms and Terms](#head.Abbreviation,_Acronyms_and_Terms)
+- [Description](#head.Description)
+- [Configuration](#head.Configuration)
+- [Methods](#head.Methods)
+- [Notifications](#head.Notifications)
 
-<a name="Abbreviation,_Acronyms_and_Terms"></a>
+<a name="head.Abbreviation,_Acronyms_and_Terms"></a>
 # Abbreviation, Acronyms and Terms
 
 [[Refer to this link](userguide/aat.md)]
 
-<a name="Description"></a>
+<a name="head.Description"></a>
 # Description
 
 The `Network` plugin allows you to manage network interfaces on a set-top box.
 
-The plugin is designed to be loaded and executed within the Thunder framework. For more information about the framework refer to [[Thunder](#Thunder)].
+The plugin is designed to be loaded and executed within the Thunder framework. For more information about the framework refer to [[Thunder](#ref.Thunder)].
 
-<a name="Configuration"></a>
+<a name="head.Configuration"></a>
 # Configuration
 
 The table below lists configuration options of the plugin.
@@ -38,7 +38,7 @@ The table below lists configuration options of the plugin.
 | locator | string | Library name: *libWPEFrameworkNetwork.so* |
 | autostart | boolean | Determines if the plugin shall be started automatically along with the framework |
 
-<a name="Methods"></a>
+<a name="head.Methods"></a>
 # Methods
 
 The following methods are provided by the org.rdk.Network plugin:
@@ -47,34 +47,34 @@ Network interface methods:
 
 | Method | Description |
 | :-------- | :-------- |
-| [getDefaultInterface](#getDefaultInterface) | Gets the default network interface |
-| [getInterfaces](#getInterfaces) | Returns a list of interfaces supported by this device including their state |
-| [getIPSettings](#getIPSettings) | Gets the IP setting for the given interface |
-| [getNamedEndpoints](#getNamedEndpoints) | Returns a list of endpoint names |
-| [getQuirks](#getQuirks) | Get standard string `RDK-20093` |
-| [getStbIp](#getStbIp) | Gets the IP address of the default interface |
-| [getSTBIPFamily](#getSTBIPFamily) | Gets the IP address of the default interface by address family |
-| [setConnectivityTestEndpoints](#setConnectivityTestEndpoints) | Set the list of endpoints used for a connectivity test |
-| [isConnectedToInternet](#isConnectedToInternet) | Whether the device has internet connectivity |
-| [getInternetConnectionState](#getInternetConnectionState) | Returns the internet connection state |
-| [getCaptivePortalURI](#getCaptivePortalURI) | Returns the captive portal URI if connected to any captive portal network |
-| [startConnectivityMonitoring](#startConnectivityMonitoring) | Enable a continuous monitoring of internet connectivity with heart beat interval thats given |
-| [stopConnectivityMonitoring](#stopConnectivityMonitoring) | Stops the connectivity monitoring |
-| [isInterfaceEnabled](#isInterfaceEnabled) | Whether the specified interface is enabled |
-| [ping](#ping) | Pings the specified endpoint with the specified number of packets |
-| [pingNamedEndpoint](#pingNamedEndpoint) | Pings the specified named endpoint with the specified number of packets |
-| [setDefaultInterface](#setDefaultInterface) | Sets the default interface |
-| [setInterfaceEnabled](#setInterfaceEnabled) | Enables the specified interface |
-| [setIPSettings](#setIPSettings) | Sets the IP settings |
-| [getPublicIP](#getPublicIP) | It allows either zero parameter or with only interface and ipv6 parameter to determine WAN ip address |
-| [setStunEndPoint](#setStunEndPoint) | Set the Stun Endpoint used for getPublicIP |
-| [configurePNI](#configurePNI) | This method configures PNI to enable or disable Connectivity test |
-| [trace](#trace) | Traces the specified endpoint with the specified number of packets using `traceroute` |
-| [traceNamedEndpoint](#traceNamedEndpoint) | Traces the specified named endpoint with the specified number of packets using `traceroute` |
+| [getDefaultInterface](#method.getDefaultInterface) | Gets the default network interface |
+| [getInterfaces](#method.getInterfaces) | Returns a list of interfaces supported by this device including their state |
+| [getIPSettings](#method.getIPSettings) | Gets the IP setting for the given interface |
+| [getNamedEndpoints](#method.getNamedEndpoints) | Returns a list of endpoint names |
+| [getQuirks](#method.getQuirks) | Get standard string `RDK-20093` |
+| [getStbIp](#method.getStbIp) | Gets the IP address of the default interface |
+| [getSTBIPFamily](#method.getSTBIPFamily) | Gets the IP address of the default interface by address family |
+| [setConnectivityTestEndpoints](#method.setConnectivityTestEndpoints) | Define up to 5 endpoints for a connectivity test |
+| [isConnectedToInternet](#method.isConnectedToInternet) | Whether the device has internet connectivity |
+| [getInternetConnectionState](#method.getInternetConnectionState) | Returns the internet connection state |
+| [getCaptivePortalURI](#method.getCaptivePortalURI) | Returns the captive portal URI if connected to any captive portal network |
+| [startConnectivityMonitoring](#method.startConnectivityMonitoring) | Enable a continuous monitoring of internet connectivity with heart beat interval thats given |
+| [stopConnectivityMonitoring](#method.stopConnectivityMonitoring) | Stops the connectivity monitoring |
+| [isInterfaceEnabled](#method.isInterfaceEnabled) | Whether the specified interface is enabled |
+| [ping](#method.ping) | Pings the specified endpoint with the specified number of packets |
+| [pingNamedEndpoint](#method.pingNamedEndpoint) | Pings the specified named endpoint with the specified number of packets |
+| [setDefaultInterface](#method.setDefaultInterface) | Sets the default interface |
+| [setInterfaceEnabled](#method.setInterfaceEnabled) | Enables the specified interface |
+| [setIPSettings](#method.setIPSettings) | Sets the IP settings |
+| [getPublicIP](#method.getPublicIP) | It allows either zero parameter or with only interface and ipv6 parameter to determine WAN ip address |
+| [setStunEndPoint](#method.setStunEndPoint) | Set the Stun Endpoint used for getPublicIP |
+| [configurePNI](#method.configurePNI) | This method configures PNI to enable or disable Connectivity test |
+| [trace](#method.trace) | Traces the specified endpoint with the specified number of packets using `traceroute` |
+| [traceNamedEndpoint](#method.traceNamedEndpoint) | Traces the specified named endpoint with the specified number of packets using `traceroute` |
 
 
-<a name="getDefaultInterface"></a>
-## *getDefaultInterface*
+<a name="method.getDefaultInterface"></a>
+## *getDefaultInterface [<sup>method</sup>](#head.Methods)*
 
 Gets the default network interface. The active network interface is defined as the one that can make requests to the external network. Returns one of the supported interfaces as per `getInterfaces`, or an empty value which indicates that there is no default network interface.
 
@@ -119,8 +119,8 @@ This method takes no parameters.
 }
 ```
 
-<a name="getInterfaces"></a>
-## *getInterfaces*
+<a name="method.getInterfaces"></a>
+## *getInterfaces [<sup>method</sup>](#head.Methods)*
 
 Returns a list of interfaces supported by this device including their state.
 
@@ -177,8 +177,8 @@ This method takes no parameters.
 }
 ```
 
-<a name="getIPSettings"></a>
-## *getIPSettings*
+<a name="method.getIPSettings"></a>
+## *getIPSettings [<sup>method</sup>](#head.Methods)*
 
 Gets the IP setting for the given interface.
 
@@ -247,8 +247,8 @@ No Events
 }
 ```
 
-<a name="getNamedEndpoints"></a>
-## *getNamedEndpoints*
+<a name="method.getNamedEndpoints"></a>
+## *getNamedEndpoints [<sup>method</sup>](#head.Methods)*
 
 Returns a list of endpoint names. Currently supported endpoint names are: `CMTS`.
 
@@ -296,8 +296,8 @@ This method takes no parameters.
 }
 ```
 
-<a name="getQuirks"></a>
-## *getQuirks*
+<a name="method.getQuirks"></a>
+## *getQuirks [<sup>method</sup>](#head.Methods)*
 
 Get standard string `RDK-20093`.
 
@@ -342,8 +342,8 @@ This method takes no parameters.
 }
 ```
 
-<a name="getStbIp"></a>
-## *getStbIp*
+<a name="method.getStbIp"></a>
+## *getStbIp [<sup>method</sup>](#head.Methods)*
 
 Gets the IP address of the default interface.
 
@@ -388,8 +388,8 @@ This method takes no parameters.
 }
 ```
 
-<a name="getSTBIPFamily"></a>
-## *getSTBIPFamily*
+<a name="method.getSTBIPFamily"></a>
+## *getSTBIPFamily [<sup>method</sup>](#head.Methods)*
 
 Gets the IP address of the default interface by address family.
 
@@ -440,15 +440,10 @@ No Events
 }
 ```
 
-<a name="setConnectivityTestEndpoints"></a>
-## *setConnectivityTestEndpoints*
+<a name="method.setConnectivityTestEndpoints"></a>
+## *setConnectivityTestEndpoints [<sup>method</sup>](#head.Methods)*
 
-Set the list of endpoints used for a connectivity test. Endpoint should return HTTP Status 204 (No Content) for successful connection and Maximum number of endpoints is 5 . 
-
-Default endpoints:-
-* http://clients3.google.com/generate_204 
-* http://edge-http.microsoft.com/captiveportal/generate_204 
-* http://gstatic.com/generate_204 .
+Define up to 5 endpoints for a connectivity test. Successful connections are verified with HTTP Status code 204 (No Content). Priority is given to endpoints configured in /etc/netsrvmgr.conf. In case of errors or if not configured, the default endpoints are considered: `http://clients3.google.com/generate_204`.
 
 ### Events
 
@@ -498,8 +493,8 @@ No Events
 }
 ```
 
-<a name="isConnectedToInternet"></a>
-## *isConnectedToInternet*
+<a name="method.isConnectedToInternet"></a>
+## *isConnectedToInternet [<sup>method</sup>](#head.Methods)*
 
 Whether the device has internet connectivity. This API might take up to 2s to validate internet connectivity.
 
@@ -509,7 +504,10 @@ No Events
 
 ### Parameters
 
-This method takes no parameters.
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.ipversion | string | either IPv4 or IPv6 |
 
 ### Result
 
@@ -517,6 +515,7 @@ This method takes no parameters.
 | :-------- | :-------- | :-------- |
 | result | object |  |
 | result.connectedToInternet | boolean | `true` if internet connectivity is detected, otherwise `false` |
+| result?.ipversion | string | <sup>*(optional)*</sup> either IPv4 or IPv6 |
 | result.success | boolean | Whether the request succeeded |
 
 ### Example
@@ -527,7 +526,10 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Network.isConnectedToInternet"
+    "method": "org.rdk.Network.isConnectedToInternet",
+    "params": {
+        "ipversion": "IPv4"
+    }
 }
 ```
 
@@ -539,13 +541,14 @@ This method takes no parameters.
     "id": 42,
     "result": {
         "connectedToInternet": true,
+        "ipversion": "IPv4",
         "success": true
     }
 }
 ```
 
-<a name="getInternetConnectionState"></a>
-## *getInternetConnectionState*
+<a name="method.getInternetConnectionState"></a>
+## *getInternetConnectionState [<sup>method</sup>](#head.Methods)*
 
 Returns the internet connection state. The possible internet connection state are as follows. 
 * `0`: NO_INTERNET - No internet connection  
@@ -559,7 +562,10 @@ No Events
 
 ### Parameters
 
-This method takes no parameters.
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.ipversion | string | either IPv4 or IPv6 |
 
 ### Result
 
@@ -568,6 +574,7 @@ This method takes no parameters.
 | result | object |  |
 | result.state | integer | Internet Connection state |
 | result?.URI | string | <sup>*(optional)*</sup> Captive portal URI |
+| result?.ipversion | string | <sup>*(optional)*</sup> either IPv4 or IPv6 |
 | result.success | boolean | Whether the request succeeded |
 
 ### Example
@@ -578,7 +585,10 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.Network.getInternetConnectionState"
+    "method": "org.rdk.Network.getInternetConnectionState",
+    "params": {
+        "ipversion": "IPv4"
+    }
 }
 ```
 
@@ -591,13 +601,14 @@ This method takes no parameters.
     "result": {
         "state": 2,
         "URI": "http://10.0.0.1/captiveportal.jst",
+        "ipversion": "IPv4",
         "success": true
     }
 }
 ```
 
-<a name="getCaptivePortalURI"></a>
-## *getCaptivePortalURI*
+<a name="method.getCaptivePortalURI"></a>
+## *getCaptivePortalURI [<sup>method</sup>](#head.Methods)*
 
 Returns the captive portal URI if connected to any captive portal network.
 
@@ -642,8 +653,8 @@ This method takes no parameters.
 }
 ```
 
-<a name="startConnectivityMonitoring"></a>
-## *startConnectivityMonitoring*
+<a name="method.startConnectivityMonitoring"></a>
+## *startConnectivityMonitoring [<sup>method</sup>](#head.Methods)*
 
 Enable a continuous monitoring of internet connectivity with heart beat interval thats given.
 
@@ -651,13 +662,13 @@ Enable a continuous monitoring of internet connectivity with heart beat interval
 
 | Event | Description |
 | :-------- | :-------- |
-| [onInternetStatusChange](#onInternetStatusChange) | Triggered when internet connection state changed. |
+| [onInternetStatusChange](#event.onInternetStatusChange) | Triggered when internet connection state changed. |
 ### Parameters
 
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
 | params | object |  |
-| params.interval | number | Interval in sec. Default value 600 sec and interval should be greater than 5 sec |
+| params.interval | number | Interval in sec. Default value 60 sec and interval should be greater than 5 sec |
 
 ### Result
 
@@ -693,8 +704,8 @@ Enable a continuous monitoring of internet connectivity with heart beat interval
 }
 ```
 
-<a name="stopConnectivityMonitoring"></a>
-## *stopConnectivityMonitoring*
+<a name="method.stopConnectivityMonitoring"></a>
+## *stopConnectivityMonitoring [<sup>method</sup>](#head.Methods)*
 
 Stops the connectivity monitoring.
 
@@ -737,8 +748,8 @@ This method takes no parameters.
 }
 ```
 
-<a name="isInterfaceEnabled"></a>
-## *isInterfaceEnabled*
+<a name="method.isInterfaceEnabled"></a>
+## *isInterfaceEnabled [<sup>method</sup>](#head.Methods)*
 
 Whether the specified interface is enabled.
 
@@ -789,8 +800,8 @@ No Events
 }
 ```
 
-<a name="ping"></a>
-## *ping*
+<a name="method.ping"></a>
+## *ping [<sup>method</sup>](#head.Methods)*
 
 Pings the specified endpoint with the specified number of packets.
 
@@ -863,8 +874,8 @@ No Events
 }
 ```
 
-<a name="pingNamedEndpoint"></a>
-## *pingNamedEndpoint*
+<a name="method.pingNamedEndpoint"></a>
+## *pingNamedEndpoint [<sup>method</sup>](#head.Methods)*
 
 Pings the specified named endpoint with the specified number of packets. Only names returned by `getNamedEndpoints` can be used. The named endpoint is resolved to a specific host or IP address on the device side based on the `endpointName`.
 
@@ -937,8 +948,8 @@ No Events
 }
 ```
 
-<a name="setDefaultInterface"></a>
-## *setDefaultInterface*
+<a name="method.setDefaultInterface"></a>
+## *setDefaultInterface [<sup>method</sup>](#head.Methods)*
 
 Sets the default interface. The call fails if the interface is not enabled.
 
@@ -946,10 +957,10 @@ Sets the default interface. The call fails if the interface is not enabled.
 
 | Event | Description |
 | :-------- | :-------- |
-| [onInterfaceStatusChanged](#onInterfaceStatusChanged) | Triggered when device’s default interface changed. |
-| [onConnectionStatusChanged](#onConnectionStatusChanged) | Triggered when interface’s status changes to enabled/disabled. |
-| [onIPAddressStatusChanged](#onIPAddressStatusChanged) | Triggered when the device connects to router. |
-| [onDefaultInterfaceChanged](#onDefaultInterfaceChanged) | Triggered when each IP address is lost or acquired. |
+| [onInterfaceStatusChanged](#event.onInterfaceStatusChanged) | Triggered when device’s default interface changed. |
+| [onConnectionStatusChanged](#event.onConnectionStatusChanged) | Triggered when interface’s status changes to enabled/disabled. |
+| [onIPAddressStatusChanged](#event.onIPAddressStatusChanged) | Triggered when the device connects to router. |
+| [onDefaultInterfaceChanged](#event.onDefaultInterfaceChanged) | Triggered when each IP address is lost or acquired. |
 ### Parameters
 
 | Name | Type | Description |
@@ -993,8 +1004,8 @@ Sets the default interface. The call fails if the interface is not enabled.
 }
 ```
 
-<a name="setInterfaceEnabled"></a>
-## *setInterfaceEnabled*
+<a name="method.setInterfaceEnabled"></a>
+## *setInterfaceEnabled [<sup>method</sup>](#head.Methods)*
 
 Enables the specified interface.
 
@@ -1002,7 +1013,7 @@ Enables the specified interface.
 
 | Event | Description |
 | :-------- | :-------- |
-| [onInterfaceStatusChanged](#onInterfaceStatusChanged) | Triggered when interface’s status changes to enabled/disabled. |
+| [onInterfaceStatusChanged](#event.onInterfaceStatusChanged) | Triggered when interface’s status changes to enabled/disabled. |
 ### Parameters
 
 | Name | Type | Description |
@@ -1048,8 +1059,8 @@ Enables the specified interface.
 }
 ```
 
-<a name="setIPSettings"></a>
-## *setIPSettings*
+<a name="method.setIPSettings"></a>
+## *setIPSettings [<sup>method</sup>](#head.Methods)*
 
 Sets the IP settings.All the inputs are mandatory for v1. But for v2, the interface and autconfig params are mandatory input to autoconfig IP settings & other parameters not required. For manual IP, all the input parameters are mandatory except secondaryDNS.
 
@@ -1057,7 +1068,7 @@ Sets the IP settings.All the inputs are mandatory for v1. But for v2, the interf
 
 | Event | Description |
 | :-------- | :-------- |
-| [onIPAddressStatusChanged](#onIPAddressStatusChanged) | Triggered when each IP address is lost or acquired. |
+| [onIPAddressStatusChanged](#event.onIPAddressStatusChanged) | Triggered when each IP address is lost or acquired. |
 ### Parameters
 
 | Name | Type | Description |
@@ -1115,8 +1126,8 @@ Sets the IP settings.All the inputs are mandatory for v1. But for v2, the interf
 }
 ```
 
-<a name="getPublicIP"></a>
-## *getPublicIP*
+<a name="method.getPublicIP"></a>
+## *getPublicIP [<sup>method</sup>](#head.Methods)*
 
 It allows either zero parameter or with only interface and ipv6 parameter to determine WAN ip address.
 
@@ -1169,8 +1180,8 @@ No Events
 }
 ```
 
-<a name="setStunEndPoint"></a>
-## *setStunEndPoint*
+<a name="method.setStunEndPoint"></a>
+## *setStunEndPoint [<sup>method</sup>](#head.Methods)*
 
 Set the Stun Endpoint used for getPublicIP.
 
@@ -1227,8 +1238,8 @@ No Events
 }
 ```
 
-<a name="configurePNI"></a>
-## *configurePNI*
+<a name="method.configurePNI"></a>
+## *configurePNI [<sup>method</sup>](#head.Methods)*
 
 This method configures PNI to enable or disable Connectivity test.
 
@@ -1277,8 +1288,8 @@ No Events
 }
 ```
 
-<a name="trace"></a>
-## *trace*
+<a name="method.trace"></a>
+## *trace [<sup>method</sup>](#head.Methods)*
 
 Traces the specified endpoint with the specified number of packets using `traceroute`.
 
@@ -1335,8 +1346,8 @@ No Events
 }
 ```
 
-<a name="traceNamedEndpoint"></a>
-## *traceNamedEndpoint*
+<a name="method.traceNamedEndpoint"></a>
+## *traceNamedEndpoint [<sup>method</sup>](#head.Methods)*
 
 Traces the specified named endpoint with the specified number of packets using `traceroute`.
 
@@ -1393,10 +1404,10 @@ No Events
 }
 ```
 
-<a name="Notifications"></a>
+<a name="head.Notifications"></a>
 # Notifications
 
-Notifications are autonomous events, triggered by the internals of the implementation, and broadcasted via JSON-RPC to all registered observers. Refer to [[Thunder](#Thunder)] for information on how to register for a notification.
+Notifications are autonomous events, triggered by the internals of the implementation, and broadcasted via JSON-RPC to all registered observers. Refer to [[Thunder](#ref.Thunder)] for information on how to register for a notification.
 
 The following events are provided by the org.rdk.Network plugin:
 
@@ -1404,15 +1415,15 @@ Network interface events:
 
 | Event | Description |
 | :-------- | :-------- |
-| [onInterfaceStatusChanged](#onInterfaceStatusChanged) | Triggered when an interface becomes enabled or disabled |
-| [onConnectionStatusChanged](#onConnectionStatusChanged) | Triggered when a connection is made or lost |
-| [onIPAddressStatusChanged](#onIPAddressStatusChanged) | Triggered when an IP Address is assigned or lost |
-| [onDefaultInterfaceChanged](#onDefaultInterfaceChanged) | Triggered when the default interface changes, regardless if it's from a system operation or through the `setDefaultInterface` method |
-| [onInternetStatusChange](#onInternetStatusChange) | Triggered when internet connection state changed |
+| [onInterfaceStatusChanged](#event.onInterfaceStatusChanged) | Triggered when an interface becomes enabled or disabled |
+| [onConnectionStatusChanged](#event.onConnectionStatusChanged) | Triggered when a connection is made or lost |
+| [onIPAddressStatusChanged](#event.onIPAddressStatusChanged) | Triggered when an IP Address is assigned or lost |
+| [onDefaultInterfaceChanged](#event.onDefaultInterfaceChanged) | Triggered when the default interface changes, regardless if it's from a system operation or through the `setDefaultInterface` method |
+| [onInternetStatusChange](#event.onInternetStatusChange) | Triggered when internet connection state changed |
 
 
-<a name="onInterfaceStatusChanged"></a>
-## *onInterfaceStatusChanged*
+<a name="event.onInterfaceStatusChanged"></a>
+## *onInterfaceStatusChanged [<sup>event</sup>](#head.Notifications)*
 
 Triggered when an interface becomes enabled or disabled.
 
@@ -1437,8 +1448,8 @@ Triggered when an interface becomes enabled or disabled.
 }
 ```
 
-<a name="onConnectionStatusChanged"></a>
-## *onConnectionStatusChanged*
+<a name="event.onConnectionStatusChanged"></a>
+## *onConnectionStatusChanged [<sup>event</sup>](#head.Notifications)*
 
 Triggered when a connection is made or lost.
 
@@ -1463,8 +1474,8 @@ Triggered when a connection is made or lost.
 }
 ```
 
-<a name="onIPAddressStatusChanged"></a>
-## *onIPAddressStatusChanged*
+<a name="event.onIPAddressStatusChanged"></a>
+## *onIPAddressStatusChanged [<sup>event</sup>](#head.Notifications)*
 
 Triggered when an IP Address is assigned or lost.
 
@@ -1493,10 +1504,10 @@ Triggered when an IP Address is assigned or lost.
 }
 ```
 
-<a name="onDefaultInterfaceChanged"></a>
-## *onDefaultInterfaceChanged*
+<a name="event.onDefaultInterfaceChanged"></a>
+## *onDefaultInterfaceChanged [<sup>event</sup>](#head.Notifications)*
 
-Triggered when the default interface changes, regardless if it's from a system operation or through the `setDefaultInterface` 
+Triggered when the default interface changes, regardless if it's from a system operation or through the `setDefaultInterface` method.
 
 ### Parameters
 
@@ -1519,8 +1530,8 @@ Triggered when the default interface changes, regardless if it's from a system o
 }
 ```
 
-<a name="onInternetStatusChange"></a>
-## *onInternetStatusChange*
+<a name="event.onInternetStatusChange"></a>
+## *onInternetStatusChange [<sup>event</sup>](#head.Notifications)*
 
 Triggered when internet connection state changed.The possible internet connection status are `NO_INTERNET`, `LIMITED_INTERNET`, `CAPTIVE_PORTAL`, `FULLY_CONNECTED`.
 


### PR DESCRIPTION
Move the Connectivity Monitoring to NetworkManager Thunder Plugin (#4577) 
Updated Network source code version and removed unnecessary log lines.(#4581) 
UNKNOWN state added as new internet state (#4591)
RDK-44997 : Notify event error fix (#4616)
Move Connectivity Monitoring to Network Plugin (204 endpoint logic) (#4644)
startConnectivityMonitoring Interval Error fix (#4147)
DELIA-63960: Removed error log line and documentation updated (#4677)

(cherry picked from commit b54756d6476d298145abcee892cfd412f23210ce)
(cherry picked from commit a001633aba763666cc86fec685daeb7ed2f240d0)
(cherry picked from commit 1a51a91731a41ec6e7c99bd1e2edbe5c89323758)
(cherry picked from commit 5ee655a3b05dc0976dd2939b0f8ba9afbb2ce79f)
(cherry picked from commit 8911bfe871ce8f5ab59e8415e3e7ee2da4660ad8)
(cherry picked from commit a6bd9dd5311b32f9ac8d0426635fd98f7ffb8c3d)
(cherry picked from commit 3a67703832e1192dcb106276845dc19b31e30086)

Signed-off-by: cmuhammedrafi <muhammed_rafi@comcast.com>
(cherry picked from commit f7d95a8e0458735b63a9f595f4e3a0e7c42a6559)