### PR TITLE
DELIA-62029 - Detached threads may not end properly.

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -562,7 +562,7 @@ namespace WPEFramework {
 		if (m_sendMsgThread.joinable())
 			m_sendMsgThread.join();
 		if(audioPortInitThread.joinable()){
-        		audioPortInitThread.join()
+        		audioPortInitThread.join();
            	}
 	   }
 	   catch(const std::system_error& e)

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -91,6 +91,7 @@ static bool isCecEnabled = false;
 static int  hdmiArcPortId = -1;
 static int retryPowerRequestCount = 0;
 static int  hdmiArcVolumeLevel = 0;
+std::thread audioPortInitThread;
 std::vector<int> sad_list;
 #ifdef USE_IARM
 namespace
@@ -561,6 +562,9 @@ namespace WPEFramework {
 		if (m_sendMsgThread.joinable())
 			m_sendMsgThread.join();
 	   }
+       if(audioPortInitThread.joinable()){
+        audioPortInitThread.join()
+       }
 	   catch(const std::system_error& e)
            {
 		LOGERR("system_error exception in thread join %s", e.what());
@@ -4677,7 +4681,7 @@ namespace WPEFramework {
 	            try
                     {
 		        LOGWARN("creating worker thread for initAudioPortsWorker ");
-		        std::thread audioPortInitThread = std::thread(initAudioPortsWorker);
+		        audioPortInitThread = std::thread(initAudioPortsWorker);
 			audioPortInitThread.detach();
                     }
                     catch(const std::system_error& e)

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -561,10 +561,10 @@ namespace WPEFramework {
 	   {
 		if (m_sendMsgThread.joinable())
 			m_sendMsgThread.join();
+		if(audioPortInitThread.joinable()){
+        		audioPortInitThread.join()
+           	}
 	   }
-       if(audioPortInitThread.joinable()){
-        audioPortInitThread.join()
-       }
 	   catch(const std::system_error& e)
            {
 		LOGERR("system_error exception in thread join %s", e.what());

--- a/XCast/XCast.cpp
+++ b/XCast/XCast.cpp
@@ -107,6 +107,7 @@ bool XCast::m_standbyBehavior = false;
 bool XCast::m_enableStatus = false;
 
 IARM_Bus_PWRMgr_PowerState_t XCast::m_powerState = IARM_BUS_PWRMGR_POWERSTATE_STANDBY;
+std::thread powerModeChangeThread;
 
 XCast::XCast() : PluginHost::JSONRPC()
 , m_apiVersionNumber(1), m_isDynamicRegistrationsRequired(false)
@@ -183,7 +184,7 @@ void XCast::powerModeChange(const char *owner, IARM_EventId_t eventId, void *dat
                      param->data.state.curState, param->data.state.newState);
             m_powerState = param->data.state.newState;
             LOGWARN("creating worker thread for threadPowerModeChangeEvent m_powerState :%d",m_powerState);
-            std::thread powerModeChangeThread = std::thread(threadPowerModeChangeEvent);
+            powerModeChangeThread = std::thread(threadPowerModeChangeEvent);
             powerModeChangeThread.detach();
          }
     }
@@ -224,6 +225,10 @@ const string XCast::Initialize(PluginHost::IShell *service)
 void XCast::Deinitialize(PluginHost::IShell* /* service */)
 {
     LOGINFO("XCast::Deinitialize  called \n ");
+    if(powerModeChangeThread.joinable())
+    {
+        powerModeChangeThread.join();
+    }
     if ( m_locateCastTimer.isActive())
     {
         m_locateCastTimer.stop();


### PR DESCRIPTION
DELIA-62029 - Detached threads may not end properly.

Reason for change:
Update detached threads, such that we wait for them to finish before de-initiailizing the system.
Test Procedure: None
Risks: Low
Priority: P1

Signed-off-by:Hayden Gfeller <Hayden_Gfeller@comcast.com>