### PR TITLE
RDKDEV-986 - Upstream FrameRate default values updated changes

### DIFF
--- a/FrameRate/FrameRate.cpp
+++ b/FrameRate/FrameRate.cpp
@@ -355,7 +355,6 @@ namespace WPEFramework
                 fpsCollectionFrequency = MINIMUM_FPS_COLLECTION_TIME_IN_MILLISECONDS;
             }
             m_reportFpsTimer.start(fpsCollectionFrequency);
-            enableFpsCollection();
             return true;
         }
 
@@ -381,7 +380,7 @@ namespace WPEFramework
                 int maxFps = -1;
                 if (m_numberOfFpsUpdates > 0)
                 {
-                averageFps = (m_totalFpsValues / m_numberOfFpsUpdates);
+                averageFps = (m_totalFpsValues / 2);
                 minFps = m_minFpsValue;
                 maxFps = m_maxFpsValue;
                 fpsCollectionUpdate(averageFps, minFps, maxFps);
@@ -407,7 +406,7 @@ namespace WPEFramework
             {
                 m_minFpsValue = newFpsValue;
             }
-            m_totalFpsValues += newFpsValue;
+	    m_totalFpsValues = m_maxFpsValue + m_minFpsValue;
             m_numberOfFpsUpdates++;
             m_lastFpsValue = newFpsValue;
         }
@@ -429,9 +428,17 @@ namespace WPEFramework
             int averageFps = -1;
             int minFps = -1;
             int maxFps = -1;
+
+	    if (m_numberOfFpsUpdates == 0)
+	    {
+		    minFps = DEFAULT_MIN_FPS_VALUE;
+	            maxFps = DEFAULT_MAX_FPS_VALUE;
+		    averageFps = (minFps + maxFps) / 2;
+		    fpsCollectionUpdate(averageFps, minFps, maxFps);
+	    }
             if (m_numberOfFpsUpdates > 0)
             {
-                averageFps = (m_totalFpsValues / m_numberOfFpsUpdates);
+                averageFps = (m_totalFpsValues / 2);
                 minFps = m_minFpsValue;
                 maxFps = m_maxFpsValue;
             }
@@ -439,9 +446,9 @@ namespace WPEFramework
             if (m_lastFpsValue >= 0)
             {
                 // store the last fps value just in case there are no updates
-                m_minFpsValue = m_lastFpsValue;
-                m_maxFpsValue = m_lastFpsValue;
-                m_totalFpsValues = m_lastFpsValue;
+                m_minFpsValue = minFps;
+                m_maxFpsValue = maxFps;
+                m_totalFpsValues = m_minFpsValue + m_lastFpsValue;
                 m_numberOfFpsUpdates = 1;
             }
             else


### PR DESCRIPTION
Reason for change: Updated default values to max and min variable when there is no fps update. As this is generic change, need to upstream the AMLS905X4-275-Fix-FrameRate-onFpsEvent-getting-negative-values.patch file.

Risks: Low

Test Procedure: Sequence of Curl command to check the fps.

curl --header "Content-Type: application/json" --request POST --data '{"jsonrpc": "2.0","id": 1234567890,"method": "Controller.1.activate","params": {"callsign": "org.rdk.FrameRate"}}' http://127.0.0.1:9998/jsonrpc
curl --header "Content-Type: application/json" --request POST --data '{"jsonrpc": "2.0","id": 1234567890,"method": "Controller.1.activate","params": {"callsign": "LightningApp"}}' http://127.0.0.1:9998/jsonrpc
curl --header "Content-Type: application/json" --request POST --data '{"jsonrpc": "2.0","id": 1234567890,"method": "LightningApp.1.url","params": "https://www.testufo.com/"}' http://127.0.0.1:9998/jsonrpc
curl --header "Content-Type: application/json" --request POST --data '{"jsonrpc": "2.0","id": 1234567890,"method": "LightningApp.1.fps"}' http://127.0.0.1:9998/jsonrpc
curl --header "Content-Type: application/json" --request POST --data '{"jsonrpc":"2.0","id":"3","method": "org.rdk.FrameRate.1.setCollectionFrequency", "params": {"frequency": 10000}}' http://127.0.0.1:9998/jsonrpc
curl --header "Content-Type: application/json" --request POST --data '{"jsonrpc":"2.0","id":"3","method": "org.rdk.FrameRate.1.startFpsCollection"}' http://127.0.0.1:9998/jsonrpc

On grepping the OnFPSChanged event in wpeframework.log, able to see fps default value:
grep -irn "onFpsEvent" /opt/logs/wpeframework.log