### PR TITLE
RDKTV-28298: DUT connect the Samsung soundbar and Press vol+/- , but …

### DIFF
--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -3487,6 +3487,11 @@ namespace WPEFramework
                             _instance->sendKeyReleaseEvent(keyInfo.logicalAddr);
                     }
 
+		    if((_instance->m_SendKeyQueue.size()<=1 || (_instance->m_SendKeyQueue.size() % 2 == 0)) && ((keyInfo.keyCode == VOLUME_UP) || (keyInfo.keyCode == VOLUME_DOWN) || (keyInfo.keyCode == MUTE)) )
+		    {
+		        _instance->sendGiveAudioStatusMsg();
+		    }
+
             }//while(!_instance->m_sendKeyEventThreadExit)
         }//threadSendKeyEvent
 


### PR DESCRIPTION
Reason for change: Request Audio status from the Audio device upon any changes done on the volume.
Test Procedure: None
Risks: None
Signed-off-by: Neethu A S neethu.arambilsunny@sky.uk