### PR TITLE
RDKTV-27253: Physical Address CEC msg should be send synchronously and retried

### DIFF
--- a/HdmiCecSink/CHANGELOG.md
+++ b/HdmiCecSink/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.3.2] - 2024-01-09
+### Fixed
+- Send Physical address synchronously and retried
+
 ## [1.3.1] - 2023-12-12
 ### Fixed
 - Reset the Activesource on putting the TV to standby

--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -177,7 +177,7 @@ static std::vector<DeviceFeatures> deviceFeatures = {DEVICE_FEATURES_TV};
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 3
-#define API_VERSION_NUMBER_PATCH 1
+#define API_VERSION_NUMBER_PATCH 2
 
 namespace WPEFramework
 {
@@ -318,7 +318,7 @@ namespace WPEFramework
                  try
                  { 
                      LOGINFO(" sending ReportPhysicalAddress response physical_addr :%s logicalAddress :%x \n",physical_addr.toString().c_str(), logicalAddress.toInt());
-                     conn.sendToAsync(LogicalAddress(LogicalAddress::BROADCAST), MessageEncoder().encode(ReportPhysicalAddress(physical_addr,logicalAddress.toInt())));
+                     conn.sendTo(LogicalAddress(LogicalAddress::BROADCAST), MessageEncoder().encode(ReportPhysicalAddress(physical_addr,logicalAddress.toInt())), 500);
                  } 
                  catch(...)
                  {


### PR DESCRIPTION
Reason for change: For the CEC certification we are expecting that reportphysical
address responds back with Give physical Address in  synchronize manner and also
needs to retry at least twice.
Test Procedure: Build and Verify.
Risks: Low
Priority: P1
Signed-off-by: Dakshayani MV <dakshayani.venkataramana@sky.uk>