### PR TITLE
RDKTV-28343: Ignore CEC messages from Unregister device

### DIFF
--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -2047,12 +2047,6 @@ namespace WPEFramework
 			if(!HdmiCecSink::_instance)
 				return;
 
-			if ( _instance->m_logicalAddressAllocated == LogicalAddress::UNREGISTERED ||
-					logicalAddress.toInt() == LogicalAddress::UNREGISTERED ){
-				LOGERR("Logical Address NOT Allocated");
-				return;
-			}
-
 			if (_instance->deviceList[logicalAddress.toInt()].m_isDevicePresent &&
 					logicalAddress.toInt() != _instance->m_logicalAddressAllocated)
 			{
@@ -2607,11 +2601,6 @@ namespace WPEFramework
 
 			if(!HdmiCecSink::_instance)
 				return;
-			
-			if ( _instance->m_logicalAddressAllocated == LogicalAddress::UNREGISTERED || logicalAddress >= LogicalAddress::UNREGISTERED ){
-				LOGERR("Logical Address NOT Allocated Or its not valid");
-				return;
-			}
 
 			if (_instance->deviceList[logicalAddress].m_isDevicePresent)
 			{

--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -234,8 +234,8 @@ namespace WPEFramework
        {
              printHeader(header);
              LOGINFO("Command: InActiveSource %s : %s : %s  \n",GetOpName(msg.opCode()),msg.physicalAddress.name().c_str(),msg.physicalAddress.toString().c_str());
-	     if(header.from.toInt() == LogicalAddress::UNREGISTERED){
-                LOGERR("Ignoring the message coming from Unregistered Logical Address");
+	     if(header.from.toInt() >= LogicalAddress::UNREGISTERED){
+                LOGERR("Ignoring the message coming from Unregistered/Invalid Logical Address");
                 return;
              }
 
@@ -246,8 +246,8 @@ namespace WPEFramework
        {
              printHeader(header);
              LOGINFO("Command: ImageViewOn from %s\n", header.from.toString().c_str());
-	     if(header.from.toInt() == LogicalAddress::UNREGISTERED){
-                LOGERR("Ignoring the message coming from Unregistered Logical Address");
+	     if(header.from.toInt() >= LogicalAddress::UNREGISTERED){
+                LOGERR("Ignoring the message coming from Unregistered/Invalid Logical Address");
                 return;
              }
 			 HdmiCecSink::_instance->addDevice(header.from.toInt());
@@ -257,8 +257,8 @@ namespace WPEFramework
        {
              printHeader(header);
              LOGINFO("Command: TextViewOn\n");
-	     if(header.from.toInt() == LogicalAddress::UNREGISTERED){
-                LOGERR("Ignoring the message coming from Unregistered Logical Address");
+	     if(header.from.toInt() >= LogicalAddress::UNREGISTERED){
+                LOGERR("Ignoring the message coming from Unregistered/Invalid Logical Address");
                 return;
              }
 			 HdmiCecSink::_instance->addDevice(header.from.toInt());
@@ -285,8 +285,8 @@ namespace WPEFramework
        {
              printHeader(header);
              LOGINFO("Command: GetCECVersion sending CECVersion response \n");
-	     if(header.to.toInt() == LogicalAddress::BROADCAST || header.from.toInt() == LogicalAddress::UNREGISTERED){
-		LOGERR("Ignoring the message coming from Unregistered Logical Address or a Broadcast messages");
+	     if(header.to.toInt() == LogicalAddress::BROADCAST || header.from.toInt() >= LogicalAddress::UNREGISTERED){
+		LOGERR("Ignoring the message coming from Unregistered/Invalid Logical Address or a Broadcast messages");
 		return;
 	     }
              try
@@ -309,8 +309,8 @@ namespace WPEFramework
 	     printHeader(header);
              LOGINFO("Command: CECVersion Version : %s \n",msg.version.toString().c_str());
 
-	     if(header.from.toInt() == LogicalAddress::UNREGISTERED){
-                LOGERR("Ignoring the message coming from Unregistered Logical Address");
+	     if(header.from.toInt() >= LogicalAddress::UNREGISTERED){
+                LOGERR("Ignoring the message coming from Unregistered/Invalid Logical Address");
                 return;
              }
 	     HdmiCecSink::_instance->addDevice(header.from.toInt());
@@ -329,8 +329,8 @@ namespace WPEFramework
        {
              printHeader(header);
              LOGINFO("Command: GiveOSDName sending SetOSDName : %s\n",osdName.toString().c_str());
-	     if(header.from.toInt() == LogicalAddress::UNREGISTERED){
-                LOGERR("Ignoring the message coming from Unregistered Logical Address");
+	     if(header.from.toInt() >= LogicalAddress::UNREGISTERED){
+                LOGERR("Ignoring the message coming from Unregistered/Invalid Logical Address");
                 return;
              }
              try
@@ -387,8 +387,8 @@ namespace WPEFramework
 	     bool updateStatus ;
              LOGINFO("Command: SetOSDName OSDName : %s\n",msg.osdName.toString().c_str());
 
-	     if(header.from.toInt() == LogicalAddress::UNREGISTERED){
-                LOGERR("Ignoring the message coming from Unregistered Logical Address");
+	     if(header.from.toInt() >= LogicalAddress::UNREGISTERED){
+                LOGERR("Ignoring the message coming from Unregistered/Invalid Logical Address");
                 return;
              }
 	     HdmiCecSink::_instance->addDevice(header.from.toInt());
@@ -456,8 +456,8 @@ namespace WPEFramework
 	     printHeader(header);
              LOGINFO("Command: DeviceVendorID VendorID : %s\n",msg.vendorId.toString().c_str());
 
-	     if(header.from.toInt() == LogicalAddress::UNREGISTERED){
-                LOGERR("Ignoring the message coming from Unregistered Logical Address");
+	     if(header.from.toInt() >= LogicalAddress::UNREGISTERED){
+                LOGERR("Ignoring the message coming from Unregistered/Invalid Logical Address");
                 return;
              }
 	     HdmiCecSink::_instance->addDevice(header.from.toInt());
@@ -471,8 +471,8 @@ namespace WPEFramework
        {
              printHeader(header);
              LOGINFO("Command: GiveDevicePowerStatus sending powerState :%d \n",powerState);
-             if(header.to.toInt() == LogicalAddress::BROADCAST || header.from.toInt() == LogicalAddress::UNREGISTERED){
-		LOGERR("Ignoring the message coming from Unregistered Logical Address or a Broadcast messages");
+             if(header.to.toInt() == LogicalAddress::BROADCAST || header.from.toInt() >= LogicalAddress::UNREGISTERED){
+		LOGERR("Ignoring the message coming from Unregistered/Invalid Logical Address or a Broadcast messages");
 		return;
 	     }
 	     try
@@ -489,8 +489,8 @@ namespace WPEFramework
 	   uint32_t  oldPowerStatus,newPowerStatus;
 	   printHeader(header);
 	   LOGINFO("Command: ReportPowerStatus Power Status from:%s status : %s \n",header.from.toString().c_str(),msg.status.toString().c_str());
-	   if(header.from.toInt() == LogicalAddress::UNREGISTERED){
-               LOGERR("Ignoring the message coming from Unregistered Logical Address");
+	   if(header.from.toInt() >= LogicalAddress::UNREGISTERED){
+               LOGERR("Ignoring the message coming from Unregistered/Invalid Logical Address");
                return;
            }
            oldPowerStatus = HdmiCecSink::_instance->deviceList[header.from.toInt()].m_powerStatus.toInt();
@@ -565,8 +565,8 @@ namespace WPEFramework
        {
               printHeader(header);
              LOGINFO("Command: Abort\n");
-	     if(header.from.toInt() == LogicalAddress::UNREGISTERED){
-                LOGERR("Ignoring the message coming from Unregistered Logical Address");
+	     if(header.from.toInt() >= LogicalAddress::UNREGISTERED){
+                LOGERR("Ignoring the message coming from Unregistered/Invalid Logical Address");
                 return;
              }
 	      if (!(header.to == LogicalAddress(LogicalAddress::BROADCAST)))
@@ -617,8 +617,8 @@ namespace WPEFramework
        void HdmiCecSinkProcessor::process (const TerminateArc &msg, const Header &header)
        {
            printHeader(header);
-           if(header.from.toInt() == LogicalAddress::UNREGISTERED){
-                LOGERR("Ignoring the message coming from Unregistered Logical Address");
+           if(header.from.toInt() >= LogicalAddress::UNREGISTERED){
+                LOGERR("Ignoring the message coming from Unregistered/Invalid Logical Address");
                 return;
            }
            if(!HdmiCecSink::_instance)
@@ -629,8 +629,8 @@ namespace WPEFramework
        {
              printHeader(header);
 	     LOGINFO("Command: ReportShortAudioDescriptor %s : %d \n",GetOpName(msg.opCode()),numberofdescriptor);
-	     if(header.from.toInt() == LogicalAddress::UNREGISTERED){
-                LOGERR("Ignoring the message coming from Unregistered Logical Address");
+	     if(header.from.toInt() >= LogicalAddress::UNREGISTERED){
+                LOGERR("Ignoring the message coming from Unregistered/Invalid Logical Address");
                 return;
              }
             HdmiCecSink::_instance->Process_ShortAudioDescriptor_msg(msg);
@@ -640,8 +640,8 @@ namespace WPEFramework
        {
              printHeader(header);
 	     LOGINFO("Command: SetSystemAudioMode  %s audio status %d audio status is  %s \n",GetOpName(msg.opCode()),msg.status.toInt(),msg.status.toString().c_str());
-	     if(header.from.toInt() == LogicalAddress::UNREGISTERED){
-                LOGERR("Ignoring the message coming from Unregistered Logical Address");
+	     if(header.from.toInt() >= LogicalAddress::UNREGISTERED){
+                LOGERR("Ignoring the message coming from Unregistered/Invalid Logical Address");
                 return;
              }
           HdmiCecSink::_instance->Process_SetSystemAudioMode_msg(msg);
@@ -650,8 +650,8 @@ namespace WPEFramework
        {
              printHeader(header);
              LOGINFO("Command: ReportAudioStatus  %s audio Mute status %d  means %s  and current Volume level is %d \n",GetOpName(msg.opCode()),msg.status.getAudioMuteStatus(),msg.status.toString().c_str(),msg.status.getAudioVolume());
-	     if(header.from.toInt() == LogicalAddress::UNREGISTERED){
-                LOGERR("Ignoring the message coming from Unregistered Logical Address");
+	     if(header.from.toInt() >= LogicalAddress::UNREGISTERED){
+                LOGERR("Ignoring the message coming from Unregistered/Invalid Logical Address");
                 return;
              }
              HdmiCecSink::_instance->Process_ReportAudioStatus_msg(msg);
@@ -2047,6 +2047,11 @@ namespace WPEFramework
 			if(!HdmiCecSink::_instance)
 				return;
 
+			if ( _instance->m_logicalAddressAllocated == LogicalAddress::UNREGISTERED){
+				LOGERR("Logical Address NOT Allocated");
+				return;
+			}
+			
 			if (_instance->deviceList[logicalAddress.toInt()].m_isDevicePresent &&
 					logicalAddress.toInt() != _instance->m_logicalAddressAllocated)
 			{
@@ -2576,6 +2581,11 @@ namespace WPEFramework
 			if(!HdmiCecSink::_instance)
 				return;
 			
+			if ( _instance->m_logicalAddressAllocated == LogicalAddress::UNREGISTERED){
+				LOGERR("Logical Address NOT Allocated");
+				return;
+			}
+			
 			if ( !HdmiCecSink::_instance->deviceList[logicalAddress].m_isDevicePresent )
 			 {
 			 	HdmiCecSink::_instance->deviceList[logicalAddress].m_isDevicePresent = true;
@@ -2602,6 +2612,11 @@ namespace WPEFramework
 			if(!HdmiCecSink::_instance)
 				return;
 
+			if ( _instance->m_logicalAddressAllocated == LogicalAddress::UNREGISTERED ){
+				LOGERR("Logical Address NOT Allocated");
+				return;
+			}
+			
 			if (_instance->deviceList[logicalAddress].m_isDevicePresent)
 			{
 				_instance->m_numberOfDevices--;

--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -230,6 +230,10 @@ namespace WPEFramework
        {
              printHeader(header);
              LOGINFO("Command: InActiveSource %s : %s : %s  \n",GetOpName(msg.opCode()),msg.physicalAddress.name().c_str(),msg.physicalAddress.toString().c_str());
+	     if(header.from.toInt() == LogicalAddress::UNREGISTERED){
+                LOGERR("Ignoring the message coming from Unregistered Logical Address");
+                return;
+             }
 
 			 HdmiCecSink::_instance->updateInActiveSource(header.from.toInt(), msg);
 	   }
@@ -238,6 +242,10 @@ namespace WPEFramework
        {
              printHeader(header);
              LOGINFO("Command: ImageViewOn from %s\n", header.from.toString().c_str());
+	     if(header.from.toInt() == LogicalAddress::UNREGISTERED){
+                LOGERR("Ignoring the message coming from Unregistered Logical Address");
+                return;
+             }
 			 HdmiCecSink::_instance->addDevice(header.from.toInt());
 			 HdmiCecSink::_instance->updateImageViewOn(header.from.toInt());
        }
@@ -245,6 +253,10 @@ namespace WPEFramework
        {
              printHeader(header);
              LOGINFO("Command: TextViewOn\n");
+	     if(header.from.toInt() == LogicalAddress::UNREGISTERED){
+                LOGERR("Ignoring the message coming from Unregistered Logical Address");
+                return;
+             }
 			 HdmiCecSink::_instance->addDevice(header.from.toInt());
 			 HdmiCecSink::_instance->updateImageViewOn(header.from.toInt());
        }
@@ -265,6 +277,10 @@ namespace WPEFramework
        {
              printHeader(header);
              LOGINFO("Command: GetCECVersion sending CECVersion response \n");
+	     if(header.from.toInt() == LogicalAddress::UNREGISTERED){
+                LOGERR("Ignoring the message coming from Unregistered Logical Address");
+                return;
+             }
              try
              { 
                  if(cecVersion == 2.0) {
@@ -285,6 +301,10 @@ namespace WPEFramework
 	     printHeader(header);
              LOGINFO("Command: CECVersion Version : %s \n",msg.version.toString().c_str());
 
+	     if(header.from.toInt() == LogicalAddress::UNREGISTERED){
+                LOGERR("Ignoring the message coming from Unregistered Logical Address");
+                return;
+             }
 	     HdmiCecSink::_instance->addDevice(header.from.toInt());
 	     updateStatus = HdmiCecSink::_instance->deviceList[header.from.toInt()].m_isVersionUpdated;
              LOGINFO("updateStatus %d\n",updateStatus);
@@ -301,6 +321,10 @@ namespace WPEFramework
        {
              printHeader(header);
              LOGINFO("Command: GiveOSDName sending SetOSDName : %s\n",osdName.toString().c_str());
+	     if(header.from.toInt() == LogicalAddress::UNREGISTERED){
+                LOGERR("Ignoring the message coming from Unregistered Logical Address");
+                return;
+             }
              try
              { 
                  conn.sendToAsync(header.from, MessageEncoder().encode(SetOSDName(osdName)));
@@ -351,6 +375,10 @@ namespace WPEFramework
 	     bool updateStatus ;
              LOGINFO("Command: SetOSDName OSDName : %s\n",msg.osdName.toString().c_str());
 
+	     if(header.from.toInt() == LogicalAddress::UNREGISTERED){
+                LOGERR("Ignoring the message coming from Unregistered Logical Address");
+                return;
+             }
 	     HdmiCecSink::_instance->addDevice(header.from.toInt());
 	     updateStatus = HdmiCecSink::_instance->deviceList[header.from.toInt()].m_isOSDNameUpdated;
 	     LOGINFO("updateStatus %d\n",updateStatus);
@@ -412,6 +440,10 @@ namespace WPEFramework
 	     printHeader(header);
              LOGINFO("Command: DeviceVendorID VendorID : %s\n",msg.vendorId.toString().c_str());
 
+	     if(header.from.toInt() == LogicalAddress::UNREGISTERED){
+                LOGERR("Ignoring the message coming from Unregistered Logical Address");
+                return;
+             }
 	     HdmiCecSink::_instance->addDevice(header.from.toInt());
 	     updateStatus = HdmiCecSink::_instance->deviceList[header.from.toInt()].m_isVendorIDUpdated;
              LOGINFO("updateStatus %d\n",updateStatus);
@@ -423,7 +455,11 @@ namespace WPEFramework
        {
              printHeader(header);
              LOGINFO("Command: GiveDevicePowerStatus sending powerState :%d \n",powerState);
-             try
+             if(header.from.toInt() == LogicalAddress::UNREGISTERED){
+                LOGERR("Ignoring the message coming from Unregistered Logical Address");
+                return;
+             }
+	     try
              { 
                  conn.sendTo(header.from, MessageEncoder().encode(ReportPowerStatus(PowerStatus(powerState))));
              } 
@@ -437,6 +473,10 @@ namespace WPEFramework
 	   uint32_t  oldPowerStatus,newPowerStatus;
 	   printHeader(header);
 	   LOGINFO("Command: ReportPowerStatus Power Status from:%s status : %s \n",header.from.toString().c_str(),msg.status.toString().c_str());
+	   if(header.from.toInt() == LogicalAddress::UNREGISTERED){
+               LOGERR("Ignoring the message coming from Unregistered Logical Address");
+               return;
+           }
            oldPowerStatus = HdmiCecSink::_instance->deviceList[header.from.toInt()].m_powerStatus.toInt();
 	   HdmiCecSink::_instance->addDevice(header.from.toInt());
 	   HdmiCecSink::_instance->deviceList[header.from.toInt()].update(msg.status);
@@ -509,6 +549,10 @@ namespace WPEFramework
        {
               printHeader(header);
              LOGINFO("Command: Abort\n");
+	     if(header.from.toInt() == LogicalAddress::UNREGISTERED){
+                LOGERR("Ignoring the message coming from Unregistered Logical Address");
+                return;
+             }
 	      if (!(header.to == LogicalAddress(LogicalAddress::BROADCAST)))
              {
                 AbortReason reason = AbortReason::UNRECOGNIZED_OPCODE;
@@ -529,6 +573,10 @@ namespace WPEFramework
        void HdmiCecSinkProcessor::process (const InitiateArc &msg, const Header &header)
        {
             printHeader(header);
+	    if(header.from.toInt() == LogicalAddress::UNREGISTERED){
+                LOGERR("Ignoring the message coming from Unregistered Logical Address");
+                return;
+             }
             PhysicalAddress physical_addr_invalid = {0x0F,0x0F,0x0F,0x0F};
             PhysicalAddress physical_addr_arc_port = {0x0F,0x0F,0x0F,0x0F};
 
@@ -553,6 +601,10 @@ namespace WPEFramework
        void HdmiCecSinkProcessor::process (const TerminateArc &msg, const Header &header)
        {
            printHeader(header);
+           if(header.from.toInt() == LogicalAddress::UNREGISTERED){
+                LOGERR("Ignoring the message coming from Unregistered Logical Address");
+                return;
+           }
            if(!HdmiCecSink::_instance)
 	     return;
            HdmiCecSink::_instance->Process_TerminateArc();
@@ -560,6 +612,10 @@ namespace WPEFramework
        void HdmiCecSinkProcessor::process (const ReportShortAudioDescriptor  &msg, const Header &header)
        {
              printHeader(header);
+	     if(header.from.toInt() == LogicalAddress::UNREGISTERED){
+                LOGERR("Ignoring the message coming from Unregistered Logical Address");
+                return;
+             }
              LOGINFO("Command: ReportShortAudioDescriptor %s : %d \n",GetOpName(msg.opCode()),numberofdescriptor);
             HdmiCecSink::_instance->Process_ShortAudioDescriptor_msg(msg);
        }
@@ -567,6 +623,10 @@ namespace WPEFramework
        void HdmiCecSinkProcessor::process (const SetSystemAudioMode &msg, const Header &header)
        {
              printHeader(header);
+	     if(header.from.toInt() == LogicalAddress::UNREGISTERED){
+                LOGERR("Ignoring the message coming from Unregistered Logical Address");
+                return;
+             }
              LOGINFO("Command: SetSystemAudioMode  %s audio status %d audio status is  %s \n",GetOpName(msg.opCode()),msg.status.toInt(),msg.status.toString().c_str());
           HdmiCecSink::_instance->Process_SetSystemAudioMode_msg(msg);
        }
@@ -574,6 +634,10 @@ namespace WPEFramework
        {
              printHeader(header);
              LOGINFO("Command: ReportAudioStatus  %s audio Mute status %d  means %s  and current Volume level is %d \n",GetOpName(msg.opCode()),msg.status.getAudioMuteStatus(),msg.status.toString().c_str(),msg.status.getAudioVolume());
+	     if(header.from.toInt() == LogicalAddress::UNREGISTERED){
+                LOGERR("Ignoring the message coming from Unregistered Logical Address");
+                return;
+             }
              HdmiCecSink::_instance->Process_ReportAudioStatus_msg(msg);
        }
       void HdmiCecSinkProcessor::process (const GiveFeatures &msg, const Header &header)

--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -234,7 +234,7 @@ namespace WPEFramework
        {
              printHeader(header);
              LOGINFO("Command: InActiveSource %s : %s : %s  \n",GetOpName(msg.opCode()),msg.physicalAddress.name().c_str(),msg.physicalAddress.toString().c_str());
-	     if(header.from.toInt() >= LogicalAddress::UNREGISTERED){
+	     if(header.from.toInt() == LogicalAddress::UNREGISTERED){
                 LOGERR("Ignoring the message coming from Unregistered/Invalid Logical Address");
                 return;
              }
@@ -246,7 +246,7 @@ namespace WPEFramework
        {
              printHeader(header);
              LOGINFO("Command: ImageViewOn from %s\n", header.from.toString().c_str());
-	     if(header.from.toInt() >= LogicalAddress::UNREGISTERED){
+	     if(header.from.toInt() == LogicalAddress::UNREGISTERED){
                 LOGERR("Ignoring the message coming from Unregistered/Invalid Logical Address");
                 return;
              }
@@ -257,7 +257,7 @@ namespace WPEFramework
        {
              printHeader(header);
              LOGINFO("Command: TextViewOn\n");
-	     if(header.from.toInt() >= LogicalAddress::UNREGISTERED){
+	     if(header.from.toInt() == LogicalAddress::UNREGISTERED){
                 LOGERR("Ignoring the message coming from Unregistered/Invalid Logical Address");
                 return;
              }
@@ -285,7 +285,7 @@ namespace WPEFramework
        {
              printHeader(header);
              LOGINFO("Command: GetCECVersion sending CECVersion response \n");
-	     if(header.to.toInt() == LogicalAddress::BROADCAST || header.from.toInt() >= LogicalAddress::UNREGISTERED){
+	     if(header.to.toInt() == LogicalAddress::BROADCAST || header.from.toInt() == LogicalAddress::UNREGISTERED){
 		LOGERR("Ignoring the message coming from Unregistered/Invalid Logical Address or a Broadcast messages");
 		return;
 	     }
@@ -309,7 +309,7 @@ namespace WPEFramework
 	     printHeader(header);
              LOGINFO("Command: CECVersion Version : %s \n",msg.version.toString().c_str());
 
-	     if(header.from.toInt() >= LogicalAddress::UNREGISTERED){
+	     if(header.from.toInt() == LogicalAddress::UNREGISTERED){
                 LOGERR("Ignoring the message coming from Unregistered/Invalid Logical Address");
                 return;
              }
@@ -329,7 +329,7 @@ namespace WPEFramework
        {
              printHeader(header);
              LOGINFO("Command: GiveOSDName sending SetOSDName : %s\n",osdName.toString().c_str());
-	     if(header.from.toInt() >= LogicalAddress::UNREGISTERED){
+	     if(header.from.toInt() == LogicalAddress::UNREGISTERED){
                 LOGERR("Ignoring the message coming from Unregistered/Invalid Logical Address");
                 return;
              }
@@ -387,7 +387,7 @@ namespace WPEFramework
 	     bool updateStatus ;
              LOGINFO("Command: SetOSDName OSDName : %s\n",msg.osdName.toString().c_str());
 
-	     if(header.from.toInt() >= LogicalAddress::UNREGISTERED){
+	     if(header.from.toInt() == LogicalAddress::UNREGISTERED){
                 LOGERR("Ignoring the message coming from Unregistered/Invalid Logical Address");
                 return;
              }
@@ -456,7 +456,7 @@ namespace WPEFramework
 	     printHeader(header);
              LOGINFO("Command: DeviceVendorID VendorID : %s\n",msg.vendorId.toString().c_str());
 
-	     if(header.from.toInt() >= LogicalAddress::UNREGISTERED){
+	     if(header.from.toInt() == LogicalAddress::UNREGISTERED){
                 LOGERR("Ignoring the message coming from Unregistered/Invalid Logical Address");
                 return;
              }
@@ -471,7 +471,7 @@ namespace WPEFramework
        {
              printHeader(header);
              LOGINFO("Command: GiveDevicePowerStatus sending powerState :%d \n",powerState);
-             if(header.to.toInt() == LogicalAddress::BROADCAST || header.from.toInt() >= LogicalAddress::UNREGISTERED){
+             if(header.to.toInt() == LogicalAddress::BROADCAST || header.from.toInt() == LogicalAddress::UNREGISTERED){
 		LOGERR("Ignoring the message coming from Unregistered/Invalid Logical Address or a Broadcast messages");
 		return;
 	     }
@@ -489,7 +489,7 @@ namespace WPEFramework
 	   uint32_t  oldPowerStatus,newPowerStatus;
 	   printHeader(header);
 	   LOGINFO("Command: ReportPowerStatus Power Status from:%s status : %s \n",header.from.toString().c_str(),msg.status.toString().c_str());
-	   if(header.from.toInt() >= LogicalAddress::UNREGISTERED){
+	   if(header.from.toInt() == LogicalAddress::UNREGISTERED){
                LOGERR("Ignoring the message coming from Unregistered/Invalid Logical Address");
                return;
            }
@@ -565,7 +565,7 @@ namespace WPEFramework
        {
               printHeader(header);
              LOGINFO("Command: Abort\n");
-	     if(header.from.toInt() >= LogicalAddress::UNREGISTERED){
+	     if(header.from.toInt() == LogicalAddress::UNREGISTERED){
                 LOGERR("Ignoring the message coming from Unregistered/Invalid Logical Address");
                 return;
              }
@@ -617,7 +617,7 @@ namespace WPEFramework
        void HdmiCecSinkProcessor::process (const TerminateArc &msg, const Header &header)
        {
            printHeader(header);
-           if(header.from.toInt() >= LogicalAddress::UNREGISTERED){
+           if(header.from.toInt() == LogicalAddress::UNREGISTERED){
                 LOGERR("Ignoring the message coming from Unregistered/Invalid Logical Address");
                 return;
            }
@@ -629,7 +629,7 @@ namespace WPEFramework
        {
              printHeader(header);
 	     LOGINFO("Command: ReportShortAudioDescriptor %s : %d \n",GetOpName(msg.opCode()),numberofdescriptor);
-	     if(header.from.toInt() >= LogicalAddress::UNREGISTERED){
+	     if(header.from.toInt() == LogicalAddress::UNREGISTERED){
                 LOGERR("Ignoring the message coming from Unregistered/Invalid Logical Address");
                 return;
              }
@@ -640,7 +640,7 @@ namespace WPEFramework
        {
              printHeader(header);
 	     LOGINFO("Command: SetSystemAudioMode  %s audio status %d audio status is  %s \n",GetOpName(msg.opCode()),msg.status.toInt(),msg.status.toString().c_str());
-	     if(header.from.toInt() >= LogicalAddress::UNREGISTERED){
+	     if(header.from.toInt() == LogicalAddress::UNREGISTERED){
                 LOGERR("Ignoring the message coming from Unregistered/Invalid Logical Address");
                 return;
              }
@@ -650,7 +650,7 @@ namespace WPEFramework
        {
              printHeader(header);
              LOGINFO("Command: ReportAudioStatus  %s audio Mute status %d  means %s  and current Volume level is %d \n",GetOpName(msg.opCode()),msg.status.getAudioMuteStatus(),msg.status.toString().c_str(),msg.status.getAudioVolume());
-	     if(header.from.toInt() >= LogicalAddress::UNREGISTERED){
+	     if(header.from.toInt() == LogicalAddress::UNREGISTERED){
                 LOGERR("Ignoring the message coming from Unregistered/Invalid Logical Address");
                 return;
              }
@@ -1519,7 +1519,7 @@ namespace WPEFramework
                         LOGINFO("getDeviceListWrapper  m_numberOfDevices :%d \n", HdmiCecSink::_instance->m_numberOfDevices);
 			JsonArray deviceList;
 			
-			for (int n = 0; n < LogicalAddress::UNREGISTERED; n++)
+			for (int n = 0; n <= LogicalAddress::UNREGISTERED; n++)
 			{
 
 				if ( n != HdmiCecSink::_instance->m_logicalAddressAllocated && 


### PR DESCRIPTION
Reason for change:Ignore CEC messages from Unregister device Test Procedure: Check for all cec messages from unregister device Risks: Low
Priority: P1
Signed-off-by: bp-tdora114 <dautapankumar.dora@sky.uk>