### PR TITLE
LLAMA-12424: Panel does not blank always during HDMI plug in & plug out

### DIFF
--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -309,6 +309,7 @@ namespace WPEFramework {
             int m_currentArcRoutingState;
             int m_AudioDeviceSADState;
 	    bool m_requestSad;
+	    bool m_requestSadRetrigger;
             PluginHost::IShell* m_service = nullptr;
 
         public:


### PR DESCRIPTION
Reason for change: Retrigger the SAD request after 3sec timeout of SAD update.
Test Procedure: None
Risks: None
Signed-off-by: Neethu A S neethu.arambilsunny@sky.uk