### PR TITLE
RDK-47994 : Return ERROR_GENERAL if call with wrong scope

### DIFF
--- a/PersistentStore/grpc/Store2.h
+++ b/PersistentStore/grpc/Store2.h
@@ -145,6 +145,9 @@ namespace Plugin {
             uint32_t SetValue(const ScopeType scope, const string& ns, const string& key, const string& value, const uint32_t ttl) override
             {
                 ASSERT(scope == ScopeType::ACCOUNT);
+                if (scope != ScopeType::ACCOUNT) {
+                    return Core::ERROR_GENERAL;
+                }
 
                 uint32_t result;
 
@@ -186,6 +189,9 @@ namespace Plugin {
             uint32_t GetValue(const ScopeType scope, const string& ns, const string& key, string& value, uint32_t& ttl) override
             {
                 ASSERT(scope == ScopeType::ACCOUNT);
+                if (scope != ScopeType::ACCOUNT) {
+                    return Core::ERROR_GENERAL;
+                }
 
                 uint32_t result;
 
@@ -239,6 +245,9 @@ namespace Plugin {
             uint32_t DeleteKey(const ScopeType scope, const string& ns, const string& key) override
             {
                 ASSERT(scope == ScopeType::ACCOUNT);
+                if (scope != ScopeType::ACCOUNT) {
+                    return Core::ERROR_GENERAL;
+                }
 
                 uint32_t result;
 
@@ -271,6 +280,9 @@ namespace Plugin {
             uint32_t DeleteNamespace(const ScopeType scope, const string& ns) override
             {
                 ASSERT(scope == ScopeType::ACCOUNT);
+                if (scope != ScopeType::ACCOUNT) {
+                    return Core::ERROR_GENERAL;
+                }
 
                 uint32_t result;
 
@@ -307,7 +319,7 @@ namespace Plugin {
                     index(_clients.begin());
 
                 while (index != _clients.end()) {
-                    (*index)->ValueChanged(ScopeType::DEVICE, ns, key, value);
+                    (*index)->ValueChanged(ScopeType::ACCOUNT, ns, key, value);
                     index++;
                 }
             }

--- a/PersistentStore/sqlite/Store2.h
+++ b/PersistentStore/sqlite/Store2.h
@@ -145,6 +145,9 @@ namespace Plugin {
             uint32_t SetValue(const ScopeType scope, const string& ns, const string& key, const string& value, const uint32_t ttl) override
             {
                 ASSERT(scope == ScopeType::DEVICE);
+                if (scope != ScopeType::DEVICE) {
+                    return Core::ERROR_GENERAL;
+                }
 
                 uint32_t result;
 
@@ -195,6 +198,9 @@ namespace Plugin {
             uint32_t GetValue(const ScopeType scope, const string& ns, const string& key, string& value, uint32_t& ttl) override
             {
                 ASSERT(scope == ScopeType::DEVICE);
+                if (scope != ScopeType::DEVICE) {
+                    return Core::ERROR_GENERAL;
+                }
 
                 uint32_t result;
 
@@ -253,6 +259,9 @@ namespace Plugin {
             uint32_t DeleteKey(const ScopeType scope, const string& ns, const string& key) override
             {
                 ASSERT(scope == ScopeType::DEVICE);
+                if (scope != ScopeType::DEVICE) {
+                    return Core::ERROR_GENERAL;
+                }
 
                 uint32_t result;
 
@@ -279,6 +288,9 @@ namespace Plugin {
             uint32_t DeleteNamespace(const ScopeType scope, const string& ns) override
             {
                 ASSERT(scope == ScopeType::DEVICE);
+                if (scope != ScopeType::DEVICE) {
+                    return Core::ERROR_GENERAL;
+                }
 
                 uint32_t result;
 

--- a/PersistentStore/sqlite/StoreInspector.h
+++ b/PersistentStore/sqlite/StoreInspector.h
@@ -84,6 +84,9 @@ namespace Plugin {
             uint32_t GetKeys(const ScopeType scope, const string& ns, RPC::IStringIterator*& keys) override
             {
                 ASSERT(scope == ScopeType::DEVICE);
+                if (scope != ScopeType::DEVICE) {
+                    return Core::ERROR_GENERAL;
+                }
 
                 uint32_t result;
 
@@ -114,6 +117,9 @@ namespace Plugin {
             uint32_t GetNamespaces(const ScopeType scope, RPC::IStringIterator*& namespaces) override
             {
                 ASSERT(scope == ScopeType::DEVICE);
+                if (scope != ScopeType::DEVICE) {
+                    return Core::ERROR_GENERAL;
+                }
 
                 uint32_t result;
 
@@ -139,6 +145,9 @@ namespace Plugin {
             uint32_t GetStorageSizes(const ScopeType scope, INamespaceSizeIterator*& storageList) override
             {
                 ASSERT(scope == ScopeType::DEVICE);
+                if (scope != ScopeType::DEVICE) {
+                    return Core::ERROR_GENERAL;
+                }
 
                 uint32_t result;
 

--- a/PersistentStore/sqlite/StoreLimit.h
+++ b/PersistentStore/sqlite/StoreLimit.h
@@ -91,6 +91,9 @@ namespace Plugin {
             uint32_t SetNamespaceStorageLimit(const ScopeType scope, const string& ns, const uint32_t size) override
             {
                 ASSERT(scope == ScopeType::DEVICE);
+                if (scope != ScopeType::DEVICE) {
+                    return Core::ERROR_GENERAL;
+                }
 
                 uint32_t result;
 
@@ -129,6 +132,9 @@ namespace Plugin {
             uint32_t GetNamespaceStorageLimit(const ScopeType scope, const string& ns, uint32_t& size) override
             {
                 ASSERT(scope == ScopeType::DEVICE);
+                if (scope != ScopeType::DEVICE) {
+                    return Core::ERROR_GENERAL;
+                }
 
                 uint32_t result;
 


### PR DESCRIPTION
Reason for change: Calling apis unsupported for account scope did use device scope.
Test Procedure: None
Risks: None
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>