### PR TITLE
XIONE-13546: Stuck on sky splash logo screen after a FSR 

### DIFF
--- a/SystemAudioPlayer/CHANGELOG.md
+++ b/SystemAudioPlayer/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.0.7] - 2023-11-29
+### Fixed
+- Timeout to launch this process is increased to 15s, to fix the bootup issue
+
 ## [1.0.6] - 2023-08-02
 ### Fixed
 - Fixed warnings treated as errors for emulator build

--- a/SystemAudioPlayer/SystemAudioPlayer.cpp
+++ b/SystemAudioPlayer/SystemAudioPlayer.cpp
@@ -57,7 +57,7 @@ namespace Plugin {
 
         _service->Register(&_notification);
 
-        _sap = _service->Root<Exchange::ISystemAudioPlayer>(_connectionId, 5000, _T("SystemAudioPlayerImplementation"));
+        _sap = _service->Root<Exchange::ISystemAudioPlayer>(_connectionId, 15000, _T("SystemAudioPlayerImplementation"));
 
         std::string message;
         if(_sap != nullptr) {


### PR DESCRIPTION
Increased the launch process timeout to 15 seconds