### PR TITLE
RDKTV-29404: Apache 2K /Pioneer-2 - R2 Builds show Blank screen after boot up

### DIFF
--- a/PersistentStore/CMakeLists.txt
+++ b/PersistentStore/CMakeLists.txt
@@ -17,12 +17,12 @@
 
 cmake_minimum_required(VERSION 3.14)
 
-project(PersistentStore)
+set(PLUGIN_NAME PersistentStore)
+set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
 
 set(CMAKE_CXX_STANDARD 11)
 
 find_package(WPEFramework)
-set(MODULE_NAME "${NAMESPACE}${PROJECT_NAME}")
 
 set(PLUGIN_PERSISTENTSTORE_MODE "Off" CACHE STRING "Controls if the plugin should run in its own process, in process or remote")
 set(PLUGIN_PERSISTENTSTORE_URI "ss.eu.prod.developer.comcast.com:443" CACHE STRING "Account scope endpoint")
@@ -67,4 +67,4 @@ endif ()
 install(TARGETS ${MODULE_NAME}
         DESTINATION lib/${STORAGE_DIRECTORY}/plugins)
 
-write_config()
+write_config(${PLUGIN_NAME})


### PR DESCRIPTION
Reason for change: PersistentStore.json is not generated  in R2 build due to write_config() empty parameter. as per Thunder R2 release , we need to pass Plugin/Project name as parameter to write_config Test Procedure: Verify in Jenkin Build
Risks: High
Signed-off-by: Thamim  Razith <tabbas651@cable.comcast.com>