### PR TITLE
RDKTV-26883: Reset the Activesource on putting the TV to standby

### DIFF
--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -897,7 +897,7 @@ namespace WPEFramework
 						if ( powerState != DEVICE_POWER_STATE_ON )
 						{
 						   /*  reset the current active source when TV on going to standby */
-                           HdmiCecSink::_instance->m_currentActiveSource = -1;
+                           			    HdmiCecSink::_instance->m_currentActiveSource = -1;
 						}
                                                 /* Initiate a ping straight away */
                                                 HdmiCecSink::_instance->m_pollNextState = POLL_THREAD_STATE_PING;

--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -896,8 +896,8 @@ namespace WPEFramework
 
 						if ( powerState != DEVICE_POWER_STATE_ON )
 						{
-						   /*  set the current active source to TV on going to standby */
-                                                   HdmiCecSink::_instance->m_currentActiveSource = _instance->m_logicalAddressAllocated;
+						   /*  reset the current active source when TV on going to standby */
+                           HdmiCecSink::_instance->m_currentActiveSource = -1;
 						}
                                                 /* Initiate a ping straight away */
                                                 HdmiCecSink::_instance->m_pollNextState = POLL_THREAD_STATE_PING;
@@ -2817,9 +2817,7 @@ namespace WPEFramework
 						_instance->m_numberOfDevices = 0;
 						_instance->deviceList[_instance->m_logicalAddressAllocated].m_deviceType = DeviceType::TV;
 						_instance->deviceList[_instance->m_logicalAddressAllocated].m_isDevicePresent = true;
-                                                _instance->deviceList[_instance->m_logicalAddressAllocated].update(physical_addr);
-                                                _instance->m_currentActiveSource = _instance->m_logicalAddressAllocated;
-                                                _instance->deviceList[_instance->m_logicalAddressAllocated].m_isActiveSource = true;
+                        _instance->deviceList[_instance->m_logicalAddressAllocated].update(physical_addr);
 						_instance->deviceList[_instance->m_logicalAddressAllocated].m_cecVersion = Version::V_1_4;
 						_instance->deviceList[_instance->m_logicalAddressAllocated].m_vendorID = appVendorId;
 						_instance->deviceList[_instance->m_logicalAddressAllocated].m_powerStatus = PowerStatus(powerState);


### PR DESCRIPTION

Reason for change: reset the current active source when TV on going to standby
Test Procedure: Build and Verify.
Risks: Low
Signed-off-by: bp-tdora114 <dautapankumar.dora@sky.uk>