### PR TITLE
RDKDEV-985 - Upstream dobby amazon container changes

### DIFF
--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -4162,6 +4162,36 @@ namespace WPEFramework {
 #endif
                 }
 
+		if (!type.empty() && type == "Amazon")
+		{
+#ifdef RFC_ENABLED
+                    RFC_ParamData_t param;
+                    if (Utils::getRFCConfig("Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.Dobby.Amazon.Enable", param))
+		    {
+			JsonObject root;
+			if (strncasecmp(param.value, "true", 4) == 0)
+	                {
+			    std::cout << "dobby rfc true - launching amazon in container mode " << std::endl;
+			    root = configSet["root"].Object();
+			    root["mode"] = JsonValue("Container");
+			}
+			else
+		        {
+		            std::cout << "dobby rfc false - launching amazon in local mode " << std::endl;
+                            root = configSet["root"].Object();
+			     root["mode"] = JsonValue("Local");
+			}
+			configSet["root"] = root;
+		     }
+		     else
+	             {
+			 std::cout << "reading amazon dobby rfc failed " << std::endl;
+	             }
+#else
+		     std::cout << "rfc is disabled and unable to check for amazon container mode " << std::endl;
+#endif
+		}
+
                 // One RFC controls all WPE-based apps
                 if (!type.empty() && (type == "HtmlApp" || type == "LightningApp"))
                 {


### PR DESCRIPTION
Reason for change: Upstream Rdkshell-Amazon-Container.patch patch changes into github , as dobby support has available on AML and RTK upstreaming the changes instead of keeping as a patch

Risks: Low

Test Procedure: Amazon launched in container mode