### PR TITLE
RDKDEV-1022: Support to play previous music in Bluetooth plugin

### DIFF
--- a/Bluetooth/Bluetooth.cpp
+++ b/Bluetooth/Bluetooth.cpp
@@ -676,7 +676,7 @@ namespace WPEFramework
             else if (audioCtrlCmd == CMD_AUDIO_CTRL_SKIP_NEXT) {
                 rc = BTRMGR_MediaControl (0, deviceHandle, BTRMGR_MEDIA_CTRL_NEXT);
             }
-            else if (audioCtrlCmd == CMD_AUDIO_CTRL_SKIP_PREV) {
+            else if (0 == audioCtrlCmd.compare(0, CMD_AUDIO_CTRL_SKIP_PREV.length(), CMD_AUDIO_CTRL_SKIP_PREV)) {
                 rc = BTRMGR_MediaControl (0, deviceHandle, BTRMGR_MEDIA_CTRL_PREVIOUS);
             } //TODO
             else if (audioCtrlCmd == CMD_AUDIO_CTRL_RESTART) {


### PR DESCRIPTION
Reason for change: PREVIOUS audio command passed to rdkservices is SKIP_PREVIOUS, but only SKIP_PREV is supported

Test Procedure:
 - Test URL: https://apps.rdkcentral.com/rdk-apps/BluetoothAudio/index.html

Risks: Low

Signed-off-by: shijianjun <shijianjun@skyworth.com>