### PR TITLE
RDKDEV-990 - Upstream onApplicationFocusChanged event change handling

### DIFF
--- a/RDKShell/RDKShell.h
+++ b/RDKShell/RDKShell.h
@@ -64,6 +64,7 @@ namespace WPEFramework {
             static const string RDKSHELL_METHOD_MOVE_TO_BACK;
             static const string RDKSHELL_METHOD_MOVE_BEHIND;
             static const string RDKSHELL_METHOD_SET_FOCUS;
+	    static const string RDKSHELL_METHOD_GET_FOCUSED;
             static const string RDKSHELL_METHOD_KILL;
             static const string RDKSHELL_METHOD_ADD_KEY_INTERCEPT;
             static const string RDKSHELL_METHOD_ADD_KEY_INTERCEPTS;
@@ -160,6 +161,7 @@ namespace WPEFramework {
             static const string RDKSHELL_EVENT_ON_APP_SUSPENDED;
             static const string RDKSHELL_EVENT_ON_APP_RESUMED;
             static const string RDKSHELL_EVENT_ON_APP_ACTIVATED;
+	    static const string RDKSHELL_EVENT_ON_APP_FOCUSCHANGED;
             static const string RDKSHELL_EVENT_ON_LAUNCHED;
             static const string RDKSHELL_EVENT_ON_SUSPENDED;
             static const string RDKSHELL_EVENT_ON_DESTROYED;
@@ -187,6 +189,7 @@ namespace WPEFramework {
             uint32_t moveToBackWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t moveBehindWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t setFocusWrapper(const JsonObject& parameters, JsonObject& response);
+	    uint32_t getFocusedWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t killWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t addKeyInterceptWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t addKeyInterceptsWrapper(const JsonObject& parameters, JsonObject& response);
@@ -282,6 +285,7 @@ namespace WPEFramework {
             bool moveToBack(const string& client);
             bool moveBehind(const string& client, const string& target);
             bool setFocus(const string& client);
+	    bool getFocused(string& client);
             bool kill(const string& client);
             bool addKeyIntercept(const uint32_t& keyCode, const JsonArray& modifiers, const string& client);
             bool addKeyIntercepts(const JsonArray& intercepts);
@@ -379,6 +383,7 @@ namespace WPEFramework {
                 virtual void onApplicationSuspended(const std::string& client);
                 virtual void onApplicationResumed(const std::string& client);
                 virtual void onApplicationActivated(const std::string& client);
+		virtual void onApplicationFocusChanged(const std::string& client);
                 virtual void onUserInactive(const double minutes);
                 virtual void onDeviceLowRamWarning(const int32_t freeKb, const int32_t availableKb, const int32_t usedSwapKb);
                 virtual void onDeviceCriticallyLowRamWarning(const int32_t freeKb, const int32_t availableKb, const int32_t usedSwapKb);


### PR DESCRIPTION
Reason for change: onApplicationFocusChanged event handling not done , so added those changes for getFocus , getFocused and corresponding event handlings

Risks: Low

Test Procedure: Getting onApplicationFocusChanged events on in ResidentUI , switch to Youtube , back to main UI in all cases