### PR TITLE
RDKTV-29180 - [Miracast]: TV name shows as "Miracast-Generic" in casting devices

### DIFF
--- a/Miracast/CHANGELOG.md
+++ b/Miracast/CHANGELOG.md
@@ -14,8 +14,8 @@ All notable changes to this RDK Service will be documented in this file.
 
     For more details, refer to versioning section under Main README.
 ## [1.0.4] - 2024-03-06
-### Added
-- Fix for RDKTV-29180.
+### Fixed
+- Added the timer to get and update the friendlyName for Miracast if it fails get it from SystemServices.
 
 ## [1.0.3] - 2023-12-22
 ### Added

--- a/Miracast/CHANGELOG.md
+++ b/Miracast/CHANGELOG.md
@@ -13,6 +13,10 @@ All notable changes to this RDK Service will be documented in this file.
     Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development.
 
     For more details, refer to versioning section under Main README.
+## [1.0.4] - 2024-03-06
+### Added
+- Fix for RDKTV-29180.
+
 ## [1.0.3] - 2023-12-22
 ### Added
 - Added the opt flags to suppress P2P events and change config methods and dynamically handled the authType.

--- a/Miracast/MiracastService/MiracastService.cpp
+++ b/Miracast/MiracastService/MiracastService.cpp
@@ -940,7 +940,7 @@ namespace WPEFramework
 				{
 					std::string friendlyName = "";
 					friendlyName = Result["friendlyName"].String();
-					m_miracast_ctrler_obj->set_FriendlyName(friendlyName);
+					m_miracast_ctrler_obj->set_FriendlyName(friendlyName,m_isServiceEnabled);
 					MIRACASTLOG_INFO("Miracast FriendlyName=%s", friendlyName.c_str());
 					return_value = true;
 				}

--- a/Miracast/MiracastService/MiracastService.cpp
+++ b/Miracast/MiracastService/MiracastService.cpp
@@ -47,7 +47,7 @@ using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 3
+#define API_VERSION_NUMBER_PATCH 4
 
 #define SERVER_DETAILS "127.0.0.1:9998"
 #define SYSTEM_CALLSIGN "org.rdk.System"

--- a/Miracast/MiracastService/MiracastService.cpp
+++ b/Miracast/MiracastService/MiracastService.cpp
@@ -113,6 +113,11 @@ namespace WPEFramework
 				delete m_SystemPluginObj;
 				m_SystemPluginObj = nullptr;
 			}
+			if (m_FriendlyNameMonitorTimerID)
+			{
+				g_source_remove(m_FriendlyNameMonitorTimerID);
+				m_FriendlyNameMonitorTimerID = 0;
+			}
 			Unregister(METHOD_MIRACAST_SET_ENABLE);
 			Unregister(METHOD_MIRACAST_GET_ENABLE);
 			Unregister(METHOD_MIRACAST_STOP_CLIENT_CONNECT);
@@ -190,7 +195,15 @@ namespace WPEFramework
 					getSystemPlugin();
 					// subscribe for event
 					m_SystemPluginObj->Subscribe<JsonObject>(1000, "onFriendlyNameChanged", &MiracastService::onFriendlyNameUpdateHandler, this);
-					updateSystemFriendlyName();
+					if ( false == updateSystemFriendlyName())
+					{
+						m_FriendlyNameMonitorTimerID = g_timeout_add(2000, MiracastService::monitor_friendly_name_timercallback, this);
+						MIRACASTLOG_WARNING("Unable to get friendlyName, requires polling [%u]...",m_FriendlyNameMonitorTimerID);
+					}
+					else
+					{
+						MIRACASTLOG_INFO("friendlyName updated properly...");
+					}
 					m_isServiceInitialized = true;
 					m_miracast_ctrler_obj->m_ePlayer_state = MIRACAST_PLAYER_STATE_IDLE;
 				}
@@ -226,7 +239,6 @@ namespace WPEFramework
 					}
 				}
 			}
-
 			// On success return empty, to indicate there is no error text.
 			return msg;
 		}
@@ -906,15 +918,18 @@ namespace WPEFramework
 			}
 		}
 
-		int MiracastService::updateSystemFriendlyName()
+		bool MiracastService::updateSystemFriendlyName()
 		{
 			JsonObject params, Result;
+			bool return_value = false;
 			MIRACASTLOG_INFO("Entering..!!!");
+
+			getSystemPlugin();
 
 			if (nullptr == m_SystemPluginObj)
 			{
 				LOGERR("m_SystemPluginObj not yet instantiated");
-				return Core::ERROR_GENERAL;
+				return false;
 			}
 
 			uint32_t ret = m_SystemPluginObj->Invoke<JsonObject, JsonObject>(THUNDER_RPC_TIMEOUT, _T("getFriendlyName"), params, Result);
@@ -927,6 +942,7 @@ namespace WPEFramework
 					friendlyName = Result["friendlyName"].String();
 					m_miracast_ctrler_obj->set_FriendlyName(friendlyName);
 					MIRACASTLOG_INFO("Miracast FriendlyName=%s", friendlyName.c_str());
+					return_value = true;
 				}
 				else
 				{
@@ -938,7 +954,7 @@ namespace WPEFramework
 			{
 				LOGERR("updateSystemFriendlyName call failed E[%u]", ret);
 			}
-			return ret;
+			return return_value;
 		}
 
 		void MiracastService::onFriendlyNameUpdateHandler(const JsonObject &parameters)
@@ -954,6 +970,25 @@ namespace WPEFramework
 				m_miracast_ctrler_obj->set_FriendlyName(value, m_isServiceEnabled);
 				MIRACASTLOG_INFO("Miracast FriendlyName=%s", value.c_str());
 			}
+		}
+
+		gboolean MiracastService::monitor_friendly_name_timercallback(gpointer userdata)
+		{
+			gboolean timer_retry_state = G_SOURCE_CONTINUE;
+			MIRACASTLOG_TRACE("Entering..!!!");
+			MiracastService *self = (MiracastService *)userdata;
+			MIRACASTLOG_INFO("TimerCallback Triggered for updating friendlyName...");
+			if ( true == self->updateSystemFriendlyName() )
+			{
+				MIRACASTLOG_INFO("friendlyName updated properly, No polling required...");
+				timer_retry_state = G_SOURCE_REMOVE;
+			}
+			else
+			{
+				MIRACASTLOG_WARNING("Unable to get friendlyName, still requires polling...");
+			}
+			MIRACASTLOG_TRACE("Exiting..!!!");
+			return timer_retry_state;
 		}
 
 		void MiracastService::onMiracastServiceLaunchRequest(string src_dev_ip, string src_dev_mac, string src_dev_name, string sink_dev_ip)

--- a/Miracast/MiracastService/MiracastService.h
+++ b/Miracast/MiracastService/MiracastService.h
@@ -88,6 +88,7 @@ namespace WPEFramework
         private:
             bool m_isServiceInitialized;
             bool m_isServiceEnabled;
+            guint m_FriendlyNameMonitorTimerID{0};
             eMIRA_SERVICE_STATES m_eService_state;
             WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement> *m_SystemPluginObj = NULL;
             uint32_t setEnable(const JsonObject &parameters, JsonObject &response);
@@ -100,8 +101,9 @@ namespace WPEFramework
 
             std::string reasonDescription(eMIRACAST_SERVICE_ERR_CODE e);
             void getSystemPlugin();
-            int updateSystemFriendlyName();
+            bool updateSystemFriendlyName();
             void onFriendlyNameUpdateHandler(const JsonObject &parameters);
+            static gboolean monitor_friendly_name_timercallback(gpointer userdata);
             bool envGetValue(const char *key, std::string &value);
 
             // We do not allow this plugin to be copied !!


### PR DESCRIPTION
RDKTV-29180: [Miracast]: TV name shows as "Miracast-Generic" in casting devices.

Reason for change: Add friendlyName fixes.
Test Procedure: Miracast functionality.
Risks: Low
Priority: P1

Signed-off-by: yuvaramachandran_gurusamy [yuvaramachandran_gurusamy@comcast.com](mailto:yuvaramachandran_gurusamy@comcast.com)