### PR TITLE
(CherryPick UnitTestcases for TTS from 23Q4) RDK-37917: Add UT for TTS and SAP

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,7 +11,6 @@ env:
   THUNDER_REF: "5e7c0b1ed3c3dd0fc31c86518a364388dc24273b"
   INTERFACES_REF: "669d9c6e5ed7a5938ff26e1e7736adf485c7a205"
 
-
 jobs:
   unit-tests:
     name: Build and run unit tests
@@ -57,7 +56,7 @@ jobs:
             !install/usr/lib/pkgconfig/gtest.pc
             !install/usr/lib/pkgconfig/gtest_main.pc
             !install/usr/lib/wpeframework/plugins
-          key: ${{ runner.os }}-${{ env.THUNDER_REF }}-${{ env.INTERFACES_REF }}-2
+          key: ${{ runner.os }}-${{ env.THUNDER_REF }}-${{ env.INTERFACES_REF }}-3
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -74,12 +73,22 @@ jobs:
         run: >
           sudo apt update
           &&
-          sudo apt install -y libsqlite3-dev libcurl4-openssl-dev valgrind lcov clang libsystemd-dev
+          sudo apt install -y libsqlite3-dev libcurl4-openssl-dev valgrind lcov clang libsystemd-dev libboost-all-dev libwebsocketpp-dev meson libcunit1 libcunit1-dev
 
       - name: Install GStreamer
         run: |
            sudo apt update
            sudo apt install -y libunwind-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev
+
+      - name: Build trevor-base64
+        run: |
+            if [ ! -d "trower-base64" ]; then
+            git clone https://github.com/xmidt-org/trower-base64.git
+            fi
+            cd trower-base64
+            meson setup --warnlevel 3 --werror build
+            ninja -C build
+            sudo ninja -C build install
 
       - name: Checkout Thunder
         if: steps.cache.outputs.cache-hit != 'true'
@@ -95,6 +104,7 @@ jobs:
           cmake
           -S "${{github.workspace}}/Thunder/Tools"
           -B build/ThunderTools
+          -DEXCEPTIONS_ENABLE=ON
           -DCMAKE_INSTALL_PREFIX="${{github.workspace}}/install/usr"
           -DCMAKE_MODULE_PATH="${{github.workspace}}/install/tools/cmake"
           -DGENERIC_CMAKE_MODULE_PATH="${{github.workspace}}/install/tools/cmake"
@@ -111,6 +121,7 @@ jobs:
           -DBUILD_TYPE=${{env.BUILD_TYPE}}
           -DBINDING=127.0.0.1
           -DPORT=55555
+          -DEXCEPTIONS_ENABLE=ON
           &&
           cmake --build build/Thunder -j8
           &&
@@ -130,6 +141,7 @@ jobs:
           cmake
           -S "${{github.workspace}}/ThunderInterfaces"
           -B build/ThunderInterfaces
+          -DEXCEPTIONS_ENABLE=ON
           -DCMAKE_INSTALL_PREFIX="${{github.workspace}}/install/usr"
           -DCMAKE_MODULE_PATH="${{github.workspace}}/install/tools/cmake"
           &&
@@ -195,7 +207,7 @@ jobs:
           maintenanceMGR.h
           pkg.h
           &&
-          cp -r /usr/include/gstreamer-1.0/gst /usr/include/glib-2.0/* /usr/lib/x86_64-linux-gnu/glib-2.0/include/* .
+          cp -r /usr/include/gstreamer-1.0/gst /usr/include/glib-2.0/* /usr/lib/x86_64-linux-gnu/glib-2.0/include/* /usr/local/include/trower-base64/base64.h .
 
       - name: Set clang toolchain
         if: ${{ matrix.compiler == 'clang' }}
@@ -214,6 +226,7 @@ jobs:
           -DCMAKE_INSTALL_PREFIX="${{github.workspace}}/install/usr"
           -DCMAKE_MODULE_PATH="${{github.workspace}}/install/tools/cmake"
           -DCMAKE_CXX_FLAGS="
+          -DEXCEPTIONS_ENABLE=ON
           -I ${{github.workspace}}/rdkservices/Tests/headers
           -I ${{github.workspace}}/rdkservices/Tests/headers/audiocapturemgr
           -I ${{github.workspace}}/rdkservices/Tests/headers/rdk/ds
@@ -229,7 +242,7 @@ jobs:
           -include ${{github.workspace}}/rdkservices/Tests/mocks/Udev.h
           -include ${{github.workspace}}/rdkservices/Tests/mocks/maintenanceMGR.h
           -include ${{github.workspace}}/rdkservices/Tests/mocks/pkg.h
-          -Wall -Werror
+          -Wall -Werror -Wno-error=format=
           -Wl,-wrap,system -Wl,-wrap,popen -Wl,-wrap,syslog
           -DENABLE_TELEMETRY_LOGGING
           -DUSE_IARMBUS
@@ -275,6 +288,7 @@ jobs:
           -DPLUGIN_ACTIVITYMONITOR=ON
           -DDS_FOUND=ON
           -DPLUGIN_TEXTTOSPEECH=ON
+          -DPLUGIN_SYSTEMAUDIOPLAYER=ON
           -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
           &&
           cmake --build build/rdkservices -j8

--- a/SystemAudioPlayer/CMakeLists.txt
+++ b/SystemAudioPlayer/CMakeLists.txt
@@ -15,7 +15,13 @@ find_package(Boost COMPONENTS system filesystem REQUIRED)
 find_package(websocketpp REQUIRED)
 find_package(OpenSSL REQUIRED)
 
-add_subdirectory(test)
+if (NOT RDK_SERVICES_TEST)
+    add_subdirectory(test)
+endif()
+
+set_source_files_properties(
+    SystemAudioPlayerImplementation.cpp
+    PROPERTIES COMPILE_FLAGS "-fexceptions")
 
 add_library(${MODULE_NAME} SHARED
         Module.cpp
@@ -64,6 +70,11 @@ elseif (BUILD_BROADCOM)
     target_sources(${MODULE_NAME}
         PRIVATE
             impl/broadcom/SoC_abstraction.cpp
+    )
+elseif (RDK_SERVICES_TEST)
+    target_sources(${MODULE_NAME}
+        PRIVATE
+            test/SoC_abstraction.cpp
     )
 endif()
 

--- a/SystemAudioPlayer/SystemAudioPlayer.cpp
+++ b/SystemAudioPlayer/SystemAudioPlayer.cpp
@@ -61,7 +61,9 @@ namespace Plugin {
 
         std::string message;
         if(_sap != nullptr) {
-            ASSERT(_connectionId != 0);
+            #ifndef UNIT_TESTING
+                ASSERT(_connectionId != 0);
+            #endif
 
             _sap->Configure(_service);
             _sap->Register(&_notification);

--- a/SystemAudioPlayer/SystemAudioPlayerImplementation.cpp
+++ b/SystemAudioPlayer/SystemAudioPlayerImplementation.cpp
@@ -99,18 +99,26 @@ namespace Plugin {
         CONVERT_PARAMETERS_TOJSON();
         CHECK_SAP_PARAMETER_RETURN_ON_FAIL("audiotype");
         CHECK_SAP_PARAMETER_RETURN_ON_FAIL("sourcetype");
+        CHECK_SAP_PARAMETER_RETURN_ON_FAIL("playmode");
         SAPLOG_INFO("SAP: SystemAudioPlayerImplementation Open\n");
-        AudioType audioType;
-        SourceType sourceType;
-        PlayMode playMode;
-        std::string s_audioType,s_sourceType,s_playMode;
-      
-        s_audioType = parameters["audiotype"].String(); 
-        s_sourceType = parameters["sourcetype"].String();
-        s_playMode = parameters["playmode"].String();    
-        audioType = audioTypeFromString( s_audioType);
-        sourceType = sourceTypeFromString( s_sourceType);
-        playMode = playModeFromString( s_playMode);
+
+        auto audioType = audioTypeFromString(parameters["audiotype"].String());
+        if(audioType == AudioType::AudioType_None) {
+            SAPLOG_INFO("SystemAudioPlayerImplementation Open Audiotype :%s is not supported", parameters["audiotype"].String().c_str());
+            returnResponse(false);
+        }
+
+        auto sourceType = sourceTypeFromString(parameters["sourcetype"].String());
+        if(sourceType == SourceType::SourceType_None) {
+            SAPLOG_INFO("SystemAudioPlayerImplementation Open SourceType :%s is not supported", parameters["sourcetype"].String().c_str());
+            returnResponse(false);
+        }
+
+        auto playMode = playModeFromString(parameters["playmode"].String());
+        if(playMode == PlayMode::PlayMode_None) {
+            SAPLOG_INFO("SystemAudioPlayerImplementation Open PlayMode :%s is not supported", parameters["playmode"].String().c_str());
+            returnResponse(false);
+        }
 
         int id;
         _adminLock.Lock();      
@@ -170,6 +178,7 @@ namespace Plugin {
         string url;
         int playerid;
         url = parameters["url"].String();
+        CHECK_SAP_PARAMETER_URL_VALID_RETURN_ON_FAIL(url.c_str());
         extractFileProtocol(url); //we do not store file:// for file playback
         _adminLock.Lock();
         if(GetSessionFromUrl(url,playerid))
@@ -199,18 +208,22 @@ namespace Plugin {
         _adminLock.Lock();
          player = getObjectFromMap(id); 
         _adminLock.Unlock();
-        if(player != NULL)
-        {
-            if(player->getSourceType() == SourceType::FILESRC)
-            {
-                if(!extractFileProtocol(url))
-                {
+
+         if(player != NULL) {
+            string sourceType = sourceTypeToString(player->getSourceType());
+            if(!std::regex_match(url, patternMap.at(sourceType))) {
+                SAPLOG_ERROR("SAP: SystemAudioPlayerImplementation Source %s and Url %s is different",sourceType.c_str(),url.c_str());
+                returnResponse(false);
+            }
+
+            if(player->getSourceType() == SourceType::FILESRC) {
+                if(!extractFileProtocol(url)) {
                     returnResponse(false);
                 }
             }
+
             _adminLock.Lock();
-            if(SameModeNotPlaying(player,id))
-            {
+            if(SameModeNotPlaying(player,id)) {
                 _adminLock.Unlock();
                 player->Play(url);
                 returnResponse(true);
@@ -316,7 +329,7 @@ namespace Plugin {
         _adminLock.Lock();
         player = getObjectFromMap(playerId);
         _adminLock.Unlock();
-        if (player != NULL &&  ( primVol >= 0 && thisVol >= 0 ) )
+        if (player != NULL &&  ( primVol >= 0 && primVol <= 100 && thisVol >= 0 && thisVol <=100) )
         {
             player->SetMixerLevels(primVol, thisVol);
             result = true;
@@ -359,7 +372,7 @@ namespace Plugin {
         _adminLock.Lock();
         player = getObjectFromMap(playerId);
         _adminLock.Unlock();
-        if (player != NULL &&  ( thresHold >= 0.0 && detectTimeMs >= 0 && holdTimeMs >= 0 && duckPercent >= 0 ) )
+        if (player != NULL &&  ( thresHold >= 0.0 && detectTimeMs >= 0 && holdTimeMs >= 0 && duckPercent >= 0 && duckPercent <=100) )
         {
             player->SetSmartVolControl( smartVolumeEnable, thresHold, detectTimeMs, holdTimeMs, duckPercent);
             result = true;
@@ -412,12 +425,20 @@ namespace Plugin {
 
     uint32_t SystemAudioPlayerImplementation::IsPlaying(const string &input, string &output)
     {
+        SAPLOG_INFO("SystemAudioPlayerImplementation Got IsPlayingrequest :%s\n",input.c_str());
         CONVERT_PARAMETERS_TOJSON();
+        AudioPlayer *player;
+        int id;
+        bool ret = false;
+        getNumberParameter("id", id);
+        SAPLOG_INFO("SAP: SystemAudioPlayerImplementation IsPlaying\n");
         _adminLock.Lock();
-
+        player = getObjectFromMap(id);
         _adminLock.Unlock();
-
-        return Core::ERROR_NONE;
+        if(player != NULL) {
+            ret = player->isPlaying();;
+        }
+        returnResponse(ret);
     }
 
     impl::SecurityParameters SystemAudioPlayerImplementation::extractSecurityParams(const JsonObject& params) const

--- a/SystemAudioPlayer/SystemAudioPlayerImplementation.h
+++ b/SystemAudioPlayer/SystemAudioPlayerImplementation.h
@@ -28,12 +28,24 @@
 #include "impl/logger.h"
 #include "impl/SecurityParameters.h"
 #include <vector>
+#include <regex>
 
 #define CHECK_SAP_PARAMETER_RETURN_ON_FAIL(param) do {\
     if(!parameters.HasLabel(param)) { \
         LOGERR("Parameter \"%s\" is not found", param); \
         returnResponse(false); \
     } } while(0)
+
+#define CHECK_SAP_PARAMETER_URL_VALID_RETURN_ON_FAIL(param) do {\
+        if(param[0] == '\0') { \
+            returnResponse(false); \
+        } \
+        std::regex uriRegex("(file:///.*|((ws|wss)://.*)|data://.*|(https?://.*)|(http://.*))"); \
+        bool status = std::regex_match(param, uriRegex); \
+        if(!status) { \
+            returnResponse(false); \
+        } \
+} while(0)
 
 #define CHECK_SAP_CONFIG_RETURN_ON_FAIL(param) do {\
     if(!config.HasLabel(param)) { \
@@ -49,6 +61,12 @@
         catch (...) { param = 0; } \
 }
 
+const static std::map<std::string, std::regex> patternMap = {
+    {"websocket", std::regex("^(ws|wss)://.*")},
+    {"data", std::regex("^data://.*")},
+    {"filesrc", std::regex("^file:///.*")},
+    {"httpsrc", std::regex("^(http|https)://.*")}
+};
 
 namespace WPEFramework {
 namespace Plugin {

--- a/SystemAudioPlayer/impl/AudioPlayer.h
+++ b/SystemAudioPlayer/impl/AudioPlayer.h
@@ -83,6 +83,9 @@ class AudioPlayer
     int m_duckPercent;
     static GMainLoop   *m_main_loop;
     static GThread     *m_main_loop_thread;
+    static bool m_isLoopStarted;
+    static std::mutex m_eventMutex;
+    static std::condition_variable m_eventCondition;
     static SAPEventCallback *m_callback;
     int objectIdentifier;
     std::atomic<bool> m_isPaused;
@@ -144,6 +147,7 @@ class AudioPlayer
     gboolean PushDataAppSrc();
     static void Init(SAPEventCallback *callback);
     static void DeInit();
+    static void waitForMainLoop();
     static int GstBusCallback(GstBus *bus, GstMessage *message, gpointer data); 
     static void event_loop();
     int getObjectIdentifier();

--- a/SystemAudioPlayer/test/SoC_abstraction.cpp
+++ b/SystemAudioPlayer/test/SoC_abstraction.cpp
@@ -1,0 +1,18 @@
+#include "../impl/SoC_abstraction.h"
+
+void Soc_Initialize()
+{
+   //To do	
+}
+void Soc_Deinitialize()
+{
+   //To do
+}
+
+void SoC_ChangePrimaryVol(MixGain gain, int volume)
+{
+	 if(gain == MIXGAIN_PRIM)
+	 {		
+	    //To do
+	 }		
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -28,7 +28,6 @@ FetchContent_Declare(
         URL https://github.com/google/googletest/archive/609281088cfefc76f9d0ce82e1ff6c30cc3591e5.zip
 )
 FetchContent_MakeAvailable(googletest)
-
 file(GLOB TESTS tests/*.cpp)
 add_executable(${PROJECT_NAME}
         ${TESTS}
@@ -89,6 +88,7 @@ include_directories(../LocationSync
         ../MaintenanceManager
         ../Packager
 	../TextToSpeech
+	../SystemAudioPlayer
         )
 link_directories(../LocationSync
         ../PersistentStore
@@ -127,6 +127,7 @@ link_directories(../LocationSync
         ../MaintenanceManager
         ../Packager
 	../TextToSpeech
+	../SystemAudioPlayer
         )
 
 target_link_libraries(${PROJECT_NAME}
@@ -169,6 +170,7 @@ target_link_libraries(${PROJECT_NAME}
         ${NAMESPACE}MaintenanceManager
         ${NAMESPACE}Packager
 	${NAMESPACE}TextToSpeech
+	${NAMESPACE}SystemAudioPlayer
         )
 
 target_include_directories(${PROJECT_NAME}

--- a/Tests/tests/test_SystemAudioPlayer.cpp
+++ b/Tests/tests/test_SystemAudioPlayer.cpp
@@ -1,0 +1,1850 @@
+#include <gtest/gtest.h>
+#include "SystemAudioPlayer.h"
+#include "SystemAudioPlayerImplementation.h"
+#include "ServiceMock.h"
+#include "COMLinkMock.h"
+#include "FactoriesImplementation.h"
+#include "WorkerPoolImplementation.h"
+
+using namespace WPEFramework;
+using ::testing::Test;
+using ::testing::NiceMock;
+
+namespace {
+const string config = _T("SystemAudioPlayer");
+const string callSign = _T("org.rdk.SystemAudioPlayer");
+const string webPrefix = _T("/Service/SystemAudioPlayer");
+const string volatilePath = _T("/tmp/");
+const string dataPath = _T("/tmp/");
+}
+
+class SAPTest : public Test {
+protected:
+    Core::ProxyType<Plugin::SystemAudioPlayer> plugin;
+    Core::JSONRPC::Handler& handler;
+    Core::JSONRPC::Connection connection;
+    Core::ProxyType<WorkerPoolImplementation> workerPool;
+
+    SAPTest()
+        : plugin(Core::ProxyType<Plugin::SystemAudioPlayer>::Create())
+        , handler(*(plugin))
+        , connection(1, 0)
+        , workerPool(Core::ProxyType<WorkerPoolImplementation>::Create(
+            2, Core::Thread::DefaultStackSize(), 16)) {
+    }
+
+    virtual ~SAPTest() = default;
+};
+
+class SAPInitializedTest : public SAPTest {
+protected:
+    NiceMock<FactoriesImplementation> factoriesImplementation;
+    NiceMock<ServiceMock> service;
+    NiceMock<COMLinkMock> comLinkMock;
+    PluginHost::IDispatcher* dispatcher;
+    Core::ProxyType<Plugin::SystemAudioPlayerImplementation> SystemAudioPlayerImplementation;
+    string response;
+
+    SAPInitializedTest() : SAPTest() {
+        SystemAudioPlayerImplementation = Core::ProxyType<Plugin::SystemAudioPlayerImplementation>::Create();
+
+        ON_CALL(service, ConfigLine())
+            .WillByDefault(::testing::Return("{}"));
+        ON_CALL(service, WebPrefix())
+            .WillByDefault(::testing::Return(webPrefix));
+        ON_CALL(service, VolatilePath())
+            .WillByDefault(::testing::Return(volatilePath));
+        ON_CALL(service, Callsign())
+            .WillByDefault(::testing::Return(callSign));
+                ON_CALL(service, DataPath())
+            .WillByDefault(::testing::Return(dataPath));
+        ON_CALL(service, COMLink())
+            .WillByDefault(::testing::Return(&comLinkMock));
+        ON_CALL(comLinkMock, Instantiate(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_))
+            .WillByDefault(::testing::Return(SystemAudioPlayerImplementation));
+
+        PluginHost::IFactories::Assign(&factoriesImplementation);
+        Core::IWorkerPool::Assign(&(*workerPool));
+        workerPool->Run();
+
+        dispatcher = static_cast<PluginHost::IDispatcher*>(
+            plugin->QueryInterface(PluginHost::IDispatcher::ID));
+        dispatcher->Activate(&service);
+    }
+
+    virtual ~SAPInitializedTest() override {
+        plugin.Release();
+        SystemAudioPlayerImplementation.Release();
+        Core::IWorkerPool::Assign(nullptr);
+        workerPool.Release();
+        PluginHost::IFactories::Assign(nullptr);
+        dispatcher->Deactivate();
+        dispatcher->Release();
+    }
+};
+
+TEST_F(SAPInitializedTest,RegisteredMethods) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("close")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("config")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("getPlayerSessionId")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("isspeaking")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("open")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("pause")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("play")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("playbuffer")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("resume")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("setMixerLevels")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("setSmartVolControl")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("stop")));
+}
+
+/*******************************************************************************************************************
+ * Test function for open
+ * Open                    :
+ *                Opens a player instance and assigns it a unique ID
+ *
+ *                @return Response object contains id and success status
+ * Use case coverage:
+ *                @Success : 24
+ *                @Failure : 3
+ ********************************************************************************************************************/
+
+/**
+ * @name  : SAPOpenPCMWebsocketSystem
+ * @brief : Open a player instance with pcm, websocket, system 
+ * 
+ * @param[in]   :  audiotype ,sourcetype, playmode
+ * @return      :  {id:1, success: true}
+ */
+
+TEST_F(SAPInitializedTest, SAPOpenPCMWebsocketSystem) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"pcm\",\"sourcetype\": \"websocket\",\"playmode\": \"system\" }"),
+         response
+    ));
+    EXPECT_EQ(response, _T("{\"id\":1,\"success\":true}"));
+}
+
+/**
+ * @name  : SAPOpenPCMDataSystem
+ * @brief : Open a player instance with pcm, websocket, app
+ * 
+ * @param[in]   :  audiotype ,sourcetype, playmode
+ * @return      :  {id:3, success: true}
+ */
+
+TEST_F(SAPInitializedTest,SAPOpenPCMDataSystem) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"pcm\",\"sourcetype\": \"data\",\"playmode\": \"system\" }"),
+         response
+    ));
+    EXPECT_EQ(response, _T("{\"id\":2,\"success\":true}"));
+}
+
+/**
+ * @name  : SAPOpenPCMWebsocketApp
+ * @brief : Open a player instance with pcm, websocket, app
+ * 
+ * @param[in]   :  audiotype ,sourcetype, playmode
+ * @return      :  {id:3, success: true}
+ */
+
+TEST_F(SAPInitializedTest,SAPOpenPCMWebsocketApp) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"pcm\",\"sourcetype\": \"websocket\",\"playmode\": \"app\" }"),
+         response
+    ));
+    EXPECT_EQ(response, _T("{\"id\":3,\"success\":true}"));
+}
+
+/**
+ * @name  : SAPOpenPCMDataApp
+ * @brief : Open a player instance with pcm, data, app
+ * 
+ * @param[in]   :  audiotype ,sourcetype, playmode
+ * @return      :  {id:4, success: true}
+ */
+
+TEST_F(SAPInitializedTest,SAPOpenPCMDataApp) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"pcm\",\"sourcetype\": \"data\",\"playmode\": \"app\" }"),
+         response
+    ));
+    EXPECT_EQ(response, _T("{\"id\":4,\"success\":true}"));
+}
+
+/**
+ * @name  : SAPOpenPCMFilesrcSystem
+ * @brief : Open a player instance with pcm, filesrc, systen
+ * 
+ * @param[in]   :  audiotype ,sourcetype, playmode
+ * @return      :  {id:5, success: true}
+ */
+
+TEST_F(SAPInitializedTest,SAPOpenPCMFilesrcSystem) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"pcm\",\"sourcetype\": \"filesrc\",\"playmode\": \"system\" }"),
+         response
+    ));
+    EXPECT_EQ(response, _T("{\"id\":5,\"success\":true}"));
+}
+
+/**
+ * @name  : SAPOpenPCMFilesrcApp
+ * @brief : Open a player instance with pcm, filesrc, app
+ * 
+ * @param[in]   :  audiotype ,sourcetype, playmode
+ * @return      :  {id:6, success: true}
+ */
+
+TEST_F(SAPInitializedTest,SAPOpenPCMFilesrcApp) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"pcm\",\"sourcetype\": \"filesrc\",\"playmode\": \"app\" }"),
+         response
+    ));
+    EXPECT_EQ(response, _T("{\"id\":6,\"success\":true}"));
+}
+
+/**
+ * @name  : SAPOpenPCMHttpsrcSystem
+ * @brief : Open a player instance with pcm, httpsrc, system
+ * 
+ * @param[in]   :  audiotype ,sourcetype, playmode
+ * @return      :  {id:7, success: true}
+ */
+
+TEST_F(SAPInitializedTest,SAPOpenPCMHttpsrcSystem) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"pcm\",\"sourcetype\": \"httpsrc\",\"playmode\": \"system\" }"),
+         response
+    ));
+    EXPECT_EQ(response, _T("{\"id\":7,\"success\":true}"));
+}
+
+/**
+ * @name  : SAPOpenPCMHttpsrcApp
+ * @brief : Open a player instance with pcm, httpsrc, app
+ * 
+ * @param[in]   :  audiotype ,sourcetype, playmode
+ * @return      :  {id:8, success: true}
+ */
+
+TEST_F(SAPInitializedTest,SAPOpenPCMHttpsrcApp) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"pcm\",\"sourcetype\": \"httpsrc\",\"playmode\": \"app\" }"),
+         response
+    ));
+    EXPECT_EQ(response, _T("{\"id\":8,\"success\":true}"));
+}
+
+/**
+ * @name  : SAPMp3WebsocketSystem
+ * @brief : Open a player instance with mp3, websocket, system
+ * 
+ * @param[in]   :  audiotype ,sourcetype, playmode
+ * @return      :  {id:9, success: true}
+ */
+
+TEST_F(SAPInitializedTest,SAPMp3WebsocketSystem) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"mp3\",\"sourcetype\": \"websocket\",\"playmode\": \"system\" }"),
+         response
+    ));
+    EXPECT_EQ(response, _T("{\"id\":9,\"success\":true}"));
+}
+
+/**
+ * @name  : SAPMp3WebsocketApp
+ * @brief : Open a player instance with mp3, websocket, app
+ * 
+ * @param[in]   :  audiotype ,sourcetype, playmode
+ * @return      :  {id:10, success: true}
+ */
+
+TEST_F(SAPInitializedTest,SAPMp3WebsocketApp) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"mp3\",\"sourcetype\": \"websocket\",\"playmode\": \"app\" }"),
+         response
+    ));
+    EXPECT_EQ(response, _T("{\"id\":10,\"success\":true}"));
+}
+
+/**
+ * @name  : SAPMp3DataSystem
+ * @brief : Open a player instance with mp3, data, system
+ * 
+ * @param[in]   :  audiotype ,sourcetype, playmode
+ * @return      :  {id:11, success: true}
+ */
+
+TEST_F(SAPInitializedTest,SAPMp3DataSystem) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"mp3\",\"sourcetype\": \"data\",\"playmode\": \"system\" }"),
+         response
+    ));
+    EXPECT_EQ(response, _T("{\"id\":11,\"success\":true}"));
+}
+
+/**
+ * @name  : SAPMp3DataApp
+ * @brief : Open a player instance with mp3, data, app
+ * 
+ * @param[in]   :  audiotype ,sourcetype, playmode
+ * @return      :  {id:12, success: true}
+ */
+
+TEST_F(SAPInitializedTest,SAPMp3DataApp) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"mp3\",\"sourcetype\": \"data\",\"playmode\": \"app\" }"),
+         response
+    ));
+    EXPECT_EQ(response, _T("{\"id\":12,\"success\":true}"));
+}
+
+/**
+ * @name  : SAPMp3FilesrcSystem
+ * @brief : Open a player instance with mp3, filesrc, system
+ * 
+ * @param[in]   :  audiotype ,sourcetype, playmode
+ * @return      :  {id:13, success: true}
+ */
+
+TEST_F(SAPInitializedTest,SAPMp3FilesrcSystem) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"mp3\",\"sourcetype\": \"filesrc\",\"playmode\": \"system\" }"),
+         response
+    ));
+    EXPECT_EQ(response, _T("{\"id\":13,\"success\":true}"));
+}
+
+/**
+ * @name  : SAPMp3FilesrcApp
+ * @brief : Open a player instance with mp3, filesrc, app
+ * 
+ * @param[in]   :  audiotype ,sourcetype, playmode
+ * @return      :  {id:14, success: true}
+ */
+
+TEST_F(SAPInitializedTest,SAPMp3FilesrcApp) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"mp3\",\"sourcetype\": \"filesrc\",\"playmode\": \"app\" }"),
+         response
+    ));
+    EXPECT_EQ(response, _T("{\"id\":14,\"success\":true}"));
+}
+
+/**
+ * @name  : SAPMp3HttpsrcSystem
+ * @brief : Open a player instance with mp3, httpsrc, system
+ * 
+ * @param[in]   :  audiotype ,sourcetype, playmode
+ * @return      :  {id:15, success: true}
+ */
+
+TEST_F(SAPInitializedTest,SAPMp3HttpsrcSystem) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"mp3\",\"sourcetype\": \"httpsrc\",\"playmode\": \"system\" }"),
+         response
+    ));
+    EXPECT_EQ(response, _T("{\"id\":15,\"success\":true}"));
+}
+
+/**
+ * @name  : SAPMp3HttpsrcApp
+ * @brief : Open a player instance with mp3, httpsrc, app
+ * 
+ * @param[in]   :  audiotype ,sourcetype, playmode
+ * @return      :  {id:16, success: true}
+ */
+
+TEST_F(SAPInitializedTest,SAPMp3HttpsrcApp) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"mp3\",\"sourcetype\": \"httpsrc\",\"playmode\": \"app\" }"),
+         response
+    ));
+    EXPECT_EQ(response, _T("{\"id\":16,\"success\":true}"));
+}
+
+/**
+ * @name  : SAPWavWebsocketSystem
+ * @brief : Open a player instance with wav, websocket, system
+ * 
+ * @param[in]   :  audiotype ,sourcetype, playmode
+ * @return      :  {id:17, success: true}
+ */
+
+TEST_F(SAPInitializedTest,SAPWavWebsocketSystem) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"wav\",\"sourcetype\": \"websocket\",\"playmode\": \"system\" }"),
+         response
+    ));
+    EXPECT_EQ(response, _T("{\"id\":17,\"success\":true}"));
+}
+
+/**
+ * @name  : SAPWavWebsocketApp
+ * @brief : Open a player instance with wav, websocket, app
+ * 
+ * @param[in]   :  audiotype ,sourcetype, playmode
+ * @return      :  {id:18, success: true}
+ */
+
+TEST_F(SAPInitializedTest,SAPWavWebsocketApp) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"wav\",\"sourcetype\": \"websocket\",\"playmode\": \"app\" }"),
+         response
+    ));
+    EXPECT_EQ(response, _T("{\"id\":18,\"success\":true}"));
+}
+
+/**
+ * @name  : SAPWavDataSystem
+ * @brief : Open a player instance with wav, data, system
+ * 
+ * @param[in]   :  audiotype ,sourcetype, playmode
+ * @return      :  {id:19, success: true}
+ */
+
+TEST_F(SAPInitializedTest,SAPWavDataSystem) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"wav\",\"sourcetype\": \"data\",\"playmode\": \"system\" }"),
+         response
+    ));
+    EXPECT_EQ(response, _T("{\"id\":19,\"success\":true}"));
+}
+
+/**
+ * @name  : SAPWavDataApp
+ * @brief : Open a player instance with wav, data, app
+ * 
+ * @param[in]   :  audiotype ,sourcetype, playmode
+ * @return      :  {id:20, success: true}
+ */
+
+TEST_F(SAPInitializedTest,SAPWavDataApp) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"wav\",\"sourcetype\": \"data\",\"playmode\": \"app\" }"),
+         response
+    ));
+    EXPECT_EQ(response, _T("{\"id\":20,\"success\":true}"));
+}
+
+/**
+ * @name  : SAPWavFileSrcSystem
+ * @brief : Open a player instance with wav, filesrc, system
+ * 
+ * @param[in]   :  audiotype ,sourcetype, playmode
+ * @return      :  {id:21, success: true}
+ */
+
+TEST_F(SAPInitializedTest,SAPWavFileSrcSystem) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"wav\",\"sourcetype\": \"filesrc\",\"playmode\": \"system\" }"),
+         response
+    ));
+    EXPECT_EQ(response, _T("{\"id\":21,\"success\":true}"));
+}
+
+/**
+ * @name  : SAPWavFileSrcApp
+ * @brief : Open a player instance with wav, filesrc, app
+ * 
+ * @param[in]   :  audiotype ,sourcetype, playmode
+ * @return      :  {id:22, success: true}
+ */
+
+TEST_F(SAPInitializedTest,SAPWavFileSrcApp) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"wav\",\"sourcetype\": \"filesrc\",\"playmode\": \"app\" }"),
+         response
+    ));
+    EXPECT_EQ(response, _T("{\"id\":22,\"success\":true}"));
+}
+
+/**
+ * @name  : SAPWavHttpSrcSystem
+ * @brief : Open a player instance with wav, httpsrc, system
+ * 
+ * @param[in]   :  audiotype ,sourcetype, playmode
+ * @return      :  {id:23, success: true}
+ */
+
+TEST_F(SAPInitializedTest,SAPWavHttpSrcSystem) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"wav\",\"sourcetype\": \"httpsrc\",\"playmode\": \"system\" }"),
+         response
+    ));
+    EXPECT_EQ(response, _T("{\"id\":23,\"success\":true}"));
+}
+
+/**
+ * @name  : SAPWavHttpSrcApp
+ * @brief : Open a player instance with wav, httpsrc, app
+ * 
+ * @param[in]   :  audiotype ,sourcetype, playmode
+ * @return      :  {id:24, success: true}
+ */
+
+TEST_F(SAPInitializedTest,SAPWavHttpSrcApp) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"wav\",\"sourcetype\": \"httpsrc\",\"playmode\": \"app\" }"),
+         response
+    ));
+    EXPECT_EQ(response, _T("{\"id\":24,\"success\":true}"));
+}
+
+/**
+ * @name  : SAPOpenInvalidAudioType
+ * @brief : Given InvalidAudioType It should return false
+ * 
+ * @param[in]   :  audiotype ,sourcetype, playmode
+ * @return      :  {success: false}
+ */
+
+TEST_F(SAPInitializedTest,SAPOpenInvalidAudioType) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"invalid\",\"sourcetype\": \"websocket\",\"playmode\": \"system\" }"),
+         response
+    ));
+    EXPECT_EQ(response, _T("{\"success\":false}"));
+}
+
+/**
+ * @name  : SAPOpenInvalidSourceType
+ * @brief : Given InvalidSourceType It should return false
+ * 
+ * @param[in]   :  audiotype ,sourcetype, playmode
+ * @return      :  {success: false}
+ */
+
+TEST_F(SAPInitializedTest,SAPOpenInvalidSourceType) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"pcm\",\"sourcetype\": \"invalid\",\"playmode\": \"system\" }"),
+         response
+    ));
+    EXPECT_EQ(response, _T("{\"success\":false}"));
+}
+
+/**
+ * @name  : SAPOpenInvalidPlayMode
+ * @brief : Given InvalidPlayMode It should return false
+ * 
+ * @param[in]   :  audiotype ,sourcetype, playmode
+ * @return      :  {success: false}
+ */
+
+TEST_F(SAPInitializedTest,SAPOpenInvalidPlayMode) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"pcm\",\"sourcetype\": \"websocket\",\"playmode\": \"invalid\" }"),
+         response
+    ));
+    EXPECT_EQ(response, _T("{\"success\":false}"));
+}
+/*******************************************************************************************************************
+ * Test function for config
+ * Open                    :
+ *                Configures playback for a PCM audio source (audio/x-raw) on the specified player
+ *
+ *                @return Response object success status
+ * Use case coverage:
+ *                @Success : 1
+ *                @Failure : 2
+ ********************************************************************************************************************/
+/**
+ * @name  : SAPConfig
+ * @brief : Sets a config for PCM audio playback
+ * 
+ * @param[in]   :  audiotype ,sourcetype, playmode
+ * @return      :  {success: true}
+ */
+
+TEST_F(SAPInitializedTest, SAPConfig) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"pcm\",\"sourcetype\": \"filesrc\",\"playmode\": \"system\" }"),
+         response
+    ));
+
+    size_t idPos = response.find("\"id\"");
+    if (idPos != string::npos) {
+        size_t idStart = response.find(':', idPos) + 1;
+        size_t idEnd = response.find(',', idPos);
+        std::string idSubstring = response.substr(idStart, idEnd - idStart);
+        int speechId = std::stoi(idSubstring);
+        std::cout << "Speech ID: " << speechId << std::endl;
+
+        EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("config"),
+        _T("{\"id\": ") +
+            std::to_string(speechId) +
+            _T(", \"pcmconfig\": {\"format\": \"S16LE\",\"rate\": \"22050\",\"channels\": \"1\",\"layout\": \"interleaved\"},")
+            _T("\"websocketsecparam\": {\"cafilenames\": [{\"cafilename\": \"/etc/ssl/certs/Xfinity_Subscriber_ECC_Root.pem\"}],")
+            _T("\"certfilename\": \"...\",\"keyfilename\": \"...\"}}"),
+        response
+        ));
+
+        EXPECT_EQ(response, _T("{\"success\":true}"));
+    } else {
+        EXPECT_TRUE(false) << "Error: 'id' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SAPConfigForOtherAudioType
+ * @brief : Sets a config for MP3 audio playback
+ * 
+ * @param[in]   :  audiotype ,sourcetype, playmode
+ * @return      :  {success: false}
+ */
+
+TEST_F(SAPInitializedTest, SAPConfigForOtherAudioType) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"mp3\",\"sourcetype\": \"websocket\",\"playmode\": \"system\" }"),
+         response
+    ));
+
+    size_t idPos = response.find("\"id\"");
+    if (idPos != string::npos) {
+        size_t idStart = response.find(':', idPos) + 1;
+        size_t idEnd = response.find(',', idPos);
+        std::string idSubstring = response.substr(idStart, idEnd - idStart);
+        int speechId = std::stoi(idSubstring);
+        std::cout << "Speech ID: " << speechId << std::endl;
+
+        EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("config"),
+        _T("{\"id\": ") +
+            std::to_string(speechId) +
+            _T(", \"pcmconfig\": {\"format\": \"S16LE\",\"rate\": \"22050\",\"channels\": \"1\",\"layout\": \"interleaved\"},")
+            _T("\"websocketsecparam\": {\"cafilenames\": [{\"cafilename\": \"/etc/ssl/certs/Xfinity_Subscriber_ECC_Root.pem\"}],")
+            _T("\"certfilename\": \"...\",\"keyfilename\": \"...\"}}"),
+        response
+        ));
+
+        EXPECT_EQ(response, _T("{\"success\":false}"));
+    } else {
+        EXPECT_TRUE(false) << "Error: 'id' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SAPConfigWithoutOpen
+ * @brief : Sets a config without player instance
+ * 
+ * @param[in]   :  audiotype ,sourcetype, playmode
+ * @return      :  {success: false}
+ */
+
+TEST_F(SAPInitializedTest,SAPConfigWithoutOpen) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+    _T("config"),
+    _T("{\"id\": 1, "
+       "\"pcmconfig\": {\"format\": \"S16LE\", \"rate\": \"22050\", \"channels\": \"1\", \"layout\": \"interleaved\"}, "
+       "\"websocketsecparam\": {\"cafilenames\": [{\"cafilename\": \"/etc/ssl/certs/Xfinity_Subscriber_ECC_Root.pem\"}], "
+       "\"certfilename\": \"...\", \"keyfilename\": \"...\"}}"),
+    response
+    ));
+    EXPECT_EQ(response, _T("{\"success\":false}"));
+}
+
+/*******************************************************************************************************************
+ * Test function for play
+ * Open                    :
+ *                Plays audio on the specified player.
+ *
+ *                @return Response object success status
+ * Use case coverage:
+ *                @Success : 4
+ *                @Failure : 3
+ ********************************************************************************************************************/
+
+/**
+ * @name  : SAPPlayWebsocket
+ * @brief : plays a player instance
+ * 
+ * @param[in]   :  id ,url 
+ * @return      :  {success: true}
+ */
+
+TEST_F(SAPInitializedTest, SAPPlayWebsocket) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"pcm\",\"sourcetype\": \"websocket\",\"playmode\": \"system\" }"),
+         response
+    ));
+
+    size_t idPos = response.find("\"id\"");
+    if (idPos != string::npos) {
+        size_t idStart = response.find(':', idPos) + 1;
+        size_t idEnd = response.find(',', idPos);
+        std::string idSubstring = response.substr(idStart, idEnd - idStart); 
+        int speechId = std::stoi(idSubstring);
+        std::cout << "Speech ID: " << speechId << std::endl;
+
+        EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+            _T("play"),
+            _T("{\"id\": ") + std::to_string(speechId) + _T(", \"url\": \"ws://example.com/socket\" }"),
+            response
+        ));
+        EXPECT_EQ(response, _T("{\"success\":true}"));
+    } else {
+        EXPECT_TRUE(false) << "Error: 'id' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SAPPlayDataSrc
+ * @brief : plays a player instance
+ * 
+ * @param[in]   :  id ,url 
+ * @return      :  {success: true}
+ */
+
+TEST_F(SAPInitializedTest, SAPPlayDataSrc) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"pcm\",\"sourcetype\": \"data\",\"playmode\": \"system\" }"),
+         response
+    ));
+
+    size_t idPos = response.find("\"id\"");
+    if (idPos != string::npos) {
+        size_t idStart = response.find(':', idPos) + 1;
+        size_t idEnd = response.find(',', idPos);
+        std::string idSubstring = response.substr(idStart, idEnd - idStart);
+        int speechId = std::stoi(idSubstring);
+        std::cout << "Speech ID: " << speechId << std::endl;
+
+        EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+            _T("play"),
+            _T("{\"id\": ") + std::to_string(speechId) + _T(", \"url\": \"data://example/data\" }"),
+            response
+        ));
+        EXPECT_EQ(response, _T("{\"success\":true}"));
+    } else {
+        EXPECT_TRUE(false) << "Error: 'id' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SAPPlayFilesrc
+ * @brief : Opens a player instance with source:filesrc but given http url
+ * 
+ * @param[in]   :  id ,url 
+ * @return      :  {success: false}
+ */
+
+TEST_F(SAPInitializedTest, SAPPlayFilesrc) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"wav\",\"sourcetype\": \"filesrc\",\"playmode\": \"system\" }"),
+         response
+    ));
+
+    size_t idPos = response.find("\"id\"");
+    if (idPos != string::npos) {
+        size_t idStart = response.find(':', idPos) + 1;
+        size_t idEnd = response.find(',', idPos);
+        std::string idSubstring = response.substr(idStart, idEnd - idStart);
+        int speechId = std::stoi(idSubstring);
+        std::cout << "Speech ID: " << speechId << std::endl;
+
+        EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+            _T("play"),
+            _T("{\"id\": ") + std::to_string(speechId) + _T(", \"url\": \"file:///example/data\" }"),
+            response
+        ));
+        EXPECT_EQ(response, _T("{\"success\":true}"));
+        sleep(1);
+    } else {
+        EXPECT_TRUE(false) << "Error: 'id' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SAPPlayHttpsrc
+ * @brief : Opens a player instance with source:httpsrc but given http url
+ * 
+ * @param[in]   :  id ,url 
+ * @return      :  {success: false}
+ */
+
+TEST_F(SAPInitializedTest, SAPPlayHttpsrc) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"pcm\",\"sourcetype\": \"httpsrc\",\"playmode\": \"system\" }"),
+         response
+    ));
+
+    size_t idPos = response.find("\"id\"");
+    if (idPos != string::npos) {
+        size_t idStart = response.find(':', idPos) + 1;
+        size_t idEnd = response.find(',', idPos);
+        std::string idSubstring = response.substr(idStart, idEnd - idStart);
+        int speechId = std::stoi(idSubstring);
+        std::cout << "Speech ID: " << speechId << std::endl;
+
+        EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+            _T("play"),
+            _T("{\"id\": ") + std::to_string(speechId) + _T(", \"url\": \"http://example/data\" }"),
+            response
+        ));
+        EXPECT_EQ(response, _T("{\"success\":true}"));
+    } else {
+        EXPECT_TRUE(false) << "Error: 'id' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SAPPlayDifferentSrcUrl
+ * @brief : Opens a player instance with source:httpsrc but given http url
+ * 
+ * @param[in]   :  id ,url 
+ * @return      :  {success: false}
+ */
+
+TEST_F(SAPInitializedTest, SAPPlayDifferentSrcUrl) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"pcm\",\"sourcetype\": \"httpsrc\",\"playmode\": \"system\" }"),
+         response
+    ));
+
+    size_t idPos = response.find("\"id\"");
+    if (idPos != string::npos) {
+        size_t idStart = response.find(':', idPos) + 1;
+        size_t idEnd = response.find(',', idPos);
+        std::string idSubstring = response.substr(idStart, idEnd - idStart);
+        int speechId = std::stoi(idSubstring);
+        std::cout << "Speech ID: " << speechId << std::endl;
+
+        EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+            _T("play"),
+            _T("{\"id\": ") + std::to_string(speechId) + _T(", \"url\": \"file:///example/data\" }"),
+            response
+        ));
+        EXPECT_EQ(response, _T("{\"success\":false}"));
+    } else {
+        EXPECT_TRUE(false) << "Error: 'id' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SAPPlayWithoutOpen
+ * @brief : Sets a play without player instance
+ * 
+ * @param[in]   :  id ,url
+ * @return      :  {success: false}
+ */
+
+TEST_F(SAPInitializedTest,SAPPlayWithoutOpen) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, \
+        _T("play"),
+        _T("{\"id\": 1, \"url\": \"https://example/data\"}"), 
+        response
+    ));
+    EXPECT_EQ(response, _T("{\"success\":false}"));
+}
+
+/**
+ * @name  : SAPPlayInvalidUrl
+ * @brief : Play with invalid url
+ * 
+ * @param[in]   :  id , url
+ * @return      :  {success: false}
+ */
+
+TEST_F(SAPInitializedTest, SAPPlayInvalidUrl) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));   
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, 
+        _T("play"),
+        _T("{\"id\": 1,\"url\": \"invalid\" }"), 
+        response
+    ));
+    EXPECT_EQ(response, _T("{\"success\":false}")); 
+}
+
+/*******************************************************************************************************************
+ * Test function for close
+ * Close                    :
+ *                Closes the specified Player
+ *
+ *                @return Response object success status
+ * Use case coverage:
+ *                @Success : 1
+ *                @Failure : 1
+ ********************************************************************************************************************/
+
+/**
+ * @name  : SAPClose
+ * @brief : Closes the player instance
+ * 
+ * @param[in]   :  id
+ * @return      :  {success: true}
+ */
+
+TEST_F(SAPInitializedTest, SAPClose) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"pcm\",\"sourcetype\": \"websocket\",\"playmode\": \"system\" }"),
+         response
+    ));
+
+    size_t idPos = response.find("\"id\"");
+    if (idPos != string::npos) {
+        size_t idStart = response.find(':', idPos) + 1;
+        size_t idEnd = response.find(',', idPos);
+        std::string idSubstring = response.substr(idStart, idEnd - idStart);
+        int speechId = std::stoi(idSubstring);
+        std::cout << "Speech ID: " << speechId << std::endl;
+
+        EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, 
+            _T("close"),
+            _T("{\"id\": ") + std::to_string(speechId) + _T("}"), 
+            response
+        ));
+        EXPECT_EQ(response, _T("{\"success\":true}"));
+    } else {
+        EXPECT_TRUE(false) << "Error: 'id' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SAPCloseWithoutOpen
+ * @brief : Close the player Which is not opened
+ * 
+ * @param[in]   :  id
+ * @return      :  {success: false}
+ */
+
+TEST_F(SAPInitializedTest,SAPCloseWithoutOpen) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("close"),
+        _T("{\"id\": 1}"),
+        response
+    ));
+    EXPECT_EQ(response, _T("{\"success\":false}"));
+}
+
+/*******************************************************************************************************************
+ * Test function for resume
+ * Resume                    :
+ *                Resumes the specified Player
+ *
+ *                @return Response object success status
+ * Use case coverage:
+ *                @Success : 1
+ *                @Failure : 1
+ ********************************************************************************************************************/
+
+/**
+ * @name  : SAPResume
+ * @brief : Resume the player instance
+ * 
+ * @param[in]   :  id
+ * @return      :  {success: false}
+ */
+
+TEST_F(SAPInitializedTest, SAPResume) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"pcm\",\"sourcetype\": \"websocket\",\"playmode\": \"system\" }"),
+         response
+    ));
+
+    size_t idPos = response.find("\"id\"");
+    if (idPos != string::npos) {
+        size_t idStart = response.find(':', idPos) + 1;
+        size_t idEnd = response.find(',', idPos);
+        std::string idSubstring = response.substr(idStart, idEnd - idStart);
+        int speechId = std::stoi(idSubstring);
+        std::cout << "Speech ID: " << speechId << std::endl;
+
+        EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, 
+            _T("resume"),
+            _T("{\"id\": ") + std::to_string(speechId) + _T("}"), 
+            response\
+        ));
+        EXPECT_EQ(response, _T("{\"success\":false}"));
+    } else {
+        EXPECT_TRUE(false) << "Error: 'id' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SAPResumeWithOutOpen
+ * @brief : Resume the invalid player
+ * 
+ * @param[in]   :  id
+ * @return      :  {success: false}
+ */
+
+TEST_F(SAPInitializedTest,SAPResumeWithOutOpen) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("resume"),
+        _T("{\"id\": 1}"),
+        response
+    ));
+    EXPECT_EQ(response, _T("{\"success\":false}"));
+}
+
+/*******************************************************************************************************************
+ * Test function for pause
+ * Pause                   :
+ *                Closes the specified Player
+ *
+ *                @return Response object success status
+ * Use case coverage:
+ *                @Success : 1
+ *                @Failure : 1
+ ********************************************************************************************************************/
+
+/**
+ * @name  : SAPPause
+ * @brief : Pause the player instance
+ * 
+ * @param[in]   :  id
+ * @return      :  {success: false}
+ */
+
+TEST_F(SAPInitializedTest, SAPPause) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"pcm\",\"sourcetype\": \"websocket\",\"playmode\": \"system\" }"),
+         response
+    ));
+
+    size_t idPos = response.find("\"id\"");
+    if (idPos != string::npos) {
+        size_t idStart = response.find(':', idPos) + 1;
+        size_t idEnd = response.find(',', idPos);
+        std::string idSubstring = response.substr(idStart, idEnd - idStart);
+        int speechId = std::stoi(idSubstring);
+        std::cout << "Speech ID: " << speechId << std::endl;
+
+        EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, 
+            _T("pause"),
+            _T("{\"id\": ") + std::to_string(speechId) + _T("}"), 
+            response\
+        ));
+        EXPECT_EQ(response, _T("{\"success\":false}"));
+    } else {
+        EXPECT_TRUE(false) << "Error: 'id' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SAPPauseWithOutOpen
+ * @brief : Pause the invalid player
+ * 
+ * @param[in]   :  id
+ * @return      :  {success: false}
+ */
+TEST_F(SAPInitializedTest,SAPPauseWithoutOpen) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("pause"),
+        _T("{\"id\": 1}"),
+        response
+    ));
+    EXPECT_EQ(response, _T("{\"success\":false}"));
+}
+
+/*******************************************************************************************************************
+ * Test function for stop
+ * Stop                  :
+ *                stop the specified Players connection with source
+ *
+ *                @return Response object success status
+ * Use case coverage:
+ *                @Success : 1
+ *                @Failure : 1
+ ********************************************************************************************************************/
+
+/**
+ * @name  : SAPStop
+ * @brief : Stop the connection between websocket
+ * 
+ * @param[in]   :  id
+ * @return      :  {success: true}
+ */
+
+TEST_F(SAPInitializedTest, SAPStop) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"pcm\",\"sourcetype\": \"websocket\",\"playmode\": \"system\" }"),
+         response
+    ));
+
+    size_t idPos = response.find("\"id\"");
+    if (idPos != string::npos) {
+        size_t idStart = response.find(':', idPos) + 1;
+        size_t idEnd = response.find(',', idPos);
+        std::string idSubstring = response.substr(idStart, idEnd - idStart);
+        int speechId = std::stoi(idSubstring);
+        std::cout << "Speech ID: " << speechId << std::endl;
+
+        EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, 
+            _T("stop"),
+            _T("{\"id\": ") + std::to_string(speechId) + _T("}"), 
+            response\
+        ));
+        EXPECT_EQ(response, _T("{\"success\":true}"));
+    } else {
+        EXPECT_TRUE(false) << "Error: 'id' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SAPStopWithOutOpen
+ * @brief : Stop the invalid player
+ * 
+ * @param[in]   :  id
+ * @return      :  {success: false}
+ */
+
+TEST_F(SAPInitializedTest,SAPStopWithoutOpen) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("stop"),
+        _T("{\"id\": 1}"),
+        response
+    ));
+    EXPECT_EQ(response, _T("{\"success\":false}"));
+}
+
+/*******************************************************************************************************************
+ * Test function for isSpeaking
+ * isSpeaking                 :
+ *                Checks the player instance is speaking or not
+ *
+ *                @return Response object success status
+ * Use case coverage:
+ *                @Success : 1
+ *                @Failure : 1
+ ********************************************************************************************************************/
+
+/**
+ * @name  : SAPIsSpeaking
+ * @brief : checks the player instance is speaking or not
+ * 
+ * @param[in]   :  id
+ * @return      :  {success: false}
+ */
+
+TEST_F(SAPInitializedTest, SAPIsSpeaking) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"pcm\",\"sourcetype\": \"websocket\",\"playmode\": \"system\" }"),
+         response
+    ));
+
+    size_t idPos = response.find("\"id\"");
+    if (idPos != string::npos) {
+        size_t idStart = response.find(':', idPos) + 1;
+        size_t idEnd = response.find(',', idPos);
+        std::string idSubstring = response.substr(idStart, idEnd - idStart);
+        int speechId = std::stoi(idSubstring);
+        std::cout << "Speech ID: " << speechId << std::endl;
+
+        EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+            _T("isspeaking"),
+            _T("{\"id\": ") + std::to_string(speechId) + _T("}"), 
+            response
+        ));
+        EXPECT_EQ(response, _T("{\"success\":false}"));
+    } else {
+        EXPECT_TRUE(false) << "Error: 'id' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SAPisSpeakingWithoutOpen
+ * @brief : Check isSpeaking the invalid player
+ * 
+ * @param[in]   :  id
+ * @return      :  {success: false}
+ */
+
+TEST_F(SAPInitializedTest,SAPisSpeakingWithoutOpen) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("isspeaking"),
+        _T("{\"id\": 1}"),
+        response
+    ));
+    EXPECT_EQ(response, _T("{\"success\":false}"));
+}
+
+/*******************************************************************************************************************
+ * Test function for playbuffer
+ * PlayBuffer                 :
+ *                Buffers the audio playback on the specified player
+ *
+ *                @return Response object success status
+ * Use case coverage:
+ *                @Success : 1
+ *                @Failure : 1
+ ********************************************************************************************************************/
+/**
+ * @name  : SAPPlayBuffer
+ * @brief : Buffers the audio playback on the specified player.
+ * 
+ * @param[in]   :  id , data
+ * @return      :  {success: true}
+ */
+
+TEST_F(SAPInitializedTest, SAPPlayBuffer) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"pcm\",\"sourcetype\": \"websocket\",\"playmode\": \"system\" }"),
+         response
+    ));
+
+    size_t idPos = response.find("\"id\"");
+    if (idPos != string::npos) {
+        size_t idStart = response.find(':', idPos) + 1;
+        size_t idEnd = response.find(',', idPos);
+        std::string idSubstring = response.substr(idStart, idEnd - idStart);
+        int speechId = std::stoi(idSubstring);
+        std::cout << "Speech ID: " << speechId << std::endl;
+
+        EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+            _T("playbuffer"), 
+            _T("{\"id\": ") + std::to_string(speechId) + _T(",\"data\": \"180\"}"),
+            response
+        ));
+        EXPECT_EQ(response, _T("{\"success\":true}"));
+    } else {
+        EXPECT_TRUE(false) << "Error: 'id' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SAPPlayBufferWithoutOpen
+ * @brief : Buffer on invalid player
+ * 
+ * @param[in]   :  id , data
+ * @return      :  {success: false}
+ */
+
+TEST_F(SAPInitializedTest,SAPPlayBufferWithoutOpen) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("playbuffer"),
+        _T("{\"id\": 1 , \"data\": \"180\"}"),
+        response
+    ));
+    EXPECT_EQ(response, _T("{\"success\":false}"));
+}
+
+/*******************************************************************************************************************
+ * Test function for setMixerLevel
+ * setMixerLevel                 :
+ *                Sets the audio level on the specified player. The SystemAudioPlayer plugin can control the volume of the content being played back as well as the primary program audio; 
+ *                thus, an application can duck down the volume on the primary program
+ *                audio when system audio is played and then restore it back when the system audio playback is complete.
+ *
+ *                @return Response object success status
+ * Use case coverage:
+ *                @Success : 1
+ *                @Failure : 5
+ ********************************************************************************************************************/
+
+/**
+ * @name  : SAPSetMixerLevel
+ * @brief : SettingMixerlevels for Player
+ * 
+ * @param[in]   :  id , primaryVolume , player volume
+ * @return      :  {success: true}
+ */
+
+TEST_F(SAPInitializedTest, SAPSetMixerLevel) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"pcm\",\"sourcetype\": \"websocket\",\"playmode\": \"system\" }"),
+         response
+    ));
+
+    size_t idPos = response.find("\"id\"");
+    if (idPos != string::npos) {
+        size_t idStart = response.find(':', idPos) + 1;
+        size_t idEnd = response.find(',', idPos);
+        std::string idSubstring = response.substr(idStart, idEnd - idStart);
+        int speechId = std::stoi(idSubstring);
+        std::cout << "Speech ID: " << speechId << std::endl;
+
+        EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+            _T("setMixerLevels"),
+            _T("{\"id\": ") + std::to_string(speechId) + _T(",\"primaryVolume\": \"80\" ,\"playerVolume\": \"70\"}"),
+            response
+        ));
+        EXPECT_EQ(response, _T("{\"success\":true}"));
+    } else {
+        EXPECT_TRUE(false) << "Error: 'id' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SAPSetMixerLevelPriVolLessThanZero
+ * @brief : Set Primary Volume less than zero and expects failure
+ * 
+ * @param[in]   :  id , primaryVolume , player volume
+ * @return      :  {success: false}
+ */
+
+TEST_F(SAPInitializedTest, SAPSetMixerLevelPriVolLessThanZero) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"pcm\",\"sourcetype\": \"websocket\",\"playmode\": \"system\" }"),
+         response
+    ));
+
+    size_t idPos = response.find("\"id\"");
+    if (idPos != string::npos) {
+        size_t idStart = response.find(':', idPos) + 1;
+        size_t idEnd = response.find(',', idPos);
+        std::string idSubstring = response.substr(idStart, idEnd - idStart);
+        int speechId = std::stoi(idSubstring);
+        std::cout << "Speech ID: " << speechId << std::endl;
+
+        EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+            _T("setMixerLevels"),
+            _T("{\"id\": ") + std::to_string(speechId) + _T(",\"primaryVolume\": \"-1\" ,\"playerVolume\": \"70\"}"),
+            response
+        ));
+        EXPECT_EQ(response, _T("{\"success\":false}"));
+    } else {
+        EXPECT_TRUE(false) << "Error: 'id' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SAPSetMixerLevelPlayerVolLessThanZero
+ * @brief : Set Player Volume less than zero and expects failure
+ * 
+ * @param[in]   :  id , primaryVolume , player volume
+ * @return      :  {success: false}
+ */
+
+TEST_F(SAPInitializedTest, SAPSetMixerLevelPlayerVolLessThanZero) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"pcm\",\"sourcetype\": \"websocket\",\"playmode\": \"system\" }"),
+         response
+    ));
+
+  size_t idPos = response.find("\"id\"");
+    if (idPos != string::npos) {
+        size_t idStart = response.find(':', idPos) + 1;
+        size_t idEnd = response.find(',', idPos);
+        std::string idSubstring = response.substr(idStart, idEnd - idStart);
+        int speechId = std::stoi(idSubstring);
+        std::cout << "Speech ID: " << speechId << std::endl;
+
+        EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+            _T("setMixerLevels"),
+            _T("{\"id\": ") + std::to_string(speechId) + _T(",\"primaryVolume\": \"80\" ,\"playerVolume\": \"-1\"}"),
+            response
+        ));
+        EXPECT_EQ(response, _T("{\"success\":false}"));
+    } else {
+        EXPECT_TRUE(false) << "Error: 'id' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SAPSetMixerLevelPriVolGreaterThan100
+ * @brief : Set Primary Volume Greater than 100 and expects failure
+ * 
+ * @param[in]   :  id , primaryVolume , player volume
+ * @return      :  {success: false}
+ */
+
+TEST_F(SAPInitializedTest, SAPSetMixerLevelPriVolGreaterThan100) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"pcm\",\"sourcetype\": \"websocket\",\"playmode\": \"system\" }"),
+         response
+    ));
+
+  size_t idPos = response.find("\"id\"");
+    if (idPos != string::npos) {
+        size_t idStart = response.find(':', idPos) + 1;
+        size_t idEnd = response.find(',', idPos);
+        std::string idSubstring = response.substr(idStart, idEnd - idStart);
+        int speechId = std::stoi(idSubstring);
+        std::cout << "Speech ID: " << speechId << std::endl;
+
+        EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+            _T("setMixerLevels"),
+            _T("{\"id\": ") + std::to_string(speechId) + _T(",\"primaryVolume\": \"101\" ,\"playerVolume\": \"70\"}"),
+            response
+        ));
+        EXPECT_EQ(response, _T("{\"success\":false}"));
+    } else {
+        EXPECT_TRUE(false) << "Error: 'id' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SAPSetMixerLevelPlayerVolGreaterThan100
+ * @brief : Set Player Volume Greater than 100 and expects failure
+ * 
+ * @param[in]   :  id , primaryVolume , player volume
+ * @return      :  {success: false}
+ */
+
+TEST_F(SAPInitializedTest, SAPSetMixerLevelPlayerVolGreaterThan100) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"pcm\",\"sourcetype\": \"websocket\",\"playmode\": \"system\" }"),
+         response
+    ));
+
+  size_t idPos = response.find("\"id\"");
+    if (idPos != string::npos) {
+        size_t idStart = response.find(':', idPos) + 1;
+        size_t idEnd = response.find(',', idPos);
+        std::string idSubstring = response.substr(idStart, idEnd - idStart);
+        int speechId = std::stoi(idSubstring);
+        std::cout << "Speech ID: " << speechId << std::endl;
+
+        EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+            _T("setMixerLevels"),
+            _T("{\"id\": ") + std::to_string(speechId) + _T(",\"primaryVolume\": \"80\" ,\"playerVolume\": \"101\"}"),
+            response
+        ));
+        EXPECT_EQ(response, _T("{\"success\":false}"));
+    } else {
+        EXPECT_TRUE(false) << "Error: 'id' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SAPSetMixerLevelsWithoutOpen
+ * @brief : SettingMixerlevels for invalidPlayer
+ * 
+ * @param[in]   :  id , primaryVolume , player volume
+ * @return      :  {success: false}
+ */
+
+TEST_F(SAPInitializedTest,SAPSetMixerLevelsWithoutOpen) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("setMixerLevels"),
+        _T("{\"id\": 1 , \"primaryVolume\": \"180\" ,\"playerVolume\": \"7\" }"), 
+        response
+    ));
+    EXPECT_EQ(response, _T("{\"success\":false}"));
+}
+
+/*******************************************************************************************************************
+ * Test function for SetSmartVolControl
+ * SetSmartVolControl                 :
+ *                Sets the smart volume audio control on the specified player. 
+ *                The plugin can control the smart volume of the content being played back as well as the primary program audio; 
+ *                thus, an application can duck down the volume on the primary program audio when system audio is played 
+ *                and then restore it back when the system audio playback is complete.
+ *
+ *                @return Response object success status
+ * Use case coverage:
+ *                @Success : 1
+ *                @Failure : 5
+ ********************************************************************************************************************/
+/**
+ * @name  : SAPSetSmartVolControl
+ * @brief : SettingSAPSetSmartVolControl for Player
+ * 
+ * @param[in]   :  id, enable, playerAudioLevelThreshold, playerDetectTimeMs, playerHoldTimeMs, primaryDuckingPercent
+ * @return      :  {success: true}
+ */
+
+TEST_F(SAPInitializedTest, SAPSetSmartVolControl) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"pcm\",\"sourcetype\": \"websocket\",\"playmode\": \"system\" }"),
+         response
+    ));
+
+    size_t idPos = response.find("\"id\"");
+    if (idPos != string::npos) {
+        size_t idStart = response.find(':', idPos) + 1;
+        size_t idEnd = response.find(',', idPos);
+        std::string idSubstring = response.substr(idStart, idEnd - idStart);
+        int speechId = std::stoi(idSubstring);
+        std::cout << "Speech ID: " << speechId << std::endl;
+
+        EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+            _T("setSmartVolControl"),
+            _T("{\"id\": ") + std::to_string(speechId) + _T(",\"enable\": true, \"playerAudioLevelThreshold\": 0.1, \"playerDetectTimeMs\": 200, \"playerHoldTimeMs\": 1000, \"primaryDuckingPercent\": 1 }"), 
+            response
+        ));
+        EXPECT_EQ(response, _T("{\"success\":true}"));
+    } else {
+        EXPECT_TRUE(false) << "Error: 'id' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SAPSetSmartVolControlThresholdLessThanZero
+ * @brief : Set Thresholdvaluse < 0 which result in failure
+ * 
+ * @param[in]   :  threshold = -1 
+ * @return      :  {success: false}
+ */
+
+TEST_F(SAPInitializedTest, SAPSetSmartVolControlThresholdLessThanZero) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"pcm\",\"sourcetype\": \"websocket\",\"playmode\": \"system\" }"),
+         response
+    ));
+
+    size_t idPos = response.find("\"id\"");
+    if (idPos != string::npos) {
+        size_t idStart = response.find(':', idPos) + 1;
+        size_t idEnd = response.find(',', idPos);
+        std::string idSubstring = response.substr(idStart, idEnd - idStart);
+        int speechId = std::stoi(idSubstring);
+        std::cout << "Speech ID: " << speechId << std::endl;
+
+        EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+            _T("setSmartVolControl"),
+            _T("{\"id\": ") + std::to_string(speechId) + _T(",\"enable\": true, \"playerAudioLevelThreshold\": -1, \"playerDetectTimeMs\": 200, \"playerHoldTimeMs\": 1000, \"primaryDuckingPercent\": 1 }"), 
+            response
+        ));
+        EXPECT_EQ(response, _T("{\"success\":false}"));
+    } else {
+        EXPECT_TRUE(false) << "Error: 'id' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SAPSetSmartVolControlDetectTimeMsLessThanZero
+ * @brief : Set detectTimeMs < 0 which result in failure
+ * 
+ * @param[in]   :   detectTimeMs = -1 
+ * @return      :  {success: false}
+ */
+
+TEST_F(SAPInitializedTest, SAPSetSmartVolControlDetectTimeMsLessThanZero) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"pcm\",\"sourcetype\": \"websocket\",\"playmode\": \"system\" }"),
+         response
+    ));
+
+    size_t idPos = response.find("\"id\"");
+    if (idPos != string::npos) {
+        size_t idStart = response.find(':', idPos) + 1;
+        size_t idEnd = response.find(',', idPos);
+        std::string idSubstring = response.substr(idStart, idEnd - idStart);
+        int speechId = std::stoi(idSubstring);
+        std::cout << "Speech ID: " << speechId << std::endl;
+
+        EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+            _T("setSmartVolControl"),
+            _T("{\"id\": ") + std::to_string(speechId) + _T(",\"enable\": true, \"playerAudioLevelThreshold\": 0.1, \"playerDetectTimeMs\": -1, \"playerHoldTimeMs\": 1000, \"primaryDuckingPercent\": 1 }"), 
+            response
+        ));
+        EXPECT_EQ(response, _T("{\"success\":false}"));
+    } else {
+        EXPECT_TRUE(false) << "Error: 'id' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SAPSetSmartVolControlHoldTimeMsLessThanZero
+ * @brief : Set holdTimeMs < 0 which result in failure
+ * 
+ * @param[in]   :  holdTimeMs = -1 
+ * @return      :  {success: false}
+ */
+
+TEST_F(SAPInitializedTest, SAPSetSmartVolControlHoldTimeMsLessThanZero) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"pcm\",\"sourcetype\": \"websocket\",\"playmode\": \"system\" }"),
+         response
+    ));
+
+    size_t idPos = response.find("\"id\"");
+    if (idPos != string::npos) {
+        size_t idStart = response.find(':', idPos) + 1;
+        size_t idEnd = response.find(',', idPos);
+        std::string idSubstring = response.substr(idStart, idEnd - idStart);
+        int speechId = std::stoi(idSubstring);
+        std::cout << "Speech ID: " << speechId << std::endl;
+
+        EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+            _T("setSmartVolControl"),
+            _T("{\"id\": ") + std::to_string(speechId) + _T(",\"enable\": true, \"playerAudioLevelThreshold\": 0.1, \"playerDetectTimeMs\": 200, \"playerHoldTimeMs\": -1, \"primaryDuckingPercent\": 1 }"), 
+            response
+        ));
+        EXPECT_EQ(response, _T("{\"success\":false}"));
+    } else {
+        EXPECT_TRUE(false) << "Error: 'id' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SAPSetSmartVolControlDuckPercentLessThanZero
+ * @brief : Set primaryDuckingPercent < 0 which result in failure
+ * 
+ * @param[in]   :  primaryDuckingPercent = -1 
+ * @return      :  {success: false}
+ */
+
+TEST_F(SAPInitializedTest, SAPSetSmartVolControlDuckPercentLessThanZero) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"pcm\",\"sourcetype\": \"websocket\",\"playmode\": \"system\" }"),
+         response
+    ));
+
+    size_t idPos = response.find("\"id\"");
+    if (idPos != string::npos) {
+        size_t idStart = response.find(':', idPos) + 1;
+        size_t idEnd = response.find(',', idPos);
+        std::string idSubstring = response.substr(idStart, idEnd - idStart);
+        int speechId = std::stoi(idSubstring);
+        std::cout << "Speech ID: " << speechId << std::endl;
+
+        EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+            _T("setSmartVolControl"),
+            _T("{\"id\": ") + std::to_string(speechId) + _T(",\"enable\": true, \"playerAudioLevelThreshold\": 0.1, \"playerDetectTimeMs\": 200, \"playerHoldTimeMs\": 1000, \"primaryDuckingPercent\": -1 }"), 
+            response
+        ));
+        EXPECT_EQ(response, _T("{\"success\":false}"));
+    } else {
+        EXPECT_TRUE(false) << "Error: 'id' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SAPSetSmartVolControlDuckPercentLessThanZero
+ * @brief : Set primaryDuckingPercent < 0 which result in failure
+ * 
+ * @param[in]   :  primaryDuckingPercent = -1 
+ * @return      :  {success: false}
+ */
+
+TEST_F(SAPInitializedTest, SAPSetSmartVolControlDuckPercentGreaterThan100) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"pcm\",\"sourcetype\": \"websocket\",\"playmode\": \"system\" }"),
+         response
+    ));
+
+    size_t idPos = response.find("\"id\"");
+    if (idPos != string::npos) {
+        size_t idStart = response.find(':', idPos) + 1;
+        size_t idEnd = response.find(',', idPos);
+        std::string idSubstring = response.substr(idStart, idEnd - idStart);
+        int speechId = std::stoi(idSubstring);
+        std::cout << "Speech ID: " << speechId << std::endl;
+
+        EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+            _T("setSmartVolControl"),
+            _T("{\"id\": ") + std::to_string(speechId) + _T(",\"enable\": true, \"playerAudioLevelThreshold\": 0.1, \"playerDetectTimeMs\": 200, \"playerHoldTimeMs\": 1000, \"primaryDuckingPercent\": 101 }"), 
+            response
+        ));
+        EXPECT_EQ(response, _T("{\"success\":false}"));
+    } else {
+        EXPECT_TRUE(false) << "Error: 'id' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SAPSetSmartVolControlWithoutOpen
+ * @brief : SettingSmartVolControl for invalidPlayer
+ * 
+ * @param[in]   :  id, enable, playerAudioLevelThreshold, playerDetectTimeMs, playerHoldTimeMs, primaryDuckingPercent
+ * @return      :  {success: false}
+ */
+TEST_F(SAPInitializedTest,SAPSetSmartVolControlWithoutOpen) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("setSmartVolControl"), 
+        _T("{\"id\": 1 , \"enable\": true, \"playerAudioLevelThreshold\": 0.1, \"playerDetectTimeMs\": 200, \"playerHoldTimeMs\": 1000, \"primaryDuckingPercent\": 1 }"), 
+        response
+    ));
+    EXPECT_EQ(response, _T("{\"success\":false}"));
+}
+
+/*******************************************************************************************************************
+ * Test function for getPlayerSessionId
+ * getPlayerSessionId                 :
+ *                Gets the session ID from the provided the URL. The session is the ID returned in open cal.
+ *                
+ *                @return Response object contains session id and success status
+ * Use case coverage:
+ *                @Success : 1
+ *                @Failure : 2
+ ********************************************************************************************************************/
+/**
+ * @name  : SAPGetPlayerSessionId
+ * @brief : Open the player and play the url and get sessionid for it
+ * 
+ * @param[in]   :  id , url
+ * @return      :  {success: true}
+ */
+TEST_F(SAPInitializedTest, SAPGetPlayerSessionId) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+        _T("open"), 
+        _T("{\"audiotype\": \"pcm\",\"sourcetype\": \"websocket\",\"playmode\": \"system\" }"),
+         response
+    ));
+
+    size_t idPos = response.find("\"id\"");
+    if (idPos != string::npos) {
+        size_t idStart = response.find(':', idPos) + 1;
+        size_t idEnd = response.find(',', idPos);
+        std::string idSubstring = response.substr(idStart, idEnd - idStart);
+        int speechId = std::stoi(idSubstring);
+        std::cout << "Speech ID: " << speechId << std::endl;
+
+        EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, 
+            _T("play"), 
+            _T("{\"id\": ") + std::to_string(speechId) + _T(", \"url\": \"ws://example.com/socket\" }"), 
+            response
+        ));
+        EXPECT_EQ(response, _T("{\"success\":true}"));
+        
+        EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
+            _T("getPlayerSessionId"), 
+            _T("{\"url\": \"ws://example.com/socket\" }"), 
+            response
+        ));
+        size_t sesPos = response.find("\"sessionId\"");
+        if (sesPos != string::npos) {
+            size_t sesStart = response.find(':', sesPos) + 1;
+            size_t sesEnd = response.find(',', sesPos);
+            std::string sesSubstring = response.substr(sesStart, sesEnd - sesStart);
+            int sessionId = std::stoi(sesSubstring);
+            std::cout << "Session ID: " << sessionId << std::endl;
+            EXPECT_EQ(speechId,sessionId);
+        } else {
+            EXPECT_TRUE(false) << "Error: 'sessionid' not found in the response.";
+        }
+    } else {
+        EXPECT_TRUE(false) << "Error: 'id' not found in the response.";
+    }
+}
+/**
+ * @name  : SAPGetPlayerSessionIdInvalid
+ * @brief : GetSessionId for non-existing url
+ * 
+ * @param[in]   :  id , url
+ * @return      :  {success: true}
+ */
+TEST_F(SAPInitializedTest, SAPGetPlayerSessionIdInvalid) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));   
+        EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, 
+            _T("getPlayerSessionId"), 
+            _T("{\"url\": \"https://www.yahoo.com\" }"), 
+            response
+        ));
+    EXPECT_EQ(response, _T("{\"sessionId\":-1,\"success\":true}")); 
+}
+/**
+ * @name  : SAPGetPlayerSessionIdInvalidUrl
+ * @brief : GetSessionId for invalid url
+ * 
+ * @param[in]   :  id , url
+ * @return      :  {success: false}
+ */
+TEST_F(SAPInitializedTest, SAPGetPlayerSessionIdInvalidUrl) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));   
+        EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, 
+            _T("getPlayerSessionId"), 
+            _T("{\"url\": \"invalid\" }"), 
+            response
+        ));
+    EXPECT_EQ(response, _T("{\"success\":false}")); 
+}

--- a/Tests/tests/test_TextToSpeech.cpp
+++ b/Tests/tests/test_TextToSpeech.cpp
@@ -101,54 +101,212 @@ TEST_F(TTSInitializedTest,RegisteredMethods) {
     EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("setACL")));
 }
 
-TEST_F(TTSInitializedTest,Test_EnableTTS_Default_Success) {
+/*******************************************************************************************************************
+ * Test function for enableTTS
+ * enableTTS    :
+ *                Enables or disables the TTS conversion processing
+ *
+ *                @return Response object contains TTS_Status and success
+ * Use case coverage:
+ *                @Success : 3
+ *                @Failure : 0
+ ********************************************************************************************************************/
+/**
+ * @name  : EnableTTSDefault
+ * @brief : Enables or disables the TTS conversion processing
+ *
+ * @param[in]   :  enabletts
+ * @return      :  TTS_Status = 0 and success = true
+ */
+
+TEST_F(TTSInitializedTest,EnableTTSDefault) {
     EXPECT_EQ(string(""), plugin->Initialize(&service));
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("enabletts"), _T("{\"enabletts\": \"true\"}"), response));
     EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"TTS_Status\":0")));
     EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"success\":true")));
 }
 
-TEST_F(TTSInitializedTest,Test_EnableTTS_True_Success) {
+/**
+ * @name  : EnableTTSTrue
+ * @brief : Enable with enabletts = true and checked if isttsenabled == true
+ *
+ * @param[in]   :  enabletts = true
+ * @return      :  isttsenabled = true; TTS_Status = 0 and success = true
+ */
+
+TEST_F(TTSInitializedTest,EnableTTSTrue) {
     EXPECT_EQ(string(""), plugin->Initialize(&service));
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("enabletts"), _T("{\"enabletts\": true }"), response));
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("isttsenabled"), _T(""), response));
     EXPECT_EQ(response, _T("{\"isenabled\":true,\"TTS_Status\":0,\"success\":true}"));
 }
 
-TEST_F(TTSInitializedTest,Test_EnableTTS_False_Success) {
+/**
+ * @name  : EnableTTSFalse
+ * @brief : Enable with enabletts = false and checked if isttsenabled == false
+ *
+ * @param[in]   :  enabletts = false
+ * @return      :  isttsenabled = false; TTS_Status = 0 and success = true
+ */
+
+TEST_F(TTSInitializedTest,EnableTTSFalse) {
     EXPECT_EQ(string(""), plugin->Initialize(&service));
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("enabletts"), _T("{\"enabletts\": false }"), response));
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("isttsenabled"), _T(""), response));
     EXPECT_EQ(response, _T("{\"isenabled\":false,\"TTS_Status\":0,\"success\":true}"));
 }
 
-TEST_F(TTSInitializedTest,Test_GetAPIVersion_Success) {
+/*******************************************************************************************************************
+ * Test function for getAPIVersion
+ * getAPIVersion :
+ *                Gets the API Version.
+ *
+ *                @return Response object contains version and success
+ * Use case coverage:
+ *                @Success : 1
+ *                @Failure : 0
+ ********************************************************************************************************************/
+/**
+ * @name  : GetAPIVersion
+ * @brief : Gets the API Version.
+ *
+ * @param[in]   :  NONE
+ * @return      :  version = 1 and success = true
+ */
+
+TEST_F(TTSInitializedTest,GetAPIVersion) {
     EXPECT_EQ(string(""), plugin->Initialize(&service));
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getapiversion"), _T(""), response));
     EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"version\":1")));
     EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"success\":true")));
 }
 
-TEST_F(TTSInitializedTest,Test_IsTTSEnabled_Default_Success) {
+/*******************************************************************************************************************
+ * Test function for isTTSEnabled
+ * isTTSEnabled    :
+ *                Returns whether the TTS engine is enabled or disabled. By default the TTS engine is disabled.
+ *
+ *                @return Response object contains isenabled, TTS_Status and success
+ * Use case coverage:
+ *                @Success : 1
+ *                @Failure : 0
+ ********************************************************************************************************************/
+/**
+ * @name  : IsTTSEnabledDefault
+ * @brief : Returns whether the TTS engine is enabled or disabled. By default the TTS engine is disabled.
+ *
+ * @param[in]   :  NONE
+ * @return      :  isenabled = false; TTS_Status = 0; success = true
+ */
+
+TEST_F(TTSInitializedTest,IsTTSEnabledDefault) {
     EXPECT_EQ(string(""), plugin->Initialize(&service));
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("isttsenabled"), _T(""), response));
     EXPECT_EQ(response, _T("{\"isenabled\":false,\"TTS_Status\":0,\"success\":true}"));
 }
 
-TEST_F(TTSInitializedTest,Test_IsListVoicesEmpty_Success) {
+/*******************************************************************************************************************
+ * Test function for listVoices
+ * SpeechState          :
+ *                Returns voice based on language
+ *
+ *                @return Response object contains speaking and success
+ * Use case coverage:
+ *                @Success : 1
+ *                @Failure : 4
+ ********************************************************************************************************************/
+/**
+ * @name  : IsListVoicesEmpty
+ * @brief : Returns speaking(true,false) of the given speechid
+ *
+ * @param[in]   :  language
+ * @return      :  ERROR_NONE
+ */
+
+TEST_F(TTSInitializedTest,IsListVoicesEmpty) {
     EXPECT_EQ(string(""), plugin->Initialize(&service));
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("listvoices"), _T("{\"language\":\"en-US\"}"), response));
     EXPECT_EQ(response, _T("{\"voices\":[],\"TTS_Status\":0,\"success\":true}"));
 }
 
-TEST_F(TTSInitializedTest,Test_Speak_Success) {
+/**
+ * @name  : ListVoicesSetEmptyLanguage
+ * @brief : Set language as empty and check whether it return error
+ *
+ * @param[in]   :  Set "" in language
+ * @expected    :  ERROR_NONE
+ */
+
+TEST_F(TTSInitializedTest, ListVoicesSetEmptyLanguage) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("listvoices"), _T("{\"language\": \"\"}"), response));
+}
+
+/**
+ * @name  : ListVoicesSetWhiteSpaceLanguage
+ * @brief : Set language as " " and check whether it return error
+ *
+ * @param[in]   :  Set " " in language
+ * @expected    :  ERROR_GENERAL
+ */
+
+TEST_F(TTSInitializedTest, ListVoicesSetWhiteSpaceAsLanguage) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("listvoices"), _T("{\"language\": \"  \"}"), response));
+}
+
+/**
+ * @name  : ListVoicesSetNumberAsLanguage
+ * @brief : Set language as Number and check whether it return error
+ *
+ * @param[in]   :  Set "" in language
+ * @expected    :  ERROR_GENERAL
+ */
+
+TEST_F(TTSInitializedTest, ListVoicesSetNumberAsLanguage) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("listvoices"), _T("{\"language\": 01}"), response));
+}
+
+/**
+ * @name  : ListVoicesSetNullLanguage
+ * @brief : Set language as NULL and check whether it return error
+ *
+ * @param[in]   :  Set NULL language
+ * @expected    :  ERROR_GENERAL
+ */
+
+TEST_F(TTSInitializedTest, ListVoicesSetNullLanguage) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("listvoices"), _T("{\"language\": NULL}"), response));
+}
+
+/*******************************************************************************************************************
+ * Test function for speak
+ * speak          :
+ *                Converts the input text to speech when TTS is enabled. Any ongoing speech is interrupted and the newly requested speech is processed.
+ *
+ *                @return Response speechid, TTS_Status and success
+ * Use case coverage:
+ *                @Success : 1
+ *                @Failure : 0
+ ********************************************************************************************************************/
+/**
+ * @name  : Speak
+ * @brief : Converts the input text to speech when TTS is enabled. Any ongoing speech is interrupted and the newly requested speech is processed.
+ *
+ * @param[in]   :  text
+ * @return      :  ERROR_NONE
+ */
+
+TEST_F(TTSInitializedTest,Speak) {
     EXPECT_EQ(string(""), plugin->Initialize(&service));
 
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection,
         _T("setttsconfiguration"),
         _T("{\"language\": \"en-US\",\"voice\": \"carol\","
-            "\"ttsendpointsecured\":\"http://cdn-ec-ric-312.voice-guidance-tts.xcr.comcast.net/tts/v1/cdn/location?\","
-            "\"ttsendpointsecured\":\"http://cdn-ec-ric-312.voice-guidance-tts.xcr.comcast.net/tts/v1/cdn/location?\"}"
+            "\"ttsendpointsecured\":\"https://example-tts-dummy.net/tts/v1/cdn/location?\","
+            "\"ttsendpoint\":\"http://example-tts-dummy.net/tts/v1/cdn/location?\"}"
         ),
         response
     ));
@@ -161,48 +319,305 @@ TEST_F(TTSInitializedTest,Test_Speak_Success) {
     EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"success\":true")));
 }
 
-TEST_F(TTSInitializedTest,Test_IsSpeaking_Success) {
+/*******************************************************************************************************************
+ * Test function for IsSpeaking
+ * SpeechState          :
+ *                Returns whether current speechid is speaking or not
+ *
+ *                @return Response object contains speaking and success
+ * Use case coverage:
+ *                @Success : 1
+ *                @Failure : 2
+ ********************************************************************************************************************/
+/**
+ * @name  : IsSpeaking
+ * @brief : Returns speaking(true,false) of the given speechid
+ *
+ * @param[in]   :  speechid
+ * @return      :  ERROR_NONE
+ */
+
+TEST_F(TTSInitializedTest,IsSpeaking) {
     EXPECT_EQ(string(""), plugin->Initialize(&service));
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("isspeaking"), _T("{\"speechid\": 1}"), response));
     EXPECT_EQ(response, _T("{\"speaking\":false,\"TTS_Status\":0,\"success\":true}"));
 }
 
-TEST_F(TTSInitializedTest,Test_GetSpeechState_Success) {
+/**
+ * @name  : IsSpeakingEmptySpeechId
+ * @brief : Given a empty speechid it should return error
+ *
+ * @param[in]   :  "" in speechId
+ * @return      :  ERROR_GENERAL
+ */
+
+TEST_F(TTSInitializedTest,IsSpeakingEmptySpeechId) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("isspeaking"), _T("{\"speechid\": }"), response));
+}
+
+/**
+ * @name  : IsSpeakingStringAsSpeechId
+ * @brief : Given a string speechid it should return error
+ *
+ * @param[in]   :  "hello" in speechId
+ * @return      :  ERROR_GENERAL
+ */
+
+TEST_F(TTSInitializedTest,IsSpeakingStringAsSpeechId) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("isspeaking"), _T("{\"speechid\": \"hello\"}"), response));
+}
+
+/*******************************************************************************************************************
+ * Test function for GetSpeechState
+ * SpeechState          :
+ *                Returns the SpeechState of the given speechid
+ *
+ *                @return Response object contains speechstate and success
+ * Use case coverage:
+ *                @Success : 1
+ *                @Failure : 2
+ ********************************************************************************************************************/
+/**
+ * @name  : SpeechState
+ * @brief : Returns the SpeechState of the given speechid
+ *
+ * @param[in]   :  speechid
+ * @return      :  ERROR_NONE
+ */
+
+TEST_F(TTSInitializedTest,SpeechState) {
     EXPECT_EQ(string(""), plugin->Initialize(&service));
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getspeechstate"), _T("{\"speechid\": 1}"), response));
     EXPECT_EQ(response, _T("{\"speechstate\":3,\"TTS_Status\":0,\"success\":true}"));
 }
 
-TEST_F(TTSInitializedTest,Test_Cancel_Success) {
+/**
+ * @name  : GetSpeechStateEmptySpeechId
+ * @brief : Given a empty speechid it should return error
+ *
+ * @param[in]   :  "" in speechId
+ * @return      :  ERROR_GENERAL
+ */
+
+TEST_F(TTSInitializedTest,GetSpeechStateEmptySpeechId) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("getspeechstate"), _T("{\"speechid\": }"), response));
+}
+
+/**
+ * @name  : GetSpeechStateStringAsSpeechId
+ * @brief : Given a string speechid it should return error
+ *
+ * @param[in]   :  "hello" in speechId
+ * @return      :  ERROR_GENERAL
+ */
+
+TEST_F(TTSInitializedTest,GetSpeechStateStringAsSpeechId) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("getspeechstate"), _T("{\"speechid\": \"hello\"}"), response));
+}
+
+/*******************************************************************************************************************
+ * Test function for Cancel
+ * cancel          :
+ *                Cancel the speech currently happening
+ *
+ *                @return Response object contains TTS_Status and success
+ * Use case coverage:
+ *                @Success : 1
+ *                @Failure : 2
+ ********************************************************************************************************************/
+/**
+ * @name  : Cancel
+ * @brief : Given a speechid it should cancel it
+ *
+ * @param[in]   :  Valid configuration
+ * @return      :  ERROR_NONE
+ */
+
+TEST_F(TTSInitializedTest,Cancel) {
     EXPECT_EQ(string(""), plugin->Initialize(&service));
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("cancel"), _T("{\"speechid\": 1}"), response));
     EXPECT_EQ(response, _T("{\"TTS_Status\":0,\"success\":true}"));
 }
 
-TEST_F(TTSInitializedTest,Test_SetTTSConfiguration_Success) {
+/**
+ * @name  : CancelEmptySpeechId
+ * @brief : Given a speechid it should return error
+ *
+ * @param[in]   :  "" in speechId
+ * @return      :  ERROR_GENERAL
+ */
+
+TEST_F(TTSInitializedTest,CancelEmptySpeechId) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("cancel"), _T("{\"speechid\": }"), response));
+}
+
+/**
+ * @name  : CancelStringAsSpeechId
+ * @brief : Given a string speechid it should return error
+ *
+ * @param[in]   :  "hello" in speechId
+ * @return      :  ERROR_GENERAL
+ */
+
+TEST_F(TTSInitializedTest,CancelStringAsSpeechId) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("cancel"), _T("{\"speechid\": \"hello\"}"), response));
+}
+
+/*******************************************************************************************************************
+ * Test function for Pause
+ * cancel          :
+ *                Cancel the speech currently happening
+ *
+ *                @return Response object contains TTS_Status and success
+ * Use case coverage:
+ *                @Success : 1
+ *                @Failure : 2
+ ********************************************************************************************************************/
+/**
+ * @name  : Pause
+ * @brief : Given a speechid it should cancel it
+ *
+ * @param[in]   :  Valid configuration
+ * @return      :  ERROR_GENERAL
+ */
+
+TEST_F(TTSInitializedTest,Pause) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("pause"), _T("{\"speechid\": 1}"), response));
+}
+
+/**
+ * @name  : PauseEmptySpeechId
+ * @brief : Given a speechid it should return error
+ *
+ * @param[in]   :  "" in speechId
+ * @return      :  ERROR_GENERAL
+ */
+
+TEST_F(TTSInitializedTest,PauseEmptySpeechId) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("pause"), _T("{\"speechid\":\"\"}"), response));
+}
+
+/**
+ * @name  : PauseStringAsSpeechId
+ * @brief : Given a string speechid it should return error
+ *
+ * @param[in]   :  "hello" in speechId
+ * @return      :  ERROR_GENERAL
+ */
+
+TEST_F(TTSInitializedTest,PauseStringAsSpeechId) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("pause"), _T("{\"speechid\": \"hello\"}"), response));
+}
+
+/*******************************************************************************************************************
+ * Test function for resume
+ * resume          :
+ *                resume the speech which is resumed
+ *
+ *                @return Response object contains TTS_Status and success
+ * Use case coverage:
+ *                @Success : 1
+ *                @Failure : 2
+ ********************************************************************************************************************/
+/**
+ * @name  : Resume
+ * @brief : Given a speechid it should resume it
+ *
+ * @param[in]   :  Valid configuration
+ * @return      :  ERROR_GENERAL
+ */
+
+TEST_F(TTSInitializedTest,Resume) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("resume"), _T("{\"speechid\": 1}"), response));
+}
+
+/**
+ * @name  : ResumeEmptySpeechId
+ * @brief : Given a speechid it should return error
+ *
+ * @param[in]   :  "" in speechId
+ * @return      :  ERROR_GENERAL
+ */
+
+TEST_F(TTSInitializedTest,ResumeEmptySpeechId) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("resume"), _T("{\"speechid\":\"\"}"), response));
+}
+
+/**
+ * @name  : ResumeStringAsSpeechId
+ * @brief : Given a string speechid it should return error
+ *
+ * @param[in]   :  "hello" in speechId
+ * @return      :  ERROR_GENERAL
+ */
+
+TEST_F(TTSInitializedTest,ResumeStringAsSpeechId) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("resume"), _T("{\"speechid\": \"hello\"}"), response));
+}
+
+/*******************************************************************************************************************
+ * Test function for :setttsconfiguration
+ * setttsconfiguration :
+ *                Set The TTS configurations based on params
+ *
+ *                @return Response object contains TTS_Status and success
+ * Use case coverage:
+ *                @Success : 2
+ *                @Failure : 34
+ ********************************************************************************************************************/
+/**
+ * @name  : SetTTSConfiguration
+ * @brief : Given a valid JSON request check whether response is success
+ *
+ * @param[in]   :  Valid configuration
+ * @return      :  ERROR_NONE
+ */
+
+TEST_F(TTSInitializedTest, SetTTSConfiguration) {
     EXPECT_EQ(string(""), plugin->Initialize(&service));
 
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(
         connection,
         _T("setttsconfiguration"),
         _T("{\"language\": \"en-US\",\"voice\": \"carol\","
-            "\"ttsendpoint\":\"http://cdn-ec-ric-312.voice-guidance-tts.xcr.comcast.net/tts/v1/cdn/location?\","
-            "\"ttsendpointsecured\":\"http://cdn-ec-ric-312.voice-guidance-tts.xcr.comcast.net/tts/v1/cdn/location?\"}"
+            "\"ttsendpoint\":\"http://example-tts-dummy.net/tts/v1/cdn/location?\","
+            "\"ttsendpointsecured\":\"https://example-tts-dummy.net/tts/v1/cdn/location?\"}"
         ),
         response
     ));
 
     EXPECT_EQ(response, _T("{\"TTS_Status\":0,\"success\":true}"));
 }
-TEST_F(TTSInitializedTest, Test_SetTTSConfiguration_Update_Success) {
+
+/**
+ * @name  : DefaultTTSConfiguration
+ * @brief : Update the value and check the value using gettsconfiguration
+ *
+ * @param[in]   :  Valid configuration
+ * @expected    :  getttsconfiguration should return the update value
+ */
+
+TEST_F(TTSInitializedTest, DefaultTTSConfiguration) {
     EXPECT_EQ(string(""), plugin->Initialize(&service));
 
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(
         connection,
         _T("setttsconfiguration"),
         _T("{\"language\": \"en-US\",\"voice\": \"carol\","
-            "\"ttsendpoint\":\"http://cdn-ec-ric-312.voice-guidance-tts.xcr.comcast.net/tts/v1/cdn/location?\","
-            "\"ttsendpointsecured\":\"http://cdn-ec-ric-312.voice-guidance-tts.xcr.comcast.net/tts/v1/cdn/location?\","
+            "\"ttsendpoint\":\"http://example-tts-dummy.net/tts/v1/cdn/location?\","
+            "\"ttsendpointsecured\":\"https://example-tts-dummy.net/tts/v1/cdn/location?\","
             "\"volume\": \"95\",\"primvolduckpercent\": \"50\",\"rate\": \"40\",\"speechrate\":\"medium\"}"
         ),
         response
@@ -211,13 +626,781 @@ TEST_F(TTSInitializedTest, Test_SetTTSConfiguration_Update_Success) {
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getttsconfiguration"), _T(""), response));
 
     EXPECT_EQ(response,
-        _T("{\"ttsendpoint\":\"http:\\/\\/cdn-ec-ric-312.voice-guidance-tts.xcr.comcast.net\\/tts\\/v1\\/cdn\\/location?\","
-            "\"ttsendpointsecured\":\"http:\\/\\/cdn-ec-ric-312.voice-guidance-tts.xcr.comcast.net\\/tts\\/v1\\/cdn\\/location?\","
+        _T("{\"ttsendpoint\":\"http:\\/\\/example-tts-dummy.net\\/tts\\/v1\\/cdn\\/location?\","
+            "\"ttsendpointsecured\":\"https:\\/\\/example-tts-dummy.net\\/tts\\/v1\\/cdn\\/location?\","
             "\"language\":\"en-US\",\"voice\":\"carol\",\"speechrate\":\"medium\",\"rate\":40,\"volume\":\"95\","
             "\"TTS_Status\":0,\"success\":true}"
         ));
 }
-TEST_F(TTSInitializedTest,Test_SetACL_Success) {
+
+/**
+ * @name  : SetInvalidTTSEndpoint
+ * @brief : Set Invalid URL in ttsendpoint and check it return error
+ *
+ * @param[in]   :  Set invalid url in ttsendpoint
+ * @expected    :  ERROR_GENERAL
+ */
+
+TEST_F(TTSInitializedTest, SetInvalidTTSEndpoint) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection,
+        _T("setttsconfiguration"),
+        _T("{\"language\": \"en-US\",\"voice\": \"carol\",\"ttsendpoint\":\"invalid1@#\","
+           "\"ttsendpointsecured\":\"https://localhost:50050/nuanceEve/tts?\"}"), response));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getttsconfiguration"), _T(""), response));
+    size_t ttsEndPointPos = response.find("\"ttsendpoint\"");
+
+    if (ttsEndPointPos  != string::npos) {
+        size_t ttsEndpointStart = response.find(':', ttsEndPointPos ) + 1;
+        size_t ttsEndpointEnd = response.find(',', ttsEndPointPos );
+        std::string ttsSubstring = response.substr(ttsEndpointStart ,ttsEndpointEnd  - ttsEndpointStart );
+        EXPECT_EQ(ttsSubstring ,"\"\"");
+     } else {
+        EXPECT_TRUE(false) << "Error: 'ttsendpoint' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SetInvalidSecuredTTSEndpoint
+ * @brief : Set Invalid URL in ttssecuredendpoint and check it return error
+ *
+ * @param[in]   :  Set invalid url in ttsendpoint
+ * @expected    :  ERROR_GENERAL
+ */
+
+TEST_F(TTSInitializedTest, SetInvalidtSecuredTTSEndpoint) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection,
+        _T("setttsconfiguration"),
+        _T("{\"language\": \"en-US\",\"voice\": \"carol\","
+           "\"ttsendpoint\":\"http://localhost:50050/nuanceEve/tts?\",\"ttsendpointsecured\":\"invalid1@#\"}"), response));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getttsconfiguration"), _T(""), response));
+    size_t ttsendpointsecuredPos = response.find("\"ttsendpointsecured\"");
+
+    if (ttsendpointsecuredPos  != string::npos) {
+        size_t ttsendpointsecuredStart = response.find(':', ttsendpointsecuredPos ) + 1;
+        size_t ttsendpointsecuredEnd = response.find(',', ttsendpointsecuredPos );
+        std::string ttsendpointsecuredSubstring = response.substr(ttsendpointsecuredStart ,ttsendpointsecuredEnd  - ttsendpointsecuredStart );
+        EXPECT_EQ(ttsendpointsecuredSubstring ,"\"\"");
+     } else {
+        EXPECT_TRUE(false) << "Error: 'ttsEndpointSecured' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SetEmptyTTSEndpoint
+ * @brief : Set Empty URL in ttsendpoint and check it returns error
+ *
+ * @param[in]   :  Set "" in ttsendpoint
+ * @expected    :  ERROR_NONE
+ */
+
+TEST_F(TTSInitializedTest, SetEmptyTTSEndpoint) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("setttsconfiguration"), _T("{\"ttsendpoint\":\"\"}"), response));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getttsconfiguration"), _T(""), response));
+    size_t ttsEndPointPos = response.find("\"ttsendpoint\"");
+
+    if (ttsEndPointPos  != string::npos) {
+        size_t ttsEndpointStart = response.find(':', ttsEndPointPos ) + 1;
+        size_t ttsEndpointEnd = response.find(',', ttsEndPointPos );
+        std::string ttsSubstring = response.substr(ttsEndpointStart ,ttsEndpointEnd  - ttsEndpointStart );
+        EXPECT_EQ(ttsSubstring ,"\"\"");
+     } else {
+        EXPECT_TRUE(false) << "Error: 'ttsendpoint' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SetEmptySecuredTTSEndpoint
+ * @brief : Set Empty URL in ttssecuredendpoint and check it returns error
+ *
+ * @param[in]   :  Set "" in ttsendpoint
+ * @expected    :  ERROR_NONE
+ */
+
+TEST_F(TTSInitializedTest, SetEmptySecuredTTSEndpoint) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("setttsconfiguration"), _T("{\"ttssecuredendpoint\":\"\"}"), response));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getttsconfiguration"), _T(""), response));
+    size_t ttsEndPointPos = response.find("\"ttsendpointsecured\"");
+
+    if (ttsEndPointPos  != string::npos) {
+        size_t ttsEndpointStart = response.find(':', ttsEndPointPos ) + 1;
+        size_t ttsEndpointEnd = response.find(',', ttsEndPointPos );
+        std::string ttsSubstring = response.substr(ttsEndpointStart ,ttsEndpointEnd  - ttsEndpointStart );
+        EXPECT_EQ(ttsSubstring ,"\"\"");
+     } else {
+        EXPECT_TRUE(false) << "Error: 'ttssecuredendpoint' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SetNullTTSEndpoint
+ * @brief : Set NULL  in ttsendpoint and check it returns error
+ *
+ * @param[in]   :  Set NULL in ttsendpoint
+ * @expected    :  ERROR_NONE
+ */
+
+TEST_F(TTSInitializedTest, SetNULLTTSEndpoint) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("setttsconfiguration"), _T("{\"ttsendpoint\": null}"), response));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getttsconfiguration"), _T(""), response));
+    size_t ttsEndPointPos = response.find("\"ttsendpoint\"");
+
+    if (ttsEndPointPos  != string::npos) {
+        size_t ttsEndpointStart = response.find(':', ttsEndPointPos ) + 1;
+        size_t ttsEndpointEnd = response.find(',', ttsEndPointPos );
+        std::string ttsSubstring = response.substr(ttsEndpointStart ,ttsEndpointEnd  - ttsEndpointStart );
+        EXPECT_EQ(ttsSubstring ,"\"\"");
+     } else {
+        EXPECT_TRUE(false) << "Error: 'ttsendpoint' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SetNULLSecuredTTSEndpoint
+ * @brief : Set NULL in ttssecuredendpoint and check it returns error
+ *
+ * @param[in]   :  Set NULL in ttsendpoint
+ * @expected    :  ERROR_NONE
+ */
+
+TEST_F(TTSInitializedTest, SetNULLSecuredTTSEndpoint) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("setttsconfiguration"), _T("{\"ttssecuredendpoint\": null}"), response));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getttsconfiguration"), _T(""), response));
+    size_t ttsendpointsecuredPos = response.find("\"ttsendpointsecured\"");
+
+    if (ttsendpointsecuredPos  != string::npos) {
+        size_t ttsendpointsecuredStart = response.find(':', ttsendpointsecuredPos ) + 1;
+        size_t ttsendpointsecuredEnd = response.find(',', ttsendpointsecuredPos );
+        std::string ttsendpointsecuredSubstring = response.substr(ttsendpointsecuredStart ,ttsendpointsecuredEnd  - ttsendpointsecuredStart );
+        EXPECT_EQ(ttsendpointsecuredSubstring ,"\"\"");
+     } else {
+        EXPECT_TRUE(false) << "Error: 'ttsendpointsecured' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SetStringAsVolume
+ * @brief : Set string in Volume and check it returns error
+ *
+ * @param[in]   :  Set "invalid" in Volume
+ * @expected    :  ERROR_GENERAL
+ */
+
+TEST_F(TTSInitializedTest, SetStringAsVolume) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("setttsconfiguration"), _T("{\"volume\": \"invalid\"}"), response));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getttsconfiguration"), _T(""), response));
+    size_t volumePos = response.find("\"volume\"");
+
+    if (volumePos  != string::npos) {
+        size_t volumeStart = response.find(':', volumePos ) + 1;
+        size_t volumeEnd = response.find(',', volumePos );
+        std::string volumeSubstring = response.substr(volumeStart ,volumeEnd  - volumeStart );
+        EXPECT_EQ(volumeSubstring ,"\"95\"");
+     } else {
+        EXPECT_TRUE(false) << "Error: 'volume' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SetVolumeLessThanMinValue
+ * @brief : Set volume as -1 and check whether it return error
+ *
+ * @param[in]   :  Set -1 in Volume
+ * @expected    :  ERROR_GENERAL
+ */
+
+TEST_F(TTSInitializedTest, SetVolumeLessThanMinValue) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("setttsconfiguration"), _T("{\"volume\": -1}"), response));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getttsconfiguration"), _T(""), response));
+    size_t volumePos = response.find("\"volume\"");
+
+    if (volumePos  != string::npos) {
+        size_t volumeStart = response.find(':', volumePos ) + 1;
+        size_t volumeEnd = response.find(',', volumePos );
+        std::string volumeSubstring = response.substr(volumeStart ,volumeEnd  - volumeStart );
+        EXPECT_EQ(volumeSubstring ,"\"95\"");
+     } else {
+        EXPECT_TRUE(false) << "Error: 'volume' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SetVolumeLessThanMaxValue
+ * @brief : Set volume as 101 and check whether it return error
+ *
+ * @param[in]   :  Set 101 in Volume
+ * @expected    :  ERROR_GENERAL
+ */
+
+TEST_F(TTSInitializedTest, SetVolumeGreaterThanMaxValue) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("setttsconfiguration"), _T("{\"volume\": 101}"), response));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getttsconfiguration"), _T(""), response));
+    size_t volumePos = response.find("\"volume\"");
+
+    if (volumePos  != string::npos) {
+        size_t volumeStart = response.find(':', volumePos ) + 1;
+        size_t volumeEnd = response.find(',', volumePos );
+        std::string volumeSubstring = response.substr(volumeStart ,volumeEnd  - volumeStart );
+        EXPECT_EQ(volumeSubstring ,"\"95\"");
+     } else {
+        EXPECT_TRUE(false) << "Error: 'volume' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SetEmptyVolume
+ * @brief : Set volume as empty and check whether it return error
+ *
+ * @param[in]   :  Set  in Volume
+ * @expected    :  ERROR_NONE
+ */
+
+TEST_F(TTSInitializedTest, SetEmptyVolume) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("setttsconfiguration"), _T("{\"volume\":}"), response));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getttsconfiguration"), _T(""), response));
+    size_t volumePos = response.find("\"volume\"");
+
+    if (volumePos  != string::npos) {
+        size_t volumeStart = response.find(':', volumePos ) + 1;
+        size_t volumeEnd = response.find(',', volumePos );
+        std::string volumeSubstring = response.substr(volumeStart ,volumeEnd  - volumeStart );
+        EXPECT_EQ(volumeSubstring ,"\"95\"");
+     } else {
+        EXPECT_TRUE(false) << "Error: 'ttsendpoint' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SetStringAsRate
+ * @brief : Set string in rate and check it returns error
+ *
+ * @param[in]   :  Set "invalid" in rate
+ * @expected    :  ERROR_NONE
+ */
+
+TEST_F(TTSInitializedTest, SetStringAsRate) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("setttsconfiguration"), _T("{\"rate\": \"invalid\"}"), response));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getttsconfiguration"), _T(""), response));
+    size_t ratePos = response.find("\"rate\"");
+
+    if (ratePos  != string::npos) {
+        size_t rateStart = response.find(':', ratePos ) + 1;
+        size_t rateEnd = response.find(',', ratePos );
+        std::string rateSubstring = response.substr(rateStart ,rateEnd  - rateStart );
+        EXPECT_EQ(rateSubstring ,"40");
+     } else {
+        EXPECT_TRUE(false) << "Error: 'rate' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SetRateLessThanMinValue
+ * @brief : Set rate as -1 and check whether it return error
+ *
+ * @param[in]   :  Set -1 in rate
+ * @expected    :  ERROR_GENERAL
+ */
+
+TEST_F(TTSInitializedTest, SetRateLessThanMinValue) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("setttsconfiguration"), _T("{\"rate\": -1}"), response));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getttsconfiguration"), _T(""), response));
+    size_t ratePos = response.find("\"rate\"");
+
+    if (ratePos  != string::npos) {
+        size_t rateStart = response.find(':', ratePos ) + 1;
+        size_t rateEnd = response.find(',', ratePos );
+        std::string rateSubstring = response.substr(rateStart ,rateEnd  - rateStart );
+        EXPECT_EQ(rateSubstring ,"40");
+     } else {
+        EXPECT_TRUE(false) << "Error: 'rate' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SetRateGreaterThanMaxValue
+ * @brief : Set rate as 101 and check whether it return error
+ *
+ * @param[in]   :  Set 101 in rate
+ * @expected    :  ERROR_GENERAL
+ */
+
+TEST_F(TTSInitializedTest, SetRateGreaterThanMaxValue) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("setttsconfiguration"), _T("{\"rate\": 101}"), response));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getttsconfiguration"), _T(""), response));
+    size_t ratePos = response.find("\"rate\"");
+
+    if (ratePos  != string::npos) {
+        size_t rateStart = response.find(':', ratePos ) + 1;
+        size_t rateEnd = response.find(',', ratePos );
+        std::string rateSubstring = response.substr(rateStart ,rateEnd  - rateStart );
+        EXPECT_EQ(rateSubstring ,"40");
+     } else {
+        EXPECT_TRUE(false) << "Error: 'rate' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SetEmptyRate
+ * @brief : Set rate as empty and check whether it return error
+ *
+ * @param[in]   :  Set  in rate
+ * @expected    :  ERROR_NONE
+ */
+
+TEST_F(TTSInitializedTest, SetEmptyRate) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("setttsconfiguration"), _T("{\"rate\":\"\"}"), response));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getttsconfiguration"), _T(""), response));
+    size_t ratePos = response.find("\"rate\"");
+
+    if (ratePos  != string::npos) {
+        size_t rateStart = response.find(':', ratePos ) + 1;
+        size_t rateEnd = response.find(',', ratePos );
+        std::string rateSubstring = response.substr(rateStart ,rateEnd  - rateStart );
+        EXPECT_EQ(rateSubstring ,"40");
+     } else {
+        EXPECT_TRUE(false) << "Error: 'rate' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SetStringAsPrimvolduckpercent
+ * @brief : Set string in primvolduckpercent and check it returns error
+ *
+ * @param[in]   :  Set "invalid" in primvolduckpercent
+ * @expected    :  ERROR_GENERAL
+ */
+
+TEST_F(TTSInitializedTest, SetStringAsprimvolduckpercent) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("setttsconfiguration"), _T("{\"primvolduckpercent\": \"invalid\"}"), response));
+}
+
+/**
+ * @name  : SetPrimvolduckpercentLessThanMinValue
+ * @brief : Set primvolduckpercent as -1 and check whether it return error
+ *
+ * @param[in]   :  Set -1 in primvolduckpercent
+ * @expected    :  ERROR_GENERAL
+ */
+
+TEST_F(TTSInitializedTest, SetPrimvolduckpercentLessThanMinValue) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("setttsconfiguration"), _T("{\"primvolduckpercent\": -1}"), response));
+}
+
+/**
+ * @name  : SetPrimvolduckpercentGreaterThanMaxValue
+ * @brief : Set primvolduckpercent as 101 and check whether it return error
+ *
+ * @param[in]   :  Set 101 in primvolduckpercent
+ * @expected    :  ERROR_GENERAL
+ */
+
+TEST_F(TTSInitializedTest, SetPrimvolduckpercentGreaterThanMaxValue) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("setttsconfiguration"), _T("{\"primvolduckpercent\": 101}"), response));
+}
+
+/**
+ * @name  : SetEmptyPrimvolduckpercent
+ * @brief : Set primvolduckpercent as empty and check whether it return error
+ *
+ * @param[in]   :  Set  in primvolduckpercent
+ * @expected    :  ERROR_GENERAL
+ */
+
+TEST_F(TTSInitializedTest, SetEmptyPrimvolduckpercent) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("setttsconfiguration"), _T("{\"primvolduckpercent\": \"\"}"), response));
+}
+
+/**
+ * @name  : SetEmptySpeechRate
+ * @brief : Set speechrate as empty and check whether it return error
+ *
+ * @param[in]   :  Set "" in speechrate
+ * @expected    :  ERROR_NONE
+ */
+
+TEST_F(TTSInitializedTest, SetEmptySpeechRate) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("setttsconfiguration"), _T("{\"speechrate\": \"\"}"), response));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getttsconfiguration"), _T(""), response));
+    size_t speechRatePos = response.find("\"speechrate\"");
+
+    if (speechRatePos  != string::npos) {
+        size_t speechRatePosStart = response.find(':', speechRatePos ) + 1;
+        size_t speechRatePosEnd = response.find(',', speechRatePos );
+        std::string speechRateSubstring = response.substr(speechRatePosStart ,speechRatePosEnd  - speechRatePosStart);
+        EXPECT_EQ(speechRateSubstring ,"\"medium\"");
+     } else {
+        EXPECT_TRUE(false) << "Error: 'speechrate' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SetWhiteSpaceSpeechRate
+ * @brief : Set speechrate as " " and check whether it return error
+ *
+ * @param[in]   :  Set " " in speechrate
+ * @expected    :  ERROR_GENERAL
+ */
+
+TEST_F(TTSInitializedTest, SetWhiteSpaceAsSpeechRate) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("setttsconfiguration"), _T("{\"speechrate\": \"  \"}"), response));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getttsconfiguration"), _T(""), response));
+    size_t speechRatePos = response.find("\"speechrate\"");
+
+    if (speechRatePos  != string::npos) {
+        size_t speechRatePosStart = response.find(':', speechRatePos ) + 1;
+        size_t speechRatePosEnd = response.find(',', speechRatePos );
+        std::string speechRateSubstring = response.substr(speechRatePosStart ,speechRatePosEnd  - speechRatePosStart);
+        EXPECT_EQ(speechRateSubstring ,"\"medium\"");
+     } else {
+        EXPECT_TRUE(false) << "Error: 'speechrate' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SetNumberAsSpeechRate
+ * @brief : Set speechrate as Number and check whether it return error
+ *
+ * @param[in]   :  Set "" in speechrate
+ * @expected    :  ERROR_GENERAL
+ */
+
+TEST_F(TTSInitializedTest, SetNumberAsSpeechRate) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("setttsconfiguration"), _T("{\"speechrate\": 01}"), response));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getttsconfiguration"), _T(""), response));
+    size_t speechRatePos = response.find("\"speechrate\"");
+
+    if (speechRatePos  != string::npos) {
+        size_t speechRatePosStart = response.find(':', speechRatePos ) + 1;
+        size_t speechRatePosEnd = response.find(',', speechRatePos );
+        std::string speechRateSubstring = response.substr(speechRatePosStart ,speechRatePosEnd  - speechRatePosStart);
+        EXPECT_EQ(speechRateSubstring ,"\"medium\"");
+     } else {
+        EXPECT_TRUE(false) << "Error: 'speechrate' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SetNullSpeechRate
+ * @brief : Set speechrate as NULL and check whether it return error
+ *
+ * @param[in]   :  Set NULL speechrate
+ * @expected    :  ERROR_NONE
+ */
+
+TEST_F(TTSInitializedTest, SetNullSpeechRate) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("setttsconfiguration"), _T("{\"speechrate\": null}"), response));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getttsconfiguration"), _T(""), response));
+    size_t speechRatePos = response.find("\"speechrate\"");
+
+    if (speechRatePos  != string::npos) {
+        size_t speechRatePosStart = response.find(':', speechRatePos ) + 1;
+        size_t speechRatePosEnd = response.find(',', speechRatePos );
+        std::string speechRateSubstring = response.substr(speechRatePosStart ,speechRatePosEnd  - speechRatePosStart);
+        EXPECT_EQ(speechRateSubstring ,"\"medium\"");
+     } else {
+        EXPECT_TRUE(false) << "Error: 'speechrate' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SetInvalidSpeechRate
+ * @brief : Set speechrate as Invalid It should be one of the following [slow,medium,fast,faster]
+ *
+ * @param[in]   :  Set invalid  speechrate
+ * @expected    :  ERROR_GENERAL
+ */
+
+TEST_F(TTSInitializedTest, SetInvalidSpeechRate) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("setttsconfiguration"), _T("{\"speechrate\": \"invalid\"}"), response));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getttsconfiguration"), _T(""), response));
+    size_t speechRatePos = response.find("\"speechrate\"");
+
+    if (speechRatePos  != string::npos) {
+        size_t speechRatePosStart = response.find(':', speechRatePos ) + 1;
+        size_t speechRatePosEnd = response.find(',', speechRatePos );
+        std::string speechRateSubstring = response.substr(speechRatePosStart ,speechRatePosEnd  - speechRatePosStart);
+        EXPECT_EQ(speechRateSubstring ,"\"medium\"");
+     } else {
+        EXPECT_TRUE(false) << "Error: 'speechrate' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SetEmptyLanguage
+ * @brief : Set language as empty and check whether it return error
+ *
+ * @param[in]   :  Set "" in language
+ * @expected    :  ERROR_NONE
+ */
+
+TEST_F(TTSInitializedTest, SetEmptyLanguage) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("setttsconfiguration"), _T("{\"language\": \"\"}"), response));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getttsconfiguration"), _T(""), response));
+    size_t languagePos = response.find("\"language\"");
+
+    if (languagePos  != string::npos) {
+        size_t languagePosStart = response.find(':', languagePos ) + 1;
+        size_t languagePosEnd = response.find(',', languagePos );
+        std::string languageSubstring = response.substr(languagePosStart ,languagePosEnd  - languagePosStart);
+        EXPECT_EQ(languageSubstring ,"\"en-US\"");
+     } else {
+        EXPECT_TRUE(false) << "Error: 'language' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SetWhiteSpaceLanguage
+ * @brief : Set language as " " and check whether it return error
+ *
+ * @param[in]   :  Set " " in language
+ * @expected    :  ERROR_GENERAL
+ */
+
+TEST_F(TTSInitializedTest, SetWhiteSpaceAsLanguage) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("setttsconfiguration"), _T("{\"language\": \"  \"}"), response));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getttsconfiguration"), _T(""), response));
+    size_t languagePos = response.find("\"language\"");
+
+    if (languagePos  != string::npos) {
+        size_t languagePosStart = response.find(':', languagePos ) + 1;
+        size_t languagePosEnd = response.find(',', languagePos );
+        std::string languageSubstring = response.substr(languagePosStart ,languagePosEnd  - languagePosStart);
+        EXPECT_EQ(languageSubstring ,"\"en-US\"");
+     } else {
+        EXPECT_TRUE(false) << "Error: 'language' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SetNumberAsLanguage
+ * @brief : Set language as Number and check whether it return error
+ *
+ * @param[in]   :  Set "" in language
+ * @expected    :  ERRERROR_GENERALOR_NONE
+ */
+
+TEST_F(TTSInitializedTest, SetNumberAsLanguage) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("setttsconfiguration"), _T("{\"language\": 01}"), response));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getttsconfiguration"), _T(""), response));
+    size_t languagePos = response.find("\"language\"");
+
+    if (languagePos  != string::npos) {
+        size_t languagePosStart = response.find(':', languagePos ) + 1;
+        size_t languagePosEnd = response.find(',', languagePos );
+        std::string languageSubstring = response.substr(languagePosStart ,languagePosEnd  - languagePosStart);
+        EXPECT_EQ(languageSubstring ,"\"en-US\"");
+     } else {
+        EXPECT_TRUE(false) << "Error: 'language' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SetNullLanguage
+ * @brief : Set language as NULL and check whether it return error
+ *
+ * @param[in]   :  Set NULL language
+ * @expected    :  ERROR_GENERAL
+ */
+
+TEST_F(TTSInitializedTest, SetNullLanguage) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("setttsconfiguration"), _T("{\"language\": NULL}"), response));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getttsconfiguration"), _T(""), response));
+    size_t languagePos = response.find("\"language\"");
+
+    if (languagePos  != string::npos) {
+        size_t languagePosStart = response.find(':', languagePos ) + 1;
+        size_t languagePosEnd = response.find(',', languagePos );
+        std::string languageSubstring = response.substr(languagePosStart ,languagePosEnd  - languagePosStart);
+        EXPECT_EQ(languageSubstring ,"\"en-US\"");
+     } else {
+        EXPECT_TRUE(false) << "Error: 'language' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SetEmptyVoice
+ * @brief : Set voice as empty and check whether it return error
+ *
+ * @param[in]   :  Set "" in voice
+ * @expected    :  ERROR_NONE
+ */
+
+TEST_F(TTSInitializedTest, SetEmptyVoice) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("setttsconfiguration"), _T("{\"voice\": \"\"}"), response));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getttsconfiguration"), _T(""), response));
+    size_t voicePos = response.find("\"voice\"");
+
+    if (voicePos  != string::npos) {
+        size_t voicePosStart = response.find(':', voicePos ) + 1;
+        size_t voicePosEnd = response.find(',', voicePos );
+        std::string voiceSubstring = response.substr(voicePosStart ,voicePosEnd  - voicePosStart );
+        EXPECT_EQ(voiceSubstring ,"\"carol\"");
+     } else {
+        EXPECT_TRUE(false) << "Error: 'voice' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SetWhiteSpaceVoice
+ * @brief : Set voice as " " and check whether it return error
+ *
+ * @param[in]   :  Set " " in voice
+ * @expected    :  ERROR_GENERAL
+ */
+
+TEST_F(TTSInitializedTest, SetWhiteSpaceAsVoice) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("setttsconfiguration"), _T("{\"voice\": \"  \"}"), response));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getttsconfiguration"), _T(""), response));
+    size_t voicePos = response.find("\"voice\"");
+
+    if (voicePos  != string::npos) {
+        size_t voicePosStart = response.find(':', voicePos ) + 1;
+        size_t voicePosEnd = response.find(',', voicePos );
+        std::string voiceSubstring = response.substr(voicePosStart ,voicePosEnd  - voicePosStart );
+        EXPECT_EQ(voiceSubstring ,"\"carol\"");
+     } else {
+        EXPECT_TRUE(false) << "Error: 'voice' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SetNumberAsVoice
+ * @brief : Set voice as Number and check whether it return error
+ *
+ * @param[in]   :  Set "" in voice
+ * @expected    :  ERROR_GENERAL
+ */
+
+TEST_F(TTSInitializedTest, SetNumberAsVoice) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("setttsconfiguration"), _T("{\"voice\": 01}"), response));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getttsconfiguration"), _T(""), response));
+    size_t voicePos = response.find("\"voice\"");
+
+    if (voicePos  != string::npos) {
+        size_t voicePosStart = response.find(':', voicePos ) + 1;
+        size_t voicePosEnd = response.find(',', voicePos );
+        std::string voiceSubstring = response.substr(voicePosStart ,voicePosEnd  - voicePosStart );
+        EXPECT_EQ(voiceSubstring ,"\"carol\"");
+     } else {
+        EXPECT_TRUE(false) << "Error: 'voice' not found in the response.";
+    }
+}
+
+/**
+ * @name  : SetNullVoice
+ * @brief : Set voice as NULL and check whether it return error
+ *
+ * @param[in]   :  Set NULL voice
+ * @expected    :  ERROR_NONE
+ */
+
+TEST_F(TTSInitializedTest, SetNullVoice) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("setttsconfiguration"), _T("{\"voice\": null}"), response));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getttsconfiguration"), _T(""), response));
+    size_t voicePos = response.find("\"voice\"");
+
+    if (voicePos  != string::npos) {
+        size_t voicePosStart = response.find(':', voicePos ) + 1;
+        size_t voicePosEnd = response.find(',', voicePos );
+        std::string voiceSubstring = response.substr(voicePosStart ,voicePosEnd  - voicePosStart );
+        EXPECT_EQ(voiceSubstring ,"\"carol\"");
+     } else {
+        EXPECT_TRUE(false) << "Error: 'voice' not found in the response.";
+    }
+}
+#if 0
+/**
+ * @name  : SetAuthInfoTypeEmpty
+ * @brief : Set AuthInfo type Empty
+ *
+ * @param[in]   :  Set type as invalid
+ * @expected    :  ERROR_GENERAL
+ */
+
+TEST_F(TTSInitializedTest, SetAuthInfoTypeEmpty) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("setttsconfiguration"),
+        _T("{\"authinfo\": {\"type\":\"\",\"value\":\"speak text\"}}"), response));
+}
+
+/**
+ * @name  : SetAuthInfoTypeWhiteSpace
+ * @brief : Set AuthInfo type " "
+ *
+ * @param[in]   :  Set type as " "
+ * @expected    :  ERROR_GENERAL
+ */
+
+TEST_F(TTSInitializedTest, SetAuthInfoTypeWhiteSpace) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("setttsconfiguration"),
+        _T("{\"authinfo\": {\"type\":\"  \",\"value\":\"speak text\"}}"), response));
+}
+
+/**
+ * @name  : SetAuthInfoTypeNull
+ * @brief : Set AuthInfo type NULL
+ *
+ * @param[in]   :  Set type as NULL
+ * @expected    :  ERROR_GENERAL
+ */
+
+TEST_F(TTSInitializedTest, SetAuthInfoTypeNull) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("setttsconfiguration"),
+        _T("{\"authinfo\": {\"type\":null,\"value\":\"speak text\"}}"), response));
+}
+#endif
+
+/*******************************************************************************************************************
+ * Test function for SetACL
+ * resume          :
+ *                Gives speak access for applications
+ *
+ *                @return Response object contains bool success
+ * Use case coverage:
+ *                @Success : 1
+ *                @Failure : 8
+ ********************************************************************************************************************/
+ /**
+ * @name  : SetACL
+ * @brief : Gives speak access for applications
+ *
+ * @param[in]   :  method of tts and app name
+ * @return      :  ERROR_NONE
+ */
+
+ TEST_F(TTSInitializedTest,SetACL) {
     EXPECT_EQ(string(""), plugin->Initialize(&service));
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(
         connection,
@@ -232,20 +1415,29 @@ TEST_F(TTSInitializedTest,Test_SetACL_Success) {
         connection,
         _T("setttsconfiguration"),
         _T("{\"language\": \"en-US\",\"voice\": \"carol\","
-            "\"ttsendpoint\":\"http://cdn-ec-ric-312.voice-guidance-tts.xcr.comcast.net/tts/v1/cdn/location?\","
-            "\"ttsendpointsecured\":\"http://cdn-ec-ric-312.voice-guidance-tts.xcr.comcast.net/tts/v1/cdn/location?\"}"
+            "\"ttsendpoint\":\"http://example-tts-dummy.net/tts/v1/cdn/location?\","
+            "\"ttsendpointsecured\":\"https://example-tts-dummy.net/tts/v1/cdn/location?\"}"
         ),
         response
     ));
 
-    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("speak"), _T("{\"text\": \"speech_123\",\"callsign\":\"WebAPP1\"}"), response));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("speak"),
+        _T("{\"text\": \"speech_123\",\"callsign\":\"WebAPP1\"}"), response));
     sleep(1);
     EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"speechid\"")));
     EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"TTS_Status\":0")));
     EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"success\":true")));
 }
 
-TEST_F(TTSInitializedTest, Test_SetACL_Failure) {
+ /**
+ * @name  : SetACLInvalidAccess
+ * @brief : Gives speak access for applications
+ *
+ * @param[in]   :  method of tts and app name
+ * @return      :  ERROR_NONE
+ */
+
+TEST_F(TTSInitializedTest, SetACLInvalidAccess) {
     EXPECT_EQ(string(""), plugin->Initialize(&service));
 
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(
@@ -261,8 +1453,8 @@ TEST_F(TTSInitializedTest, Test_SetACL_Failure) {
         connection,
         _T("setttsconfiguration"),
         _T("{\"language\": \"en-US\",\"voice\": \"carol\","
-            "\"ttsendpoint\":\"http://cdn-ec-ric-312.voice-guidance-tts.xcr.comcast.net/tts/v1/cdn/location?\","
-            "\"ttsendpointsecured\":\"http://cdn-ec-ric-312.voice-guidance-tts.xcr.comcast.net/tts/v1/cdn/location?\"}"
+            "\"ttsendpoint\":\"http://example-tts-dummy.net/tts/v1/cdn/location?\","
+            "\"ttsendpointsecured\":\"https://example-tts-dummy.net/tts/v1/cdn/location?\"}"
         ),
         response
     ));
@@ -275,4 +1467,137 @@ TEST_F(TTSInitializedTest, Test_SetACL_Failure) {
     ));
 
     EXPECT_EQ(response, _T(""));
+}
+
+/**
+ * @name  : SetACLInvalidMethod
+ * @brief : Calling speak method with  invalid method other than speak
+ *
+ * @param[in]   :  method of tts and app name
+ * @return      :  ERROR_GENERAL
+ */
+
+TEST_F(TTSInitializedTest, SetACLInvalidMethod) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(
+        connection,
+        _T("setACL"),
+        _T("{\"accesslist\": [{\"method\":\"invalid\",\"apps\":\"WebAPP1\"}]}"),
+        response
+    ));
+}
+
+/**
+ * @name  : SetACLEmptyMethod
+ * @brief : Calling speak method with empty method
+ *
+ * @param[in]   :  method of tts and app name
+ * @return      :  ERROR_GENERAL
+ */
+
+TEST_F(TTSInitializedTest, SetACLEmptyMethod) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(
+        connection,
+        _T("setACL"),
+        _T("{\"accesslist\": [{\"method\":\"\",\"apps\":\"WebAPP1\"}]}"),
+        response
+    ));
+}
+
+/**
+ * @name  : SetACLWhiteSpaceMethod
+ * @brief : Calling speak method with empty method
+ *
+ * @param[in]   :  method of tts and app name
+ * @return      :  ERROR_GENERAL
+ */
+
+TEST_F(TTSInitializedTest, SetACLWhitespaceMethod) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(
+        connection,
+        _T("setACL"),
+        _T("{\"accesslist\": [{\"method\":\" \",\"apps\":\"WebAPP1\"}]}"),
+        response
+    ));
+}
+
+/**
+ * @name  : SetACLNullMethod
+ * @brief : Calling speak method with empty method
+ *
+ * @param[in]   :  method of tts and app name
+ * @return      :  ERROR_GENERAL
+ */
+
+TEST_F(TTSInitializedTest, SetACLNullMethod) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(
+        connection,
+        _T("setACL"),
+        _T("{\"accesslist\": [{\"method\":NULL,\"apps\":\"WebAPP1\"}]}"),
+        response
+    ));
+}
+
+/***
+ * @name  : SetACLEmptyApp
+ * @brief : Calling speak method with empty method
+ *
+ * @param[in]   :  method of tts and app name
+ * @return      :  ERROR_GENERAL
+ */
+
+TEST_F(TTSInitializedTest, SetACLEmptyApp) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(
+        connection,
+        _T("setACL"),
+        _T("{\"accesslist\": [{\"method\":\"speak\",\"apps\":\"\"}]}"),
+        response
+    ));
+}
+
+/**
+ * @name  : SetACLWhiteSpaceApp
+ * @brief : Calling speak method with empty method
+ *
+ * @param[in]   :  method of tts and app name
+ * @return      :  ERROR_GENERAL
+ */
+
+TEST_F(TTSInitializedTest, SetACLWhitespaceApp) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(
+        connection,
+        _T("setACL"),
+        _T("{\"accesslist\": [{\"method\":\"speak\",\"apps\":\" \"}]}"),
+        response
+    ));
+}
+
+/**
+ * @name  : SetACLNullApp
+ * @brief : Calling speak method with empty method
+ *
+ * @param[in]   :  method of tts and app name
+ * @return      :  ERROR_GENERAL
+ */
+
+TEST_F(TTSInitializedTest, SetACLNullApp) {
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(
+        connection,
+        _T("setACL"),
+        _T("{\"accesslist\": [{\"method\":\"speak\",\"apps\":NULL}]}"),
+        response
+    ));
 }

--- a/TextToSpeech/CMakeLists.txt
+++ b/TextToSpeech/CMakeLists.txt
@@ -12,6 +12,10 @@ if(NOT WPEFRAMEWORK_SECURITYUTIL_FOUND)
     add_definitions(-DSECURITY_TOKEN_ENABLED=0)
 endif()
 
+if (NOT RDK_SERVICES_TEST)
+    add_subdirectory(test)
+endif()
+
 set_source_files_properties(
         TextToSpeechImplementation.cpp
         PROPERTIES COMPILE_FLAGS "-fexceptions")

--- a/TextToSpeech/TextToSpeechImplementation.cpp
+++ b/TextToSpeech/TextToSpeechImplementation.cpp
@@ -22,6 +22,8 @@
 #include "UtilsJsonRpc.h"
 #include <mutex>
 
+#include "TextToSpeechValidator.h"
+
 #define TTS_MAJOR_VERSION 1
 #define TTS_MINOR_VERSION 0
 
@@ -36,6 +38,7 @@
 
 namespace WPEFramework {
 namespace Plugin {
+
     SERVICE_REGISTRATION(TextToSpeechImplementation, TTS_MAJOR_VERSION, TTS_MINOR_VERSION);
 
     TTS::TTSManager* TextToSpeechImplementation::_ttsManager = NULL;
@@ -59,6 +62,17 @@ namespace Plugin {
         if(!_ttsManager)
             return 0;
 
+        InputValidation::Instance().setLogger([] (const char *log) { TTSLOG_WARNING(log); });
+        InputValidation::Instance().addValidator("ttsendpoint", ExpectedValues<std::string>("^https?://[a-zA-Z0-9]+.*"));
+        InputValidation::Instance().addValidator("ttsendpointsecured", ExpectedValues<std::string>("^https://[a-zA-Z0-9]+.*"));
+        InputValidation::Instance().addValidator("double_str", ExpectedValues<std::string>("^-?[0-9]+(\\.[0-9]+)?"));
+        InputValidation::Instance().addValidator("speechid", ExpectedValues<uint32_t>(1, UINT32_MAX));
+        InputValidation::Instance().addValidator("speechrate", ExpectedValues<std::string>({"slow", "medium", "fast", "faster", "fastest"}));
+        InputValidation::Instance().addValidator("rate", ExpectedValues<uint8_t>(0, 100));
+        InputValidation::Instance().addValidator("volume", ExpectedValues<uint8_t>(0, 100));
+        InputValidation::Instance().addValidator("primvolduckpercent", ExpectedValues<std::string>("^-?[0-9]+$"));
+        InputValidation::Instance().addValidator("setPrimaryVolDuck", ExpectedValues<uint8_t>(0, 100));
+
         JsonObject config;
         config.FromString(service->ConfigLine());
 
@@ -75,23 +89,42 @@ namespace Plugin {
         ttsConfig->setPrimVolDuck(std::stoi(GET_STR(config,"primvolduckpercent", "25")));
         ttsConfig->setSATPluginCallsign(GET_STR(config, "satplugincallsign", ""));
 
+        std::set<std::string> expectedLanguageSet;
+        std::set<std::string> expectedVoicesSet;
+
+        expectedLanguageSet.insert("*");
+
         if(config.HasLabel("voices")) {
             JsonObject voices = config["voices"].Object();
-            JsonObject::Iterator it = voices.Variants();
-            while(it.Next())
+            for(JsonObject::Iterator it = voices.Variants(); it.Next(); ) {
                 ttsConfig->m_others["voice_for_" + string(it.Label())] = it.Current().String();
+                expectedLanguageSet.insert(toLower(string(it.Label())));
+                expectedVoicesSet.insert(toLower(it.Current().String()));
+            }
 
             if(!config.HasLabel("voice"))
                 ttsConfig->setVoice(ttsConfig->voice());
         } else {
             TTSLOG_WARNING("Doesn't find default voice configuration");
         }
+
         if(config.HasLabel("local_voices")) {
             JsonObject voices = config["local_voices"].Object();
-            JsonObject::Iterator it = voices.Variants();
-            while(it.Next())
+            for(JsonObject::Iterator it = voices.Variants(); it.Next(); ) {
                 ttsConfig->m_others["voice_for_local_" + string(it.Label())] = it.Current().String();
+                expectedLanguageSet.insert(toLower(string(it.Label())));
+                expectedVoicesSet.insert(toLower(it.Current().String()));
+            }
         }
+
+#ifndef UNIT_TESTING
+        InputValidation::Instance().addValidator("language", ExpectedValues<std::string>(expectedLanguageSet));
+        InputValidation::Instance().addValidator("voice", ExpectedValues<std::string>(expectedVoicesSet));
+#else
+        InputValidation::Instance().addValidator("language", ExpectedValues<std::string>(expectedLanguageSetCollection));
+        InputValidation::Instance().addValidator("voice", ExpectedValues<std::string>(expectedVoicesSetCollection));
+#endif
+
         ttsConfig->loadFromConfigStore();
         TTSLOG_INFO("TTSEndPoint : %s", ttsConfig->endPoint().c_str());
         TTSLOG_INFO("SecureTTSEndPoint : %s", ttsConfig->secureEndPoint().c_str());
@@ -168,9 +201,11 @@ namespace Plugin {
     uint32_t TextToSpeechImplementation::Enable(const bool enable)
     {
         CHECK_TTS_MANAGER_RETURN_ON_FAIL();
+
         _adminLock.Lock();
         auto status = _ttsManager->enableTTS(enable);
         _adminLock.Unlock();
+
         TTSLOG_INFO("Enable TTS %s", enable ? "Enabled" : "Disabled");
         logResponse(status);
         return (status == TTS::TTS_OK) ? (Core::ERROR_NONE) : (Core::ERROR_GENERAL);
@@ -179,17 +214,35 @@ namespace Plugin {
     uint32_t TextToSpeechImplementation::ListVoices(const string language,RPC::IStringIterator*& voices) const
     {
         CHECK_TTS_MANAGER_RETURN_ON_FAIL();
-        _adminLock.Lock();
         std::vector<std::string> voice;
-        auto status = _ttsManager->listVoices(language,voice);
+        auto status = TTS::TTS_FAIL;
+
+        if(InputValidation::Instance().validate("language", language)) {
+            _adminLock.Lock();
+            status = _ttsManager->listVoices(language, voice);
+            _adminLock.Unlock();
+        }
+
         voices = (Core::Service<RPC::StringIterator>::Create<RPC::IStringIterator>(voice));
-        _adminLock.Unlock();
         logResponse(status);
         return (status == TTS::TTS_OK) ? (Core::ERROR_NONE) : (Core::ERROR_GENERAL);
     }
 
     uint32_t TextToSpeechImplementation::SetConfiguration(const Exchange::ITextToSpeech::Configuration &object,Exchange::ITextToSpeech::TTSErrorDetail &ttsStatus)
     {
+        ttsStatus = (Exchange::ITextToSpeech::TTSErrorDetail) Exchange::ITextToSpeech::TTS_INVALID_CONFIGURATION;
+
+        if((!object.ttsEndPoint.empty() && !InputValidation::Instance().validate("ttsendpoint", object.ttsEndPoint))
+        || (!object.ttsEndPointSecured.empty() && !InputValidation::Instance().validate("ttsendpointsecured", object.ttsEndPointSecured))
+        || (!object.speechRate.empty() && !InputValidation::Instance().validate("speechrate", object.speechRate))
+        || (!object.language.empty() && !InputValidation::Instance().validate("language", toLower(object.language)))
+        || (!object.voice.empty() && !InputValidation::Instance().validate("voice", toLower(object.voice)))
+        || (!InputValidation::Instance().validate("rate", object.rate))
+        || (!InputValidation::Instance().validate("volume", object.volume))) {
+            TTSLOG_WARNING("Input configuration(s) are invalid");
+            return Core::ERROR_GENERAL;
+        }
+
         TTS::Configuration config;
         config.ttsEndPoint = object.ttsEndPoint;
         config.ttsEndPointSecured = object.ttsEndPointSecured;
@@ -198,6 +251,7 @@ namespace Plugin {
         config.speechRate = object.speechRate;
         config.volume = (double) object.volume;
         config.rate =  object.rate;
+
         _adminLock.Lock();
         auto status = _ttsManager->setConfiguration(config);
         ttsStatus = (Exchange::ITextToSpeech::TTSErrorDetail) status;
@@ -211,6 +265,7 @@ namespace Plugin {
         TTSLOG_INFO("Volume : %lf",config.volume);
         TTSLOG_INFO("Rate : %u", config.rate);
         TTSLOG_INFO("SpeechRate : %s", config.speechRate.c_str());
+
         logResponse(status);
         return (status == TTS::TTS_OK) ? (Core::ERROR_NONE) : (Core::ERROR_GENERAL);
     }
@@ -221,18 +276,24 @@ namespace Plugin {
         data.scenario = scenario;
         data.value = value;
         data.path ="";
+
         _adminLock.Lock();
         _ttsManager->setFallbackText(data);
         _adminLock.Unlock();
+
         TTSLOG_INFO("Fallback text updated scenario %s.. value %s\n",scenario.c_str(),value.c_str());
         return (Core::ERROR_NONE);
     }
 
     uint32_t TextToSpeechImplementation::SetPrimaryVolDuck(const uint8_t prim)
     {
+        if(!InputValidation::Instance().validate("setPrimaryVolDuck", prim))
+            return Core::ERROR_GENERAL;
+
         _adminLock.Lock();
         _ttsManager->setPrimaryVolDuck((int8_t)prim);
         _adminLock.Unlock();
+
         TTSLOG_INFO("prim volume duck updated %d\n",prim);
         return (Core::ERROR_NONE);
     }
@@ -242,6 +303,7 @@ namespace Plugin {
         _adminLock.Lock();
         _ttsManager->setAPIKey(apikey);
         _adminLock.Unlock();
+
         TTSLOG_INFO("api key updated\n");
         return (Core::ERROR_NONE);
     }
@@ -249,9 +311,17 @@ namespace Plugin {
     uint32_t TextToSpeechImplementation::SetACL(const string method,const string apps)
     {
         CHECK_TTS_MANAGER_RETURN_ON_FAIL();
+
+        if(method != "speak")
+            return Core::ERROR_GENERAL;
+
+        if(apps.empty() || apps.c_str()[0] == ' ' || apps == "NULL")
+           return Core::ERROR_GENERAL;
+
         _adminLock.Lock();
         auto status = _ttsManager->setACL(method,apps);
         _adminLock.Unlock();
+
         TTSLOG_INFO("setACL invoked with method %s and app list %s",method.c_str(),apps.c_str());
         logResponse(status);
         return (status == TTS::TTS_OK) ? (Core::ERROR_NONE) : (Core::ERROR_GENERAL);
@@ -259,8 +329,9 @@ namespace Plugin {
     
     uint32_t TextToSpeechImplementation::GetConfiguration(Exchange::ITextToSpeech::Configuration &exchangeConfig) const
     {
-        _adminLock.Lock();
         TTS::Configuration ttsConfig;
+
+        _adminLock.Lock();
         auto status = _ttsManager->getConfiguration(ttsConfig);
         _adminLock.Unlock();
 
@@ -273,6 +344,7 @@ namespace Plugin {
             exchangeConfig.rate               = (uint8_t) ttsConfig.rate;
             exchangeConfig.volume             = (uint8_t) ttsConfig.volume;
         }
+
         TTSLOG_INFO("Get Configuration invoked\n");
         TTSLOG_INFO("TTSEndPoint : %s",  ttsConfig.ttsEndPoint.c_str());
         TTSLOG_INFO("SecureTTSEndPoint : %s", ttsConfig.ttsEndPointSecured.c_str());
@@ -281,6 +353,7 @@ namespace Plugin {
         TTSLOG_INFO("Volume : %lf", ttsConfig.volume);
         TTSLOG_INFO("Rate : %u",  ttsConfig.rate);
         TTSLOG_INFO("SpeechRate : %s",  ttsConfig.speechRate.c_str());
+
         logResponse(status);
         return (status == TTS::TTS_OK) ? (Core::ERROR_NONE) : (Core::ERROR_GENERAL);
     }
@@ -288,9 +361,11 @@ namespace Plugin {
     uint32_t TextToSpeechImplementation::Enable(bool &enable) const
     {
         CHECK_TTS_MANAGER_RETURN_ON_FAIL();
+
         _adminLock.Lock();
         enable = _ttsManager->isTTSEnabled();
         _adminLock.Unlock();
+
         TTSLOG_INFO("Is TTS Enabled %s", enable ? "Enabled" : "Disabled");
         return (Core::ERROR_NONE);
     }
@@ -307,6 +382,7 @@ namespace Plugin {
     uint32_t TextToSpeechImplementation::Speak(const string callsign,const string text,uint32_t &speechid,Exchange::ITextToSpeech::TTSErrorDetail &ttsStatus)
     {
         CHECK_TTS_MANAGER_RETURN_ON_FAIL();
+
         _adminLock.Lock();
         speechid = nextSpeechId();
         auto status = _ttsManager->speak(speechid,callsign,text);
@@ -314,9 +390,8 @@ namespace Plugin {
         _adminLock.Unlock();
 
         if(status != TTS::TTS_OK)
-         {
             speechid = -1;
-         }
+
         TTSLOG_INFO("Speak invoked with text %s and speech id returned %d\n",text.c_str(),speechid);
         logResponse(status);
         return (status == TTS::TTS_OK) ? (Core::ERROR_NONE) : (Core::ERROR_GENERAL);
@@ -325,9 +400,14 @@ namespace Plugin {
     uint32_t TextToSpeechImplementation::Cancel(const uint32_t speechid)
     {
         CHECK_TTS_MANAGER_RETURN_ON_FAIL();
-        _adminLock.Lock();
-        auto status = _ttsManager->shut(speechid);
-        _adminLock.Unlock();
+        auto status = TTS::TTS_FAIL;
+
+        if(InputValidation::Instance().validate("speechid",speechid)) {
+            _adminLock.Lock();
+            status = _ttsManager->shut(speechid);
+            _adminLock.Unlock();
+        }
+
         TTSLOG_INFO("Cancel invoked with speechid %d",speechid);
         logResponse(status);
         return (status == TTS::TTS_OK) ? (Core::ERROR_NONE) : (Core::ERROR_GENERAL);
@@ -336,10 +416,12 @@ namespace Plugin {
     uint32_t TextToSpeechImplementation::Pause(const uint32_t speechid,Exchange::ITextToSpeech::TTSErrorDetail &ttsStatus)
     {
         CHECK_TTS_MANAGER_RETURN_ON_FAIL();
+
         _adminLock.Lock();
         auto status =  _ttsManager->pause(speechid);
         ttsStatus = (Exchange::ITextToSpeech::TTSErrorDetail) status;
         _adminLock.Unlock();
+
         TTSLOG_INFO("Pause invoked with speechid %d",speechid);
         logResponse(status);
         return (status == TTS::TTS_OK) ? (Core::ERROR_NONE) : (Core::ERROR_GENERAL);
@@ -348,10 +430,12 @@ namespace Plugin {
     uint32_t TextToSpeechImplementation::Resume(const uint32_t speechid,Exchange::ITextToSpeech::TTSErrorDetail &ttsStatus)
     {
         CHECK_TTS_MANAGER_RETURN_ON_FAIL();
+
         _adminLock.Lock();
         auto status = _ttsManager->resume(speechid);
         ttsStatus = (Exchange::ITextToSpeech::TTSErrorDetail) status;
         _adminLock.Unlock();
+
         TTSLOG_INFO("Resume invoked with speechid %d",speechid);
         logResponse(status);
         return (status == TTS::TTS_OK) ? (Core::ERROR_NONE) : (Core::ERROR_GENERAL);
@@ -361,10 +445,15 @@ namespace Plugin {
     uint32_t TextToSpeechImplementation::GetSpeechState(const  uint32_t speechid,Exchange::ITextToSpeech::SpeechState &estate)
     {
         CHECK_TTS_MANAGER_RETURN_ON_FAIL();
-        _adminLock.Lock();
         TTS::SpeechState state;
-        auto status = _ttsManager->getSpeechState(speechid, state);
-        _adminLock.Unlock();
+        auto status = TTS::TTS_FAIL;
+
+        if(InputValidation::Instance().validate("speechid", speechid)) {
+            _adminLock.Lock();
+            status = _ttsManager->getSpeechState(speechid, state);
+            _adminLock.Unlock();
+        }
+
         if(status == TTS::TTS_OK)
             estate = (Exchange::ITextToSpeech::SpeechState) state;
 

--- a/TextToSpeech/TextToSpeechJsonRpc.cpp
+++ b/TextToSpeech/TextToSpeechJsonRpc.cpp
@@ -18,9 +18,11 @@
  */
 
 #include "TextToSpeech.h"
+#include "TextToSpeechValidator.h"
 #include "UtilsJsonRpc.h"
 #include "UtilsUnused.h"
 #include "impl/TTSCommon.h"
+#include "UtilsString.h"
 
 #define GET_STR(map, key, def) ((map.HasLabel(key) && !map[key].String().empty() && map[key].String() != "null") ? map[key].String() : def)
 
@@ -42,6 +44,10 @@ namespace Plugin {
         Register("getspeechstate", &TextToSpeech::GetSpeechState, this);
         Register("setACL", &TextToSpeech::SetACL, this);
         Register("getapiversion", &TextToSpeech::getapiversion, this);
+
+        InputValidation::Instance().setLogger([] (const char *log) { TTSLOG_WARNING(log); });
+        InputValidation::Instance().addValidator("double_str", ExpectedValues<std::string>("^-?[0-9]+(\\.[0-9]+)?"));
+        InputValidation::Instance().addValidator("primvolduckpercent", ExpectedValues<std::string>("^-?[0-9]+$"));
     }
     
     bool TextToSpeech::AddToAccessList(const string &key,const string &value)
@@ -88,26 +94,34 @@ namespace Plugin {
         }
     }
 
-    uint32_t TextToSpeech::SetACL(const JsonObject& parameters, JsonObject& response)
+uint32_t TextToSpeech::SetACL(const JsonObject& parameters, JsonObject& response)
     {
         if(_tts) {
             CHECK_TTS_PARAMETER_RETURN_ON_FAIL("accesslist");
             TTSLOG_INFO("SetACL request:%s\n",parameters["accesslist"].String().c_str());
             JsonArray list = parameters["accesslist"].Array();
-            JsonArray::Iterator it = list.Elements();
-            while(it.Next())
+
+            for (JsonArray::Iterator it = list.Elements(); it.Next();)
             {
                 JsonObject accesslist = it.Current().Object();
-                if (accesslist.HasLabel("method") && accesslist.HasLabel("apps"))
-                {
-                    _tts->SetACL(accesslist["method"].String(),accesslist["apps"].String());
-                }
-                else
+
+                std::string method = accesslist["method"].String();
+                std::string apps = accesslist["apps"].String();
+                Utils::String::trim(apps);
+
+                if (method != "speak" ||  apps.empty() || apps == "NULL")
                 {
                     TTSLOG_WARNING("SetACL wrong input parameters\n");
                     returnResponse(false);
                 }
             }
+
+            for (JsonArray::Iterator it = list.Elements(); it.Next();)
+            {
+                JsonObject accesslist = it.Current().Object();
+                _tts->SetACL(accesslist["method"].String(), accesslist["apps"].String());
+            }
+
             returnResponse(true);
         }
         return Core::ERROR_NONE;
@@ -129,16 +143,16 @@ namespace Plugin {
         if(_tts) {
             CHECK_TTS_PARAMETER_RETURN_ON_FAIL("language");
             RPC::IStringIterator* voices = nullptr;
-            _tts->ListVoices(parameters["language"].String(),voices);
+            auto status = _tts->ListVoices(parameters["language"].String(), voices);
             JsonArray arr;
             string element;
             while (voices->Next(element) == true) {
                 arr.Add(JsonValue(element));
             }
             response["voices"] = arr;
-            response["TTS_Status"] = static_cast<uint32_t> (TTS::TTS_OK);
+            response["TTS_Status"] = status;
             voices->Release();
-            returnResponse(true);
+            returnResponse((status == TTS::TTS_OK) ? true : false);
         }
         return Core::ERROR_NONE;
     }
@@ -159,61 +173,62 @@ namespace Plugin {
             returnResponse(true);
          }
          return Core::ERROR_NONE;
-
     }
 
     uint32_t TextToSpeech::SetConfiguration(const JsonObject& parameters, JsonObject& response)
     {
         if(_tts) {
-        Exchange::ITextToSpeech::Configuration config;
-        config.ttsEndPoint = GET_STR(parameters, "ttsendpoint", "");
-        config.ttsEndPointSecured = GET_STR(parameters, "ttsendpointsecured", "");
-        config.language = GET_STR(parameters, "language", "");
-        config.voice = GET_STR(parameters, "voice", "");
-        config.speechRate = GET_STR(parameters, "speechrate", "");
-        config.volume = (uint8_t) std::stod(GET_STR(parameters, "volume", "0.0"));
+            Exchange::ITextToSpeech::TTSErrorDetail status = Exchange::ITextToSpeech::TTSErrorDetail::TTS_FAIL;
+            Exchange::ITextToSpeech::Configuration config;
+            config.ttsEndPoint = GET_STR(parameters, "ttsendpoint", "");
+            config.ttsEndPointSecured = GET_STR(parameters, "ttsendpointsecured", "");
+            config.language = GET_STR(parameters, "language", "");
+            config.voice = GET_STR(parameters, "voice", "");
+            config.speechRate = GET_STR(parameters, "speechrate", "");
 
-        if(parameters.HasLabel("rate")) {
-            int rate=0;
-            getNumberParameter("rate", rate);
-            config.rate = static_cast<uint8_t>(rate);
-        }
-        else {
-            config.rate = 0;
-        }
+            std::string proxyVolume = GET_STR(parameters, "volume", "0.0");
+            if(!InputValidation::Instance().validate("double_str", proxyVolume))
+                goto config_failure;
+            config.volume = (uint8_t) std::stod(proxyVolume);
 
-        if(parameters.HasLabel("authinfo")) {
-            JsonObject auth;
-            string apikey;
-            auth = parameters["authinfo"].Object();
-            if(((auth["type"].String()).compare("apikey")) == 0)
-            {
-                apikey = GET_STR(auth,"value", "");
-                _tts->SetAPIKey(apikey);
+            if(parameters.HasLabel("rate")) {
+                int rate=0;
+                getNumberParameter("rate", rate);
+                config.rate = static_cast<uint8_t>(rate);
+            } else {
+                config.rate = 0;
             }
-        }
 
-        if(parameters.HasLabel("fallbacktext")) {
-            JsonObject fallback;
-            string scenario,value;
-            fallback = parameters["fallbacktext"].Object();
-            scenario = fallback["scenario"].String();
-            value    = fallback["value"].String();
-            _tts->SetFallbackText(scenario,value);
-        }
+            if(parameters.HasLabel("authinfo")) {
+                JsonObject auth = parameters["authinfo"].Object();
+                if(auth["type"].String().compare("apikey") == 0) {
+                    _tts->SetAPIKey(GET_STR(auth, "value", ""));
+                }
+            }
 
-        if(parameters.HasLabel("primvolduckpercent")) {
-           int8_t  primVolDuck;
-           primVolDuck = (int8_t) std::stoi(GET_STR(parameters,"primvolduckpercent","-1"));
-           _tts->SetPrimaryVolDuck(primVolDuck);
+            if(parameters.HasLabel("fallbacktext")) {
+                JsonObject fallback = parameters["fallbacktext"].Object();
+                _tts->SetFallbackText(fallback["scenario"].String(), fallback["value"].String());
+            }
+
+            if(parameters.HasLabel("primvolduckpercent")) {
+                std::string primVolDuckProxy = GET_STR(parameters, "primvolduckpercent", "-1");
+                if(!InputValidation::Instance().validate("primvolduckpercent", primVolDuckProxy))
+                    goto config_failure;
+
+                int8_t primVolDuck = (int8_t) std::stoi(primVolDuckProxy);
+                if(Core::ERROR_NONE != _tts->SetPrimaryVolDuck(primVolDuck))
+                    goto config_failure;
+            }
+
+            _tts->SetConfiguration(config, status);
+
+        config_failure:
+            response["TTS_Status"] = static_cast<uint32_t>(status);
+            returnResponse(status == Exchange::ITextToSpeech::TTSErrorDetail::TTS_OK);
         }
-         Exchange::ITextToSpeech::TTSErrorDetail status;
-         _tts->SetConfiguration(config,status);
-         response["TTS_Status"] = static_cast<uint32_t>(status);
-         returnResponse(status == Exchange::ITextToSpeech::TTSErrorDetail::TTS_OK);
-     }
-     return Core::ERROR_NONE;
-}
+        return Core::ERROR_NONE;
+    }
 
     uint32_t TextToSpeech::IsEnabled(const JsonObject& parameters ,JsonObject& response)
     {
@@ -245,13 +260,12 @@ namespace Plugin {
     {
         CHECK_TTS_PARAMETER_RETURN_ON_FAIL("speechid");
         if(_tts) {
-            _tts->Cancel(parameters["speechid"].Number());
-            response["TTS_Status"] = static_cast<uint32_t> (TTS::TTS_OK);
-            returnResponse(true);
+            auto status = _tts->Cancel(parameters["speechid"].Number());
+            response["TTS_Status"] = status;
+            returnResponse((status == TTS::TTS_OK) ? true : false);
         }
         return Core::ERROR_NONE;
     }
-
 
     uint32_t TextToSpeech::Pause(const JsonObject& parameters, JsonObject& response)
     {
@@ -282,14 +296,14 @@ namespace Plugin {
         if(_tts) {
             bool isspeaking = false;
             Exchange::ITextToSpeech::SpeechState state;
-            _tts->GetSpeechState(parameters["speechid"].Number(),state);
+            auto status = _tts->GetSpeechState(parameters["speechid"].Number(),state);
+
             if(state == Exchange::ITextToSpeech::SpeechState::SPEECH_IN_PROGRESS)
-            {
                isspeaking = true;
-            }
+
             response["speaking"] = isspeaking;
-            response["TTS_Status"] = static_cast<uint32_t> (TTS::TTS_OK);
-            returnResponse(true);
+            response["TTS_Status"] = status;
+            returnResponse((status == TTS::TTS_OK) ? true : false);
         }
         return Core::ERROR_NONE;
     }
@@ -298,10 +312,10 @@ namespace Plugin {
     {
         if(_tts) {
             Exchange::ITextToSpeech::SpeechState state;
-            _tts->GetSpeechState(parameters["speechid"].Number(),state);
+            auto status = _tts->GetSpeechState(parameters["speechid"].Number(),state);
             response["speechstate"] = (int) state;
-            response["TTS_Status"] = static_cast<uint32_t> (TTS::TTS_OK);
-            returnResponse(true);
+            response["TTS_Status"] = status;
+            returnResponse((status == TTS::TTS_OK) ? true : false);
         }
         return Core::ERROR_NONE;
     }

--- a/TextToSpeech/TextToSpeechValidator.h
+++ b/TextToSpeech/TextToSpeechValidator.h
@@ -1,0 +1,90 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2023 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+#pragma once
+
+#include "../helpers/UtilsInputValidator.h"
+
+namespace WPEFramework {
+namespace Plugin {
+
+using Utils::ExpectedValues;
+using Utils::Validator;
+using Utils::ValidationManager;
+
+// Country and language codes from ISO-639/ISO-3166.
+static const std::set<std::string> expectedLanguageSetCollection = {
+    "af", "*", "en-us", "af-ZA", "ar", "ar-AE", "ar-BH", "ar-DZ", "ar-EG", "ar-IQ", "ar-JO", "ar-KW", "ar-LB", "ar-LY",
+    "ar-MA", "ar-OM", "ar-QA", "ar-SA", "ar-SY", "ar-TN", "ar-YE", "az", "az-AZ", "az-AZ",
+    "be", "be-BY", "bg", "bg-BG", "bs-BA",
+    "ca", "ca-ES", "cs", "cs-CZ", "cy", "cy-GB",
+    "da", "da-DK", "de", "de-AT", "de-CH", "de-DE", "de-LI", "de-LU", "dv", "dv-MV",
+    "el", "el-GR", "en", "en-AU", "en-BZ", "en-CA", "en-CB", "en-GB", "en-IE", "en-JM", "en-NZ", "en-PH",
+    "en-TT", "en-US", "en-ZA", "en-ZW", "eo", "es", "es-AR", "es-BO", "es-CL", "es-CO", "es-CR", "es-DO",
+    "es-EC", "es-ES", "es-ES", "es-GT", "es-HN", "es-MX", "es-NI", "es-PA", "es-PE", "es-PR", "es-PY", "es-SV",
+    "es-UY", "es-VE", "et", "et-EE", "eu", "eu-ES",
+    "fa", "fa-IR", "fi", "fi-FI", "fo", "fo-FO", "fr", "fr-BE", "fr-CA", "fr-CH", "fr-FR", "fr-LU", "fr-MC",
+    "gl", "gl-ES", "gu", "gu-IN",
+    "he", "he-IL", "hi", "hi-IN", "hr", "hr-BA", "hr-HR", "hu", "hu-HU", "hy", "hy-AM", "id", "id-ID",
+    "is", "is-IS", "it", "it-CH", "it-IT",
+    "ja", "ja-JP",
+    "ka", "ka-GE", "kk", "kk-KZ", "kn", "kn-IN", "ko", "ko-KR", "kok", "kok-IN", "ky", "ky-KG",
+    "lt", "lt-LT", "lv", "lv-LV",
+    "mi", "mi-NZ", "mk", "mk-MK", "mn", "mn-MN", "mr", "mr-IN", "ms", "ms-BN", "ms-MY", "mt", "mt-MT",
+    "nb", "nb-NO", "nl", "nl-BE", "nl-NL", "nn-NO", "ns", "ns-ZA",
+    "pa", "pa-IN", "pl", "pl-PL", "ps", "ps-AR", "pt", "pt-BR", "pt-PT",
+    "qu", "qu-BO", "qu-EC", "qu-PE",
+    "ro", "ro-RO", "ru", "ru-RU",
+    "sa", "sa-IN", "se", "se-FI", "se-FI", "se-FI", "se-NO", "se-NO", "se-NO", "se-SE", "se-SE",
+    "se-SE", "sk", "sk-SK", "sl", "sl-SI", "sq", "sq-AL", "sr-BA", "sr-BA", "sr-SP", "sr-SP",
+    "sv", "sv-FI", "sv-SE", "sw", "sw-KE", "syr", "syr-SY",
+    "ta", "ta-IN", "te", "te-IN", "th", "th-TH", "tl", "tl-PH", "tn", "tn-ZA", "tr", "tr-TR", "tt", "tt-RU", "ts",
+    "uk", "uk-UA", "ur", "ur-PK", "uz", "uz-UZ", "uz-UZ",
+    "vi", "vi-VN",
+    "xh", "xh-ZA",
+    "zh", "zh-CN", "zh-HK", "zh-MO", "zh-SG", "zh-TW", "zu", "zu-ZA",""};
+
+static const std::set<std::string> expectedVoicesSetCollection = {"carol","amelie","Angelica","ava",""};
+
+inline std::string toLower(std::string s) {
+    std::transform(s.begin(), s.end(), s.begin(), ::tolower);
+    return s;
+}
+
+struct InputValidation
+{
+    NON_COPYABLE(InputValidation);
+    NON_MOVABLE(InputValidation);
+    ~InputValidation() = default;
+
+    static ValidationManager &Instance()
+    {
+        static InputValidation s_instance;
+        return s_instance.m_validationManager;
+    }
+
+    private:
+        InputValidation() = default;
+
+    private:
+        ValidationManager m_validationManager;
+};
+
+} // namespace Plugin
+} // namespace WPEFramework

--- a/helpers/UtilsInputValidator.h
+++ b/helpers/UtilsInputValidator.h
@@ -1,0 +1,351 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2023 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+#pragma once
+
+#include <string>
+#include <memory>
+#include <regex>
+#include <vector>
+#include <set>
+#include <map>
+#include <functional>
+#include <type_traits>
+#include <initializer_list>
+
+namespace Utils {
+
+#define NON_COPYABLE(Type) \
+    Type(Type &) = delete; \
+    Type& operator=(Type &) = delete;\
+
+#define NON_MOVABLE(Type) \
+    Type(Type &&) = delete; \
+    Type& operator=(Type &&) = delete;\
+
+template <typename T>
+class ExpectedValues
+{
+private:
+    enum Type
+    {
+        None,
+        Discrete,
+        Range,
+        RegExp
+    };
+
+public:
+    ExpectedValues() = default;
+
+    ExpectedValues &operator=(const ExpectedValues &copy)
+    {
+        m_type = copy.m_type;
+        switch (m_type)
+        {
+        case Type::Discrete:
+            for (auto &value : copy.m_values)
+                m_values.emplace(value);
+            break;
+        case Type::Range:
+            m_range = copy.m_range;
+            break;
+        case Type::RegExp:
+            m_regex = copy.m_regex;
+            break;
+        case None:
+        default:
+            break;
+        }
+
+        return *this;
+    };
+    ExpectedValues(const ExpectedValues &copy)
+    {
+        operator=(copy);
+    }
+
+    ExpectedValues &operator=(ExpectedValues &&copy)
+    {
+        std::swap(m_type, copy.m_type);
+        switch (m_type)
+        {
+        case Type::Discrete:
+            m_values = std::move(copy.m_values);
+            break;
+        case Type::Range:
+            m_range = copy.m_range;
+            break;
+        case Type::RegExp:
+            m_regex = std::move(copy.m_regex);
+            break;
+        case None:
+        default:
+            break;
+        }
+
+        return *this;
+    };
+    ExpectedValues(ExpectedValues &&copy)
+    {
+        operator=(std::forward<ExpectedValues<T>>(copy));
+    };
+
+    virtual ~ExpectedValues(){};
+
+    ExpectedValues(T min, T max) : m_type(Range), m_range({min, max}) {}
+    ExpectedValues(std::string regexStr) : m_type(RegExp), m_regex(std::regex(std::move(regexStr))) {}
+    ExpectedValues(std::regex regex) : m_type(RegExp), m_regex(std::move(regex)) {}
+    ExpectedValues(std::set<T> values) : m_type(Discrete), m_values(std::move(values)) {}
+
+    ExpectedValues(std::initializer_list<T> values) : m_type(Discrete), m_values(std::move(values)) {}
+    ExpectedValues(std::initializer_list<const char *> values) : m_type(Discrete)
+    {
+        for (auto *value : values) {
+            if (!value)
+                continue;
+            m_values.emplace(std::string(value));
+        }
+    }
+
+    ExpectedValues(std::vector<T> values) : m_type(Discrete), m_values(std::move(values)) {}
+    ExpectedValues(std::vector<const char *> values) : m_type(Discrete)
+    {
+        for (auto *value : values) {
+            if (!value)
+                continue;
+            m_values.emplace(std::string(value));
+        }
+    }
+
+    inline bool validate(const T &value) const
+    {
+        switch (m_type)
+        {
+        case Type::Discrete:
+            return std::find(m_values.begin(), m_values.end(), value) != m_values.end();
+        case Type::Range:
+            return value >= m_range.m_min && value <= m_range.m_max;
+        case Type::RegExp:
+            return regexMatch(value);
+        case None:
+        default:
+            return true;
+        }
+    }
+
+    inline bool validate(const char *value)
+    {
+        return value ? validate(std::string(value)) : false;
+    }
+
+private:
+    inline bool regexMatch(const std::string &value) const
+    {
+        return std::regex_match(value, m_regex);
+    }
+
+    template <typename U>
+    inline bool regexMatch(const U &value) const
+    {
+        return regexMatch(std::to_string(value));
+    }
+
+private:
+    Type m_type{None};
+
+    struct
+    {
+        T m_min;
+        T m_max;
+    } m_range;
+    std::set<T> m_values;
+    std::regex m_regex;
+};
+
+struct ValidatorBase
+{
+    virtual ~ValidatorBase(){};
+};
+
+template <typename T>
+class Validator : public ValidatorBase
+{
+    using FunctionType = std::function<bool(const T &)>;
+
+    enum Type
+    {
+        None,
+        UseExpectedValues,
+        CustomValidation
+    };
+
+public:
+    NON_COPYABLE(Validator);
+    NON_MOVABLE(Validator);
+    virtual ~Validator(){};
+
+    inline static std::shared_ptr<ValidatorBase> create(ExpectedValues<T> &&expectedValues)
+    {
+        return std::shared_ptr<ValidatorBase>(static_cast<ValidatorBase *>(new Validator<T>(std::forward<ExpectedValues<T>>(expectedValues))));
+    }
+
+    inline static std::shared_ptr<ValidatorBase> create(FunctionType &&func)
+    {
+        return std::shared_ptr<ValidatorBase>(static_cast<ValidatorBase *>(new Validator<T>(std::forward<FunctionType>(func))));
+    }
+
+public:
+    inline virtual bool validate(const T &value)
+    {
+        switch (m_type)
+        {
+            case Type::CustomValidation:
+                return m_func(value);
+                break;
+            case Type::UseExpectedValues:
+                return m_expectedValues.validate(value);
+                break;
+            case None:
+            default:
+                return false;
+        }
+    }
+
+protected:
+    Validator() : m_type(Type::None) {}
+
+private:
+    Validator(ExpectedValues<T> expectedValues) : m_type(UseExpectedValues), m_expectedValues(std::move(expectedValues)) {}
+    Validator(std::function<bool(const T &)> func) : m_type(CustomValidation), m_func(std::move(func)) {}
+
+private:
+    Type m_type;
+
+    union
+    {
+        ExpectedValues<T> m_expectedValues;
+        std::function<bool(const T &)> m_func;
+    };
+};
+
+class ValidationManager
+{
+public:
+    using ValidatorMap = std::map<std::string, std::vector<std::shared_ptr<ValidatorBase>>>;
+    using LoggerFunction = void(*)(const char *log);
+
+public:
+    inline void addValidator(std::string name, std::shared_ptr<ValidatorBase> validator)
+    {
+        m_validators[name].emplace_back(std::move(validator));
+    }
+
+    template <typename T>
+    inline void addValidator(std::string name, ExpectedValues<T> &&expectedValues)
+    {
+        addValidator(name, Validator<T>::create(std::forward<ExpectedValues<T>>(expectedValues)));
+    }
+
+    template <typename T, typename FunctionType = std::function<bool(const T &)>>
+    inline void addValidator(std::string name, FunctionType &&func)
+    {
+        addValidator(name, Validator<T>::create(std::forward<FunctionType>(func)));
+    }
+
+    template <typename T>
+    inline bool validate(std::string name, const T &value)
+    {
+        auto it = m_validators.find(name);
+        if (it != m_validators.end())
+        {
+            for (auto &strValidatorBase : it->second)
+            {
+                auto *validator = dynamic_cast<Validator<T> *>(strValidatorBase.get());
+                if (validator == nullptr || !validator->validate(value))
+                {
+                    std::stringstream ss;
+                    if (!validator)
+                        ss << "Validator not found for key \"" << name << "\" with type \"" << typeid(T).name() << "\"" << std::endl;
+                    ss << "Validation failed for key \"" << name << "\" with type \"" << typeid(T).name() << "\" & value \"" << value << "\"" << std::endl;
+
+                    if (m_logger)
+                        m_logger(ss.str().c_str());
+                    else
+                        std::cout << ss.str();
+
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    inline bool validate(std::string name, const char *value)
+    {
+        return value ? validate(name, std::string(value)) : false;
+    }
+
+    void setLogger(LoggerFunction logger)
+    {
+        m_logger = logger;
+    }
+
+private:
+    ValidatorMap m_validators;
+    LoggerFunction m_logger { nullptr };
+};
+
+} // namespace Utils
+
+#if 0
+namespace {
+    using namespace Utils;
+
+    template <typename T>
+    class MyCustomValidator : public Validator<T>
+    {
+    public:
+        NON_COPYABLE(MyCustomValidator);
+        NON_MOVABLE(MyCustomValidator);
+        virtual ~MyCustomValidator(){};
+
+        inline static std::shared_ptr<ValidatorBase> create()
+        {
+            return std::shared_ptr<ValidatorBase>(static_cast<ValidatorBase *>(new MyCustomValidator<T>()));
+        }
+
+    public:
+        inline virtual bool validate(const T &value) override
+        {
+            return true;
+        }
+
+    private:
+        MyCustomValidator() : Validator<T>() {}
+    };
+
+    ValidationManager validator;
+    validator.addValidator("key", MyCustomValidator<std::string>::create());
+}
+#endif
+

--- a/tests.cmake
+++ b/tests.cmake
@@ -134,7 +134,7 @@ set(FAKE_HEADERS
         ${BASEDIR}/Dobby.h
         ${BASEDIR}/HdmiCec.h
         ${BASEDIR}/rdkshell.h
-	      ${BASEDIR}/RdkLoggerMilestone.h
+	${BASEDIR}/RdkLoggerMilestone.h
         )
 
 foreach (file ${FAKE_HEADERS})
@@ -213,5 +213,5 @@ set(PLUGIN_HDMICECSINK ON)
 set(PLUGIN_RDKSHELL ON)
 set(PLUGIN_MAINTENANCEMANAGER ON)
 set(PLUGIN_PACKAGER ON)
-
 set(DS_FOUND ON)
+set(PLUGIN_SYSTEMAUDIOPLAYER ON)


### PR DESCRIPTION
Reason for change: To Add UT for SystemAudioPlayer

Test Procedure: Github workflow
Priority: P1
Risks: None

XRE-16779: Fix compilation issue in SystemAudioPlayer

Reason for change: Compilation issue

Test Procedure: TBD
Priority: P1
Risks: None

Reason for change: Added validation checks

Test Procedure: Regression Testing
Risks: None
Priority: P1
Signed-off-by: Rajan Y.(rajan_yadav@Comcast.Com)

DELIA-64023: Race condition in AudioPlayer deinit in SystemAudioPlayer (#4714)

Reason for change: To prevent glip thread hangs

Test Procedure: Unit test
Priority: P0
Risks: None

Move InputValidator to Utils (#4731)

Removing Authinfo Test Case in TTS (#4743)

Priority: P1
Test Procedure: Github workflow

LLAMA-13029: Make language and voice as Case-insenstive parameters

Reason for change: Both Vrex and googe endpoint support case-insensitive inputs