### PR TITLE
RDKTV-26929 : Add chipset in DeviceIdentification

### DIFF
--- a/DeviceIdentification/CHANGELOG.md
+++ b/DeviceIdentification/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.0.5] - 2024-01-10
+### Fixed
+- Add chipset name in DeviceIdentification plugin
+
 ## [1.0.4] - 2023-09-12
 ### Added
 - Implement Thunder Plugin Configuration for Kirkstone builds(CMake-3.20 & above)

--- a/DeviceIdentification/CMakeLists.txt
+++ b/DeviceIdentification/CMakeLists.txt
@@ -33,6 +33,10 @@ set(PLUGIN_DEVICEIDENTIFICATION_MODE "Off" CACHE STRING "Controls if the plugin 
 set(PLUGIN_DEVICEIDENTIFICATION_INTERFACE_NAME "eth0" CACHE STRING "Ethernet Card name which has to be associated for the Raw Device Id creation")
 option(PLUGIN_DEVICEIDENTIFICATION_USE_MFR "Get device identification details using MFR library" OFF)
 
+if (DEVICE_IDENTIFICATION_CHIPSET_INFO)
+  add_definitions (-DDEVICE_IDENTIFICATION_CHIPSET_INFO=\"${DEVICE_IDENTIFICATION_CHIPSET_INFO}\")
+endif (DEVICE_IDENTIFICATION_CHIPSET_INFO)
+
 find_package(NEXUS QUIET)
 find_package(BCM_HOST QUIET)
 find_package(MFRFWLibs QUIET)


### PR DESCRIPTION
Reason for change: Chipset name in deviceidentification is incorrect for new cvte based platforms
Test Procedure: Refer Ticket.
Risks: Create None
Signed-off-by: jijonath kannath jijonath.kannath@sky.uk