### PR TITLE
RDKDEV-1021: Adding helpers for Realtek builds in DeviceIdentification

### DIFF
--- a/DeviceIdentification/CMakeLists.txt
+++ b/DeviceIdentification/CMakeLists.txt
@@ -101,6 +101,7 @@ elseif (BUILD_REALTEK)
     target_sources(${MODULE_NAME}
         PRIVATE
             Implementation/Realtek/Realtek.cpp)
+    target_include_directories(${MODULE_NAME} PRIVATE ../helpers)
 elseif(UNIX AND NOT APPLE)
     target_sources(${MODULE_NAME}
         PRIVATE


### PR DESCRIPTION
Reason for change: Adding helpers for Realtek builds in DeviceIdentification

Test Procedure: Build and verify

Risks: Low

Signed-off-by: Ligin Abraham Punoose <ligin_punoose@comcast.com>