### PR TITLE
RDKDEV-940: WPEFramework is crashing while trying to take screen capt…

### DIFF
--- a/ScreenCapture/Implementation/Realtek/Realtek.cpp
+++ b/ScreenCapture/Implementation/Realtek/Realtek.cpp
@@ -187,6 +187,13 @@ bool DRMScreenCapture_ScreenCapture(DRMScreenCapture* handle, uint8_t* output, u
 		// copy frame
 		void *vaddr = NULL;
 		vaddr =(void*) mmap(NULL, size, PROT_READ , MAP_SHARED, context->fd, context->offset) ;
+
+        if (vaddr == MAP_FAILED) {
+        perror("mmap failed : ");
+        ret = false;
+        break;
+        }
+
 		memcpy(output,(unsigned char*)vaddr, size);
 		munmap(vaddr, size);
 


### PR DESCRIPTION
RDKDEV-940: WPEFramework is crashing while trying to take screen capture in Realtek devices.

Reason for change:  RDK Splash Screen is showing while calling upload screen capture API due to crash.

Test Procedure: Build and verify.

Risks: Low