### PR TITLE
DELIA-64243:  Add Conditional WAI Compile Code for Amlogic and RTK

### DIFF
--- a/MaintenanceManager/CHANGELOG.md
+++ b/MaintenanceManager/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.0.26] - 2024-01-04
+### Added
+- Add WAI Conditional Compile Code in amlogic.cmake and realtek.cmake
+
 ## [1.0.25] - 2023-11-09
 ### Changed
 - Proceed with maintenance tasks during first time activation once we got internet

--- a/amlogic.cmake
+++ b/amlogic.cmake
@@ -51,6 +51,11 @@ if (BUILD_DONT_SET_POWER_BRIGHTNESS)
     add_definitions (-DDONT_SET_POWER_BRIGHTNESS)
 endif()
 
+if (ENABLE_WHOAMI)
+    message("Enable WHOAMI")
+    add_definitions (-DENABLE_WHOAMI=ON)
+endif()
+
 if (BUILD_ENABLE_HDCP)
     message("Building with hdcp profile")
     add_definitions (-DBUILD_ENABLE_HDCP)

--- a/realtek.cmake
+++ b/realtek.cmake
@@ -51,6 +51,11 @@ if (BUILD_DONT_SET_POWER_BRIGHTNESS)
     add_definitions (-DDONT_SET_POWER_BRIGHTNESS)
 endif()
 
+if (ENABLE_WHOAMI)
+    message("Enable WHOAMI")
+    add_definitions (-DENABLE_WHOAMI=ON)
+endif()
+
 if (BUILD_ENABLE_HDCP)
     message("Building with hdcp profile")
     add_definitions (-DBUILD_ENABLE_HDCP)


### PR DESCRIPTION

**Reason for change:** Added Conditional Compile Code for
WhoAmI in Amlogic and RealTek Platforms
**Test Procedure:** Check if the Maintenance Manager gets WAI data from SecMgr
**Risks:** Medium
**Priority:** P1