### PR TITLE
RDKTV-26816: Fix Network Retry Logic in Maintenance Manager

### DIFF
--- a/MaintenanceManager/CHANGELOG.md
+++ b/MaintenanceManager/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
-## [1.0.27] - 2024-01-29
+## [1.0.27] - 2024-01-16
 ### Fixed
 - Fixed Network Retry logic in Maintenance Manager in isDeviceOnline()
 

--- a/MaintenanceManager/CHANGELOG.md
+++ b/MaintenanceManager/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
-## [1.0.27] - 2024-01-16
+## [1.0.27] - 2024-01-29
 ### Fixed
 - Fixed Network Retry logic in Maintenance Manager in isDeviceOnline()
 

--- a/MaintenanceManager/CHANGELOG.md
+++ b/MaintenanceManager/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.0.27] - 2024-01-16
+### Fixed
+- Fixed Network Retry logic in Maintenance Manager in isDeviceOnline()
+
 ## [1.0.26] - 2024-01-04
 ### Added
 - Add WAI Conditional Compile Code in amlogic.cmake and realtek.cmake

--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -818,25 +818,22 @@ namespace WPEFramework {
             bool network_available =  false;
             LOGINFO("Checking device has network connectivity\n");
 
-            /* add 4 checks every 30 seconds */
-            int i=0;
-            do{
-	        network_available = checkNetwork();
-                if ( !network_available ){
-                    sleep(30);
-                    i++;
-                    LOGINFO("Network retries [%d/4] \n",i);
-                }else{
-                    break;
-                }
-            }while( i < MAX_NETWORK_RETRIES );
-
-            if ( network_available ){
-                return true;
-            }else {
-                return false;
-            }
-        }
+	    /* add 4 checks every 30 seconds */
+            network_available = checkNetwork();
+	    if (!network_available) {
+                int retry_count = 0;
+		while (retry_count < MAX_NETWORK_RETRIES) {
+                    LOGINFO("Network not available. Sleeping for %d seconds", NETWORK_RETRY_INTERVAL);
+                    sleep(NETWORK_RETRY_INTERVAL);
+		    LOGINFO("Network retries [%d/%d] \n", ++retry_count, MAX_NETWORK_RETRIES);
+		    network_available = checkNetwork();
+                    if (network_available) {
+	                break;
+		    }
+		}
+	    }
+	    return network_available;
+	}
 
         MaintenanceManager::~MaintenanceManager()
         {

--- a/MaintenanceManager/MaintenanceManager.h
+++ b/MaintenanceManager/MaintenanceManager.h
@@ -75,6 +75,8 @@ typedef enum{
 #define MAX_NETWORK_RETRIES             4
 #define MAX_ACTIVATION_RETRIES          4
 
+#define NETWORK_RETRY_INTERVAL          30
+
 #define DCM_SUCCESS                     0
 #define DCM_COMPLETE                    1
 #define RFC_SUCCESS                     2


### PR DESCRIPTION
**Reason for change:** Fixed Network Check logic in Maintenance Manager
* This Takes 1 Try for Network Check
* 4 Retries with 30 Seconds of Sleep between every retry checks

**Test Procedure:** Check Maintenance Manager Network Check and Retry
Mechanism in both Solicited and Unsolicited Maintenance
**Risks:** Medium
**Priority:** P1