### PR TITLE
RDKDEV-987 - Upstream PlayerInfo Resolution 2160P60 Changes

### DIFF
--- a/PlayerInfo/DeviceSettings/PlatformImplementation.cpp
+++ b/PlayerInfo/DeviceSettings/PlatformImplementation.cpp
@@ -522,7 +522,7 @@ private:
         {"2160p25", RESOLUTION_2160P25},
         {"2160p50", RESOLUTION_2160P50},
         {"2160p30", RESOLUTION_2160P30},
-        {"2160p60", RESOLUTION_2160P60},
+        {"2160p60", RESOLUTION_2160P},
         {"2160p", RESOLUTION_2160P}
     };
     std::list<Exchange::Dolby::IOutput::INotification*> _observers;


### PR DESCRIPTION
Reason for change: After setting resolution 2160P60, while fetching for PlayerInfo.resolution its returning 2160P60 instead of 2160P. As this is generic change, need to upstream the AMLS905X4-763_2160p-PlayerInfo_Resolution.patch file.

Risks: Low

Test Procedure:
TDK PlayerInfo test cases: SetAndGet_All_Supported_Resolutions