### PR TITLE
RDKCI-1560 - LLAMA getIPSettings curl command is failing

### DIFF
--- a/NetworkManager/service/NetworkManager.h
+++ b/NetworkManager/service/NetworkManager.h
@@ -417,6 +417,7 @@ namespace WPEFramework
             Exchange::INetworkManager *_NetworkManager;
             Core::Sink<Notification> _notification;
             string m_publicIPAddress;
+            string m_defaultInterface;
             string m_publicIPAddressType;
         };
     }

--- a/NetworkManager/service/NetworkManagerJsonRpc.cpp
+++ b/NetworkManager/service/NetworkManagerJsonRpc.cpp
@@ -188,6 +188,7 @@ namespace WPEFramework
             {
                 response["interface"] = interface;      
                 response["success"] = true;
+                m_defaultInterface = interface;
             }
             LOGTRACEMETHODFIN();
             return rc;
@@ -263,7 +264,12 @@ namespace WPEFramework
             if (Core::ERROR_NONE == rc)
             {
                 response["interface"] = interface;
-                response["ipversion"] = ipversion;
+                if(result.m_ipAddrType == "IPV6")
+                    response["ipversion"] = "IPv6";
+                else if(result.m_ipAddrType == "IPV4")
+                    response["ipversion"] = "IPv4";
+                else
+                    response["ipversion"] = ipversion;
                 response["autoconfig"]   = result.m_autoConfig;
                 response["ipaddress"]    = result.m_ipAddress;
                 response["prefix"]       = result.m_prefix;    

--- a/NetworkManager/service/NetworkManagerRDKProxy.cpp
+++ b/NetworkManager/service/NetworkManagerRDKProxy.cpp
@@ -697,11 +697,6 @@ namespace WPEFramework
                 strncpy(iarmData.interface, "WIFI", INTERFACE_SIZE);
             else if ("eth0" == interface)
                 strncpy(iarmData.interface, "ETHERNET", INTERFACE_SIZE);
-            else
-            {
-                rc = Core::ERROR_BAD_REQUEST;
-                return rc;
-            }
 
             strncpy(iarmData.ipversion, ipversion.c_str(), 16);
             iarmData.isSupported = true;


### PR DESCRIPTION
Reason for change: Addressed no argument getIPSettings scenario in Sky devices
Test Procedure: Build and verified
Risks: Low
Priority: P1
Signed-off-by: Gururaaja ESR <Gururaja_ErodeSriranganRamlingham@comcast.com>