### PR TITLE
RDKTV-26134 : TV always shows IPV4 address even when it is connected to IPV6 XB

### DIFF
--- a/Network/CHANGELOG.md
+++ b/Network/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.3.1] - 2023-11-30
+### Fixed
+- Addressed the IPv4 & IPv6 cache issue where it was not suppose to be cached when DNS or other parameter is not received yet
+
 ## [1.3.0] - 2023-11-25
 ### Added 
 - added connectivity monitor class remove Connectivity related IARM Calls

--- a/Network/Network.cpp
+++ b/Network/Network.cpp
@@ -35,7 +35,7 @@ using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 3
-#define API_VERSION_NUMBER_PATCH 0
+#define API_VERSION_NUMBER_PATCH 1
 
 /* Netsrvmgr Based Macros & Structures */
 #define IARM_BUS_NM_SRV_MGR_NAME "NET_SRV_MGR"
@@ -153,19 +153,15 @@ typedef struct _IARM_BUS_NetSrvMgr_Iface_EventData_t {
             m_stunBindTimeout = 30;
             m_stunCacheTimeout = 0;
             m_stunSync = true;
-            m_useIpv4WifiCache = false;
-            m_useIpv6WifiCache = false;
-            m_useIpv4EthCache = false;
-            m_useIpv6EthCache = false;
+            m_useIpv4Cache = false;
+            m_useIpv6Cache = false;
             m_useStbIPCache = false;
             m_stbIpCache = "";
             m_useDefInterfaceCache = false;
             m_defInterfaceCache = "";
             m_defIpversionCache = "";
-            m_ipv4WifiCache = {0};
-            m_ipv6WifiCache = {0};
-            m_ipv4EthCache = {0};
-            m_ipv6EthCache = {0};
+            m_ipv4Cache = {0};
+            m_ipv6Cache = {0};
         }
 
         Network::~Network()
@@ -1042,8 +1038,7 @@ typedef struct _IARM_BUS_NetSrvMgr_Iface_EventData_t {
            strncpy(iarmData.interface, interface.c_str(), 16);
            strncpy(iarmData.ipversion, ipversion.c_str(), 16);
            if (IARM_RESULT_SUCCESS == IARM_Bus_Call (IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_NETSRVMGR_API_getIPSettings, (void *)&iarmData, sizeof(iarmData)))
-               return true;
-
+                return true;
            return false;
         }
 
@@ -1061,60 +1056,58 @@ typedef struct _IARM_BUS_NetSrvMgr_Iface_EventData_t {
             if (ipversion.empty())
                 ipversion = m_defIpversionCache;
 
+            Utils::String::toUpper(interface);
+            Utils::String::toUpper(ipversion);
+
             IARM_BUS_NetSrvMgr_Iface_Settings_t iarmData = { 0 };
-            strncpy(iarmData.interface, interface.c_str(), 16);
-            strncpy(iarmData.ipversion, ipversion.c_str(), 16);
-            iarmData.isSupported = true;
-
-            if (Utils::String::equal(ipversion, "ipv4") && Utils::String::equal(interface, "wifi"))
+            if(Utils::String::equal(ipversion, "IPV4") && m_useIpv4Cache && Utils::String::equal(interface, m_ipv4Cache.interface))
             {
-                if ((!m_useIpv4WifiCache) && (getIPIARMWrapper(m_ipv4WifiCache, interface, ipversion)))
-                    m_useIpv4WifiCache = true;
-
-                if (m_useIpv4WifiCache)
-                {
-                    memcpy(&iarmData, &m_ipv4WifiCache, sizeof(m_ipv4WifiCache));
-                    result = true;
-                }
-            }
-            else if (Utils::String::equal(ipversion, "ipv4") && Utils::String::equal(interface, "ethernet"))
-            {
-                if ((!m_useIpv4EthCache) && (getIPIARMWrapper(m_ipv4EthCache, interface, ipversion)))
-                    m_useIpv4EthCache = true;
-
-                if (m_useIpv4EthCache)
-                {
-                    memcpy(&iarmData, &m_ipv4EthCache, sizeof(m_ipv4EthCache));
-                    result = true;
-                }
-            }
-            else if (Utils::String::equal(ipversion, "ipv6") && Utils::String::equal(interface, "wifi"))
-            {
-                if ((!m_useIpv6WifiCache) && (getIPIARMWrapper(m_ipv6WifiCache, interface, ipversion)))
-                    m_useIpv6WifiCache = true;
-
-                if (m_useIpv6WifiCache)
-                {
-                    memcpy(&iarmData, &m_ipv6WifiCache, sizeof(m_ipv6WifiCache));
-                    result = true;
-                }
-            }
-            else if (Utils::String::equal(ipversion, "ipv6") && Utils::String::equal(interface, "ethernet"))
-            {
-                if ((!m_useIpv6EthCache) && (getIPIARMWrapper(m_ipv6EthCache, interface, ipversion)))
-                    m_useIpv6EthCache = true;
-
-                if (m_useIpv6EthCache)
-                {
-                    memcpy(&iarmData, &m_ipv6EthCache, sizeof(m_ipv6EthCache));
-                    result = true;
-                }
-            }
-            else if (getIPIARMWrapper(iarmData, interface, ipversion))
-            {
+                LOGINFO("Reading Ipv4 cache");
+                memcpy(&iarmData, &m_ipv4Cache, sizeof(m_ipv4Cache));
                 result = true;
-                m_defInterfaceCache = string(iarmData.interface);
-                m_defIpversionCache = string(iarmData.ipversion);
+            }
+            else if (Utils::String::equal(ipversion, "IPV6") && m_useIpv6Cache && Utils::String::equal(interface, m_ipv6Cache.interface))
+            {
+                LOGINFO("Reading Ipv6 cache");
+                memcpy(&iarmData, &m_ipv6Cache, sizeof(m_ipv6Cache));
+                result = true;
+            }
+            else
+            {
+                iarmData.isSupported = true;
+                if(getIPIARMWrapper(iarmData, interface, ipversion))
+                {
+                    if(strcmp(iarmData.ipversion, "IPV4") == 0)
+                    {
+                        if(NETWORK_IPADDRESS_ACQUIRED == iarmData.errCode)
+                        {
+                            memcpy(&m_ipv4Cache, &iarmData, sizeof(m_ipv4Cache));
+                            m_useIpv4Cache = true;
+                        }
+                        result = true;
+                    }
+                    else if(strcmp(iarmData.ipversion, "IPV6") == 0)
+                    {
+                        if(NETWORK_IPADDRESS_ACQUIRED == iarmData.errCode)
+                        {
+                            memcpy(&m_ipv6Cache, &iarmData, sizeof(m_ipv6Cache));
+                            m_useIpv6Cache = true;
+                        }
+                        result = true;
+                    }
+                    else
+                    {
+                        LOGERR("wrong ipversion returned ! <%s>", iarmData.ipversion);
+                    }
+
+                    if (ipversion.empty() || interface.empty())
+                    {
+                        m_defInterfaceCache = string(iarmData.interface);
+                        m_defIpversionCache = string(iarmData.ipversion);
+                    }
+                }
+                else
+                    LOGERR ("IARM Call Failed: %s", IARM_BUS_NETSRVMGR_API_getIPSettings);
             }
 
             if (result == true)
@@ -1132,7 +1125,6 @@ typedef struct _IARM_BUS_NetSrvMgr_Iface_EventData_t {
 
                 m_ipversion = string(iarmData.ipversion);
             }
-
             return result;
         }
 
@@ -1456,10 +1448,8 @@ typedef struct _IARM_BUS_NetSrvMgr_Iface_EventData_t {
             params["status"] = string (connected ? "CONNECTED" : "DISCONNECTED");
             m_useStbIPCache = false;
             m_useDefInterfaceCache = false;
-            m_useIpv4WifiCache = false;
-            m_useIpv6WifiCache = false;
-            m_useIpv4EthCache = false;
-            m_useIpv6EthCache = false;
+            m_useIpv4Cache = false;
+            m_useIpv6Cache = false;
             m_defIpversionCache = "";
             m_defInterfaceCache = "";
 
@@ -1503,26 +1493,12 @@ typedef struct _IARM_BUS_NetSrvMgr_Iface_EventData_t {
             if (!ipv6Addr.empty())
             {
                 params["ip6Address"] = ipv6Addr;
-                if (Utils::String::equal(onInterface, "wifi"))
-                {
-                    m_useIpv6WifiCache = false;
-                }
-                else if (Utils::String::equal(onInterface, "ethernet"))
-                {
-                    m_useIpv6EthCache = false;
-                }
+                m_useIpv6Cache = false;
             }
             if (!ipv4Addr.empty())
             {
                 params["ip4Address"] = ipv4Addr;
-                if (Utils::String::equal(onInterface, "wifi"))
-                {
-                    m_useIpv4WifiCache = false;
-                }
-                else if (Utils::String::equal(onInterface, "ethernet"))
-                {
-                    m_useIpv4EthCache = false;
-                }
+                m_useIpv4Cache = false;
             }
             params["status"] = string (acquired ? "ACQUIRED" : "LOST");
             sendNotify("onIPAddressStatusChanged", params);
@@ -1536,10 +1512,8 @@ typedef struct _IARM_BUS_NetSrvMgr_Iface_EventData_t {
             params["newInterfaceName"] = m_netUtils.getInterfaceDescription(newInterface);
             m_useStbIPCache = false;
             m_useDefInterfaceCache = false;
-            m_useIpv4WifiCache = false;
-            m_useIpv6WifiCache = false;
-            m_useIpv4EthCache = false;
-            m_useIpv6EthCache = false;
+            m_useIpv4Cache = false;
+            m_useIpv6Cache = false;
             m_defIpversionCache = "";
             m_defaultInterface = ""; /* REFPLTV-1319 : Resetting when there is switch in interface, to get new value in getDefaultInterface() */
             m_gatewayInterface = "";

--- a/Network/Network.h
+++ b/Network/Network.h
@@ -270,20 +270,16 @@ namespace WPEFramework {
             uint16_t m_stunCacheTimeout;
             bool m_stunSync;
             uint32_t m_apiVersionNumber;
-            std::atomic<bool> m_useIpv4WifiCache;
-            std::atomic<bool> m_useIpv6WifiCache;
-            std::atomic<bool> m_useIpv4EthCache;
-            std::atomic<bool> m_useIpv6EthCache;
+            std::atomic<bool> m_useIpv4Cache;
+            std::atomic<bool> m_useIpv6Cache;
             std::atomic<bool> m_useStbIPCache;
             string m_stbIpCache;
             std::atomic<bool> m_useDefInterfaceCache;
             string m_defInterfaceCache;
             string m_defIpversionCache;
 
-            IARM_BUS_NetSrvMgr_Iface_Settings_t m_ipv4WifiCache;
-            IARM_BUS_NetSrvMgr_Iface_Settings_t m_ipv6WifiCache;
-            IARM_BUS_NetSrvMgr_Iface_Settings_t m_ipv4EthCache;
-            IARM_BUS_NetSrvMgr_Iface_Settings_t m_ipv6EthCache;
+            IARM_BUS_NetSrvMgr_Iface_Settings_t m_ipv4Cache;
+            IARM_BUS_NetSrvMgr_Iface_Settings_t m_ipv6Cache;
         };
     } // namespace Plugin
 } // namespace WPEFramework

--- a/docs/api/NetworkPlugin.md
+++ b/docs/api/NetworkPlugin.md
@@ -2,7 +2,7 @@
 <a name="head.NetworkPlugin"></a>
 # NetworkPlugin
 
-**Version: [1.3.0](https://github.com/rdkcentral/rdkservices/blob/main/Network/CHANGELOG.md)**
+**Version: [1.3.1](https://github.com/rdkcentral/rdkservices/blob/main/Network/CHANGELOG.md)**
 
 A org.rdk.Network plugin for Thunder framework.
 


### PR DESCRIPTION
Addressed the IPv4 & IPv6 cache issue where it was not suppose to be cached when DNS or other parameter is not received yet