### PR TITLE
RDKDEV-995 : Fix to Get "getActiveSourceStatus" Status in HdmiCec_2

### DIFF
--- a/HdmiCec_2/HdmiCec_2.cpp
+++ b/HdmiCec_2/HdmiCec_2.cpp
@@ -184,7 +184,9 @@ namespace WPEFramework
              printHeader(header);
              LOGINFO("Command: Standby from %s\n", header.from.toString().c_str());
              HdmiCec_2::_instance->SendStandbyMsgEvent(header.from.toInt());
-
+	     isDeviceActiveSource = false;
+	     LOGINFO("ActiveSource isDeviceActiveSource status :%d \n", isDeviceActiveSource);
+	     HdmiCec_2::_instance->sendActiveSourceEvent();
        }
        void HdmiCec_2Processor::process (const GetCECVersion &msg, const Header &header)
        {


### PR DESCRIPTION
Reason for change: Added fix to get status of "getActiveSourceStatus" when we put TV into org.rdk.HdmiCec_2.sendStandbyMessage

Test Procedure: Build and verify

Risks: Low

Signed-off-by: Kumari Priyanka [kumari_priyanka@comcast.com](mailto:kumari_priyanka@comcast.com)