### PR TITLE
RDKDEV-988 - Upstream PlayerInfo dolby audio mode changes

### DIFF
--- a/PlayerInfo/DeviceSettings/PlatformImplementation.cpp
+++ b/PlayerInfo/DeviceSettings/PlatformImplementation.cpp
@@ -269,6 +269,8 @@ public:
             else if(amode == device::AudioStereoMode::kStereo) mode = STEREO;
             else if(amode == device::AudioStereoMode::kMono) mode = MONO;
             else if(amode == device::AudioStereoMode::kPassThru) mode = PASSTHRU;
+           else if(amode == device::AudioStereoMode::kDD) mode = DOLBYDIGITAL;
+           else if(amode == device::AudioStereoMode::kDDPlus) mode = DOLBYDIGITALPLUS;
             else mode = UNKNOWN;
             PlayerInfoImplementation::_instance->audiomodeChanged(mode, true);
         }


### PR DESCRIPTION
Reason for change: Added missing audio modes for dolby_audiomodechanged event in PlayerInfo plugin.
otherwise 'client.events.1.dolby_audiomodechanged' event will return with unknown for DOLBYDIGITAL and DOLBYDIGITALPLUS audio modes.

Risks: Low

Test Procedure:
TDK PlayerInfo test cases: Check_Dolby_AudioMode_Changed_Event