### PR TITLE
LLAMA-13120: HDMI In/AV In onInputStatusChanged event should include …

### DIFF
--- a/AVInput/AVInput.cpp
+++ b/AVInput/AVInput.cpp
@@ -62,6 +62,7 @@
 #define AVINPUT_EVENT_ON_GAME_FEATURE_STATUS_CHANGED "gameFeatureStatusUpdate"
 #define AVINPUT_EVENT_ON_AVI_CONTENT_TYPE_CHANGED "aviContentTypeUpdate"
 
+static int planeType = 0;
 using namespace std;
 int getTypeOfInput(string sType)
 {
@@ -335,7 +336,7 @@ uint32_t AVInput::startInput(const JsonObject& parameters, JsonObject& response)
     string sType = parameters["typeOfInput"].String();
     int portId = 0;
     int iType = 0;
-    int planeType = 0; //planeType = 0 -  primary, 1 - secondary video plane type
+    planeType = 0; //planeType = 0 -  primary, 1 - secondary video plane type
     bool topMostPlane = parameters["topMost"].Boolean();
     LOGINFO("topMost value in thunder: %d\n",topMostPlane);
     if (parameters.HasLabel("portId") && parameters.HasLabel("typeOfInput"))
@@ -405,6 +406,7 @@ uint32_t AVInput::stopInput(const JsonObject& parameters, JsonObject& response)
         else if (iType == COMPOSITE) {
             device::CompositeInput::getInstance().selectPort(-1);
         }
+	planeType = -1;
     }
     catch (const device::Exception& err) {
         LOGWARN("AVInputService::stopInput Failed");
@@ -723,6 +725,8 @@ void AVInput::AVInputStatusChange( int port , bool isPresented, int type)
     else {
         params["status"] = "stopped";
     }
+    params["plane"] = planeType;
+
     sendNotify(AVINPUT_EVENT_ON_STATUS_CHANGED, params);
 }
 

--- a/AVInput/AVInput.json
+++ b/AVInput/AVInput.json
@@ -684,6 +684,11 @@
                             "type": "integer",
                             "example": 0
                     }
+		     "planeType": {
+                            "summary": "Defines whether the video plane type, 0 - Primary video plane, 1 - Secondary Video Plane, Other values - Invalid ",
+                            "type": "integer",
+                            "example": 0
+                    }
                 },
                 "required": [
                     "id",

--- a/AVInput/AVInput.json
+++ b/AVInput/AVInput.json
@@ -678,6 +678,11 @@
                         "summary": "Status of the HDMI/Composite Input. Valid values are `started` or `stopped`.",
                         "type": "string",
                         "example": "started"
+                    },
+		     "planeType": {
+                            "summary": "Defines whether the video plane type, 0 - Primary video plane, 1 - Secondary Video Plane, Other values - Invalid ",
+                            "type": "integer",
+                            "example": 0
                     }
                 },
                 "required": [

--- a/AVInput/AVInput.json
+++ b/AVInput/AVInput.json
@@ -679,12 +679,7 @@
                         "type": "string",
                         "example": "started"
                     },
-		     "planeType": {
-                            "summary": "Defines whether the video plane type, 0 - Primary video plane, 1 - Secondary Video Plane, Other values - Invalid ",
-                            "type": "integer",
-                            "example": 0
-                    }
-		     "planeType": {
+		     "plane": {
                             "summary": "Defines whether the video plane type, 0 - Primary video plane, 1 - Secondary Video Plane, Other values - Invalid ",
                             "type": "integer",
                             "example": 0

--- a/HdmiInput/HdmiInput.cpp
+++ b/HdmiInput/HdmiInput.cpp
@@ -71,6 +71,7 @@ static int audio_output_delay = 100;
 static int video_latency = 20;
 #define TVMGR_GAME_MODE_EVENT "gameModeEvent"
 static bool lowLatencyMode = false;
+static int planeType = 0;
 #define SERVER_DETAILS  "127.0.0.1:9998"
 
 using namespace std;
@@ -233,7 +234,7 @@ namespace WPEFramework
 	    int portId = 0;    
 	    bool topMostPlane = parameters["topMost"].Boolean();
 	    //planeType = 0 -  primary, 1 - secondary video plane type
-	    int planeType = 0;
+	    planeType = 0;// default video plane
 	    try {
 	        portId = stoi(sPortId);
 		if (parameters.HasLabel("plane")){
@@ -271,6 +272,7 @@ namespace WPEFramework
             try
             {
                 device::HdmiInput::getInstance().selectPort(-1);
+		planeType = -1;// plane index when stopping hdmi input
             }
             catch (const device::Exception& err)
             {
@@ -556,6 +558,8 @@ namespace WPEFramework
 	    else {
                 params["status"] = "stopped";
             }
+            
+	    params["plane"] = planeType;
 
             sendNotify(HDMIINPUT_EVENT_ON_STATUS_CHANGED, params);
         }

--- a/HdmiInput/HdmiInput.json
+++ b/HdmiInput/HdmiInput.json
@@ -453,7 +453,7 @@
                         "type": "string",
                         "example": "started"
                     },
-		    "planeType": {
+		    "plane": {
 			    "summary": "Defines whether the video plane type, 0 - Primary video plane, 1 - Secondary Video Plane, Other values - Invalid ",
 			    "type": "integer",
 			    "example": 0

--- a/HdmiInput/HdmiInput.json
+++ b/HdmiInput/HdmiInput.json
@@ -452,7 +452,12 @@
                         "summary": "Status of the HDMI Input. Valid values are `started` or `stopped`.",
                         "type": "string",
                         "example": "started"
-                    }
+                    },
+		    "planeType": {
+			    "summary": "Defines whether the video plane type, 0 - Primary video plane, 1 - Secondary Video Plane, Other values - Invalid ",
+			    "type": "integer",
+			    "example": 0
+		    }
                 },
                 "required": [
                     "id",

--- a/Tests/tests/test_HdmiInput.cpp
+++ b/Tests/tests/test_HdmiInput.cpp
@@ -430,7 +430,7 @@ TEST_F(HdmiInputInitializedEventDsTest, onInputStatusChangeOn)
             [&](const uint32_t, const Core::ProxyType<Core::JSON::IElement>& json) {
                 string text;
                 EXPECT_TRUE(json->ToString(text));
-                EXPECT_EQ(text, string(_T("{\"jsonrpc\":\"2.0\",\"method\":\"client.events.onInputStatusChanged.onInputStatusChanged\",\"params\":{\"id\":0,\"locator\":\"hdmiin:\\/\\/localhost\\/deviceid\\/0\",\"status\":\"started\"}}")));
+                EXPECT_EQ(text, string(_T("{\"jsonrpc\":\"2.0\",\"method\":\"client.events.onInputStatusChanged.onInputStatusChanged\",\"params\":{\"id\":0,\"locator\":\"hdmiin:\\/\\/localhost\\/deviceid\\/0\",\"status\":\"started\",\"plane\":0}}")));
                 return Core::ERROR_NONE;
             }));
     IARM_Bus_DSMgr_EventData_t eventData;
@@ -449,7 +449,7 @@ TEST_F(HdmiInputInitializedEventDsTest, onInputStatusChangeOff)
             [&](const uint32_t, const Core::ProxyType<Core::JSON::IElement>& json) {
                 string text;
                 EXPECT_TRUE(json->ToString(text));
-                EXPECT_EQ(text, string(_T("{\"jsonrpc\":\"2.0\",\"method\":\"client.events.onInputStatusChanged.onInputStatusChanged\",\"params\":{\"id\":0,\"locator\":\"hdmiin:\\/\\/localhost\\/deviceid\\/0\",\"status\":\"stopped\"}}")));
+                EXPECT_EQ(text, string(_T("{\"jsonrpc\":\"2.0\",\"method\":\"client.events.onInputStatusChanged.onInputStatusChanged\",\"params\":{\"id\":0,\"locator\":\"hdmiin:\\/\\/localhost\\/deviceid\\/0\",\"status\":\"stopped\",\"plane\":-1}}")));
                 return Core::ERROR_NONE;
             }));
     IARM_Bus_DSMgr_EventData_t eventData;


### PR DESCRIPTION
…Plane Parameter

Reason for change: Window manager uses plane parameter to examine if the Hdmi/Composite geometry is updated against correct video window.
Test Procedure: Build and verify
Risks: Medium
Priority: P1
Signed-off-by: Aishwariya B <aishwariya.bhaskar@sky.uk>