### PR TITLE
RDK-47625 - Implement GNOME support for NetworkManager-2.0.0 Thunder plugin

### DIFF
--- a/NetworkManager/service/NetworkManagerGnomeProxy.cpp
+++ b/NetworkManager/service/NetworkManagerGnomeProxy.cpp
@@ -704,5 +704,13 @@ namespace WPEFramework
             uint32_t rc = Core::ERROR_RPC_CALL_FAILED;
             return rc;
         }
+
+        uint32_t NetworkManagerImplementation::GetWifiState(WiFiState &state)
+        {
+            uint32_t rc = Core::ERROR_NONE;
+
+            state = Exchange::INetworkManager::WIFI_STATE_CONNECTED;
+            return rc;
+        }
     }
 }


### PR DESCRIPTION
Reason for change: Added GetWifiState API to fix the issue of Network manager plugin not getting activated with desktop
Test Procedure: Build and verified with desktop
Risks: Low
Priority: P1
Signed-off-by: Gururaaja ESR <Gururaja_ErodeSriranganRamlingham@comcast.com>