### PR TITLE
RDKTV-19422: Support for long key press using RDKShell

### DIFF
--- a/RDKShell/CHANGELOG.md
+++ b/RDKShell/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+## [1.4.16] - 2024-03-13
+### Addded
+- Added long key press support
+
 ## [1.4.15] - 2024-03-05
 ### Fixed
 - Fix RDKShell Initialize and Deinitialize

--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -53,7 +53,7 @@
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 4
-#define API_VERSION_NUMBER_PATCH 15
+#define API_VERSION_NUMBER_PATCH 16
 
 const string WPEFramework::Plugin::RDKShell::SERVICE_NAME = "org.rdk.RDKShell";
 //methods

--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -7098,6 +7098,11 @@ namespace WPEFramework {
                 {
                   keyClient = keyInputInfo.HasLabel("callsign")? keyInputInfo["callsign"].String(): "";
                 }
+		double duration = 0.0;
+                if (keyInputInfo.HasLabel("duration"))
+                {
+                    duration = keyInputInfo["duration"].Number();
+                }
                 lockRdkShellMutex();
 		bool targetFound = false;
                 if (keyClient != "")
@@ -7112,7 +7117,14 @@ namespace WPEFramework {
                 }
                 if (targetFound || keyClient == "")
                 {
-                  ret = CompositorController::generateKey(keyClient, keyCode, flags, virtualKey);
+		    if (duration > 0.0)
+                    {
+                        ret = CompositorController::generateKey(keyClient, keyCode, flags, virtualKey, duration);
+                    }
+                    else
+                    {
+                        ret = CompositorController::generateKey(keyClient, keyCode, flags, virtualKey);
+                    }
                 }
                 gRdkShellMutex.unlock();
             }

--- a/RDKShell/RDKShell.json
+++ b/RDKShell/RDKShell.json
@@ -566,6 +566,11 @@
                                     "type": "number",
                                     "example": 1.0
                                 },
+				"duration": {
+                                    "summary":"The amount of time between key press and key release events",
+                                    "type": "number",
+                                    "example": 1.0
+                                },
                                 "callsign": {
                                     "$ref": "#/definitions/callsign"
                                 },

--- a/Tests/mocks/rdkshell.h
+++ b/Tests/mocks/rdkshell.h
@@ -355,6 +355,7 @@ namespace RdkShell
      virtual bool createDisplay(const std::string& client, const std::string& displayName, uint32_t displayWidth=0, uint32_t displayHeight=0,
                 bool virtualDisplayEnabled=false, uint32_t virtualWidth=0, uint32_t virtualHeight=0, bool topmost = false, bool focus = false , bool autodestroy = true) = 0;
      virtual bool generateKey(const std::string& client, const uint32_t& keyCode, const uint32_t& flags, std::string virtualKey="") = 0;
+     virtual bool generateKey(const std::string& client, const uint32_t& keyCode, const uint32_t& flags, std::string virtualKey, double duration) = 0;
      virtual bool addKeyMetadataListener(const std::string& client) = 0;
      virtual bool removeNativeKeyListener(const std::string& client, const uint32_t& keyCode, const uint32_t& flags) = 0;
      virtual bool addNativeKeyListener(const std::string& client, const uint32_t& keyCode, const uint32_t& flags, std::map<std::string, RdkShellData> &listenerProperties) = 0;
@@ -445,6 +446,10 @@ namespace RdkShell
 	    {
 		    return getInstance().impl->generateKey(client, keyCode, flags, virtualKey);
 	    }
+	    static bool generateKey(const std::string& client, const uint32_t& keyCode, const uint32_t& flags, std::string virtualKey, double duration)
+            {
+                    return getInstance().impl->generateKey(client, keyCode, flags, virtualKey, duration);
+            }
             static bool getScreenResolution(uint32_t &width, uint32_t &height)
 	    {
 		    return getInstance().impl->getScreenResolution(width,height);

--- a/Tests/mocks/rdkshellmock.h
+++ b/Tests/mocks/rdkshellmock.h
@@ -151,6 +151,7 @@ public:
     MOCK_METHOD(bool, createDisplay, (const std::string& client, const std::string& displayName, uint32_t displayWidth, uint32_t displayHeight,
                 bool virtualDisplayEnabled, uint32_t virtualWidth, uint32_t virtualHeight, bool topmost, bool focus, bool autodestroy), (override));
     MOCK_METHOD(bool, generateKey, (const std::string& client, const uint32_t& keyCode, const uint32_t& flags, std::string virtualKey), (override));
+    MOCK_METHOD(bool, generateKey, (const std::string& client, const uint32_t& keyCode, const uint32_t& flags, std::string virtualKey, double duration), (override));
     MOCK_METHOD(bool, addKeyMetadataListener, (const std::string& client), (override));
     MOCK_METHOD(bool, removeNativeKeyListener, (const std::string& client, const uint32_t& keyCode, const uint32_t& flags), (override));
     MOCK_METHOD(bool, addNativeKeyListener, (const std::string& client, const uint32_t& keyCode, const uint32_t& flags, (std::map<std::string, RdkShell::RdkShellData> &listenerProperties)), (override));


### PR DESCRIPTION
Reason for change: Enabled support for long key press using RDKShell plugin. Test Procedure: RDKShell.generateKey curl command with "duration" parameter in "Keys" Risks: Low
Priority: P1
Signed-off-by:Ezhilarasi Velumani Ezhilarasi_Velumani@comcast.com