### PR TITLE
RDKCI-1560 - LLAMA getIPSettings curl command is failing

### DIFF
--- a/NetworkManager/service/NetworkManagerJsonRpc.cpp
+++ b/NetworkManager/service/NetworkManagerJsonRpc.cpp
@@ -187,6 +187,7 @@ namespace WPEFramework
             if (Core::ERROR_NONE == rc)
             {
                 response["interface"] = interface;      
+                m_defaultInterface = interface;
                 response["success"] = true;
             }
             LOGTRACEMETHODFIN();

--- a/NetworkManager/service/NetworkManagerLegacy.cpp
+++ b/NetworkManager/service/NetworkManagerLegacy.cpp
@@ -313,21 +313,17 @@ const string CIDR_PREFIXES[CIDR_NETMASK_IP_LEN] = {
             size_t index;
 
             LOGINFOMETHOD();
-            tmpParameters["ipversion"] = parameters["ipversion"];
-            if ("WIFI" == parameters["interface"].String())
-                tmpParameters["interface"] = "wlan0";
-            else if("ETHERNET" == parameters["interface"].String())
-                tmpParameters["interface"] = "eth0";
 
+            if (parameters.HasLabel("ipversion"))
+                tmpParameters["ipversion"] = parameters["ipversion"];
             if (parameters.HasLabel("interface"))
-                response["interface"] = parameters["interface"];
-            else
             {
-                if ("wlan0" == m_defaultInterface)
-                    response["interface"] = "WIFI";
-                else if("eth0" == m_defaultInterface)
-                    response["interface"] = "ETHERNET";
+                if ("WIFI" == parameters["interface"].String())
+                    tmpParameters["interface"] = "wlan0";
+                else if("ETHERNET" == parameters["interface"].String())
+                    tmpParameters["interface"] = "eth0";
             }
+
             rc = GetIPSettings(tmpParameters, tmpResponse); 
 
             if (Core::ERROR_NONE == rc)
@@ -337,6 +333,17 @@ const string CIDR_PREFIXES[CIDR_NETMASK_IP_LEN] = {
                     return Core::ERROR_GENERAL;
                 else
                     response["netmask"]  = CIDR_PREFIXES[index];
+                if (parameters.HasLabel("interface"))
+                {
+                    response["interface"] = parameters["interface"];
+                }
+                else
+                {
+                    if ("wlan0" == m_defaultInterface)
+                        response["interface"] = "WIFI";
+                    else if("eth0" == m_defaultInterface)
+                        response["interface"] = "ETHERNET";
+                }
                 response["ipversion"]    = tmpResponse["ipversion"];
                 response["autoconfig"]   = tmpResponse["autoconfig"];
                 response["dhcpserver"]   = tmpResponse["dhcpserver"];


### PR DESCRIPTION
Reason for change: Addressed interface name not present issue
Test Procedure: Build and verified
Risks: Low
Priority: P1
Signed-off-by: Gururaaja ESR <Gururaja_ErodeSriranganRamlingham@comcast.com>