### PR TITLE
ES1-631: Send TTS notifications to TTSclients based on callsign

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -9,7 +9,7 @@ on:
 env:
   BUILD_TYPE: Debug
   THUNDER_REF: "5e7c0b1ed3c3dd0fc31c86518a364388dc24273b"
-  INTERFACES_REF: "669d9c6e5ed7a5938ff26e1e7736adf485c7a205"
+  INTERFACES_REF: "930e01ec9aec8aa60254dec0be3beca932df63cd"
 
 jobs:
   unit-tests:

--- a/TextToSpeech/impl/TTSManager.cpp
+++ b/TextToSpeech/impl/TTSManager.cpp
@@ -309,7 +309,7 @@ TTS_Error TTSManager::speak(int speechId, std::string callsign, std::string text
         // TODO: Currently 'secure' is set to true. Need to decide about this variable while Resident app integration.
         if(checkAccess("speak", callsign))
         {
-            m_speaker->speak(this, speechId , text, true, m_defaultConfiguration.primVolDuck());
+            m_speaker->speak(this, speechId , callsign, text, true, m_defaultConfiguration.primVolDuck());
         }
         else
         {
@@ -362,68 +362,71 @@ TTS_Error TTSManager::getSpeechState(uint32_t id, SpeechState &state) {
     return TTS_OK;
 }
 
-void TTSManager::willSpeak(uint32_t speech_id, std::string text) {
+void TTSManager::willSpeak(uint32_t speech_id, std::string callsign, std::string text) {
     TTSLOG_TRACE(" [%d, %s]", speech_id, text.c_str());
 
     SpeechData d;
     d.id = speech_id;
+    d.callsign = callsign;
     d.text = text;
     m_callback->onWillSpeak(d);
 }
 
-void TTSManager::started(uint32_t speech_id, std::string text) {
+void TTSManager::started(uint32_t speech_id, std::string callsign, std::string text) {
     TTSLOG_TRACE(" [%d, %s]", speech_id, text.c_str());
 
     SpeechData d;
     d.id = speech_id;
+    d.callsign = callsign;
     d.text = text;
     m_callback->onSpeechStart(d);
 }
 
-void TTSManager::spoke(uint32_t speech_id, std::string text) {
+void TTSManager::spoke(uint32_t speech_id, std::string callsign, std::string text) {
     TTSLOG_TRACE(" [%d, %s]", speech_id, text.c_str());
 
     SpeechData d;
     d.id = speech_id;
+    d.callsign = callsign;
     d.text = text;
     m_callback->onSpeechComplete(d);
 }
 
-void TTSManager::paused(uint32_t speech_id) {
+void TTSManager::paused(uint32_t speech_id, std::string callsign) {
     TTSLOG_TRACE(" [id=%d]", speech_id);
 
-    m_callback->onSpeechPause(speech_id);
+    m_callback->onSpeechPause(speech_id, callsign);
 }
 
-void TTSManager::resumed(uint32_t speech_id) {
+void TTSManager::resumed(uint32_t speech_id, std::string callsign) {
     TTSLOG_WARNING(" [id=%d]", speech_id);
 
-    m_callback->onSpeechResume(speech_id);
+    m_callback->onSpeechResume(speech_id, callsign);
 }
 
-void TTSManager::cancelled(std::vector<uint32_t> &speeches) {
+void TTSManager::cancelled(std::vector<uint32_t> &speeches, std::string callsign) {
     if(speeches.size() <= 0)
         return;
 
-    m_callback->onSpeechCancelled(speeches);
+    m_callback->onSpeechCancelled(speeches, callsign);
 }
 
-void TTSManager::interrupted(uint32_t speech_id) {
+void TTSManager::interrupted(uint32_t speech_id, std::string callsign) {
     TTSLOG_WARNING(" [id=%d]", speech_id);
 
-    m_callback->onSpeechInterrupted(speech_id);
+    m_callback->onSpeechInterrupted(speech_id, callsign);
 }
 
-void TTSManager::networkerror(uint32_t speech_id){
+void TTSManager::networkerror(uint32_t speech_id, std::string callsign){
     TTSLOG_WARNING(" [id=%d]", speech_id);
 
-    m_callback->onNetworkError(speech_id);
+    m_callback->onNetworkError(speech_id, callsign);
 }
 
-void TTSManager::playbackerror(uint32_t speech_id){
+void TTSManager::playbackerror(uint32_t speech_id, std::string callsign){
     TTSLOG_WARNING(" [id=%d]", speech_id);
 
-    m_callback->onPlaybackError(speech_id);
+    m_callback->onPlaybackError(speech_id, callsign);
 }
 
 } // namespace TTS

--- a/TextToSpeech/impl/TTSManager.h
+++ b/TextToSpeech/impl/TTSManager.h
@@ -52,12 +52,12 @@ public:
     virtual void onVoiceChanged(std::string voice) { (void)voice; }
     virtual void onWillSpeak(SpeechData &data) { (void)data; }
     virtual void onSpeechStart(SpeechData &data) { (void)data; }
-    virtual void onSpeechPause(uint32_t speechId) { (void)speechId; }
-    virtual void onSpeechResume(uint32_t speechId) { (void)speechId; }
-    virtual void onSpeechCancelled(std::vector<uint32_t> speechIds) { (void)speechIds; }
-    virtual void onSpeechInterrupted(uint32_t speechId) { (void)speechId; }
-    virtual void onNetworkError(uint32_t speechId) { (void)speechId; }
-    virtual void onPlaybackError(uint32_t speechId) { (void)speechId; }
+    virtual void onSpeechPause(uint32_t speechId,string callsign) { (void)speechId; }
+    virtual void onSpeechResume(uint32_t speechId,string callsign) { (void)speechId; }
+    virtual void onSpeechCancelled(std::vector<uint32_t> speechIds,string callsign) { (void)speechIds; }
+    virtual void onSpeechInterrupted(uint32_t speechId,string callsign) { (void)speechId; }
+    virtual void onNetworkError(uint32_t speechId, string callsign) { (void)speechId; }
+    virtual void onPlaybackError(uint32_t speechId, string callsign) { (void)speechId; }
     virtual void onSpeechComplete(SpeechData &data) { (void)data; }
 };
 
@@ -96,15 +96,15 @@ public:
     virtual TTSConfiguration *configuration() {return &m_defaultConfiguration;}
 
     //Speak Events
-    virtual void willSpeak(uint32_t speech_id, std::string text);
-    virtual void started(uint32_t speech_id, std::string text);
-    virtual void spoke(uint32_t speech_id, std::string text);
-    virtual void paused(uint32_t speech_id);
-    virtual void resumed(uint32_t speech_id);
-    virtual void cancelled(std::vector<uint32_t> &speeches);
-    virtual void interrupted(uint32_t speech_id);
-    virtual void networkerror(uint32_t speech_id);
-    virtual void playbackerror(uint32_t speech_id);
+    virtual void willSpeak(uint32_t speech_id, std::string callsign, std::string text);
+    virtual void started(uint32_t speech_id, std::string callsign, std::string text);
+    virtual void spoke(uint32_t speech_id, std::string callsign, std::string text);
+    virtual void paused(uint32_t speech_id, std::string callsign);
+    virtual void resumed(uint32_t speech_id, std::string callsign);
+    virtual void cancelled(std::vector<uint32_t> &speeches, std::string callsign);
+    virtual void interrupted(uint32_t speech_id, std::string callsign);
+    virtual void networkerror(uint32_t speech_id, std::string callsign);
+    virtual void playbackerror(uint32_t speech_id, std::string callsign);
 
 private:
     TTSConfiguration m_defaultConfiguration;

--- a/TextToSpeech/impl/TTSSpeaker.cpp
+++ b/TextToSpeech/impl/TTSSpeaker.cpp
@@ -411,14 +411,14 @@ void TTSSpeaker::ensurePipeline(bool flag) {
     m_condition.notify_one();
 }
 
-int TTSSpeaker::speak(TTSSpeakerClient *client, uint32_t id, std::string text, bool secure,int8_t primVolDuck) {
+int TTSSpeaker::speak(TTSSpeakerClient *client, uint32_t id, std::string callsign, std::string text, bool secure,int8_t primVolDuck) {
     TTSLOG_TRACE("id=%d, text=\"%s\"", id, text.c_str());
 
     // If force speak is set, clear old queued data & stop speaking
     if(client->configuration()->isPreemptive())
         reset();
 
-    SpeechData data(client, id, text, secure,primVolDuck);
+    SpeechData data(client, id, callsign, text, secure,primVolDuck);
     queueData(data);
 
     return 0;
@@ -1045,7 +1045,7 @@ void TTSSpeaker::GStreamerThreadFunc(void *ctx) {
                 if(!speaker->m_pipeline && !speaker->m_queue.empty()) {
                     SpeechData data = speaker->dequeueData();
                     TTSLOG_ERROR("Pipeline creation failed, sending error for speech=%d from client %p\n", data.id, data.client);
-                    data.client->playbackerror(data.id);
+                    data.client->playbackerror(data.id,data.callsign);
                     speaker->m_pipelineConstructionFailures = 0;
                 }
             } else {
@@ -1082,7 +1082,7 @@ void TTSSpeaker::GStreamerThreadFunc(void *ctx) {
         speaker->setSpeakingState(true, data.client);
         // Inform the client before speaking
         if(!speaker->m_flushed)
-            data.client->willSpeak(data.id, data.text);
+            data.client->willSpeak(data.id, data.callsign, data.text);
 
         // Push it to gstreamer for speaking
         if(!speaker->m_flushed) {
@@ -1103,16 +1103,16 @@ void TTSSpeaker::GStreamerThreadFunc(void *ctx) {
         }
         // Inform the client after speaking
         if(speaker->m_flushed)
-            data.client->interrupted(data.id);
+            data.client->interrupted(data.id, data.callsign);
         else if(speaker->m_networkError)
-            data.client->networkerror(data.id);
+            data.client->networkerror(data.id, data.callsign);
         else if(!speaker->m_pipeline || speaker->m_pipelineError)
-            data.client->playbackerror(data.id);
+            data.client->playbackerror(data.id, data.callsign);
         else {
             #if defined(PLATFORM_AMLOGIC) || defined(PLATFORM_REALTEK)
 	    speaker->setMixGain(MIXGAIN_PRIM,100);
             #endif
-            data.client->spoke(data.id, data.text);
+            data.client->spoke(data.id, data.callsign, data.text);
 	}
         speaker->setSpeakingState(false);
 
@@ -1208,10 +1208,10 @@ bool TTSSpeaker::handleMessage(GstMessage *message) {
                             #if defined(PLATFORM_AMLOGIC) || defined(PLATFORM_REALTEK)
                             setMixGain(MIXGAIN_PRIM,m_currentSpeech->primVolDuck);
                             #endif
-                            m_clientSpeaking->resumed(m_currentSpeech->id);
+                            m_clientSpeaking->resumed(m_currentSpeech->id, m_currentSpeech->callsign);
                             m_condition.notify_one();
                         } else {
-                            m_clientSpeaking->started(m_currentSpeech->id, m_currentSpeech->text);
+                            m_clientSpeaking->started(m_currentSpeech->id, m_currentSpeech->callsign, m_currentSpeech->text);
                         }
                     }
                 } else if (oldstate == GST_STATE_PLAYING && newstate == GST_STATE_PAUSED) {
@@ -1220,7 +1220,7 @@ bool TTSSpeaker::handleMessage(GstMessage *message) {
                         #if defined(PLATFORM_AMLOGIC) || defined(PLATFORM_REALTEK)
 			setMixGain(MIXGAIN_PRIM,100);
                         #endif
-                        m_clientSpeaking->paused(m_currentSpeech->id);
+                        m_clientSpeaking->paused(m_currentSpeech->id, m_currentSpeech->callsign);
                         m_condition.notify_one();
                     }
                 } else if (oldstate == GST_STATE_PAUSED && newstate == GST_STATE_READY) {

--- a/TextToSpeech/impl/TTSSpeaker.h
+++ b/TextToSpeech/impl/TTSSpeaker.h
@@ -55,24 +55,25 @@ namespace TTS {
 class TTSSpeakerClient {
 public:
     virtual TTSConfiguration* configuration() = 0;
-    virtual void willSpeak(uint32_t speech_id, std::string text) = 0;
-    virtual void started(uint32_t speech_id, std::string text) = 0;
-    virtual void spoke(uint32_t speech_id, std::string text) = 0;
-    virtual void paused(uint32_t speech_id) = 0;
-    virtual void resumed(uint32_t speech_id) = 0;
-    virtual void cancelled(std::vector<uint32_t> &speeches) = 0;
-    virtual void interrupted(uint32_t speech_id) = 0;
-    virtual void networkerror(uint32_t speech_id) = 0;
-    virtual void playbackerror(uint32_t speech_id) = 0;
+    virtual void willSpeak(uint32_t speech_id, std::string callsign, std::string text) = 0;
+    virtual void started(uint32_t speech_id, std::string callsign, std::string text) = 0;
+    virtual void spoke(uint32_t speech_id, std::string callsign, std::string text) = 0;
+    virtual void paused(uint32_t speech_id, std::string callsign) = 0;
+    virtual void resumed(uint32_t speech_id, std::string callsign) = 0;
+    virtual void cancelled(std::vector<uint32_t> &speeches, std::string callsign) = 0;
+    virtual void interrupted(uint32_t speech_id, std::string callsign) = 0;
+    virtual void networkerror(uint32_t speech_id, std::string callsign) = 0;
+    virtual void playbackerror(uint32_t speech_id, std::string callsign) = 0;
 };
 
 struct SpeechData {
     public:
-        SpeechData() : client(NULL), secure(false), id(0), text(), primVolDuck(25) {}
-        SpeechData(TTSSpeakerClient *c, uint32_t i, std::string t, bool s=false,int8_t vol=25) : client(c), secure(s), id(i), text(t), primVolDuck(vol) {}
+        SpeechData() : client(NULL), secure(false), id(0), callsign(), text(), primVolDuck(25) {}
+        SpeechData(TTSSpeakerClient *c, uint32_t i, std::string callsign,std::string t, bool s=false,int8_t vol=25) : client(c), secure(s), id(i), callsign(callsign), text(t), primVolDuck(vol) {}
         SpeechData(const SpeechData &n) {
             client = n.client;
             id = n.id;
+            callsign =n.callsign;
             text = n.text;
             secure = n.secure;
             primVolDuck = n.primVolDuck;
@@ -82,6 +83,7 @@ struct SpeechData {
         TTSSpeakerClient *client;
         bool secure;
         uint32_t id;
+        std::string callsign;
         std::string text;
         int8_t primVolDuck;
 };
@@ -100,7 +102,7 @@ public:
     void ensurePipeline(bool flag=true);
 
     // Speak Functions
-    int speak(TTSSpeakerClient* client, uint32_t id, std::string text, bool secure,int8_t primVolDuck); // Formalize data to speak API
+    int speak(TTSSpeakerClient* client, uint32_t id, std::string callsign, std::string text, bool secure,int8_t primVolDuck); // Formalize data to speak API
     bool isSpeaking(uint32_t id);
     SpeechState getSpeechState(uint32_t id);
     bool cancelSpeech(uint32_t id=0);


### PR DESCRIPTION
Reason for change: TTS Thunder plugin to support callsign based notification
Test Procedure: Mentioned in ticket
Risks: Low