### PR TITLE
RDKTV-28616 : Add C style callbacks for L1 in tvsettings

### DIFF
--- a/AVOutput/AVOutputTV.cpp
+++ b/AVOutput/AVOutputTV.cpp
@@ -398,16 +398,28 @@ namespace Plugin {
         }
 
         tvVideoFormatCallbackData callbackData = {this,tvVideoFormatChangeHandler};
-        RegisterVideoFormatChangeCB(callbackData);
+        ret = RegisterVideoFormatChangeCB(&callbackData);
+        if(ret != tvERROR_NONE) {
+            LOGWARN("RegisterVideoFormatChangeCB failed");
+        }
 
         tvVideoContentCallbackData ConcallbackData = {this,tvFilmMakerModeChangeHandler};
-        RegisterVideoContentChangeCB(ConcallbackData);
+        ret = RegisterVideoContentChangeCB(&ConcallbackData);
+        if(ret != tvERROR_NONE) {
+            LOGWARN("RegisterVideoContentChangeCB failed");
+        }
 
         tvVideoResolutionCallbackData RescallbackData = {this,tvVideoResolutionChangeHandler};
-        RegisterVideoResolutionChangeCB(RescallbackData);
+        ret = RegisterVideoResolutionChangeCB(&RescallbackData);
+        if(ret != tvERROR_NONE) {
+            LOGWARN("RegisterVideoResolutionChangeCB failed");
+        }
 
         tvVideoFrameRateCallbackData FpscallbackData = {this,tvVideoFrameRateChangeHandler};
-        RegisterVideoFrameRateChangeCB(FpscallbackData);
+        ret = RegisterVideoFrameRateChangeCB(&FpscallbackData);
+        if(ret != tvERROR_NONE) {
+            LOGWARN("RegisterVideoFrameRateChangeCB failed");
+        }
 
         LocatePQSettingsFile();
 

--- a/AVOutput/CHANGELOG.md
+++ b/AVOutput/CHANGELOG.md
@@ -15,6 +15,11 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+
+## [1.0.4] - 2024-03-01
+### Fixed
+- Change to c style callback
+
 ## [1.0.3] - 2024-02-23
 ### Fixed
 - DolbyMode index issue


### PR DESCRIPTION
Reason for change: Add C style callbacks for L1 in tvsettings
Test Procedure: in jira
Risks: Low
Priority: P1
Signed-off-by: Utkarsh Patel <utkarsh.patel@sky.uk>