### PR TITLE
SERXIONE-4269: remove IARM term from remotecontrol plugins

### DIFF
--- a/RemoteControl/CHANGELOG.md
+++ b/RemoteControl/CHANGELOG.md
@@ -13,6 +13,11 @@ All notable changes to this RDK Service will be documented in this file.
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 * The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [1.4.2] - 2023-10-04
+### Added
+- Removed unwanted iarmbus cleanup functions
+
 ## [1.4.1] - 2023-10-04
 ### Added
 - Implement Thunder Plugin Configuration for Kirkstone builds(CMake-3.20 & above)

--- a/RemoteControl/RemoteControl.cpp
+++ b/RemoteControl/RemoteControl.cpp
@@ -34,7 +34,7 @@ using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 4
-#define API_VERSION_NUMBER_PATCH 0
+#define API_VERSION_NUMBER_PATCH 2
 
 namespace WPEFramework {
 
@@ -131,9 +131,8 @@ namespace WPEFramework {
                 IARM_CHECK( IARM_Bus_RemoveEventHandler(CTRLM_MAIN_IARM_BUS_NAME, CTRLM_RCU_IARM_EVENT_VALIDATION_END, remoteEventHandler) );
                 IARM_CHECK( IARM_Bus_RemoveEventHandler(CTRLM_MAIN_IARM_BUS_NAME, CTRLM_RCU_IARM_EVENT_CONFIGURATION_COMPLETE, remoteEventHandler) );
                 IARM_CHECK( IARM_Bus_RemoveEventHandler(CTRLM_MAIN_IARM_BUS_NAME, CTRLM_RCU_IARM_EVENT_RF4CE_PAIRING_WINDOW_TIMEOUT, remoteEventHandler) );
+                LOGWARN("WARNING - IARMBUSDEBUG removed IARM_Bus_Disconnect and  IARM_Bus_Term ");
 
-                IARM_CHECK( IARM_Bus_Disconnect() );
-                IARM_CHECK( IARM_Bus_Term() );
                 m_hasOwnProcess = false;
             }
         }


### PR DESCRIPTION
Reason for change:
 Removed unwanted iarmbus cleanup
Test Procedure: None
Risks: Low

Change-Id: Ifce41caf233dabdf12254843e491af178cdedbb0 Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>