### PR TITLE
DELIA-62029 - Detached threads may not end properly.

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -97,7 +97,7 @@ bool isStbHDRcapabilitiesCache = false;
 static int  hdmiArcPortId = -1;
 static int retryPowerRequestCount = 0;
 static int  hdmiArcVolumeLevel = 0;
-std::thread audioPortInitThread;
+bool audioPortInitActive = false;
 std::vector<int> sad_list;
 #ifdef USE_IARM
 namespace
@@ -4712,7 +4712,9 @@ namespace WPEFramework {
 
         void DisplaySettings::initAudioPortsWorker(void)
         {
+            audioPortInitActive = true;
             DisplaySettings::_instance->InitAudioPorts();
+            audioPortInitActive = false;
         }
 
         void DisplaySettings::powerEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
@@ -4736,7 +4738,7 @@ namespace WPEFramework {
 	            try
                     {
 		        LOGWARN("creating worker thread for initAudioPortsWorker ");
-		        audioPortInitThread = std::thread(initAudioPortsWorker);
+		        std::thread audioPortInitThread = std::thread(initAudioPortsWorker);
 			audioPortInitThread.detach();
                     }
                     catch(const std::system_error& e)

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -97,6 +97,7 @@ bool isStbHDRcapabilitiesCache = false;
 static int  hdmiArcPortId = -1;
 static int retryPowerRequestCount = 0;
 static int  hdmiArcVolumeLevel = 0;
+std::thread audioPortInitThread;
 std::vector<int> sad_list;
 #ifdef USE_IARM
 namespace
@@ -572,6 +573,11 @@ namespace WPEFramework {
 	   {
 		if (m_sendMsgThread.joinable())
 			m_sendMsgThread.join();
+        int count = 0;
+		while(audioPortInitActive && count < 20){
+            sleep(100);
+            count++:
+        }
 	   }
 	   catch(const std::system_error& e)
            {
@@ -4730,7 +4736,7 @@ namespace WPEFramework {
 	            try
                     {
 		        LOGWARN("creating worker thread for initAudioPortsWorker ");
-		        std::thread audioPortInitThread = std::thread(initAudioPortsWorker);
+		        audioPortInitThread = std::thread(initAudioPortsWorker);
 			audioPortInitThread.detach();
                     }
                     catch(const std::system_error& e)

--- a/XCast/XCast.cpp
+++ b/XCast/XCast.cpp
@@ -107,6 +107,7 @@ bool XCast::m_standbyBehavior = false;
 bool XCast::m_enableStatus = false;
 
 IARM_Bus_PWRMgr_PowerState_t XCast::m_powerState = IARM_BUS_PWRMGR_POWERSTATE_STANDBY;
+std::thread powerModeChangeThread;
 
 XCast::XCast() : PluginHost::JSONRPC()
 , m_apiVersionNumber(1), m_isDynamicRegistrationsRequired(false)
@@ -183,7 +184,7 @@ void XCast::powerModeChange(const char *owner, IARM_EventId_t eventId, void *dat
                      param->data.state.curState, param->data.state.newState);
             m_powerState = param->data.state.newState;
             LOGWARN("creating worker thread for threadPowerModeChangeEvent m_powerState :%d",m_powerState);
-            std::thread powerModeChangeThread = std::thread(threadPowerModeChangeEvent);
+            powerModeChangeThread = std::thread(threadPowerModeChangeEvent);
             powerModeChangeThread.detach();
          }
     }
@@ -224,6 +225,11 @@ const string XCast::Initialize(PluginHost::IShell *service)
 void XCast::Deinitialize(PluginHost::IShell* /* service */)
 {
     LOGINFO("XCast::Deinitialize  called \n ");
+    int count = 0;
+    while(powerModeChangeActive && count < 20){
+        sleep(100);
+        count++;
+    }
     if ( m_locateCastTimer.isActive())
     {
         m_locateCastTimer.stop();

--- a/XCast/XCast.cpp
+++ b/XCast/XCast.cpp
@@ -230,9 +230,6 @@ void XCast::Deinitialize(PluginHost::IShell* /* service */)
         sleep(100);
         count++;
     }
-    while(powerModeChangeActive){
-        sleep(100);
-    }
     if ( m_locateCastTimer.isActive())
     {
         m_locateCastTimer.stop();


### PR DESCRIPTION
DELIA-62029 - Detached threads may not end properly.
Reason for change:
Update detached threads, such that we wait for them to finish before
de-initiailizing the system.
Test Procedure: None
Risks: Low
Priority: P1

Signed-off-by:Hayden Gfeller Hayden_Gfeller@comcast.com