### PR TITLE
RDK-44762 : Implement Unit Test framework to cover L1 test cases in N…

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -227,6 +227,8 @@ jobs:
           -DCMAKE_MODULE_PATH="${{github.workspace}}/install/tools/cmake"
           -DCMAKE_CXX_FLAGS="
           -DEXCEPTIONS_ENABLE=ON
+          -fprofile-arcs
+          -ftest-coverage
           -I ${{github.workspace}}/rdkservices/Tests/headers
           -I ${{github.workspace}}/rdkservices/Tests/headers/audiocapturemgr
           -I ${{github.workspace}}/rdkservices/Tests/headers/rdk/ds

--- a/Network/CHANGELOG.md
+++ b/Network/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.3.2] - 2023-12-21
+### Changed
+- Changed eventHandler function to public
+
 ## [1.3.1] - 2023-11-30
 ### Fixed
 - Addressed the IPv4 & IPv6 cache issue where it was not suppose to be cached when DNS or other parameter is not received yet

--- a/Network/Network.h
+++ b/Network/Network.h
@@ -199,7 +199,6 @@ namespace WPEFramework {
             void onInterfaceIPAddressChanged(std::string interface, std::string ipv6Addr, std::string ipv4Addr, bool acquired);
             void onDefaultInterfaceChanged(std::string oldInterface, std::string newInterface);
 
-            static void eventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
             void iarmEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
 
             // Netmask Validation
@@ -222,6 +221,7 @@ namespace WPEFramework {
         public:
             Network();
             virtual ~Network();
+	    static void eventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
 
             //Build QueryInterface implementation, specifying all possible interfaces to be returned.
             BEGIN_INTERFACE_MAP(Network)

--- a/Tests/mocks/Iarm.h
+++ b/Tests/mocks/Iarm.h
@@ -920,6 +920,7 @@ typedef enum _IARM_Bus_NMgr_WiFi_EventId_t {
 #define IARM_BUS_NETSRVMGR_API_stopConnectivityMonitoring "stopConnectivityMonitoring"
 #define IARM_BUS_NETSRVMGR_API_isAvailable "isAvailable"
 #define IARM_BUS_NETSRVMGR_API_getPublicIP "getPublicIP"
+#define IARM_BUS_NETSRVMGR_API_configurePNI "configurePNI"
 
 // TODO: remove this
 #define registerMethod(...) for (uint8_t i = 1; GetHandler(i); i++) GetHandler(i)->Register<JsonObject, JsonObject>(__VA_ARGS__)

--- a/Tests/tests/test_Network.cpp
+++ b/Tests/tests/test_Network.cpp
@@ -2,6 +2,7 @@
 #include <fstream>
 #include <iostream>
 #include "Network.h"
+#include "NetworkConnectivity.h"
 
 #include "FactoriesImplementation.h"
 #include "ServiceMock.h"
@@ -104,6 +105,31 @@ protected:
     }
 };
 
+class NetworkInitializedEventTest : public NetworkTest {
+protected:
+    FactoriesImplementation factoriesImplementation;
+    PluginHost::IDispatcher* dispatcher;
+
+
+    NetworkInitializedEventTest()
+        : NetworkTest()
+    {
+        PluginHost::IFactories::Assign(&factoriesImplementation);
+
+        dispatcher = static_cast<PluginHost::IDispatcher*>(
+            plugin->QueryInterface(PluginHost::IDispatcher::ID));
+        dispatcher->Activate(&service);
+    }
+
+    virtual ~NetworkInitializedEventTest() override
+    {
+        dispatcher->Deactivate();
+        dispatcher->Release();
+        PluginHost::IFactories::Assign(nullptr);
+
+    }
+};
+
 TEST_F(NetworkTest, RegisteredMethods)
 {
     EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("getStbIp")));
@@ -148,6 +174,63 @@ TEST_F(NetworkTest, getStbIp)
     EXPECT_EQ(response, string("{\"ip\":\"192.168.1.101\",\"success\":true}"));
 }
 
+TEST_F(NetworkTest, getStbIp_cache)
+{
+    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_getSTBip)));
+
+                auto param = static_cast<IARM_BUS_NetSrvMgr_Iface_EventData_t*>(arg);
+                memcpy(&param->activeIfaceIpaddr, "192.168.1.101", sizeof("192.168.1.101"));
+                EXPECT_EQ(string(param->activeIfaceIpaddr), string(_T("192.168.1.101")));
+
+                return IARM_RESULT_SUCCESS;
+           });
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getStbIp"), _T("{}"), response));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getStbIp"), _T("{}"), response));
+    EXPECT_EQ(response, string("{\"ip\":\"192.168.1.101\",\"success\":true}"));
+
+}
+
+TEST_F(NetworkTest, getNullStbIp)
+{
+         EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_getSTBip)));
+
+                auto param = static_cast<IARM_BUS_NetSrvMgr_Iface_EventData_t*>(arg);
+                EXPECT_EQ(string(param->activeIfaceIpaddr), string(_T("")));
+
+                return IARM_RESULT_SUCCESS;
+           });
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getStbIp"), _T("{}"), response));
+    EXPECT_EQ(response, string("{\"ip\":\"\",\"success\":true}"));
+}
+
+TEST_F(NetworkTest, getFailedStbIp)
+{
+         EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_getSTBip)));
+
+                auto param = static_cast<IARM_BUS_NetSrvMgr_Iface_EventData_t*>(arg);
+                EXPECT_EQ(string(param->activeIfaceIpaddr), string(_T("")));
+
+                return IARM_RESULT_IPCCORE_FAIL;
+           });
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("getStbIp"), _T("{}"), response));
+
+}
+
 TEST_F(NetworkTest, getInterfaces)
 {
     EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
@@ -173,6 +256,20 @@ TEST_F(NetworkTest, getInterfaces)
 	EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"success\":true")));
 }
 
+TEST_F(NetworkTest, getInterfacesFailed)
+{
+    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_getInterfaceList)));
+
+                return IARM_RESULT_IPCCORE_FAIL;
+            });
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("getInterfaces"), _T("{}"), response));
+}
+
 TEST_F(NetworkTest, isInterfaceEnabled)
 {
     EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
@@ -196,6 +293,27 @@ TEST_F(NetworkTest, isInterfaceEnabled)
     EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"success\":true")));
 }
 
+TEST_F(NetworkTest, isInterfaceEnabled_failed)
+{
+    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_isInterfaceEnabled)));
+                auto param = static_cast<IARM_BUS_NetSrvMgr_Iface_EventData_t  *>(arg);
+
+                memcpy(&param->setInterface, "ETHERNET", sizeof("ETHERNET"));
+                    param->isInterfaceEnabled = true;
+
+                EXPECT_EQ(string(param->setInterface), string(_T("ETHERNET")));
+                EXPECT_EQ(param->isInterfaceEnabled, true);
+
+                return IARM_RESULT_IPCCORE_FAIL;
+            });
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("isInterfaceEnabled"), _T("{\"interface\": \"ETHERNET\"}"), response));
+}
+
 TEST_F(NetworkTest, getDefaultInterface)
 {
     EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
@@ -213,6 +331,70 @@ TEST_F(NetworkTest, getDefaultInterface)
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getDefaultInterface"), _T("{}"), response));
     EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"interface\":\"ETHERNET\"")));
     EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"success\":true")));
+}
+
+TEST_F(NetworkTest, getDefaultInterface_cache)
+{
+    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_getDefaultInterface)));
+                auto param = static_cast<IARM_BUS_NetSrvMgr_DefaultRoute_t *>(arg);
+                memcpy(&param->interface, "eth0", sizeof("eth0"));
+                memcpy(&param->gateway, "192.168.1.1", sizeof("192.168.1.1"));
+
+                return IARM_RESULT_SUCCESS;
+            });
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getDefaultInterface"), _T("{}"), response));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"interface\":\"ETHERNET\"")));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"success\":true")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getDefaultInterface"), _T("{}"), response));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"interface\":\"ETHERNET\"")));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"success\":true")));
+}
+
+TEST_F(NetworkTest, isInterfaceEnabled_WrongIface)
+{
+    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_isInterfaceEnabled)));
+                auto param = static_cast<IARM_BUS_NetSrvMgr_Iface_EventData_t  *>(arg);
+
+                memcpy(&param->setInterface, "ETHERNET", sizeof("ETHERNET"));
+                    param->isInterfaceEnabled = true;
+
+                EXPECT_EQ(string(param->setInterface), string(_T("ETHERNET")));
+                EXPECT_EQ(param->isInterfaceEnabled, true);
+
+                return IARM_RESULT_SUCCESS;
+            });
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("isInterfaceEnabled"), _T("{\"interface\": \"TEST\"}"), response));
+}
+
+TEST_F(NetworkTest, isInterfaceEnabled_Fail)
+{
+    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_isInterfaceEnabled)));
+                auto param = static_cast<IARM_BUS_NetSrvMgr_Iface_EventData_t  *>(arg);
+
+                memcpy(&param->setInterface, "ETHERNET", sizeof("ETHERNET"));
+                    param->isInterfaceEnabled = true;
+
+                EXPECT_EQ(string(param->setInterface), string(_T("ETHERNET")));
+                EXPECT_EQ(param->isInterfaceEnabled, true);
+
+                return IARM_RESULT_IPCCORE_FAIL;
+            });
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("isInterfaceEnabled"), _T("{\"interface\": \"TEST\"}"), response));
 }
 
 TEST_F(NetworkTest, getIPSettings)
@@ -257,6 +439,200 @@ TEST_F(NetworkTest, getIPSettings)
     EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"success\":true")));
 }
 
+TEST_F(NetworkTest, getIP6Settings)
+{
+    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_getIPSettings)));
+
+                auto param = static_cast<IARM_BUS_NetSrvMgr_Iface_Settings_t  *>(arg);
+                    memcpy(&param->interface, "ETHERNET", sizeof("ETHERNET"));
+                memcpy(&param->ipversion, "IPV6", sizeof("IPV6"));
+                param->autoconfig  = true;
+                memcpy(&param->ipaddress, "192.168.1.101", sizeof("192.168.1.101"));
+                memcpy(&param->netmask, "255.255.255.0", sizeof("255.255.255.0"));
+                    memcpy(&param->gateway, "192.168.1.1", sizeof("192.168.1.1"));
+                memcpy(&param->primarydns, "192.168.1.1", sizeof("192.168.1.1"));
+                memcpy(&param->secondarydns, "192.168.1.2", sizeof("192.168.1.2"));
+
+                EXPECT_EQ(string(param->interface), string(_T("ETHERNET")));
+                EXPECT_EQ(string(param->ipversion), string(_T("IPV6")));
+                EXPECT_EQ(string(param->ipaddress), string(_T("192.168.1.101")));
+                EXPECT_EQ(string(param->netmask), string(_T("255.255.255.0")));
+                EXPECT_EQ(string(param->gateway), string(_T("192.168.1.1")));
+                EXPECT_EQ(string(param->primarydns), string(_T("192.168.1.1")));
+                EXPECT_EQ(string(param->secondarydns), string(_T("192.168.1.2")));
+                EXPECT_EQ(param->autoconfig, true);
+
+                return IARM_RESULT_SUCCESS;
+            });
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getIPSettings"), _T("{\"interface\": \"ETHERNET\",\"ipversion\": \"IPV6\"}"), response));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"interface\":\"ETHERNET\"")));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"ipversion\":\"IPV6\"")));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"autoconfig\":true")));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"ipaddr\":\"192.168.1.101\"")));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"netmask\":\"255.255.255.0\"")));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"gateway\":\"192.168.1.1\"")));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"primarydns\":\"192.168.1.1\"")));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"secondarydns\":\"192.168.1.2\"")));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"success\":true")));
+}
+
+TEST_F(NetworkTest, getIPSettings_wifi)
+{
+    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_getIPSettings)));
+
+                auto param = static_cast<IARM_BUS_NetSrvMgr_Iface_Settings_t  *>(arg);
+                    memcpy(&param->interface, "WIFI", sizeof("WIFI"));
+                memcpy(&param->ipversion, "IPV4", sizeof("IPV4"));
+                param->autoconfig  = true;
+                memcpy(&param->ipaddress, "192.168.1.101", sizeof("192.168.1.101"));
+                memcpy(&param->netmask, "255.255.255.0", sizeof("255.255.255.0"));
+                    memcpy(&param->gateway, "192.168.1.1", sizeof("192.168.1.1"));
+                memcpy(&param->primarydns, "192.168.1.1", sizeof("192.168.1.1"));
+                memcpy(&param->secondarydns, "192.168.1.2", sizeof("192.168.1.2"));
+
+                EXPECT_EQ(string(param->interface), string(_T("WIFI")));
+                EXPECT_EQ(string(param->ipversion), string(_T("IPV4")));
+                EXPECT_EQ(string(param->ipaddress), string(_T("192.168.1.101")));
+                EXPECT_EQ(string(param->netmask), string(_T("255.255.255.0")));
+                EXPECT_EQ(string(param->gateway), string(_T("192.168.1.1")));
+                EXPECT_EQ(string(param->primarydns), string(_T("192.168.1.1")));
+                EXPECT_EQ(string(param->secondarydns), string(_T("192.168.1.2")));
+                EXPECT_EQ(param->autoconfig, true);
+
+                return IARM_RESULT_SUCCESS;
+            });
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getIPSettings"), _T("{\"interface\": \"WIFI\",\"ipversion\": \"IPV4\"}"), response));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"interface\":\"WIFI\"")));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"ipversion\":\"IPV4\"")));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"autoconfig\":true")));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"ipaddr\":\"192.168.1.101\"")));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"netmask\":\"255.255.255.0\"")));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"gateway\":\"192.168.1.1\"")));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"primarydns\":\"192.168.1.1\"")));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"secondarydns\":\"192.168.1.2\"")));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"success\":true")));
+
+}
+
+TEST_F(NetworkTest, getIP6Settings_wifi)
+{
+    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_getIPSettings)));
+
+                auto param = static_cast<IARM_BUS_NetSrvMgr_Iface_Settings_t  *>(arg);
+                    memcpy(&param->interface, "WIFI", sizeof("WIFI"));
+                memcpy(&param->ipversion, "IPV6", sizeof("IPV6"));
+                param->autoconfig  = true;
+                memcpy(&param->ipaddress, "192.168.1.101", sizeof("192.168.1.101"));
+                memcpy(&param->netmask, "255.255.255.0", sizeof("255.255.255.0"));
+                    memcpy(&param->gateway, "192.168.1.1", sizeof("192.168.1.1"));
+                memcpy(&param->primarydns, "192.168.1.1", sizeof("192.168.1.1"));
+                memcpy(&param->secondarydns, "192.168.1.2", sizeof("192.168.1.2"));
+
+                EXPECT_EQ(string(param->interface), string(_T("WIFI")));
+                EXPECT_EQ(string(param->ipversion), string(_T("IPV6")));
+                EXPECT_EQ(string(param->ipaddress), string(_T("192.168.1.101")));
+                EXPECT_EQ(string(param->netmask), string(_T("255.255.255.0")));
+                EXPECT_EQ(string(param->gateway), string(_T("192.168.1.1")));
+                EXPECT_EQ(string(param->primarydns), string(_T("192.168.1.1")));
+                EXPECT_EQ(string(param->secondarydns), string(_T("192.168.1.2")));
+                EXPECT_EQ(param->autoconfig, true);
+
+                return IARM_RESULT_SUCCESS;
+            });
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getIPSettings"), _T("{\"interface\": \"WIFI\",\"ipversion\": \"IPV6\"}"), response));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"interface\":\"WIFI\"")));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"ipversion\":\"IPV6\"")));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"autoconfig\":true")));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"ipaddr\":\"192.168.1.101\"")));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"netmask\":\"255.255.255.0\"")));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"gateway\":\"192.168.1.1\"")));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"primarydns\":\"192.168.1.1\"")));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"secondarydns\":\"192.168.1.2\"")));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"success\":true")));
+
+}
+
+TEST_F(NetworkTest, getIPSettings_Failed)
+{
+    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_getIPSettings)));
+
+                auto param = static_cast<IARM_BUS_NetSrvMgr_Iface_Settings_t  *>(arg);
+                    memcpy(&param->interface, "ETHERNET", sizeof("ETHERNET"));
+                memcpy(&param->ipversion, "IPV4", sizeof("IPV4"));
+                param->autoconfig  = true;
+                memcpy(&param->ipaddress, "192.168.1.101", sizeof("192.168.1.101"));
+                memcpy(&param->netmask, "255.255.255.0", sizeof("255.255.255.0"));
+                    memcpy(&param->gateway, "192.168.1.1", sizeof("192.168.1.1"));
+                memcpy(&param->primarydns, "192.168.1.1", sizeof("192.168.1.1"));
+                memcpy(&param->secondarydns, "192.168.1.2", sizeof("192.168.1.2"));
+
+                EXPECT_EQ(string(param->interface), string(_T("ETHERNET")));
+                EXPECT_EQ(string(param->ipversion), string(_T("IPV4")));
+                EXPECT_EQ(string(param->ipaddress), string(_T("192.168.1.101")));
+                EXPECT_EQ(string(param->netmask), string(_T("255.255.255.0")));
+                EXPECT_EQ(string(param->gateway), string(_T("192.168.1.1")));
+                EXPECT_EQ(string(param->primarydns), string(_T("192.168.1.1")));
+                EXPECT_EQ(string(param->secondarydns), string(_T("192.168.1.2")));
+                EXPECT_EQ(param->autoconfig, true);
+
+                return IARM_RESULT_IPCCORE_FAIL;
+            });
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("getIPSettings"), _T("{\"interface\": \"ETHERNET\",\"ipversion\": \"IPV4\"}"), response));
+}
+
+TEST_F(NetworkTest, getIPSettings_WrongIface)
+{
+    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_getIPSettings)));
+
+                auto param = static_cast<IARM_BUS_NetSrvMgr_Iface_Settings_t  *>(arg);
+                    memcpy(&param->interface, "ETHERNET", sizeof("ETHERNET"));
+                memcpy(&param->ipversion, "IPV4", sizeof("IPV4"));
+                param->autoconfig  = true;
+                memcpy(&param->ipaddress, "192.168.1.101", sizeof("192.168.1.101"));
+                memcpy(&param->netmask, "255.255.255.0", sizeof("255.255.255.0"));
+                    memcpy(&param->gateway, "192.168.1.1", sizeof("192.168.1.1"));
+                memcpy(&param->primarydns, "192.168.1.1", sizeof("192.168.1.1"));
+                memcpy(&param->secondarydns, "192.168.1.2", sizeof("192.168.1.2"));
+
+                EXPECT_EQ(string(param->interface), string(_T("ETHERNET")));
+                EXPECT_EQ(string(param->ipversion), string(_T("IPV4")));
+                EXPECT_EQ(string(param->ipaddress), string(_T("192.168.1.101")));
+                EXPECT_EQ(string(param->netmask), string(_T("255.255.255.0")));
+                EXPECT_EQ(string(param->gateway), string(_T("192.168.1.1")));
+                EXPECT_EQ(string(param->primarydns), string(_T("192.168.1.1")));
+                EXPECT_EQ(string(param->secondarydns), string(_T("192.168.1.2")));
+                EXPECT_EQ(param->autoconfig, true);
+
+                return IARM_RESULT_IPCCORE_FAIL;
+            });
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("getIPSettings"), _T("{\"interface\": \"TEST\",\"ipversion\": \"IPV4\"}"), response));
+}
+
 TEST_F(NetworkTest, getPublicIP)
 {
     EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
@@ -290,6 +666,34 @@ TEST_F(NetworkTest, setInterfaceEnabled)
             });
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("setInterfaceEnabled"), _T("{\"interface\": \"WIFI\", \"enabled\": true, \"persist\": true}"), response));
     EXPECT_EQ(response, string("{\"success\":true}"));
+}
+
+TEST_F(NetworkTest, setInterfaceEnabled_Failed)
+{
+    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_setInterfaceEnabled)));
+
+                return IARM_RESULT_IPCCORE_FAIL;
+            });
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("setInterfaceEnabled"), _T("{\"interface\": \"WIFI\", \"enabled\": true, \"persist\": true}"), response));
+}
+
+TEST_F(NetworkTest, setInterfaceEnabled_WrongIface)
+{
+    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_setInterfaceEnabled)));
+
+                return IARM_RESULT_IPCCORE_FAIL;
+            });
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("setInterfaceEnabled"), _T("{\"interface\": \"TEST\", \"enabled\": true, \"persist\": true}"), response));
 }
 
 TEST_F(NetworkTest, getSTBIPFamily)
@@ -326,7 +730,76 @@ TEST_F(NetworkTest, getSTBIPFamily)
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getIPSettings"), _T("{\"interface\": \"ETHERNET\",\"ipversion\": \"IPV4\"}"), response));
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getSTBIPFamily"), _T("{\"family\": \"AF_INET\"}"), response));
     EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"ip\":\"192.168.1.101\"")));
-	EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"success\":true")));
+    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"success\":true")));
+}
+
+TEST_F(NetworkTest, getSTBIPFamily_Error)
+{
+
+    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_getIPSettings)));
+
+                auto param = static_cast<IARM_BUS_NetSrvMgr_Iface_Settings_t  *>(arg);
+                memcpy(&param->interface, "ETHERNET", sizeof("ETHERNET"));
+                memcpy(&param->ipversion, "IPV4", sizeof("IPV4"));
+                param->autoconfig  = true;
+                memcpy(&param->ipaddress, "192.168.1.101", sizeof("192.168.1.101"));
+                memcpy(&param->netmask, "255.255.255.0", sizeof("255.255.255.0"));
+                memcpy(&param->gateway, "192.168.1.1", sizeof("192.168.1.1"));
+                memcpy(&param->primarydns, "192.168.1.1", sizeof("192.168.1.1"));
+                memcpy(&param->secondarydns, "192.168.1.2", sizeof("192.168.1.2"));
+
+                EXPECT_EQ(string(param->interface), string(_T("ETHERNET")));
+                EXPECT_EQ(string(param->ipversion), string(_T("IPV4")));
+                EXPECT_EQ(string(param->ipaddress), string(_T("192.168.1.101")));
+                EXPECT_EQ(string(param->netmask), string(_T("255.255.255.0")));
+                EXPECT_EQ(string(param->gateway), string(_T("192.168.1.1")));
+                EXPECT_EQ(string(param->primarydns), string(_T("192.168.1.1")));
+                EXPECT_EQ(string(param->secondarydns), string(_T("192.168.1.2")));
+                EXPECT_EQ(param->autoconfig, true);
+
+                return IARM_RESULT_SUCCESS;
+            });
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getIPSettings"), _T("{\"interface\": \"ETHERNET\",\"ipversion\": \"IPV4\"}"), response));
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("getSTBIPFamily"), _T("{\"test\": \"AF_INET\"}"), response));
+}
+
+TEST_F(NetworkTest, getSTBIPFamily_Failed)
+{
+
+    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_getIPSettings)));
+
+                auto param = static_cast<IARM_BUS_NetSrvMgr_Iface_Settings_t  *>(arg);
+                memcpy(&param->interface, "ETHERNET", sizeof("ETHERNET"));
+                memcpy(&param->ipversion, "IPV4", sizeof("IPV4"));
+                param->autoconfig  = true;
+                memcpy(&param->ipaddress, "192.168.1.101", sizeof("192.168.1.101"));
+                memcpy(&param->netmask, "255.255.255.0", sizeof("255.255.255.0"));
+                memcpy(&param->gateway, "192.168.1.1", sizeof("192.168.1.1"));
+                memcpy(&param->primarydns, "192.168.1.1", sizeof("192.168.1.1"));
+                memcpy(&param->secondarydns, "192.168.1.2", sizeof("192.168.1.2"));
+
+                EXPECT_EQ(string(param->interface), string(_T("ETHERNET")));
+                EXPECT_EQ(string(param->ipversion), string(_T("IPV4")));
+                EXPECT_EQ(string(param->ipaddress), string(_T("192.168.1.101")));
+                EXPECT_EQ(string(param->netmask), string(_T("255.255.255.0")));
+                EXPECT_EQ(string(param->gateway), string(_T("192.168.1.1")));
+                EXPECT_EQ(string(param->primarydns), string(_T("192.168.1.1")));
+                EXPECT_EQ(string(param->secondarydns), string(_T("192.168.1.2")));
+                EXPECT_EQ(param->autoconfig, true);
+
+                return IARM_RESULT_IPCCORE_FAIL;
+            });
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("getIPSettings"), _T("{\"interface\": \"ETHERNET\",\"ipversion\": \"IPV4\"}"), response));
 }
 
 TEST_F(NetworkTest, setDefaultInterface)
@@ -342,6 +815,34 @@ TEST_F(NetworkTest, setDefaultInterface)
             });
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("setDefaultInterface"), _T("{\"interface\": \"WIFI\", \"persist\": true}"), response));
     EXPECT_EQ(response, string("{\"success\":true}"));
+}
+
+TEST_F(NetworkTest, setDefaultInterface_WrongIface)
+{
+    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_setDefaultInterface)));
+
+                return IARM_RESULT_SUCCESS;
+            });
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("setDefaultInterface"), _T("{\"interface\": \"TEST\", \"persist\": true}"), response));
+}
+
+TEST_F(NetworkTest, setDefaultInterface_failed)
+{
+    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_setDefaultInterface)));
+
+                return IARM_RESULT_IPCCORE_FAIL;
+            });
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("setDefaultInterface"), _T("{\"interface\": \"TEST\", \"persist\": true}"), response));
 }
 
 TEST_F(NetworkTest, setIPSettings)
@@ -361,6 +862,8 @@ TEST_F(NetworkTest, setIPSettings)
     EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"supported\":true")));
     EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"success\":true")));
 }
+
+
 
 //TEST_F(NetworkTest, trace)
 //{
@@ -382,6 +885,42 @@ TEST_F(NetworkTest, setIPSettings)
 //	EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"success\":true")));
 //}
 //
+TEST_F(NetworkTest, trace_fail)
+{
+    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_getDefaultInterface)));
+
+                auto param = static_cast<IARM_BUS_NetSrvMgr_DefaultRoute_t *>(arg);
+                memcpy(&param->interface, "eth0", sizeof("eth0"));
+                memcpy(&param->gateway, "45.57.221.20", sizeof("45.57.221.20"));
+
+                return IARM_RESULT_IPCCORE_FAIL;
+            });
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("trace"), _T("{\"endpoint\":\"45.57.221.20\", \"packets\":5}"), response));
+}
+
+TEST_F(NetworkTest, trace_noiface)
+{
+    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_getDefaultInterface)));
+
+                auto param = static_cast<IARM_BUS_NetSrvMgr_DefaultRoute_t *>(arg);
+                memcpy(&param->interface, "eth0", sizeof("eth0"));
+                memcpy(&param->gateway, "45.57.221.20", sizeof("45.57.221.20"));
+
+                return IARM_RESULT_IPCCORE_FAIL;
+            });
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("trace"), _T("{\"test\":\"45.57.221.20\", \"packets\":5}"), response));
+}
+
 //TEST_F(NetworkTest, traceNamedEndpoint)
 //{
 //	EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
@@ -401,6 +940,43 @@ TEST_F(NetworkTest, setIPSettings)
 //    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("traceNamedEndpoint"), _T("{\"endpointName\": \"CMTS\", \"packets\": 5}"), response));
 //    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"success\":true")));
 //}
+
+TEST_F(NetworkTest, traceNamedEndpoint_noendoint)
+{
+      EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+           [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_getDefaultInterface)));
+
+                auto param = static_cast<IARM_BUS_NetSrvMgr_DefaultRoute_t *>(arg);
+                memcpy(&param->interface, "eth0", sizeof("eth0"));
+                              memcpy(&param->gateway, "45.57.221.20", sizeof("45.57.221.20"));
+
+                return IARM_RESULT_SUCCESS;
+            });
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getDefaultInterface"), _T("{}"), response));
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("traceNamedEndpoint"), _T("{\"test\": \"CMTS\", \"packets\": 5}"), response));
+}
+
+TEST_F(NetworkTest, traceNamedEndpoint_fail)
+{
+      EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_getDefaultInterface)));
+
+                auto param = static_cast<IARM_BUS_NetSrvMgr_DefaultRoute_t *>(arg);
+                memcpy(&param->interface, "eth0", sizeof("eth0"));
+                              memcpy(&param->gateway, "45.57.221.20", sizeof("45.57.221.20"));
+
+                return IARM_RESULT_IPCCORE_FAIL;
+            });
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("traceNamedEndpoint"), _T("{\"endpointName\": \"CMTS\", \"packets\": 5}"), response));
+}
 
 TEST_F(NetworkTest, getNamedEndpoints)
 {
@@ -431,7 +1007,44 @@ TEST_F(NetworkTest, getNamedEndpoints)
 //	EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"packetsReceived\":5")));
 //	EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"packetLoss\":\" 0\"")));
 //}
-//
+
+TEST_F(NetworkTest, pingNamedEndpoint_noarg)
+{
+        EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_getDefaultInterface)));
+
+                auto param = static_cast<IARM_BUS_NetSrvMgr_DefaultRoute_t *>(arg);
+                memcpy(&param->interface, "eth0", sizeof("eth0"));
+                memcpy(&param->gateway, "127.0.0.1", sizeof("127.0.0.1"));
+
+                return IARM_RESULT_SUCCESS;
+            });
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getDefaultInterface"), _T("{}"), response));
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("pingNamedEndpoint"), _T("{\"test\": \"CMTS\", \"packets\": 5, \"guid\": \"...\"}"), response));
+}
+
+TEST_F(NetworkTest, pingNamedEndpoint_fail)
+{
+      EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_getDefaultInterface)));
+
+                auto param = static_cast<IARM_BUS_NetSrvMgr_DefaultRoute_t *>(arg);
+                memcpy(&param->interface, "eth0", sizeof("eth0"));
+                memcpy(&param->gateway, "127.0.0.1", sizeof("127.0.0.1"));
+
+                return IARM_RESULT_IPCCORE_FAIL;
+            });
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("pingNamedEndpoint"), _T("{\"endpointName\": \"CMTS\", \"packets\": 5, \"guid\": \"...\"}"), response));
+}
+
 //TEST_F(NetworkTest, ping)
 //{
 //	EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
@@ -456,14 +1069,77 @@ TEST_F(NetworkTest, getNamedEndpoints)
 //    EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"packetLoss\":\" 0\"")));
 //}
 
+TEST_F(NetworkTest, ping_noendpoint)
+{
+        EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_getDefaultInterface)));
+
+                auto param = static_cast<IARM_BUS_NetSrvMgr_DefaultRoute_t *>(arg);
+                memcpy(&param->interface, "eth0", sizeof("eth0"));
+                memcpy(&param->gateway, "192.168.1.1", sizeof("192.168.1.1"));
+
+                return IARM_RESULT_SUCCESS;
+            });
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getDefaultInterface"), _T("{}"), response));
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("ping"), _T("{\"test\": \"127.0.0.1\", \"packets\": 5, \"guid\": \"...\"}"), response));
+}
+
+TEST_F(NetworkTest, ping_fail)
+{
+      EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_getDefaultInterface)));
+
+                auto param = static_cast<IARM_BUS_NetSrvMgr_DefaultRoute_t *>(arg);
+                memcpy(&param->interface, "eth0", sizeof("eth0"));
+                memcpy(&param->gateway, "192.168.1.1", sizeof("192.168.1.1"));
+
+                return IARM_RESULT_IPCCORE_FAIL;
+            });
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("ping"), _T("{\"endpoint\": \"127.0.0.1\", \"packets\": 5, \"guid\": \"...\"}"), response));
+}
+
+TEST_F(NetworkTest, ping_fail1)
+{
+      EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_getDefaultInterface)));
+
+                auto param = static_cast<IARM_BUS_NetSrvMgr_DefaultRoute_t *>(arg);
+                memcpy(&param->interface, "eth0", sizeof("eth0"));
+                memcpy(&param->gateway, "192.168.1.1", sizeof("192.168.1.1"));
+
+                return IARM_RESULT_IPCCORE_FAIL;
+            });
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("ping"), _T("{\"test\": \"127.0.0.1\", \"packets\": 5, \"guid\": \"...\"}"), response));
+}
+
 TEST_F(NetworkTest, getQuirks)
 {
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getQuirks"), _T("{}"), response));
-	EXPECT_EQ(response, string("{\"quirks\":[\"RDK-20093\"],\"success\":true}"));
+    EXPECT_EQ(response, string("{\"quirks\":[\"RDK-20093\"],\"success\":true}"));
 }
 /*
 TEST_F(NetworkTest, getInternetConnectionState)
 {
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getInternetConnectionState"), _T("{\"ipversion\": \"IPV6\"}"), response));
+    EXPECT_EQ(response, string("{\"state\":0,\"ipversion\":\"IPV6\",\"success\":true}"));
+}
+
+TEST_F(NetworkTest, getInternetConnectionState_cache)
+{
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getInternetConnectionState"), _T("{\"ipversion\": \"IPV6\"}"), response));
+    EXPECT_EQ(response, string("{\"state\":0,\"ipversion\":\"IPV6\",\"success\":true}"));
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getInternetConnectionState"), _T("{\"ipversion\": \"IPV6\"}"), response));
     EXPECT_EQ(response, string("{\"state\":0,\"ipversion\":\"IPV6\",\"success\":true}"));
 }
@@ -477,7 +1153,24 @@ TEST_F(NetworkTest, isConnectedToInternet)
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("isConnectedToInternet"), _T("{}"), response));
     EXPECT_EQ(response, string("{\"connectedToInternet\":false,\"success\":true}"));
 }
+
+TEST_F(NetworkTest, isConnectedToInternet_cache)
+{
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("isConnectedToInternet"), _T("{\"ipversion\": \"IPV6\"}"), response));
+    EXPECT_EQ(response, string("{\"connectedToInternet\":false,\"ipversion\":\"IPV6\",\"success\":true}"));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("isConnectedToInternet"), _T("{\"ipversion\": \"IPV6\"}"), response));
+    EXPECT_EQ(response, string("{\"connectedToInternet\":false,\"ipversion\":\"IPV6\",\"success\":true}"));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("isConnectedToInternet"), _T("{\"ipversion\": \"IPV4\"}"), response));
+    EXPECT_EQ(response, string("{\"connectedToInternet\":false,\"ipversion\":\"IPV4\",\"success\":true}"));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("isConnectedToInternet"), _T("{\"ipversion\": \"IPV4\"}"), response));
+    EXPECT_EQ(response, string("{\"connectedToInternet\":false,\"ipversion\":\"IPV4\",\"success\":true}"));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("isConnectedToInternet"), _T("{}"), response));
+    EXPECT_EQ(response, string("{\"connectedToInternet\":false,\"success\":true}"));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("isConnectedToInternet"), _T("{}"), response));
+    EXPECT_EQ(response, string("{\"connectedToInternet\":false,\"success\":true}"));
+}
 */
+
 TEST_F(NetworkTest, stopConnectivityMonitoring)
 {
     EXPECT_NE(Core::ERROR_NONE, handler.Invoke(connection, _T("stopConnectivityMonitoring"), _T("{}"), response));
@@ -502,4 +1195,157 @@ TEST_F(NetworkTest, setConnectivityTestEndpoints)
 {
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("setConnectivityTestEndpoints"), _T("{\"endpoints\": [\"http://clients3.google.com/generate_204\"]}"), response));
     EXPECT_EQ(response, string("{\"success\":true}"));
+}
+
+TEST_F(NetworkTest, setStunEndPoint)
+{
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("setStunEndPoint"), _T("{}"), response));
+    //EXPECT_EQ(response, string("{\"quirks\":[\"RDK-20093\"],\"success\":true}"));
+}
+
+TEST_F(NetworkTest, configurePNI)
+{
+     EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_configurePNI)));
+                return IARM_RESULT_SUCCESS;
+            });
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("configurePNI"), _T("{}"), response));
+}
+
+TEST_F(NetworkTest, configurePNI_fail)
+{
+     EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_configurePNI)));
+                return IARM_RESULT_IPCCORE_FAIL;
+            });
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("configurePNI"), _T("{}"), response));
+}
+
+TEST_F(NetworkInitializedEventTest, onInterfaceStatusChanged)
+{
+    EXPECT_CALL(iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_NM_SRV_MGR_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_NETSRVMGR_API_getInterfaceList)));
+                auto param = static_cast<IARM_BUS_NetSrvMgr_InterfaceList_t *>(arg);
+
+                                param->size = 1;
+                memcpy(&param->interfaces[0].name, "eth0", sizeof("eth0"));
+                memcpy(&param->interfaces[0].mac, "AA:AA:AA:AA:AA:AA", sizeof("AA:AA:AA:AA:AA:AA"));
+                param->interfaces[0].flags = 69699;
+
+                return IARM_RESULT_SUCCESS;
+            });
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getInterfaces"), _T("{}"), response));
+        EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"interface\":\"ETHERNET\"")));
+        EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"macAddress\":\"AA:AA:AA:AA:AA:AA\"")));
+        EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"enabled\":true")));
+        EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"connected\":true")));
+        EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"success\":true")));
+    EXPECT_CALL(service, Submit(::testing::_, ::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Invoke(
+            [&](const uint32_t, const Core::ProxyType<Core::JSON::IElement>& json) {
+                string text;
+                EXPECT_TRUE(json->ToString(text));
+                EXPECT_EQ(text, string(_T("{\"jsonrpc\":\"2.0\",\"method\":\"org.rdk.Network.onInterfaceStatusChanged\",\"params\":{\"interface\":\"ETHERNET\",\"enabled\":true}}")));
+                return Core::ERROR_NONE;
+            }));
+    IARM_BUS_NetSrvMgr_Iface_EventInterfaceEnabledStatus_t intData;
+    intData.status = 1;
+    strcpy(intData.interface,"eth0");
+    handler.Subscribe(0, _T("onInterfaceStatusChanged"), _T("org.rdk.Network"), message);
+    plugin->eventHandler("NET_SRV_MGR", IARM_BUS_NETWORK_MANAGER_EVENT_INTERFACE_ENABLED_STATUS, static_cast<void*>(&intData), sizeof(intData));
+    handler.Unsubscribe(0, _T("onInterfaceStatusChanged"), _T("org.rdk.Network"), message);
+}
+
+TEST_F(NetworkInitializedEventTest, onConnectionStatusChanged)
+{
+    EXPECT_CALL(service, Submit(::testing::_, ::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Invoke(
+            [&](const uint32_t, const Core::ProxyType<Core::JSON::IElement>& json) {
+                string text;
+                EXPECT_TRUE(json->ToString(text));
+                EXPECT_EQ(text, string(_T("{\"jsonrpc\":\"2.0\",\"method\":\"org.rdk.Network.onConnectionStatusChanged\",\"params\":{\"interface\":\"ETHERNET\",\"status\":\"CONNECTED\"}}")));
+                return Core::ERROR_NONE;
+            }));
+    IARM_BUS_NetSrvMgr_Iface_EventInterfaceConnectionStatus_t intData;
+    intData.status = 1;
+    strcpy(intData.interface,"eth0");
+    handler.Subscribe(0, _T("onConnectionStatusChanged"), _T("org.rdk.Network"), message);
+    plugin->eventHandler("NET_SRV_MGR", IARM_BUS_NETWORK_MANAGER_EVENT_INTERFACE_CONNECTION_STATUS, static_cast<void*>(&intData), sizeof(intData));
+    handler.Unsubscribe(0, _T("onConnectionStatusChanged"), _T("org.rdk.Network"), message);
+}
+
+TEST_F(NetworkInitializedEventTest, onIPAddressStatusChanged)
+{
+    EXPECT_CALL(service, Submit(::testing::_, ::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Invoke(
+            [&](const uint32_t, const Core::ProxyType<Core::JSON::IElement>& json) {
+                string text;
+                EXPECT_TRUE(json->ToString(text));
+                EXPECT_EQ(text, string(_T("{\"jsonrpc\":\"2.0\",\"method\":\"org.rdk.Network.onIPAddressStatusChanged\",\"params\":{\"interface\":\"ETHERNET\",\"ip4Address\":\"192.168.1.10\",\"status\":\"ACQUIRED\"}}")));
+                return Core::ERROR_NONE;
+            }));
+    IARM_BUS_NetSrvMgr_Iface_EventInterfaceIPAddress_t intData;
+    intData.is_ipv6 = 0;
+    strcpy(intData.interface,"eth0");
+    intData.acquired = 1;
+    strcpy(intData.ip_address,"192.168.1.10");
+    handler.Subscribe(0, _T("onIPAddressStatusChanged"), _T("org.rdk.Network"), message);
+    plugin->eventHandler("NET_SRV_MGR", IARM_BUS_NETWORK_MANAGER_EVENT_INTERFACE_IPADDRESS, static_cast<void*>(&intData), sizeof(intData));
+    handler.Unsubscribe(0, _T("onIPAddressStatusChanged"), _T("org.rdk.Network"), message);
+}
+
+TEST_F(NetworkInitializedEventTest, onDefaultInterfaceChanged)
+{
+    /*EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getInterfaces"), _T("{}"), response));
+        EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"interface\":\"ETHERNET\"")));
+        EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"macAddress\":\"AA:AA:AA:AA:AA:AA\"")));
+        EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"enabled\":true")));
+        EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"connected\":true")));
+        EXPECT_THAT(response, ::testing::ContainsRegex(_T("\"success\":true")));*/
+    EXPECT_CALL(service, Submit(::testing::_, ::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Invoke(
+            [&](const uint32_t, const Core::ProxyType<Core::JSON::IElement>& json) {
+                string text;
+                EXPECT_TRUE(json->ToString(text));
+                EXPECT_EQ(text, string(_T("{\"jsonrpc\":\"2.0\",\"method\":\"org.rdk.Network.onDefaultInterfaceChanged\",\"params\":{\"oldInterfaceName\":\"\",\"newInterfaceName\":\"ETHERNET\"}}")));
+                return Core::ERROR_NONE;
+            }));
+    IARM_BUS_NetSrvMgr_Iface_EventDefaultInterface_t intData;
+    strcpy(intData.newInterface,"eth0");
+    handler.Subscribe(0, _T("onDefaultInterfaceChanged"), _T("org.rdk.Network"), message);
+    plugin->eventHandler("NET_SRV_MGR", IARM_BUS_NETWORK_MANAGER_EVENT_DEFAULT_INTERFACE, static_cast<void*>(&intData), sizeof(intData));
+    handler.Unsubscribe(0, _T("onDefaultInterfaceChanged"), _T("org.rdk.Network"), message);
+}
+
+TEST_F(NetworkInitializedEventTest, onInternetStatusChange)
+{
+    EXPECT_CALL(service, Submit(::testing::_, ::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Invoke(
+            [&](const uint32_t, const Core::ProxyType<Core::JSON::IElement>& json) {
+                string text;
+                EXPECT_TRUE(json->ToString(text));
+                EXPECT_EQ(text, string(_T("{\"jsonrpc\":\"2.0\",\"method\":\"org.rdk.Network.onInternetStatusChange\",\"params\":{\"state\":0,\"status\":\"NO_INTERNET\"}}")));
+                return Core::ERROR_NONE;
+            }));
+    nsm_internetState  intData = NO_INTERNET;
+    handler.Subscribe(0, _T("onInternetStatusChange"), _T("org.rdk.Network"), message);
+    plugin->notifyInternetStatusChange(intData);
+    handler.Unsubscribe(0, _T("onInternetStatusChange"), _T("org.rdk.Network"), message);
 }


### PR DESCRIPTION
…… (#4754)

* RDK-44762 : Implement Unit Test framework to cover L1 test cases in Network Thunder Plugin (#4659)

Reason for change: Adding new gtest cases
Test Procedure: Run gtest
Risks: High


* RDK-44763 : Implement Unit Test framework to cover L1 test cases in WiFiManager Thunder Plugin (#4676)

Reason for change: Adding new gtest cases
Test Procedure: Run gtest
Risks: High


---------