### PR TITLE
RDK-45868:Coverity fixes - Phase 3b (keyActionMap)

### DIFF
--- a/RemoteActionMapping/RemoteActionMapping.cpp
+++ b/RemoteActionMapping/RemoteActionMapping.cpp
@@ -1403,7 +1403,8 @@ namespace WPEFramework {
         bool RemoteActionMapping::setKeyActionMapping(int deviceID, int keymapType, std::map<int, keyActionMap>& localActionMaps, const KeyGroupSrcInfo& srcInfo)
         {
             keyActionMap actionMap;
-            keyActionMap altActionMap = KED_UNDEFINEDKEY;
+            keyActionMap altActionMap;
+            altActionMap.keyName = KED_UNDEFINEDKEY;
             int rfKeyCode = -1;
             bool status = false;
             bool success = true;


### PR DESCRIPTION
Reason for change: Issue with keyActionMap altActionMap initialization
Test Procedure: Regression testing on effected plugins
Risks: Low
Priority: P1