### PR TITLE
RDK-48709: Synchronize the MiracastService discovery

### DIFF
--- a/Miracast/CHANGELOG.md
+++ b/Miracast/CHANGELOG.md
@@ -13,6 +13,10 @@ All notable changes to this RDK Service will be documented in this file.
     Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development.
 
     For more details, refer to versioning section under Main README.
+## [1.0.5] - 2024-04-04
+### Fixed
+- Added the synchronization the enable/disbable the MiracastService discovery.
+
 ## [1.0.4] - 2024-03-06
 ### Fixed
 - Added the timer to get and update the friendlyName for Miracast if it fails get it from SystemServices.

--- a/Miracast/CHANGELOG.md
+++ b/Miracast/CHANGELOG.md
@@ -15,7 +15,8 @@ All notable changes to this RDK Service will be documented in this file.
     For more details, refer to versioning section under Main README.
 ## [1.0.5] - 2024-04-04
 ### Fixed
-- Added the synchronization the enable/disbable the MiracastService discovery.
+- Added the synchronization for enable/disable the MiracastService discovery.
+- Added the check to avoid the P2P events when MiracastService discovery not enabled.
 
 ## [1.0.4] - 2024-03-06
 ### Fixed

--- a/Miracast/MiracastService/MiracastController.cpp
+++ b/Miracast/MiracastService/MiracastController.cpp
@@ -462,8 +462,7 @@ void MiracastController::event_handler(P2P_EVENTS eventId, void *data, size_t le
     event_buffer = (char *)data;
     free(data);
 
-    std::string opt_flag_buffer = MiracastCommon::parse_opt_flag("/opt/miracast_suppress_p2p_events");
-    if (!opt_flag_buffer.empty())
+    if ( false == m_start_discovering_enabled )
     {
         MIRACASTLOG_TRACE("Exiting...");
         return;

--- a/Miracast/MiracastService/MiracastController.cpp
+++ b/Miracast/MiracastService/MiracastController.cpp
@@ -637,7 +637,6 @@ void MiracastController::Controller_Thread(void *args)
     CONTROLLER_MSGQ_STRUCT controller_msgq_data = {0};
     bool    new_thunder_req_client_connection_sent = false,
             another_thunder_req_client_connection_sent = false,
-            start_discovering_enabled = false,
             session_restart_required = false,
             p2p_group_instance_alive = false;
 
@@ -1067,7 +1066,7 @@ void MiracastController::Controller_Thread(void *args)
                                 m_notify_handler->onMiracastServiceClientConnectionError( mac_address , device_name , error_code );
                             }
                             MIRACASTLOG_INFO("!!! Restarting Session !!!");
-                            restart_session(start_discovering_enabled);
+                            restart_session(m_start_discovering_enabled);
                             session_restart_required = false;
                         }
                     }
@@ -1140,14 +1139,14 @@ void MiracastController::Controller_Thread(void *args)
                         MIRACASTLOG_INFO("CONTROLLER_START_DISCOVERING Received\n");
                         set_WFDParameters();
                         discover_devices();
-                        start_discovering_enabled = true;
+                        m_start_discovering_enabled = true;
                     }
                     break;
                     case CONTROLLER_STOP_DISCOVERING:
                     {
                         MIRACASTLOG_INFO("CONTROLLER_STOP_DISCOVERING Received\n");
                         stop_session(true);
-                        start_discovering_enabled = false;
+                        m_start_discovering_enabled = false;
                     }
                     break;
                     case CONTROLLER_RESTART_DISCOVERING:
@@ -1163,7 +1162,7 @@ void MiracastController::Controller_Thread(void *args)
                             reset_NewSourceName();
                             MIRACASTLOG_INFO("[%s] Cached Device info removed...",cached_mac_address.c_str());
                         }
-                        restart_session(start_discovering_enabled);
+                        restart_session(m_start_discovering_enabled);
                         new_thunder_req_client_connection_sent = false;
                         another_thunder_req_client_connection_sent = false;
                         session_restart_required = true;
@@ -1244,7 +1243,7 @@ void MiracastController::Controller_Thread(void *args)
                     {
                         MIRACASTLOG_INFO("TEARDOWN request sent to RTSP handler\n");
                         //stop_streaming(CONTROLLER_TEARDOWN_REQ_FROM_THUNDER);
-                        restart_session(start_discovering_enabled);
+                        restart_session(m_start_discovering_enabled);
                     }
                     break;
                     default:
@@ -1557,16 +1556,22 @@ void MiracastController::send_thundermsg_to_controller_thread(MIRACAST_SERVICE_S
 
 void MiracastController::set_enable(bool is_enabled)
 {
-    MIRACAST_SERVICE_STATES state = MIRACAST_SERVICE_WFD_STOP;
-
     MIRACASTLOG_TRACE("Entering...");
 
     if ( true == is_enabled)
     {
-        state = MIRACAST_SERVICE_WFD_START;
+        MIRACASTLOG_INFO("MIRACAST_SERVICE_WFD_START Received");
+        set_WFDParameters();
+        discover_devices();
+        m_start_discovering_enabled = true;
     }
-
-    send_thundermsg_to_controller_thread(state);
+    else
+    {
+        MIRACASTLOG_INFO("MIRACAST_SERVICE_WFD_STOP Received");
+        stop_session(true);
+        m_start_discovering_enabled = false;
+    }
+    //send_thundermsg_to_controller_thread(state);
     MIRACASTLOG_TRACE("Exiting...");
 }
 

--- a/Miracast/MiracastService/MiracastService.cpp
+++ b/Miracast/MiracastService/MiracastService.cpp
@@ -47,7 +47,7 @@ using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 4
+#define API_VERSION_NUMBER_PATCH 5
 
 #define SERVER_DETAILS "127.0.0.1:9998"
 #define SYSTEM_CALLSIGN "org.rdk.System"

--- a/Miracast/MiracastService/MiracastService.cpp
+++ b/Miracast/MiracastService/MiracastService.cpp
@@ -298,7 +298,11 @@ namespace WPEFramework
 				}
 				else
 				{
-					if (m_isServiceEnabled)
+					if ( MIRACAST_SERVICE_STATE_PLAYER_LAUNCHED == m_eService_state )
+					{
+						response["message"] = "Failed as MiracastPlayer already Launched";
+					}
+					else if (m_isServiceEnabled)
 					{
 						m_miracast_ctrler_obj->set_enable(is_enabled);
 						success = true;

--- a/Miracast/P2P/MiracastP2P.cpp
+++ b/Miracast/P2P/MiracastP2P.cpp
@@ -457,7 +457,7 @@ void MiracastP2P::reset_WFDParameters(void)
 MiracastError MiracastP2P::discover_devices(void)
 {
     MiracastError ret = MIRACAST_FAIL;
-    std::string command, retBuffer,opt_flag_buffer;
+    std::string command, retBuffer;
     MIRACASTLOG_TRACE("Entering..");
 
     /*Start Passive Scanning*/
@@ -478,12 +478,28 @@ MiracastError MiracastP2P::stop_discover_devices(void)
     std::string command, retBuffer;
     MIRACASTLOG_TRACE("Entering...");
 
+    std::string opt_flag_buffer = MiracastCommon::parse_opt_flag( "/opt/miracast_custom_stop_discovery" , true );
+
     /*Stop Passive Scanning*/
-    command = "P2P_EXT_LISTEN 0 0";
+    if (opt_flag_buffer.empty())
+    {
+        command = "P2P_STOP_FIND";
+    }
+    else
+    {
+        command = "P2P_EXT_LISTEN 0 0";
+    }
+
     ret = executeCommand(command, NON_GLOBAL_INTERFACE, retBuffer);
     if (ret != MIRACAST_OK)
     {
         MIRACASTLOG_ERROR("Failed to Stop discovering devices");
+    }
+
+    if (!opt_flag_buffer.empty())
+    {
+        usleep(std::stoul(opt_flag_buffer));
+        MIRACASTLOG_INFO("micro sleep[%s]",opt_flag_buffer);
     }
     MIRACASTLOG_TRACE("Exiting...");
     return ret;

--- a/Miracast/P2P/MiracastP2P.cpp
+++ b/Miracast/P2P/MiracastP2P.cpp
@@ -478,17 +478,8 @@ MiracastError MiracastP2P::stop_discover_devices(void)
     std::string command, retBuffer;
     MIRACASTLOG_TRACE("Entering...");
 
-    std::string opt_flag_buffer = MiracastCommon::parse_opt_flag( "/opt/miracast_custom_stop_discovery" , true );
-
     /*Stop Passive Scanning*/
-    if (opt_flag_buffer.empty())
-    {
-        command = "P2P_STOP_FIND";
-    }
-    else
-    {
-        command = "P2P_EXT_LISTEN 0 0";
-    }
+    command = "P2P_STOP_FIND";
 
     ret = executeCommand(command, NON_GLOBAL_INTERFACE, retBuffer);
     if (ret != MIRACAST_OK)
@@ -496,11 +487,6 @@ MiracastError MiracastP2P::stop_discover_devices(void)
         MIRACASTLOG_ERROR("Failed to Stop discovering devices");
     }
 
-    if (!opt_flag_buffer.empty())
-    {
-        usleep(std::stoul(opt_flag_buffer));
-        MIRACASTLOG_INFO("micro sleep[%s]",opt_flag_buffer);
-    }
     MIRACASTLOG_TRACE("Exiting...");
     return ret;
 }

--- a/Miracast/P2P/MiracastP2P.cpp
+++ b/Miracast/P2P/MiracastP2P.cpp
@@ -422,7 +422,7 @@ MiracastError MiracastP2P::set_WFDParameters(void)
         {
             command = "SET config_methods pbc";
         }
-	executeCommand(command, NON_GLOBAL_INTERFACE, retBuffer);
+        executeCommand(command, NON_GLOBAL_INTERFACE, retBuffer);
 
         set_FriendlyName(get_FriendlyName() , true);
         /* Set Device type */
@@ -479,8 +479,14 @@ MiracastError MiracastP2P::stop_discover_devices(void)
     MIRACASTLOG_TRACE("Entering...");
 
     /*Stop Passive Scanning*/
-    command = "P2P_STOP_FIND";
+    command = "P2P_EXT_LISTEN 0 0";
+    ret = executeCommand(command, NON_GLOBAL_INTERFACE, retBuffer);
+    if (ret != MIRACAST_OK)
+    {
+        MIRACASTLOG_ERROR("Failed to stop discovering devices");
+    }
 
+    command = "P2P_STOP_FIND";
     ret = executeCommand(command, NON_GLOBAL_INTERFACE, retBuffer);
     if (ret != MIRACAST_OK)
     {

--- a/Miracast/include/MiracastController.h
+++ b/Miracast/include/MiracastController.h
@@ -137,6 +137,7 @@ private:
     GroupInfo *m_groupInfo;
     bool m_connectionStatus;
     bool m_p2p_backend_discovery{false};
+    bool m_start_discovering_enabled{false};
     std::string  m_current_device_name;
     std::string  m_current_device_mac_addr;
 


### PR DESCRIPTION
[RDK-48709](https://ccp.sys.comcast.net/browse/RDK-48709): Synchronize the MiracastService discovery

Reason for change: Synchronizing the enable/disbable the MiracastService discovery.
Test Procedure: Miracast functionality.

Priority: P1
Risks: Medium

Change-Id: Iab943e8f5f84d816ce252370bed3d47ea2f94a0c
Signed-off-by: yuvaramachandran_gurusamy <yuvaramachandran_gurusamy@comcast.com>