### PR TITLE
RDK-44991: Upgrade Flex-2.0 devices to use Thunder R4.4.1 (#4777)

### DIFF
--- a/ControlService/CHANGELOG.md
+++ b/ControlService/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.0.7] - 2023-01-26
+### Changed
+- RDK-44991: Upgrade Flex-2.0 devices to use Thunder R4.4.1
+
 ## [1.0.6] - 2023-12-13
 ### Changed
 - Remove controlServiceTestClient from build

--- a/ControlService/test/CMakeLists.txt
+++ b/ControlService/test/CMakeLists.txt
@@ -17,6 +17,8 @@
 
 set(PLUGIN_NAME controlSvcTestClient)
 
+find_package(${NAMESPACE}Core REQUIRED)
+
 if (USE_THUNDER_R4)
     find_package(${NAMESPACE}COM REQUIRED)
     find_package(${NAMESPACE}WebSocket REQUIRED)
@@ -30,6 +32,8 @@ set_target_properties(${PLUGIN_NAME} PROPERTIES
     CXX_STANDARD 11
     CXX_STANDARD_REQUIRED YES
     )
+
+target_link_libraries(${PLUGIN_NAME} PRIVATE ${NAMESPACE}Core::${NAMESPACE}Core)
 
 if (USE_THUNDER_R4)
 target_link_libraries(${PLUGIN_NAME} PRIVATE ${NAMESPACE}COM::${NAMESPACE}COM ${NAMESPACE}WebSocket::${NAMESPACE}WebSocket)

--- a/DeviceInfo/CHANGELOG.md
+++ b/DeviceInfo/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+## [1.0.12] - 2023-01-26
+### Changed
+- RDK-44991: Upgrade Flex-2.0 devices to use Thunder R4.4.1
 
 ## [1.0.11] - 2023-10-20
 ### Fixed

--- a/DeviceInfo/DeviceInfo.cpp
+++ b/DeviceInfo/DeviceInfo.cpp
@@ -161,7 +161,11 @@ namespace Plugin {
         Core::SystemInfo& singleton(Core::SystemInfo::Instance());
 
         systemInfo.Time = Core::Time::Now().ToRFC1123(true);
-        systemInfo.Version = _service->Version() + _T("#") + _subSystem->BuildTreeHash();
+#if ((THUNDER_VERSION_MAJOR >= 4) && (THUNDER_VERSION_MINOR >= 4))
+	systemInfo.Version = _subSystem->Version() + _T("#") + _subSystem->BuildTreeHash();
+#else
+	systemInfo.Version = _service->Version() + _T("#") + _subSystem->BuildTreeHash();
+#endif
         systemInfo.Uptime = singleton.GetUpTime();
         systemInfo.Freeram = singleton.GetFreeRam();
         systemInfo.Totalram = singleton.GetTotalRam();

--- a/DeviceInfo/Module.h
+++ b/DeviceInfo/Module.h
@@ -25,7 +25,11 @@
 #endif
 
 #include <plugins/plugins.h>
+#if ((THUNDER_VERSION_MAJOR >= 4) && (THUNDER_VERSION_MINOR == 4))
+#include <definitions/definitions.h>
+#else
 #include <interfaces/definitions.h>
+#endif
 
 #undef EXTERNAL
 #define EXTERNAL

--- a/Messenger/CHANGELOG.md
+++ b/Messenger/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.1.3] - 2023-01-26
+### Changed
+- RDK-44991: Upgrade Flex-2.0 devices to use Thunder R4.4.1
+
 ## [1.1.2] - 2023-09-12
 ### Added
 - Implement Thunder Plugin Configuration for Kirkstone builds(CMake-3.20 & above)

--- a/Messenger/Module.h
+++ b/Messenger/Module.h
@@ -24,7 +24,11 @@
 #endif
 
 #include <plugins/plugins.h>
+#if ((THUNDER_VERSION_MAJOR >= 4) && (THUNDER_VERSION_MINOR == 4))
+#include <definitions/definitions.h>
+#else
 #include <interfaces/definitions.h>
+#endif
 
 #undef EXTERNAL
 #define EXTERNAL

--- a/Monitor/CHANGELOG.md
+++ b/Monitor/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+## [1.0.5] - 2023-09-26
+### Changed
+- RDK-44991: Upgrade Flex-2.0 devices to use Thunder R4.4.1
 
 ## [1.0.4] - 2023-09-12
 ### Added

--- a/Monitor/Monitor.h
+++ b/Monitor/Monitor.h
@@ -819,7 +819,9 @@ namespace Plugin {
 
                 _adminLock.Unlock();
             }
-#ifdef USE_THUNDER_R4
+#if (THUNDER_VERSION_MAJOR >= 4)
+
+#if (THUNDER_VERSION_MINOR == 2)
             void Activation(const string& name, PluginHost::IShell* service) override
             {
                 StateChange(service);
@@ -829,7 +831,7 @@ namespace Plugin {
            {
                StateChange(service);
            }
-
+#endif
            void Activated (const string& callsign, PluginHost::IShell* service) override
            {
                 StateChange(service);
@@ -841,7 +843,7 @@ namespace Plugin {
            void Unavailable(const string&, PluginHost::IShell*) override
            {
            }
-#endif /* USE_THUNDER_R4 */
+#endif
             void Snapshot(Core::JSON::ArrayType<Monitor::Data>& snapshot)
             {
                 _adminLock.Lock();
@@ -990,12 +992,7 @@ namespace Plugin {
                                 Core::EnumerateType<PluginHost::IShell::reason> why(((value & MonitorObject::EXCEEDED_MEMORY) != 0) ? PluginHost::IShell::MEMORY_EXCEEDED : PluginHost::IShell::FAILURE);
 
                                 const string message("{\"callsign\": \"" + plugin->Callsign() + "\", \"action\": \"Deactivate\", \"reason\": \"" + why.Data() + "\" }");
-#ifdef USE_THUNDER_R4
-                                SYSLOG_GLOBAL(Logging::Fatal, (_T("FORCED Shutdown: %s by reason: %s."), plugin->Callsign().c_str(), why.Data()));
-#else
-                                SYSLOG(Trace::Fatal, (_T("FORCED Shutdown: %s by reason: %s."), plugin->Callsign().c_str(), why.Data()));
-#endif /* USE_THUNDER_R4 */
-
+                                SYSLOG(Logging::Fatal, (_T("FORCED Shutdown: %s by reason: %s."), plugin->Callsign().c_str(), why.Data()));
                                 _service->Notify(message);
 
                                 _parent.event_action(plugin->Callsign(), "Deactivate", why.Data());

--- a/OpenCDMi/CHANGELOG.md
+++ b/OpenCDMi/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+## [1.0.4] - 2023-01-26
+### Changed
+- RDK-44991: Upgrade Flex-2.0 devices to use Thunder R4.4.1
+
 ## [1.0.3] - 2023-09-12
 ### Added
 - Implement Thunder Plugin Configuration for Kirkstone builds(CMake-3.20 & above)

--- a/OpenCDMi/FrameworkRPC.cpp
+++ b/OpenCDMi/FrameworkRPC.cpp
@@ -114,7 +114,9 @@ namespace Plugin {
                 : RPC::Communicator(source, _T(""), Core::ProxyType<Core::IIPCServer>(engine))
                 , _parentInterface(parentInterface)
             {
+#if ((THUNDER_VERSION_MAJOR == 2) || ((THUNDER_VERSION_MAJOR == 4) && (THUNDER_VERSION_MINOR == 2)))
                 engine->Announcements(Announcement());
+#endif
                 Open(Core::infinite);
             }
             ~ExternalAccess()

--- a/RemoteActionMapping/CHANGELOG.md
+++ b/RemoteActionMapping/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.0.6] - 2023-01-26
+### Changed
+- RDK-44991: Upgrade Flex-2.0 devices to use Thunder R4.4.1
+
 ## [1.0.5] - 2023-12-13
 ### Changed
 - Remove remoteActionMappingTestClient from build

--- a/RemoteActionMapping/test/CMakeLists.txt
+++ b/RemoteActionMapping/test/CMakeLists.txt
@@ -16,6 +16,8 @@
 # limitations under the License.
 
 set(PLUGIN_NAME ramTestClient)
+find_package(${NAMESPACE}Core REQUIRED)
+
 if (USE_THUNDER_R4)
     find_package(${NAMESPACE}COM REQUIRED)
 else ()
@@ -28,6 +30,8 @@ set_target_properties(${PLUGIN_NAME} PROPERTIES
         CXX_STANDARD 11
         CXX_STANDARD_REQUIRED YES
         )
+
+target_link_libraries(${PLUGIN_NAME} PRIVATE ${NAMESPACE}Core::${NAMESPACE}Core)
 
 if (USE_THUNDER_R4)
 target_link_libraries(${PLUGIN_NAME} PRIVATE ${NAMESPACE}COM::${NAMESPACE}COM ${NAMESPACE}WebSocket::${NAMESPACE}WebSocket)

--- a/RemoteControl/CHANGELOG.md
+++ b/RemoteControl/CHANGELOG.md
@@ -13,6 +13,10 @@ All notable changes to this RDK Service will be documented in this file.
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 * The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.3] - 2023-01-26
+### Changed
+- RDK-44991: Upgrade Flex-2.0 devices to use Thunder R4.4.1
+
 ## [1.4.2] - 2023-12-13
 ### Changed
 - Remove remoteControlTestClient from build

--- a/RemoteControl/test/CMakeLists.txt
+++ b/RemoteControl/test/CMakeLists.txt
@@ -1,4 +1,6 @@
 set(PLUGIN_NAME remoteControlTestClient)
+find_package(${NAMESPACE}Core REQUIRED)
+
 if (USE_THUNDER_R4)
     find_package(${NAMESPACE}COM REQUIRED)
 else ()
@@ -11,6 +13,8 @@ set_target_properties(${PLUGIN_NAME} PROPERTIES
     CXX_STANDARD 11
     CXX_STANDARD_REQUIRED YES
     )
+
+target_link_libraries(${PLUGIN_NAME} PRIVATE ${NAMESPACE}Core::${NAMESPACE}Core)
 
 if (USE_THUNDER_R4)
 target_link_libraries(${PLUGIN_NAME} PRIVATE ${NAMESPACE}COM::${NAMESPACE}COM  ${NAMESPACE}WebSocket::${NAMESPACE}WebSocket)

--- a/RustAdapter/CHANGELOG.md
+++ b/RustAdapter/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+## [1.0.3] - 2023-01-26
+### Changed
+- RDK-44991: Upgrade Flex-2.0 devices to use Thunder R4.4.1
 
 ## [1.0.2] - 2023-07-07
 ### Fixed

--- a/RustAdapter/LocalPlugin.cpp
+++ b/RustAdapter/LocalPlugin.cpp
@@ -193,6 +193,21 @@ WPEFramework::Plugin::Rust::LocalPlugin::SendTo(uint32_t channel_id, const char 
 }
 
 #if JSON_RPC_CONTEXT
+
+#if ((THUNDER_VERSION_MAJOR >= 4) && (THUNDER_VERSION_MINOR == 4))
+WPEFramework::Core::hresult
+  WPEFramework::Plugin::Rust::LocalPlugin::Invoke(ICallback* callback, const uint32_t channelId, const uint32_t id, const string& token, const string& method, const string& parameters, string& response)
+{
+  Rust::RequestContext req_ctx;
+  req_ctx.channel_id = channelId;
+  req_ctx.auth_token = token.c_str();
+
+  m_rust_plugin_invoke(m_rust_plugin, response.c_str(), req_ctx);
+
+  // indicates to Thunder that this request is being processed asynchronously
+  return {};
+}
+#else
 WPEFramework::Core::ProxyType<WPEFramework::Core::JSONRPC::Message>
 WPEFramework::Plugin::Rust::LocalPlugin::Invoke(
   const WPEFramework::Core::JSONRPC::Context &ctx,
@@ -207,6 +222,8 @@ WPEFramework::Plugin::Rust::LocalPlugin::Invoke(
   // indicates to Thunder that this request is being processed asynchronously
   return {};
 }
+#endif
+
 #else
 WPEFramework::Core::ProxyType<WPEFramework::Core::JSONRPC::Message>
   WPEFramework::Plugin::Rust::LocalPlugin::Invoke(
@@ -222,6 +239,21 @@ WPEFramework::Core::ProxyType<WPEFramework::Core::JSONRPC::Message>
   return {};
 }
 #endif
+
+#if ((THUNDER_VERSION_MAJOR == 4) && (THUNDER_VERSION_MINOR == 4))
+WPEFramework::Core::hresult WPEFramework::Plugin::Rust::LocalPlugin::Revoke(ICallback* callback)
+{
+    return {};
+}
+
+WPEFramework::Core::hresult WPEFramework::Plugin::Rust::LocalPlugin::Validate(const string& token, const string& method, const string& paramaters) const
+{
+  return {};
+}
+#endif
+
+
+#if ((THUNDER_VERSION_MAJOR == 2) || ((THUNDER_VERSION_MAJOR == 4) && (THUNDER_VERSION_MINOR == 2)))
 void
 WPEFramework::Plugin::Rust::LocalPlugin::Activate(
   WPEFramework::PluginHost::IShell *shell)
@@ -232,7 +264,7 @@ void
 WPEFramework::Plugin::Rust::LocalPlugin::Deactivate()
 {
 }
-
+#endif
 bool
 WPEFramework::Plugin::Rust::LocalPlugin::Attach(PluginHost::Channel &channel)
 {
@@ -289,9 +321,9 @@ WPEFramework::Plugin::Rust::LocalPlugin::Information() const
   return { };
 }
 
-#if THUNDER_VERSION == 4
+#if ((THUNDER_VERSION_MAJOR >= 4) && (THUNDER_VERSION_MINOR == 2))
 void WPEFramework::Plugin::Rust::LocalPlugin::Close(const uint32_t channelId) /* override */
 {
   return;
 }
-#endif /* THUNDER_VERSION */
+#endif

--- a/RustAdapter/LocalPlugin.h
+++ b/RustAdapter/LocalPlugin.h
@@ -72,12 +72,13 @@ public:
   /**
    * IDispatcher::Activate
    */
+#if ((THUNDER_VERSION_MAJOR == 2) || ((THUNDER_VERSION_MAJOR == 4) && (THUNDER_VERSION_MINOR == 2)))
   void Activate(PluginHost::IShell *shell) override;
-
   /**
    *
    */
   void Deactivate() override;
+#endif
 
   /**
    *
@@ -88,19 +89,30 @@ public:
   /**
    * IDispatcher::Close
    */
-#if THUNDER_VERSION == 4
+#if ((THUNDER_VERSION_MAJOR >= 4) && (THUNDER_VERSION_MINOR == 2))
   void Close(const uint32_t channelId) override;
 #endif /* THUNDER_VERSION */
   /**
    * WPEFramework::PluginHost::IDispatcher::Invoke
    */
 #if JSON_RPC_CONTEXT
+
+#if ((THUNDER_VERSION_MAJOR >= 4) && (THUNDER_VERSION_MINOR == 4))
+  Core::hresult Invoke(ICallback* callback, const uint32_t channelId, const uint32_t id, const string& token, const string& method, const string& parameters, string& response ) override;
+#else
   Core::ProxyType<Core::JSONRPC::Message> Invoke(
     const Core::JSONRPC::Context& context,
     const Core::JSONRPC::Message& message) override;
+#endif
+
 #else
   Core::ProxyType<Core::JSONRPC::Message> Invoke(
     const string& token, const uint32_t channelId, const Core::JSONRPC::Message& req) override;
+#endif
+
+#if ((THUNDER_VERSION_MAJOR >= 4) && (THUNDER_VERSION_MINOR == 4))
+  Core::hresult Revoke(ICallback* callback) override;
+  Core::hresult Validate(const string& token, const string& method, const string& paramaters /* @restrict:(4M-1) */) const override;
 #endif
   /**
    *
@@ -108,6 +120,13 @@ public:
   Core::ProxyType<Core::JSON::IElement> Inbound(const string &identifier) override;
   Core::ProxyType<Core::JSON::IElement> Inbound(const uint32_t id,
     const Core::ProxyType<Core::JSON::IElement> &element) override;
+
+#if ((THUNDER_VERSION_MAJOR >= 4) && (THUNDER_VERSION_MINOR == 4))
+public:
+   WPEFramework::PluginHost::ILocalDispatcher* Local() override {
+        return nullptr; // Replace nullptr with your actual implementation.
+    }
+#endif /* THUNDER_VERSION */
 
 private:
   using RustPlugin_SendTo = void (*)(uint32_t, const char *, uint32_t ctx_id);

--- a/RustAdapter/RemotePlugin.cpp
+++ b/RustAdapter/RemotePlugin.cpp
@@ -94,6 +94,15 @@ RemotePlugin::SendTo(uint32_t channel_id, const char *json)
   m_service->Submit(channel_id, Core::ProxyType<Core::JSON::IElement>(res));
 }
 #if JSON_RPC_CONTEXT
+
+#if ((THUNDER_VERSION_MAJOR >= 4) && (THUNDER_VERSION_MINOR == 4))
+WPEFramework::Core::hresult RemotePlugin::Invoke(ICallback* callback, const uint32_t channelId, const uint32_t id, const string& token, const string& method, const string& parameters, string& response)
+{
+  m_stream.SendInvoke(channelId, token, response);
+  return {};
+}
+
+#else
 WPEFramework::Core::ProxyType<WPEFramework::Core::JSONRPC::Message>
 RemotePlugin::Invoke(
   const WPEFramework::Core::JSONRPC::Context &ctx,
@@ -104,6 +113,8 @@ RemotePlugin::Invoke(
   m_stream.SendInvoke(ctx.ChannelId(), ctx.Token(), json);
   return {};
 }
+#endif
+
 #else
 WPEFramework::Core::ProxyType<WPEFramework::Core::JSONRPC::Message>
 RemotePlugin::Invoke(
@@ -115,6 +126,8 @@ RemotePlugin::Invoke(
   return {};
 }
 #endif
+
+#if ((THUNDER_VERSION_MAJOR == 2) || ((THUNDER_VERSION_MAJOR == 4) && (THUNDER_VERSION_MINOR == 2)))
 void
 RemotePlugin::Activate(
   WPEFramework::PluginHost::IShell *shell)
@@ -125,6 +138,7 @@ void
 RemotePlugin::Deactivate()
 {
 }
+#endif
 
 bool
 RemotePlugin::Attach(PluginHost::Channel &channel)
@@ -175,13 +189,27 @@ RemotePlugin::Information() const
   return { };
 }
 
-#if THUNDER_VERSION == 4
+#if (THUNDER_VERSION_MAJOR >= 4)
+#if (THUNDER_VERSION_MINOR == 2)
 void RemotePlugin::Close(const uint32_t channelId) /* override */
 {
   return;
 }
-#endif /* THUNDER_VERSION */
+#endif
 
+#if (THUNDER_VERSION_MINOR == 4)
+WPEFramework::Core::hresult RemotePlugin::Revoke(ICallback* callback)
+{
+    return {};
+}
+
+WPEFramework::Core::hresult RemotePlugin::Validate(const string& token, const string& method, const string& paramaters) const
+{
+    return {};
+}
+
+#endif
+#endif
 void RemotePlugin::onRead(const Response& rsp)
 {
     LOGDBG("RemotePlugin::onRead response: channel_id=%u, json=\"%s\"", rsp.channel_id, rsp.json.c_str());

--- a/RustAdapter/RemotePlugin.h
+++ b/RustAdapter/RemotePlugin.h
@@ -74,13 +74,13 @@ public:
   /**
    * IDispatcher::Activate
    */
+#if ((THUNDER_VERSION_MAJOR == 2) || ((THUNDER_VERSION_MAJOR == 4) && (THUNDER_VERSION_MINOR == 2)))
   void Activate(PluginHost::IShell *shell) override;
-
   /**
    *
    */
   void Deactivate() override;
-
+#endif
   /**
    *
    */
@@ -90,17 +90,30 @@ public:
   /**
    * IDispatcher::Close
    */
-#if THUNDER_VERSION == 4
+#if ((THUNDER_VERSION_MAJOR >= 4) && (THUNDER_VERSION_MINOR == 2))
   void Close(const uint32_t channelId) override;
+#endif
+
+  /**
+   * IDispatcher::Close
+   */
+#if ((THUNDER_VERSION_MAJOR >= 4 && THUNDER_VERSION_MINOR == 4))
+  Core::hresult Revoke(ICallback* callback) override;
+  Core::hresult Validate(const string& token, const string& method, const string& paramaters /* @restrict:(4M-1) */) const override;
 #endif /* THUNDER_VERSION */
 
   /**
    * WPEFramework::PluginHost::IDispatcher::Invoke
    */
 #if JSON_RPC_CONTEXT   
+
+#if ((THUNDER_VERSION_MAJOR >= 4) && (THUNDER_VERSION_MINOR == 4))
+  Core::hresult Invoke(ICallback* callback, const uint32_t channelId, const uint32_t id, const string& token, const string& method, const string& parameters, string& response ) override;
+#else
   Core::ProxyType<Core::JSONRPC::Message> Invoke(
     const Core::JSONRPC::Context& context,
     const Core::JSONRPC::Message& message) override;
+#endif
 #else
   Core::ProxyType<Core::JSONRPC::Message> Invoke(
     const string& token, const uint32_t channelId, const Core::JSONRPC::Message& req) override;
@@ -113,6 +126,13 @@ public:
     const Core::ProxyType<Core::JSON::IElement> &element) override;
 
   void onRead(const Response& rsp);
+#if ((THUNDER_VERSION_MAJOR == 4) && (THUNDER_VERSION_MINOR == 4))
+public:
+   WPEFramework::PluginHost::ILocalDispatcher* Local() override {
+        return nullptr; // Replace nullptr with your actual implementation.
+    }
+#endif
+
 private:
   int LaunchRemoteProcess(const string& rust_shared_lib, const string& host_ip, int port);
   void SendTo(uint32_t channel_id, const char *json);

--- a/RustAdapter/RustAdapter.cpp
+++ b/RustAdapter/RustAdapter.cpp
@@ -100,6 +100,14 @@ WPEFramework::Plugin::RustAdapter::Release() const
 }
 
 #if JSON_RPC_CONTEXT
+
+#if ((THUNDER_VERSION_MAJOR == 4) && (THUNDER_VERSION_MINOR == 4))
+WPEFramework::Core::hresult
+WPEFramework::Plugin::RustAdapter::Invoke(ICallback* callback, const uint32_t channelId, const uint32_t id, const string& token, const string& method, const string& parameters, string& response )
+{
+  return m_impl->Invoke(callback, channelId,id, token, method, parameters, response);
+}
+#else
 WPEFramework::Core::ProxyType<WPEFramework::Core::JSONRPC::Message>
 WPEFramework::Plugin::RustAdapter::Invoke(
   const WPEFramework::Core::JSONRPC::Context &ctx,
@@ -107,6 +115,8 @@ WPEFramework::Plugin::RustAdapter::Invoke(
 {
   return m_impl->Invoke(ctx, req);
 }
+#endif
+
 #else
 WPEFramework::Core::ProxyType<WPEFramework::Core::JSONRPC::Message> 
   WPEFramework::Plugin::RustAdapter::Invoke(
@@ -116,6 +126,7 @@ WPEFramework::Core::ProxyType<WPEFramework::Core::JSONRPC::Message>
 }
 #endif
 
+#if ((THUNDER_VERSION_MAJOR == 2) || ((THUNDER_VERSION_MAJOR == 4)  && (THUNDER_VERSION_MINOR == 2)))
 void
 WPEFramework::Plugin::RustAdapter::Activate(
   WPEFramework::PluginHost::IShell *shell)
@@ -129,6 +140,7 @@ WPEFramework::Plugin::RustAdapter::Deactivate()
   m_impl->Deactivate();
 }
 
+#endif
 bool
 WPEFramework::Plugin::RustAdapter::Attach(PluginHost::Channel &channel)
 {
@@ -141,13 +153,26 @@ WPEFramework::Plugin::RustAdapter::Detach(PluginHost::Channel &channel)
   m_impl->Detach(channel);
 }
 
-#if THUNDER_VERSION == 4
+#if ((THUNDER_VERSION_MAJOR == 4) && (THUNDER_VERSION_MINOR == 2))
 void
 WPEFramework::Plugin::RustAdapter::Close(const uint32_t channelId)
 {
     m_impl->Close(channelId);
 }
 #endif /* THUNDER_VERSION */
+
+#if ((THUNDER_VERSION_MAJOR == 4) && (THUNDER_VERSION_MINOR == 4))
+WPEFramework::Core::hresult WPEFramework::Plugin::RustAdapter::Revoke(ICallback* callback)
+{
+     return {};
+}
+
+WPEFramework::Core::hresult WPEFramework::Plugin::RustAdapter::Validate(const string& token, const string& method, const string& paramaters) const
+{
+  return {};
+}
+
+#endif
 
 WPEFramework::Core::ProxyType<WPEFramework::Core::JSON::IElement>
 WPEFramework::Plugin::RustAdapter::Inbound(const string &identifier)

--- a/RustAdapter/RustAdapter.h
+++ b/RustAdapter/RustAdapter.h
@@ -112,13 +112,13 @@ public:
   /**
    * IDispatcher::Activate
    */
+#if ((THUNDER_VERSION_MAJOR == 2) || ((THUNDER_VERSION_MAJOR == 4) && (THUNDER_VERSION_MINOR == 2)))
   void Activate(PluginHost::IShell *shell) override;
-
   /**
    *
    */
   void Deactivate() override;
-
+#endif
   /**
    *
    */
@@ -128,17 +128,29 @@ public:
   /**
    * IDispatcher::Close
    */
-#if THUNDER_VERSION == 4
+#if (THUNDER_VERSION_MAJOR >= 4)
+#if (THUNDER_VERSION_MINOR == 2)
   void Close(const uint32_t channelId) override;
-#endif /* THUNDER_VERSION */
+#endif
 
+#if (THUNDER_VERSION_MINOR == 4)
+  Core::hresult Revoke(ICallback* callback) override;
+  Core::hresult Validate(const string& token, const string& method, const string& paramaters /* @restrict:(4M-1) */) const override;
+#endif
+#endif
   /**
    * WPEFramework::PluginHost::IDispatcher::Invoke
    */
 #if JSON_RPC_CONTEXT
+
+#if ((THUNDER_VERSION_MAJOR >= 4) && (THUNDER_VERSION_MINOR == 4))
+  Core::hresult Invoke(ICallback* callback, const uint32_t channelId, const uint32_t id, const string& token, const string& method, const string& parameters, string& response ) override;
+#else
   Core::ProxyType<Core::JSONRPC::Message> Invoke(
     const Core::JSONRPC::Context& context,
     const Core::JSONRPC::Message& message) override;
+#endif
+
 #else 
   Core::ProxyType<Core::JSONRPC::Message> Invoke(
     const string& token, const uint32_t channelId, const Core::JSONRPC::Message& message) override;
@@ -163,6 +175,13 @@ public:
     const std::string& callsign);
 
   static std::string GetAuthToken(WPEFramework::PluginHost::IShell* service, const std::string &callsign);
+
+#if ((THUNDER_VERSION_MAJOR >= 4) && (THUNDER_VERSION_MINOR == 4))
+public:
+   WPEFramework::PluginHost::ILocalDispatcher* Local() override {
+        return nullptr; // Replace nullptr with your actual implementation.
+    }
+#endif
 
 private:
   std::unique_ptr<Rust::IPlugin> m_impl;

--- a/SystemServices/CHANGELOG.md
+++ b/SystemServices/CHANGELOG.md
@@ -16,6 +16,9 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [2.0.3] - 2023-01-26
+### Changed
+- RDK-44991: Upgrade Flex-2.0 devices to use Thunder R4.4.1
 
 ## [2.0.2] - 2023-01-10
 ### Added

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -2234,8 +2234,9 @@ namespace WPEFramework {
                     newState == IARM_BUS_SYSMGR_LOG_UPLOAD_ABORTED ? LOG_UPLOAD_STATUS_ABORTED : LOG_UPLOAD_STATUS_FAILURE;
 
                 sendNotify(EVT_ONLOGUPLOAD, params);
+#if ((THUNDER_VERSION_MAJOR == 2) || ((THUNDER_VERSION_MAJOR == 4) && (THUNDER_VERSION_MINOR == 2)))
                 GetHandler(2)->Notify(EVT_ONLOGUPLOAD, params);
-
+#endif
                 pid_t wp;
                 int status;
 

--- a/TextToSpeech/CHANGELOG.md
+++ b/TextToSpeech/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.0.22] - 2023-01-26
+### Changed
+- RDK-44991: Upgrade Flex-2.0 devices to use Thunder R4.4.1
+
 ## [1.0.21] - 2024-01-05
 ### Added
 - Added UT and Validation Checks

--- a/TextToSpeech/test/CMakeLists.txt
+++ b/TextToSpeech/test/CMakeLists.txt
@@ -16,11 +16,15 @@
 # limitations under the License.
 
 set(PLUGIN_NAME TTSThunderAPITest)
+
+find_package(${NAMESPACE}Core REQUIRED)
+
 if (USE_THUNDER_R4)
     find_package(${NAMESPACE}COM REQUIRED)
 else ()
     find_package(${NAMESPACE}Protocols REQUIRED)
 endif (USE_THUNDER_R4)
+
 find_package(securityagent REQUIRED)
 
 option(PLUGIN_SECURITY_AGENT "Enable the Security Agent Features interface in javascript." OFF)
@@ -34,6 +38,8 @@ set_target_properties(${PLUGIN_NAME} PROPERTIES
 
 set(LIBRARIES WPEFrameworkSecurityUtil)
 target_include_directories(${PLUGIN_NAME} PRIVATE ../../helpers ../impl)
+
+target_link_libraries(${PLUGIN_NAME} PUBLIC ${LIBRARIES} PRIVATE ${NAMESPACE}Core::${NAMESPACE}Core)
 
 if (USE_THUNDER_R4)
 target_link_libraries(${PLUGIN_NAME} PUBLIC ${LIBRARIES} PRIVATE ${NAMESPACE}COM::${NAMESPACE}COM ${NAMESPACE}WebSocket::${NAMESPACE}WebSocket)

--- a/helpers/UtilsJsonRpc.h
+++ b/helpers/UtilsJsonRpc.h
@@ -49,6 +49,23 @@
  *
  * You should be capable of just using "Notify".
  */
+#if ((THUNDER_VERSION_MAJOR >= 4) && (THUNDER_VERSION_MINOR == 4))
+
+#define sendNotify(event,params) { \
+    std::string json; \
+    params.ToString(json); \
+    LOGINFO("Notify %s %s", event, json.c_str()); \
+    Notify(event,params); \
+}
+
+#define sendNotifyMaskParameters(event,params) { \
+    std::string json; \
+    params.ToString(json); \
+    LOGINFO("Notify %s <***>", event); \
+    Notify(event,params); \
+}
+
+#else
 
 #define sendNotify(event,params) { \
     std::string json; \
@@ -63,6 +80,7 @@
     for (uint8_t i = 1; GetHandler(i); i++) GetHandler(i)->Notify(event,params); \
 }
 
+#endif
 /**
  * DO NOT USE THIS.
  *


### PR DESCRIPTION
* RDK-44991: Upgrade Flex-2.0 devices to use Thunder R4.4.1

Reason for change: Compilation Error Fixed of rdkservices plugins against Thunder R4.4.1
Test Procedure: Verify in Jenkin Build
Risks: High
Signed-off-by: Thamim Razith tabbas651@cable.comcast.com

* Update Monitor.h

* Update DeviceInfo.cpp

* Update LocalPlugin.cpp

* Update LocalPlugin.h

* Update RemotePlugin.cpp

* Update RemotePlugin.h

* Update RustAdapter.cpp

* Update RustAdapter.h

* Update SystemServices.cpp

* Update RustAdapter.cpp

---------

Co-authored-by: Karunakaran A <48997923+karuna2git@users.noreply.github.com>

(cherry picked from commit 80b8139f8ca1ce8676f5967e2acbad2335a98882)