### PR TITLE
DELIA-61725: [SECVULN] Thunder Services - Open Source - SystemServices - uploadlogs.cpp - User Controlled Upload URL

### DIFF
--- a/SystemServices/CHANGELOG.md
+++ b/SystemServices/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+## [2.2.3] - 2024-04-03
+### Deprecated
+- Deprecated uploadLogs API
+
 ## [2.1.3] - 2024-03-29
 ### Security
 - Resolved security vulnerabilities

--- a/SystemServices/System.json
+++ b/SystemServices/System.json
@@ -1954,6 +1954,7 @@
             }
         },
         "uploadLogs": {
+            "deprecated": true,
             "summary": "Uploads logs to a URL returned by SSR.",
             "params": {
                 "type": "object",

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -66,7 +66,7 @@
 using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 2
-#define API_VERSION_NUMBER_MINOR 1
+#define API_VERSION_NUMBER_MINOR 2
 #define API_VERSION_NUMBER_PATCH 3
 
 #define MAX_REBOOT_DELAY 86400 /* 24Hr = 86400 sec */
@@ -4470,9 +4470,12 @@ namespace WPEFramework {
 
             bool success = false;
 
-            string url;
-            getStringParameter("url", url);
-            auto err = UploadLogs::upload(url);
+            string tftp_server;
+            string upload_protocol;
+            string upload_httplink;
+            if (E_NOK == UploadLogs::getUploadLogParameters(tftp_server, upload_protocol, upload_httplink))
+                return -1;
+            auto err = UploadLogs::upload(upload_httplink);
             if (err != UploadLogs::OK)
                 response["error"] = UploadLogs::errToText(err);
             else

--- a/SystemServices/uploadlogs.h
+++ b/SystemServices/uploadlogs.h
@@ -30,7 +30,7 @@ namespace UploadLogs
 {
     enum err_t { OK = 0, BadUrl, FilenameFail, SsrFail, TarFail, UploadFail, };
     err_t upload(const std::string& ssrUrl = std::string());
-    std::int32_t getUploadLogParameters();
+    std::int32_t getUploadLogParameters(std::string &tftp_server, std::string &upload_protocol, std::string &upload_httplink);
     int32_t LogUploadBeforeDeepSleep(void);
     pid_t logUploadAsync(void);
     std::string errToText(err_t err);

--- a/docs/api/SystemPlugin.md
+++ b/docs/api/SystemPlugin.md
@@ -2,7 +2,7 @@
 <a name="System_Plugin"></a>
 # System Plugin
 
-**Version: [2.1.3](https://github.com/rdkcentral/rdkservices/blob/main/SystemServices/CHANGELOG.md)**
+**Version: [2.2.3](https://github.com/rdkcentral/rdkservices/blob/main/SystemServices/CHANGELOG.md)**
 
 A org.rdk.System plugin for Thunder framework.
 
@@ -3616,6 +3616,8 @@ This method takes no parameters.
 ## *uploadLogs*
 
 Uploads logs to a URL returned by SSR.
+
+> This API is **deprecated** and may be removed in the future. It is no longer recommended for use in new implementations.
 
 ### Events
 


### PR DESCRIPTION
Reason for change: Deprecating uploadLogs API
Test Procedure: Confirm API is deprecated and that it uses uploadLogsAsync implementation to get upload url
Risks: Low
Priority: P1