### PR TITLE
[WebKitBrowser] Updating methods deprecated since 2.42 WebKit API

### DIFF
--- a/WebKitBrowser/Extension/main.cpp
+++ b/WebKitBrowser/Extension/main.cpp
@@ -195,6 +195,8 @@ private:
                 G_CALLBACK(didStartProvisionalLoadForFrame), nullptr);
 #endif
     }
+
+PUSH_WARNING(DISABLE_WARNING_DEPRECATED_USE)
     static void consoleMessageSentCallback(VARIABLE_IS_NOT_USED WebKitWebPage* page, WebKitConsoleMessage* message, PluginHost* host)
     {
         string messageString = Core::ToString(webkit_console_message_get_text(message));
@@ -202,6 +204,8 @@ private:
 
         TRACE_GLOBAL(BrowserConsoleLog, (host->_consoleLogPrefix, messageString, line, 0));
     }
+POP_WARNING()
+
     static gboolean userMessageReceivedCallback(WebKitWebPage* page, WebKitUserMessage* message)
     {
         const char* name = webkit_user_message_get_name(message);

--- a/WebKitBrowser/WebKitImplementation.cpp
+++ b/WebKitBrowser/WebKitImplementation.cpp
@@ -1282,7 +1282,14 @@ static GSourceFuncs _handlerIntervention =
                     WebKitImplementation* object = std::get<0>(data);
                     auto& script = std::get<1>(data);
 #ifdef WEBKIT_GLIB_API
+
+#if WEBKIT_CHECK_VERSION(2, 42, 0)
+                    // length: size of script, or -1 if script is a nul-terminated string
+                    webkit_web_view_evaluate_javascript(object->_view, script.c_str(), -1, nullptr, nullptr, nullptr, nullptr, nullptr);
+#else
                     webkit_web_view_run_javascript(object->_view, script.c_str(), nullptr, nullptr, nullptr);
+#endif
+
 #else
                     auto scriptRef = WKStringCreateWithUTF8CString(script.c_str());
                     WKPageRunJavaScriptInMainFrame(object->_page, scriptRef, nullptr, [](WKSerializedScriptValueRef, WKErrorRef, void*){});


### PR DESCRIPTION
`consoleMessageSentCallback()` has to be marked as `DEPRECATED`, since `webkit_console_message_get_text()` has been deprecated in version 2.40 of WebKit in this PR: https://github.com/WebKit/WebKit/pull/6784. It seems like at the moment there is no other way to get the console messages: https://bugs.webkit.org/show_bug.cgi?id=247791#c4.