### PR TITLE
RDKVREFPLT-721: [BCM72126] RDK Services: DeviceIdentification plugin is not enabled in the device

### DIFF
--- a/DeviceIdentification/Implementation/Broadcom/Broadcom.cpp
+++ b/DeviceIdentification/Implementation/Broadcom/Broadcom.cpp
@@ -78,39 +78,63 @@ public:
 private:
     inline void UpdateDeviceInfo(string& identifier, string& chipset, string& firmwareVersion) const
     {
-        static constexpr uint8_t MaxInfoCollection = 3;
-        static constexpr const TCHAR ChipsetKey[] = _T("Chip ID");
-        static constexpr const TCHAR IdentifierKey[] = _T("CHIPID");
-        static constexpr const TCHAR FirmwareVersionKey[] = _T("Nexus Release");
+        identifier.assign(extractSerialNumber());
+        chipset.assign(extractChipId());
+        firmwareVersion.assign(extractFirmwareVersion());
+    }
 
+    inline std::string extractSerialNumber() const
+    {
+        std::string serialNumber;
+        std::ifstream serialNumberFile("/proc/device-tree/serial-number");
+
+        if (serialNumberFile.is_open())
+        {
+                getline(serialNumberFile,serialNumber);
+                serialNumberFile.close();
+        }
+
+        return serialNumber;
+    }
+
+    inline std::string extractChipId() const
+    {
+        std::string chipId;
+        std::ifstream chipIdFile("/proc/device-tree/model");
+
+        if (chipIdFile.is_open())
+        {
+                getline(chipIdFile, chipId);
+                chipIdFile.close();
+        }
+
+        return chipId;
+    }
+
+    inline std::string extractFirmwareVersion() const
+    {
+        std::string versionIdentifier("VERSION");
+        std::ifstream versionFile("/version.txt");
         std::string line;
-        std::ifstream file(PlatformFile);
-        uint32_t collectedInfo = 0;
+        std::string firmwareVersion;
 
-        if (file.is_open()) {
-            while (getline(file, line) && (collectedInfo < MaxInfoCollection)) {
-                if ((identifier.empty() == true) && (line.find(IdentifierKey) != std::string::npos)) {
-                    std::size_t position = line.find(IdentifierKey) + sizeof(IdentifierKey);
-                    if (position != std::string::npos) {
-                        identifier.assign(line.substr(position, line.find(']')-position));
-                        collectedInfo++;
-                    }
-                } else if ((chipset.empty() == true) && (line.find(ChipsetKey) != std::string::npos)) {
-                    std::size_t position = line.find(ChipsetKey) + sizeof(ChipsetKey);
-                    if (position != std::string::npos) {
-                        chipset.assign(line.substr(position, std::string::npos));
-                        collectedInfo++;
-                    }
-                } else if ((firmwareVersion.empty() == true) &&
-                           (line.find(FirmwareVersionKey) != std::string::npos)) {
-                    std::size_t position = line.find(FirmwareVersionKey) + sizeof(FirmwareVersionKey);
-                    if (position != std::string::npos) {
+        if (versionFile.is_open())
+        {
+            while (getline(versionFile, line))
+            {
+                if (0 == line.find(versionIdentifier))
+                {
+                    std::size_t position = line.find(versionIdentifier) + versionIdentifier.length() + 1; // +1 is to skip '='
+                    if (position != std::string::npos)
+                    {
                         firmwareVersion.assign(line.substr(position, std::string::npos));
-                        collectedInfo++;
                     }
                 }
             }
+            versionFile.close();
         }
+
+        return firmwareVersion;
     }
 
 private:


### PR DESCRIPTION
Reason for change: Enabled the DeviceIdentification plugin and added methods for retrieving Serial number, Chip Id and Firmware version.

Test Procedure:

root@brcm972126ott-refboard-PR0013720:~#  curl -X POST http://127.0.0.1:9998/jsonrpc -d '{"jsonrpc":"2.0","id":"42","method":"DeviceIdentification.1.deviceidentification"}';echo; {"jsonrpc":"2.0","id":42,"result":{"firmwareversion":"5.01.23.24","chipset":"BCM972126OTT_V20","deviceid":"OEUFIwMDEzNzIwAA"}}

Risks: Medium

Signed-off-by: rajapriya_radhakrishnan <rajapriya_radhakrishnan@comcast.com>