### PR TITLE
RDKTV-28343: Ignore CEC messages from Unregister device

### DIFF
--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -1439,7 +1439,7 @@ namespace WPEFramework
                         LOGINFO("getDeviceListWrapper  m_numberOfDevices :%d \n", HdmiCecSink::_instance->m_numberOfDevices);
 			JsonArray deviceList;
 			
-			for (int n = 0; n < LogicalAddress::UNREGISTERED; n++)
+			for (int n = 0; n <= LogicalAddress::UNREGISTERED; n++)
 			{
 
 				if ( n != HdmiCecSink::_instance->m_logicalAddressAllocated && 
@@ -1967,8 +1967,7 @@ namespace WPEFramework
 			if(!HdmiCecSink::_instance)
 				return;
 
-			if ( _instance->m_logicalAddressAllocated == LogicalAddress::UNREGISTERED ||
-					logicalAddress.toInt() == LogicalAddress::UNREGISTERED ){
+			if ( _instance->m_logicalAddressAllocated == LogicalAddress::UNREGISTERED){
 				LOGERR("Logical Address NOT Allocated");
 				return;
 			}
@@ -2502,8 +2501,8 @@ namespace WPEFramework
 			if(!HdmiCecSink::_instance)
 				return;
 			
-			if ( _instance->m_logicalAddressAllocated == LogicalAddress::UNREGISTERED || logicalAddress >= LogicalAddress::UNREGISTERED){
-				LOGERR("Logical Address NOT Allocated Or its not valid");
+			if ( _instance->m_logicalAddressAllocated == LogicalAddress::UNREGISTERED){
+				LOGERR("Logical Address NOT Allocated");
 				return;
 			}
 			

--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -2532,8 +2532,8 @@ namespace WPEFramework
 			if(!HdmiCecSink::_instance)
 				return;
 			
-			if ( _instance->m_logicalAddressAllocated == LogicalAddress::UNREGISTERED || logicalAddress >= LogicalAddress::UNREGISTERED ){
-				LOGERR("Logical Address NOT Allocated Or its not valid");
+			if ( _instance->m_logicalAddressAllocated == LogicalAddress::UNREGISTERED){
+				LOGERR("Logical Address NOT Allocated");
 				return;
 			}
 


### PR DESCRIPTION
Reason for change:Ignore CEC messages from Unregister device Test Procedure: Check for all cec messages from unregister device Risks: Low
Priority: P1
Signed-off-by: bp-tdora114 <dautapankumar.dora@sky.uk>