### PR TITLE
RDKDEV-990 - Upstream onApplicationFocusChanged event change handling

### DIFF
--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -61,6 +61,7 @@ const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_MOVE_TO_FRONT = "mo
 const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_MOVE_TO_BACK = "moveToBack";
 const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_MOVE_BEHIND = "moveBehind";
 const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_SET_FOCUS = "setFocus";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_GET_FOCUSED = "getFocused";
 const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_KILL = "kill";
 const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_ADD_KEY_INTERCEPT = "addKeyIntercept";
 const string WPEFramework::Plugin::RDKShell::RDKSHELL_METHOD_ADD_KEY_INTERCEPTS = "addKeyIntercepts";
@@ -156,6 +157,7 @@ const string WPEFramework::Plugin::RDKShell::RDKSHELL_EVENT_ON_APP_FIRST_FRAME =
 const string WPEFramework::Plugin::RDKShell::RDKSHELL_EVENT_ON_APP_SUSPENDED = "onApplicationSuspended";
 const string WPEFramework::Plugin::RDKShell::RDKSHELL_EVENT_ON_APP_RESUMED = "onApplicationResumed";
 const string WPEFramework::Plugin::RDKShell::RDKSHELL_EVENT_ON_APP_ACTIVATED = "onApplicationActivated";
+const string WPEFramework::Plugin::RDKShell::RDKSHELL_EVENT_ON_APP_FOCUSCHANGED = "onApplicationFocusChanged";
 const string WPEFramework::Plugin::RDKShell::RDKSHELL_EVENT_ON_LAUNCHED = "onLaunched";
 const string WPEFramework::Plugin::RDKShell::RDKSHELL_EVENT_ON_SUSPENDED = "onSuspended";
 const string WPEFramework::Plugin::RDKShell::RDKSHELL_EVENT_ON_DESTROYED = "onDestroyed";
@@ -1510,6 +1512,7 @@ namespace WPEFramework {
             Register(RDKSHELL_METHOD_MOVE_TO_BACK, &RDKShell::moveToBackWrapper, this);
             Register(RDKSHELL_METHOD_MOVE_BEHIND, &RDKShell::moveBehindWrapper, this);
             Register(RDKSHELL_METHOD_SET_FOCUS, &RDKShell::setFocusWrapper, this);
+	    Register(RDKSHELL_METHOD_GET_FOCUSED, &RDKShell::getFocusedWrapper, this);
             Register(RDKSHELL_METHOD_KILL, &RDKShell::killWrapper, this);
             Register(RDKSHELL_METHOD_ADD_KEY_INTERCEPT, &RDKShell::addKeyInterceptWrapper, this);
             Register(RDKSHELL_METHOD_ADD_KEY_INTERCEPTS, &RDKShell::addKeyInterceptsWrapper, this);
@@ -2260,7 +2263,15 @@ namespace WPEFramework {
             mShell.notify(RDKSHELL_EVENT_ON_APP_ACTIVATED, params);
         }
 
-        void RDKShell::RdkShellListener::onUserInactive(const double minutes)
+	void RDKShell::RdkShellListener::onApplicationFocusChanged(const std::string& client)
+	{
+		std::cout << "RDKShell onApplicationFocused event received for " << client << std::endl;
+		JsonObject params;
+		params["client"] = client;
+		mShell.notify(RDKSHELL_EVENT_ON_APP_FOCUSCHANGED, params);
+	}
+
+	void RDKShell::RdkShellListener::onUserInactive(const double minutes)
         {
           std::cout << "RDKShell onUserInactive event received ..." << minutes << std::endl;
           JsonObject params;
@@ -2636,6 +2647,21 @@ namespace WPEFramework {
             }
             returnResponse(result);
         }
+
+	uint32_t RDKShell::getFocusedWrapper(const JsonObject& parameters, JsonObject& response)
+	{
+		LOGINFOMETHOD();
+		bool result = true;
+		string client = "";
+		result = getFocused(client);
+		if (result & !client.empty()) {
+			response["message"] = "success to get focused app";
+			response["client"] = client;
+		} else {
+			response["message"] = "success to get focused app";
+		}
+		returnResponse(result);
+	}
 
         uint32_t RDKShell::killWrapper(const JsonObject& parameters, JsonObject& response)
         {
@@ -6859,6 +6885,15 @@ namespace WPEFramework {
             }
             return ret;
         }
+
+	bool RDKShell::getFocused(string& client)
+	{
+		bool ret = false;
+		gRdkShellMutex.lock();
+		ret = CompositorController::getFocused(client);
+		gRdkShellMutex.unlock();
+		return ret;
+	}
 
         bool RDKShell::kill(const string& client)
         {

--- a/RDKShell/RDKShell.h
+++ b/RDKShell/RDKShell.h
@@ -64,6 +64,7 @@ namespace WPEFramework {
             static const string RDKSHELL_METHOD_MOVE_TO_BACK;
             static const string RDKSHELL_METHOD_MOVE_BEHIND;
             static const string RDKSHELL_METHOD_SET_FOCUS;
+	    static const string RDKSHELL_METHOD_GET_FOCUSED;
             static const string RDKSHELL_METHOD_KILL;
             static const string RDKSHELL_METHOD_ADD_KEY_INTERCEPT;
             static const string RDKSHELL_METHOD_ADD_KEY_INTERCEPTS;
@@ -160,6 +161,7 @@ namespace WPEFramework {
             static const string RDKSHELL_EVENT_ON_APP_SUSPENDED;
             static const string RDKSHELL_EVENT_ON_APP_RESUMED;
             static const string RDKSHELL_EVENT_ON_APP_ACTIVATED;
+	    static const string RDKSHELL_EVENT_ON_APP_FOCUSCHANGED;
             static const string RDKSHELL_EVENT_ON_LAUNCHED;
             static const string RDKSHELL_EVENT_ON_SUSPENDED;
             static const string RDKSHELL_EVENT_ON_DESTROYED;
@@ -187,6 +189,7 @@ namespace WPEFramework {
             uint32_t moveToBackWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t moveBehindWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t setFocusWrapper(const JsonObject& parameters, JsonObject& response);
+	    uint32_t getFocusedWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t killWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t addKeyInterceptWrapper(const JsonObject& parameters, JsonObject& response);
             uint32_t addKeyInterceptsWrapper(const JsonObject& parameters, JsonObject& response);
@@ -282,6 +285,7 @@ namespace WPEFramework {
             bool moveToBack(const string& client);
             bool moveBehind(const string& client, const string& target);
             bool setFocus(const string& client);
+	    bool getFocused(string& client);
             bool kill(const string& client);
             bool addKeyIntercept(const uint32_t& keyCode, const JsonArray& modifiers, const string& client);
             bool addKeyIntercepts(const JsonArray& intercepts);
@@ -379,6 +383,7 @@ namespace WPEFramework {
                 virtual void onApplicationSuspended(const std::string& client);
                 virtual void onApplicationResumed(const std::string& client);
                 virtual void onApplicationActivated(const std::string& client);
+		virtual void onApplicationFocusChanged(const std::string& client);
                 virtual void onUserInactive(const double minutes);
                 virtual void onDeviceLowRamWarning(const int32_t freeKb, const int32_t availableKb, const int32_t usedSwapKb);
                 virtual void onDeviceCriticallyLowRamWarning(const int32_t freeKb, const int32_t availableKb, const int32_t usedSwapKb);


### PR DESCRIPTION
Reason for change: onApplicationFocusChanged event handling not done , so added those changes for getFocus , getFocused and corresponding event handlings

Risks: Low

Test Procedure: Getting onApplicationFocusChanged events on in ResidentUI , switch to Youtube , back to main UI in all cases