### PR TITLE
RDKCOM-4452 Added file MediaEngineRMF.conf.in to resolve Build error …

### DIFF
--- a/MediaEngineRMF/CHANGELOG.md
+++ b/MediaEngineRMF/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.0.1] - 2023-12-07
+### Added
+- Added MediaEngineRMF.conf.in file to remove build error for hybrid image with Thunder4 enabled.
+
 ## [1.0.0] - 2023-01-10
 ### Added
 - Added support for video playback via RDK mediaframework (RMF). It's in early stages and capabilities are limited to channel change ability and little else.

--- a/MediaEngineRMF/MediaEngineRMF.conf.in
+++ b/MediaEngineRMF/MediaEngineRMF.conf.in
@@ -1,0 +1,3 @@
+precondition = ["Platform"]
+callsign = "org.rdk.MediaEngineRMF"
+autostart = "false"

--- a/MediaEngineRMF/MediaEngineRMF.cpp
+++ b/MediaEngineRMF/MediaEngineRMF.cpp
@@ -41,7 +41,7 @@ const string WPEFramework::Plugin::MediaEngineRMF::EVT_ON_ERROR = "onError";
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 0
+#define API_VERSION_NUMBER_PATCH 1
 
 using namespace std;
 using namespace libmediaplayer;


### PR DESCRIPTION
RDKCOM-4452 Added file MediaEngineRMF.conf.in to resolve Build error seen in rdkservices on Thunder4.2 enabled Hybrid image

Added file MediaEngineRMF.conf.in to resolve Build error seen in rdkservices on Thunder4.2 enabled Hybrid image

Reason for change: Fixed build error for MediaEngineRMF for Thunder4.2 enabled Hybrid image. Test Procedure: Ensure the hybrid image build successful with Thunder4.2 enabled Risks: low.
Signed-off-by: SajjadMusa_Shaikh@comcast.com
(cherry picked from commit 63ca91de3f8d1ba2c77cad13f63e640d00895cc7)