### PR TITLE
RDK-38840: return appearance value from btmgr

### DIFF
--- a/Bluetooth/Bluetooth.cpp
+++ b/Bluetooth/Bluetooth.cpp
@@ -40,7 +40,7 @@
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 5
+#define API_VERSION_NUMBER_PATCH 6
 
 const string WPEFramework::Plugin::Bluetooth::SERVICE_NAME = "org.rdk.Bluetooth";
 const string WPEFramework::Plugin::Bluetooth::METHOD_START_SCAN = "startScan";
@@ -396,7 +396,8 @@ namespace WPEFramework
                     deviceDetails["deviceType"] = string(BTRMGR_GetDeviceTypeAsString(discoveredDevices.m_deviceProperty[i].m_deviceType));
                     deviceDetails["connected"] = discoveredDevices.m_deviceProperty[i].m_isConnected?true:false;
                     deviceDetails["paired"] = discoveredDevices.m_deviceProperty[i].m_isPairedDevice?true:false;
-                    deviceDetails["rawDeviceType"] = std::to_string(discoveredDevices.m_deviceProperty[i].m_ui32DevClassBtSpec);    
+                    deviceDetails["rawDeviceType"] = std::to_string(discoveredDevices.m_deviceProperty[i].m_ui32DevClassBtSpec);
+                    deviceDetails["rawBleDeviceType"] = std::to_string(discoveredDevices.m_deviceProperty[i].m_ui16DevAppearanceBleSpec);
                     deviceArray.Add(deviceDetails);
                 }
             }
@@ -880,6 +881,7 @@ namespace WPEFramework
                     params["name"] = string(eventMsg.m_discoveredDevice.m_name);
                     params["deviceType"] = BTRMGR_GetDeviceTypeAsString(eventMsg.m_discoveredDevice.m_deviceType);
                     params["rawDeviceType"] = C_STR(std::to_string(eventMsg.m_discoveredDevice.m_ui32DevClassBtSpec));
+                    params["rawBleDeviceType"] = C_STR(std::to_string(eventMsg.m_discoveredDevice.m_ui16DevAppearanceBleSpec));
                     params["lastConnectedState"] = eventMsg.m_discoveredDevice.m_isLastConnectedDevice ? true : false;
                     params["paired"] = eventMsg.m_discoveredDevice.m_isPairedDevice ? true : false;
                     params["connected"] = eventMsg.m_discoveredDevice.m_isConnected ? true : false;
@@ -894,6 +896,7 @@ namespace WPEFramework
                     params["name"] = string(eventMsg.m_pairedDevice.m_name);
                     params["deviceType"] = BTRMGR_GetDeviceTypeAsString(eventMsg.m_pairedDevice.m_deviceType);
                     params["rawDeviceType"] = std::to_string(eventMsg.m_pairedDevice.m_ui32DevClassBtSpec);
+                    params["rawBleDeviceType"] = std::to_string(eventMsg.m_pairedDevice.m_ui16DevAppearanceBleSpec);
                     params["lastConnectedState"] = eventMsg.m_pairedDevice.m_isLastConnectedDevice ? true : false;
                     params["paired"] = false;
                     params["connected"] = eventMsg.m_pairedDevice.m_isConnected ? true : false;
@@ -909,6 +912,7 @@ namespace WPEFramework
                     params["name"] = string(eventMsg.m_pairedDevice.m_name);
                     params["deviceType"] = BTRMGR_GetDeviceTypeAsString(eventMsg.m_pairedDevice.m_deviceType);
                     params["rawDeviceType"] = std::to_string(eventMsg.m_pairedDevice.m_ui32DevClassBtSpec);
+                    params["rawBleDeviceType"] = std::to_string(eventMsg.m_pairedDevice.m_ui16DevAppearanceBleSpec);
                     params["lastConnectedState"] = eventMsg.m_pairedDevice.m_isLastConnectedDevice ? true : false;
                     params["paired"] = true;
                     params["connected"] = eventMsg.m_pairedDevice.m_isConnected ? true : false;
@@ -956,6 +960,7 @@ namespace WPEFramework
                     params["name"] = string(eventMsg.m_discoveredDevice.m_name);
                     params["deviceType"] = BTRMGR_GetDeviceTypeAsString(eventMsg.m_discoveredDevice.m_deviceType);
                     params["rawDeviceType"] = std::to_string(eventMsg.m_discoveredDevice.m_ui32DevClassBtSpec);
+                    params["rawBleDeviceType"] = std::to_string(eventMsg.m_discoveredDevice.m_ui16DevAppearanceBleSpec);
                     params["lastConnectedState"] = eventMsg.m_discoveredDevice.m_isLastConnectedDevice ? true : false;
                     params["paired"] = eventMsg.m_discoveredDevice.m_isPairedDevice ? true : false;
                     params["connected"] = eventMsg.m_discoveredDevice.m_isConnected ? true : false;
@@ -970,6 +975,7 @@ namespace WPEFramework
                     params["name"] = string(eventMsg.m_pairedDevice.m_name);
                     params["deviceType"] = BTRMGR_GetDeviceTypeAsString(eventMsg.m_pairedDevice.m_deviceType);
                     params["rawDeviceType"] = std::to_string(eventMsg.m_pairedDevice.m_ui32DevClassBtSpec);
+                    params["rawBleDeviceType"] = std::to_string(eventMsg.m_pairedDevice.m_ui16DevAppearanceBleSpec);
                     params["lastConnectedState"] = eventMsg.m_pairedDevice.m_isLastConnectedDevice ? true : false;
                     params["paired"] = true;
                     params["connected"] = eventMsg.m_pairedDevice.m_isConnected ? true : false;
@@ -984,6 +990,7 @@ namespace WPEFramework
                     params["name"] = string(eventMsg.m_pairedDevice.m_name);
                     params["deviceType"] = BTRMGR_GetDeviceTypeAsString(eventMsg.m_pairedDevice.m_deviceType);
                     params["rawDeviceType"] = std::to_string(eventMsg.m_pairedDevice.m_ui32DevClassBtSpec);
+                    params["rawBleDeviceType"] = std::to_string(eventMsg.m_pairedDevice.m_ui16DevAppearanceBleSpec);
                     params["lastConnectedState"] = eventMsg.m_pairedDevice.m_isLastConnectedDevice ? true : false;
                     params["paired"] = true;
                     params["connected"] = eventMsg.m_pairedDevice.m_isConnected ? true : false;
@@ -1094,6 +1101,7 @@ namespace WPEFramework
                     params["name"] = string(eventMsg.m_pairedDevice.m_name);
                     params["deviceType"] = BTRMGR_GetDeviceTypeAsString(eventMsg.m_pairedDevice.m_deviceType);
                     params["rawDeviceType"] = std::to_string(eventMsg.m_pairedDevice.m_ui32DevClassBtSpec);
+                    params["rawBleDeviceType"] = std::to_string(eventMsg.m_pairedDevice.m_ui16DevAppearanceBleSpec);
                     params["lastConnectedState"] = eventMsg.m_pairedDevice.m_isLastConnectedDevice?true:false;
 
                     eventId = EVT_DEVICE_FOUND;
@@ -1104,6 +1112,7 @@ namespace WPEFramework
                     params["name"] = string(eventMsg.m_pairedDevice.m_name);
                     params["deviceType"] = BTRMGR_GetDeviceTypeAsString(eventMsg.m_pairedDevice.m_deviceType);
                     params["rawDeviceType"] = std::to_string(eventMsg.m_pairedDevice.m_ui32DevClassBtSpec);
+                    params["rawBleDeviceType"] = std::to_string(eventMsg.m_pairedDevice.m_ui16DevAppearanceBleSpec);
                     params["lastConnectedState"] = eventMsg.m_pairedDevice.m_isLastConnectedDevice?true:false;
                     eventId = EVT_DEVICE_LOST_OR_OUT_OF_RANGE;
                     break;
@@ -1114,6 +1123,7 @@ namespace WPEFramework
                     params["name"] = string(eventMsg.m_discoveredDevice.m_name);
                     params["deviceType"] = BTRMGR_GetDeviceTypeAsString(eventMsg.m_discoveredDevice.m_deviceType);
                     params["rawDeviceType"] = std::to_string(eventMsg.m_discoveredDevice.m_ui32DevClassBtSpec);
+                    params["rawBleDeviceType"] = std::to_string(eventMsg.m_discoveredDevice.m_ui16DevAppearanceBleSpec);
                     params["lastConnectedState"] = eventMsg.m_discoveredDevice.m_isLastConnectedDevice? true:false;
                     params["paired"] = eventMsg.m_discoveredDevice.m_isPairedDevice ? true:false;
 

--- a/Bluetooth/Bluetooth.json
+++ b/Bluetooth/Bluetooth.json
@@ -60,9 +60,14 @@
             "example":"E8:FB:E9:0C:XX:80"
         },
         "rawDeviceType": {
-            "summary": "Bluetooth device class as hex code",
+            "summary": "Bluetooth device class",
             "type": "string",
-            "example": "0x060104"
+            "example": "2360344"
+        },
+        "rawBleDeviceType": {
+            "summary": "Bluetooth device appearance",
+            "type": "string",
+            "example": "180"
         },
         "lastConnectedState": {
             "summary": "Whether the device was last to connect. Only the last connected device has a value of `true`.",
@@ -967,6 +972,9 @@
                     "rawDeviceType": {
                         "$ref": "#/definitions/rawDeviceType"
                     },
+                    "rawBleDeviceType": {
+                        "$ref": "#/definitions/rawBleDeviceType"
+                    },
                     "lastConnectedState": {
                         "$ref": "#/definitions/lastConnectedState"
                     },
@@ -982,6 +990,7 @@
                     "name",
                     "deviceType",
                     "rawDeviceType",
+                    "rawBleDeviceType",
                     "lastConnectedState",
                     "paired"
                 ]
@@ -1173,6 +1182,9 @@
                     "rawDeviceType": {
                         "$ref": "#/definitions/rawDeviceType"
                     },
+                    "rawBleDeviceType": {
+                        "$ref": "#/definitions/rawBleDeviceType"
+                    },
                     "lastConnectedState": {
                         "$ref": "#/definitions/lastConnectedState"
                     },
@@ -1191,6 +1203,7 @@
                     "name",
                     "deviceType",
                     "rawDeviceType",
+                    "rawBleDeviceType",
                     "lastConnectedState",
                     "paired",
                     "connected"
@@ -1217,6 +1230,9 @@
                     "rawDeviceType": {
                         "$ref": "#/definitions/rawDeviceType"
                     },
+                    "rawBleDeviceType": {
+                        "$ref": "#/definitions/rawBleDeviceType"
+                    },
                     "lastConnectedState": {
                         "$ref": "#/definitions/lastConnectedState"
                     },
@@ -1235,6 +1251,7 @@
                     "name",
                     "deviceType",
                     "rawDeviceType",
+                    "rawBleDeviceType",
                     "lastConnectedState",
                     "paired",
                     "connected"
@@ -1258,6 +1275,9 @@
                     "rawDeviceType": {
                         "$ref": "#/definitions/rawDeviceType"
                     },
+                    "rawBleDeviceType": {
+                        "$ref": "#/definitions/rawBleDeviceType"
+                    },
                     "lastConnectedState": {
                         "$ref": "#/definitions/lastConnectedState"
                     }
@@ -1267,6 +1287,7 @@
                     "name",
                     "deviceType",
                     "rawDeviceType",
+                    "rawBleDeviceType",
                     "lastConnectedState"
                 ]
             }
@@ -1288,6 +1309,9 @@
                     "rawDeviceType": {
                         "$ref": "#/definitions/rawDeviceType"
                     },
+                    "rawBleDeviceType": {
+                        "$ref": "#/definitions/rawBleDeviceType"
+                    },
                     "lastConnectedState": {
                         "$ref": "#/definitions/lastConnectedState"
                     }
@@ -1297,6 +1321,7 @@
                     "name",
                     "deviceType",
                     "rawDeviceType",
+                    "rawBleDeviceType",
                     "lastConnectedState"
                 ]
             }

--- a/Bluetooth/CHANGELOG.md
+++ b/Bluetooth/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+## [1.0.6] - 2023-11-13
+### Added
+- add appearance value in discovered devices to be able to distinguish different types of device
+
 ## [1.0.5] - 2023-11-21
 ### Added
 - add modalias and firmware revision string (derived from modalias) to device info

--- a/Bluetooth/README.md
+++ b/Bluetooth/README.md
@@ -60,7 +60,7 @@ stopScan:
 {"jsonrpc":"2.0","id":3,"result":{"success":true}}
 
 getDiscoveredDevices:
-{"jsonrpc":"2.0","id":3,"result":{"discoveredDevices":[{"deviceID":"61579454946360","name":"[TV] UE32J5530","deviceType":"TV","rawDeviceType": "2360344","connected":false,"paired":false}],"success":true}}
+{"jsonrpc":"2.0","id":3,"result":{"discoveredDevices":[{"deviceID":"61579454946360","name":"[TV] UE32J5530","deviceType":"TV","rawDeviceType": "2360344","rawBleDeviceType": "180","connected":false,"paired":false}],"success":true}}
 
 getPairedDevices:
 {"jsonrpc":"2.0","id":3,"result":{"pairedDevices":[{"deviceID":"256168644324480","name":"Eleven","deviceType":"SMARTPHONE","connected":true},{"deviceID":"26499258260618","name":"Little Big","deviceType":"SMARTPHONE","connected":false}],"success":true}}

--- a/docs/api/BluetoothPlugin.md
+++ b/docs/api/BluetoothPlugin.md
@@ -2,7 +2,7 @@
 <a name="Bluetooth_Plugin"></a>
 # Bluetooth Plugin
 
-**Version: [1.0.5](https://github.com/rdkcentral/rdkservices/blob/main/Bluetooth/CHANGELOG.md)**
+**Version: [1.0.6](https://github.com/rdkcentral/rdkservices/blob/main/Bluetooth/CHANGELOG.md)**
 
 A org.rdk.Bluetooth plugin for Thunder framework.
 
@@ -489,6 +489,8 @@ This method takes no parameters.
 | result.discoveredDevices[#].deviceID | string | ID that is derived from the Bluetooth MAC address. 6 byte MAC value is packed into 8 byte with leading zeros for first 2 bytes |
 | result.discoveredDevices[#].name | string | Name of the Bluetooth Device |
 | result.discoveredDevices[#].deviceType | string | Device class (for example: `headset`, `speakers`, etc.) |
+| result.discoveredDevices[#]rawDeviceType | string | Bluetooth device class as decimal |
+| result.discoveredDevices[#]rawBleDeviceType | string | Bluetooth (LE) device appearance as decimal |
 | result.discoveredDevices[#].connected | boolean | Whether the device is connected |
 | result.discoveredDevices[#].paired | boolean | Whether paired or not |
 | result.success | boolean | Whether the request succeeded |
@@ -1385,7 +1387,8 @@ Triggered during device discovery when a new device is discovered or a discovere
 | params.discoveryType | string | either `DISCOVERED` or `LOST` |
 | params.name | string | Name of the Bluetooth Device |
 | params.deviceType | string | Device class (for example: `headset`, `speakers`, etc.) |
-| params.rawDeviceType | string | Bluetooth device class as hex code |
+| params.rawDeviceType | string | Bluetooth device class as decimal |
+| params.rawBleDeviceType | string | Bluetooth (LE) device appearance as decimal |
 | params.lastConnectedState | boolean | Whether the device was last to connect. Only the last connected device has a value of `true` |
 | params.paired | boolean | Whether the device is paired. 1. `true` if the device is paired when the PAIRING_CHANGE status is sent 2. `false` if the device is unpaired. **Note** The set-top box does not retain/store all paired devices across previous power cycles. In addition, if the device is unpaired as part of a previous operation and the same device gets detected in a new discovery cycle, the device will not be a paired device |
 
@@ -1400,7 +1403,8 @@ Triggered during device discovery when a new device is discovered or a discovere
         "discoveryType": "DISCOVERED",
         "name": "[TV] UE32J5530",
         "deviceType": "TV",
-        "rawDeviceType": "0x060104",
+        "rawDeviceType": "2360344",
+        "rawBleDeviceType": "0",
         "lastConnectedState": true,
         "paired": true
     }
@@ -1591,7 +1595,8 @@ Triggered when the previous request to pair or connect failed. In absence of a f
 | params.deviceID | string | ID that is derived from the Bluetooth MAC address. 6 byte MAC value is packed into 8 byte with leading zeros for first 2 bytes |
 | params.name | string | Name of the Bluetooth Device |
 | params.deviceType | string | Device class (for example: `headset`, `speakers`, etc.) |
-| params.rawDeviceType | string | Bluetooth device class as hex code |
+| params.rawDeviceType | string | Bluetooth device class as decimal |
+| params.rawBleDeviceType | string | Bluetooth (LE) device appearance as decimal |
 | params.lastConnectedState | boolean | Whether the device was last to connect. Only the last connected device has a value of `true` |
 | params.paired | boolean | Whether paired or not |
 | params.connected | boolean | Whether the device is connected. `true` if the device is connected when the `CONNECTION_CHANGE` status is sent. `false` if the device is disconnected |
@@ -1607,7 +1612,8 @@ Triggered when the previous request to pair or connect failed. In absence of a f
         "deviceID": "61579454946360",
         "name": "[TV] UE32J5530",
         "deviceType": "TV",
-        "rawDeviceType": "0x060104",
+        "rawDeviceType": "2360344",
+        "rawBleDeviceType": "0",
         "lastConnectedState": true,
         "paired": true,
         "connected": true
@@ -1633,7 +1639,8 @@ Triggered when the Bluetooth functionality status changes. Supported statuses ar
 | params.deviceID | string | ID that is derived from the Bluetooth MAC address. 6 byte MAC value is packed into 8 byte with leading zeros for first 2 bytes |
 | params.name | string | Name of the Bluetooth Device |
 | params.deviceType | string | Device class (for example: `headset`, `speakers`, etc.) |
-| params.rawDeviceType | string | Bluetooth device class as hex code |
+| params.rawDeviceType | string | Bluetooth device class as decimal |
+| params.rawBleDeviceType | string | Bluetooth (LE) device appearance as decimal |
 | params.lastConnectedState | boolean | Whether the device was last to connect. Only the last connected device has a value of `true` |
 | params.paired | boolean | Whether paired or not |
 | params.connected | boolean | Whether device connected or not |
@@ -1649,7 +1656,8 @@ Triggered when the Bluetooth functionality status changes. Supported statuses ar
         "deviceID": "61579454946360",
         "name": "[TV] UE32J5530",
         "deviceType": "TV",
-        "rawDeviceType": "0x060104",
+        "rawDeviceType": "2360344",
+        "rawBleDeviceType": "0",
         "lastConnectedState": true,
         "paired": true,
         "connected": false
@@ -1670,7 +1678,8 @@ Triggered when the new device got discovered.
 | params.deviceID | string | ID that is derived from the Bluetooth MAC address. 6 byte MAC value is packed into 8 byte with leading zeros for first 2 bytes |
 | params.name | string | Name of the Bluetooth Device |
 | params.deviceType | string | Device class (for example: `headset`, `speakers`, etc.) |
-| params.rawDeviceType | string | Bluetooth device class as hex code |
+| params.rawDeviceType | string | Bluetooth device class as decimal |
+| params.rawBleDeviceType | string | Bluetooth (LE) device appearance as decimal |
 | params.lastConnectedState | boolean | Whether the device was last to connect. Only the last connected device has a value of `true` |
 
 ### Example
@@ -1683,7 +1692,8 @@ Triggered when the new device got discovered.
         "deviceID": "61579454946360",
         "name": "[TV] UE32J5530",
         "deviceType": "TV",
-        "rawDeviceType": "0x060104",
+        "rawDeviceType": "2360344",
+        "rawBleDeviceType": "0",
         "lastConnectedState": true
     }
 }
@@ -1702,7 +1712,8 @@ Triggered when any discovered device lost or out of range.
 | params.deviceID | string | ID that is derived from the Bluetooth MAC address. 6 byte MAC value is packed into 8 byte with leading zeros for first 2 bytes |
 | params.name | string | Name of the Bluetooth Device |
 | params.deviceType | string | Device class (for example: `headset`, `speakers`, etc.) |
-| params.rawDeviceType | string | Bluetooth device class as hex code |
+| params.rawDeviceType | string | Bluetooth device class as decimal |
+| params.rawBleDeviceType | string | Bluetooth (LE) device appearance as decimal |
 | params.lastConnectedState | boolean | Whether the device was last to connect. Only the last connected device has a value of `true` |
 
 ### Example
@@ -1715,7 +1726,8 @@ Triggered when any discovered device lost or out of range.
         "deviceID": "61579454946360",
         "name": "[TV] UE32J5530",
         "deviceType": "TV",
-        "rawDeviceType": "0x060104",
+        "rawDeviceType": "2360344",
+        "rawBleDeviceType": "0",
         "lastConnectedState": true
     }
 }


### PR DESCRIPTION
Reason for change: add in appearance value which would allow one to distiguish between different le devices similar to device class for bt classic
Test Procedure: start a scan, check discovered devices, appearance value should be listed for those that expose it
Risks: Low
Priority: P1
Signed-off-by: Jack O'Gorman <jack.ogorman@sky.uk>