### PR TITLE
DELIA-62404: Ensure Detached threads are quit before deactivating plu…

### DIFF
--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -556,6 +556,7 @@ namespace WPEFramework {
 
         void SystemServices::Deinitialize(PluginHost::IShell*)
         {
+            m_operatingModeTimer.stop();
 #if defined(USE_IARMBUS) || defined(USE_IARM_BUS)
             DeinitializeIARM();
 #endif /* defined(USE_IARMBUS) || defined(USE_IARM_BUS) */

--- a/SystemServices/cTimer.cpp
+++ b/SystemServices/cTimer.cpp
@@ -39,6 +39,22 @@ cTimer::~cTimer()
 }
 
 /***
+Running this timer function as thread function
+*/
+void cTimer::timerFunction() {
+    while (true) {
+         if (this->clear) {
+            return;
+            }
+        std::this_thread::sleep_for(std::chrono::milliseconds(interval));
+         if (this->clear) {
+            return;
+            }
+
+        this->callBack_function();
+    }
+}
+/***
  * @brief : start timer thread.
  * @return   : <bool> False if timer thread couldn't be started.
  */
@@ -48,15 +64,7 @@ bool cTimer::start()
         return false;
     }
     this->clear = false;
-    std::thread timerThread([=]() {
-            while (true) {
-            if (this->clear) return;
-            std::this_thread::sleep_for(std::chrono::milliseconds(interval));
-            if (this->clear) return;
-            this->callBack_function();
-            }
-            });
-    timerThread.detach();
+    timerThread = std::thread(&cTimer::timerFunction, this);
     return true;
 }
 
@@ -67,6 +75,9 @@ bool cTimer::start()
 void cTimer::stop()
 {
     this->clear = true;
+    if (timerThread.joinable()) {
+        timerThread.join();
+    }
 }
 
 /***

--- a/SystemServices/cTimer.h
+++ b/SystemServices/cTimer.h
@@ -27,6 +27,8 @@ class cTimer{
         bool clear;
         int interval;
         void (*callBack_function)() = NULL;
+        std::thread timerThread;
+        void timerFunction();
     public:
         /***
          * @brief    : Constructor.


### PR DESCRIPTION
…gin to avoid crashes (System)

Reason for change: Detached threads are quit before deactivating plugin Test Procedure: Check no crashed is reported after call setmode api and deactivating Systemservices plugin Risks: Low
Priority: P1
Signed-off-by:AkshayKumar_Gampa <AkshayKumar_Gampa@comcast.com>