### PR TITLE
BCM-751 : Upstream PlayerInfo-2160P-Resolution Change

### DIFF
--- a/PlayerInfo/DeviceSettings/PlatformImplementation.cpp
+++ b/PlayerInfo/DeviceSettings/PlatformImplementation.cpp
@@ -520,7 +520,7 @@ private:
         {"2160p25", RESOLUTION_2160P25},
         {"2160p50", RESOLUTION_2160P50},
         {"2160p30", RESOLUTION_2160P30},
-        {"2160p60", RESOLUTION_2160P60},
+        {"2160p60", RESOLUTION_2160P},
         {"2160p", RESOLUTION_2160P}
     };
     std::list<Exchange::Dolby::IOutput::INotification*> _observers;


### PR DESCRIPTION
PlayerInfo resolution returning 2160P60 instead of 2160P. changes the RESOLUTION_2160P60 to RESOLUTION_2160P in PlayerInfo on rdkservices returns expected value properly.