### PR TITLE
RDKTV-27994 : TVSettings-hal-header syncronization Phase 3

### DIFF
--- a/AVOutput/AVOutputTV.h
+++ b/AVOutput/AVOutputTV.h
@@ -25,10 +25,10 @@
 
 #include "tvTypes.h"
 #include "tvSettings.h"
+#include "tvSettingsExtODM.h"
 #include <pthread.h>
 #include "Module.h"
 #include "tvError.h"
-#include "tvTypes.h"
 #include "tr181api.h"
 #include "AVOutputBase.h"
 #include "libIARM.h"

--- a/AVOutput/CHANGELOG.md
+++ b/AVOutput/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.0.3] - 2024-02-26
+### Fixed
+- Header cleanup
+
 ## [1.0.2] - 2024-02-15
 ### Fixed
 - DolbyMode index issue


### PR DESCRIPTION
Reason for change: TVSettings-hal-header syncronization Phase 3 for all platforms and all branch
Test Procedure: in jira
Risks: Low
Priority: P1
Signed-off-by: utkarsh.patel@sky.uk