### PR TITLE
DELIA-62029 - Detached threads may not end properly. Reason for change:

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -564,7 +564,7 @@ namespace WPEFramework {
         int count = 0;
 		while(audioPortInitActive && count < 20){
             sleep(100);
-            count++:
+            count++;
         }
 	   }
 	   catch(const std::system_error& e)


### PR DESCRIPTION
Update detached threads, such that we wait for them to finish before de-initiailizing the system.
Test Procedure: None
Risks: Low
Priority: P1

Signed-off-by:Hayden Gfeller Hayden_Gfeller@comcast.com