### PR TITLE
RDKTV-26356: Wifi SSID's are not scanning and only connected SSID is …

### DIFF
--- a/Miracast/CHANGELOG.md
+++ b/Miracast/CHANGELOG.md
@@ -13,6 +13,10 @@ All notable changes to this RDK Service will be documented in this file.
     Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development.
 
     For more details, refer to versioning section under Main README.
+## [1.0.2] - 2023-12-16
+### Added
+- Fix for RDKTV-26356.
+- Resolve racing condition for wlan and p2p active sacn. Change P2P scan from active to passive scanning
 
 ## [1.0.1] - 2023-11-22
 ### Added

--- a/Miracast/MiracastService/MiracastController.cpp
+++ b/Miracast/MiracastService/MiracastController.cpp
@@ -443,6 +443,7 @@ void MiracastController::checkAndInitiateP2PBackendDiscovery(void)
     else
     {
         MIRACASTLOG_INFO("!!! BACKEND P2P DISCOVERY HAS DISABLED !!!");
+        stop_discover_devices();
     }
 }
 

--- a/Miracast/MiracastService/MiracastService.cpp
+++ b/Miracast/MiracastService/MiracastService.cpp
@@ -47,7 +47,7 @@ using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 1
+#define API_VERSION_NUMBER_PATCH 2
 
 #define SERVER_DETAILS "127.0.0.1:9998"
 #define SYSTEM_CALLSIGN "org.rdk.System"

--- a/Miracast/P2P/MiracastP2P.cpp
+++ b/Miracast/P2P/MiracastP2P.cpp
@@ -437,7 +437,8 @@ MiracastError MiracastP2P::discover_devices(void)
     std::string command, retBuffer,opt_flag_buffer;
     MIRACASTLOG_TRACE("Entering..");
 
-    command = "P2P_FIND";
+    /*Start Passive Scanning*/
+    command = "P2P_EXT_LISTEN 200 1000";
 
     ret = executeCommand(command, NON_GLOBAL_INTERFACE, retBuffer);
     if (ret != MIRACAST_OK)
@@ -454,7 +455,8 @@ MiracastError MiracastP2P::stop_discover_devices(void)
     std::string command, retBuffer;
     MIRACASTLOG_TRACE("Entering...");
 
-    command = "P2P_STOP_FIND";
+    /*Stop Passive Scanning*/
+    command = "P2P_EXT_LISTEN 0 0";
     ret = executeCommand(command, NON_GLOBAL_INTERFACE, retBuffer);
     if (ret != MIRACAST_OK)
     {


### PR DESCRIPTION
…shown

Reason for change: Resolve racing condition for wlan and p2p active sacn. Change P2P scan from active to passive scanning
Test Procedure: Refer RDKTV-26356.
Risks: None
Priority: P1