### PR TITLE
RDKCOM-4529 RDKDEV-922: RDKServices : getPlatformConfiguration API in system plugin

### DIFF
--- a/SystemServices/CHANGELOG.md
+++ b/SystemServices/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [2.0.4] - 2024-02-13
+### Fixed
+- Fix for getPlatformConfiguration API in system plugin
+
 ## [2.0.3] - 2023-01-26
 ### Changed
 - RDK-44991: Upgrade Flex-2.0 devices to use Thunder R4.4.1
@@ -27,6 +31,10 @@ All notable changes to this RDK Service will be documented in this file.
 ## [2.0.1] - 2024-01-02
 ### Security
 - resolved security vulnerabilities
+
+## [1.7.4] - 2023-01-04
+### Fixed
+- Fix for getPlatformConfiguration api returning empty deviceType
 
 ## [2.0.0] - 2023-11-17
 ### Removed

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -67,7 +67,7 @@ using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 2
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 2
+#define API_VERSION_NUMBER_PATCH 4
 
 #define MAX_REBOOT_DELAY 86400 /* 24Hr = 86400 sec */
 #define TR181_FW_DELAY_REBOOT "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.AutoReboot.fwDelayReboot"
@@ -1043,6 +1043,7 @@ namespace WPEFramework {
 
             if (res.size() > 0) {
                 std::string model_number;
+		std::string device_type;
                 if (queryParams.empty()) {
                     retAPIStatus = true;
 
@@ -1070,6 +1071,9 @@ namespace WPEFramework {
                             else if (key == "model_number") {
                                 model_number = value;
                             }
+			    else if(key == "device_type") {
+				device_type = value;
+			    }
                         }
                     }
 #ifdef ENABLE_DEVICE_MANUFACTURER_INFO

--- a/SystemServices/platformcaps/platformcapsdatarpc.cpp
+++ b/SystemServices/platformcaps/platformcapsdatarpc.cpp
@@ -48,6 +48,7 @@ string PlatformCapsData::GetModel() {
       .Get(_T("model_number")).String();
 }
 
+#ifndef ENABLE_COMMUNITY_DEVICE_TYPE
 string PlatformCapsData::GetDeviceType() {
   auto hex = jsonRpc.invoke(_T("org.rdk.AuthService"),
                             _T("getDeviceInfo"), 10000)
@@ -58,6 +59,13 @@ string PlatformCapsData::GetDeviceType() {
   std::regex_search(deviceInfo, m, std::regex("deviceType=(\\w+),"));
   return (m.empty() ? string() : m[1]);
 }
+#else
+string PlatformCapsData::GetDeviceType() {
+  return jsonRpc.invoke(_T("org.rdk.System"),
+                        _T("getDeviceInfo"), 10000)
+      .Get(_T("device_type")).String();
+}
+#endif
 
 string PlatformCapsData::GetHDRCapability() {
   JsonArray hdrCaps = jsonRpc.invoke(_T("org.rdk.DisplaySettings"),


### PR DESCRIPTION
RDKCOM-4529 RDKDEV-922: RDKServices : getPlatformConfiguration API in system plugin

Reason for change: Added required changes in rdkservices and sysint to get System plugin getPlatformConfiguration deviceType

Test Procedure: Build and verify.

Risks: Low

Signed-off-by: UmmadiSetty Venkatesh <venkatesh_ummadisetty@comcast.com>
(cherry picked from commit c81f912405fe1bbbca936b4acdd001a27483e167)