### PR TITLE
RDKTV-29404: Apache 2K /Pioneer-2 - R2 Builds show Blank screen after bootup

### DIFF
--- a/PersistentStore/CHANGELOG.md
+++ b/PersistentStore/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.0.7] - 2024-03-18
+### Fixed
+- PersistentStore.json is not generated  in R2 build due to write_config() empty parameter & its fixed for R2 builds
+
 ## [1.0.6] - 2024-03-11
 ### Added
 - RPC COM interface IStore2, IStoreInspector, IStoreLimit

--- a/PersistentStore/CMakeLists.txt
+++ b/PersistentStore/CMakeLists.txt
@@ -18,6 +18,7 @@
 cmake_minimum_required(VERSION 3.14)
 
 set(PLUGIN_NAME PersistentStore)
+find_package(WPEFramework)
 set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
 
 set(CMAKE_CXX_STANDARD 11)

--- a/PersistentStore/CMakeLists.txt
+++ b/PersistentStore/CMakeLists.txt
@@ -17,12 +17,10 @@
 
 cmake_minimum_required(VERSION 3.14)
 
-project(PersistentStore)
+set(PLUGIN_NAME PersistentStore)
+set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
 
 set(CMAKE_CXX_STANDARD 11)
-
-find_package(WPEFramework)
-set(MODULE_NAME "${NAMESPACE}${PROJECT_NAME}")
 
 set(PLUGIN_PERSISTENTSTORE_MODE "Off" CACHE STRING "Controls if the plugin should run in its own process, in process or remote")
 set(PLUGIN_PERSISTENTSTORE_URI "ss.eu.prod.developer.comcast.com:443" CACHE STRING "Account scope endpoint")
@@ -67,4 +65,4 @@ endif ()
 install(TARGETS ${MODULE_NAME}
         DESTINATION lib/${STORAGE_DIRECTORY}/plugins)
 
-write_config()
+write_config(${PLUGIN_NAME})


### PR DESCRIPTION
Reason for change: PersistentStore.json is not generated  in R2 build due to write_config() empty parameter. as per Thunder R2 release , we need to pass Plugin/Project name as parameter to write_config Test Procedure: Verify in Jenkin Build
Risks: High
Signed-off-by: Thamim  Razith <tabbas651@cable.comcast.com>
(cherry picked from commit 122c7e99064c44ce9e030f7fbb2cb20f963c964a)