### PR TITLE
Fixes for RDKTV-30016 and RDKTV-29983

### DIFF
--- a/Miracast/MiracastService/MiracastController.cpp
+++ b/Miracast/MiracastService/MiracastController.cpp
@@ -1061,21 +1061,31 @@ void MiracastController::Controller_Thread(void *args)
                             if (!remote_address.empty())
                             {
                                 src_dev_ip = remote_address;
+                                sink_dev_ip = local_address;
                                 src_dev_mac = get_WFDSourceMACAddress();;
                                 src_dev_name = get_WFDSourceName();
-                                sink_dev_ip = local_address;
-                                MIRACASTLOG_INFO("#### MCAST-TRIAGE-OK-LAUNCH LAUNCH REQ FOR SRC_NAME[%s] SRC_MAC[%s] SRC_IP[%s] SINK_IP[%s] ####",
+
+                                if (!m_connect_req_notified && src_dev_mac.empty() && src_dev_name.empty())
+                                {
+                                    src_dev_mac = m_groupInfo->goDevAddr;
+                                    src_dev_name = get_device_name(src_dev_mac);
+                                    set_WFDSourceMACAddress(src_dev_mac);
+                                    set_WFDSourceName(src_dev_name);
+                                }
+                                MIRACASTLOG_INFO("#### MCAST-TRIAGE-OK-LAUNCH LAUNCH REQ FOR SRC_NAME[%s] SRC_MAC[%s] SRC_IP[%s] SINK_IP[%s] ConnectReq[%u]####",
                                                     src_dev_name.c_str(),
                                                     src_dev_mac.c_str(),
                                                     src_dev_ip.c_str(),
-                                                    sink_dev_ip.c_str());
+                                                    sink_dev_ip.c_str(),
+                                                    m_connect_req_notified);
                                 if (nullptr != m_notify_handler)
                                 {
-                                    m_notify_handler->onMiracastServiceLaunchRequest(src_dev_ip, src_dev_mac, src_dev_name, sink_dev_ip);
+                                    m_notify_handler->onMiracastServiceLaunchRequest(src_dev_ip, src_dev_mac, src_dev_name, sink_dev_ip, m_connect_req_notified );
                                 }
                                 checkAndInitiateP2PBackendDiscovery();
                                 session_restart_required = false;
                                 p2p_group_instance_alive = true;
+                                m_connect_req_notified = false;
                             }
                             else
                             {
@@ -1104,6 +1114,7 @@ void MiracastController::Controller_Thread(void *args)
                                                     controller_msgq_data.state );
                                 p2p_group_instance_alive = false;
                             }
+                            m_connect_req_notified = false;
                         }
 
                         if ( true == session_restart_required )
@@ -1151,17 +1162,17 @@ void MiracastController::Controller_Thread(void *args)
                     break;
                     case CONTROLLER_GO_STOP_FIND:
                     {
-                        MIRACASTLOG_TRACE("[CONTROLLER_GO_STOP_FIND] Received\n");
+                        MIRACASTLOG_TRACE("[CONTROLLER_GO_STOP_FIND] Received");
                     }
                     break;
                     case CONTROLLER_GO_NEG_SUCCESS:
                     {
-                        MIRACASTLOG_INFO("[CONTROLLER_GO_NEG_SUCCESS] Received\n");
+                        MIRACASTLOG_INFO("[CONTROLLER_GO_NEG_SUCCESS] Received");
                     }
                     break;
                     case CONTROLLER_GO_GROUP_FORMATION_SUCCESS:
                     {
-                        MIRACASTLOG_INFO("[CONTROLLER_GO_GROUP_FORMATION_SUCCESS] Received\n");
+                        MIRACASTLOG_INFO("[CONTROLLER_GO_GROUP_FORMATION_SUCCESS] Received");
                     }
                     break;
                     case CONTROLLER_GO_EVENT_ERROR:
@@ -1216,6 +1227,7 @@ void MiracastController::Controller_Thread(void *args)
                         another_thunder_req_client_connection_sent = false;
                         session_restart_required = true;
                         p2p_group_instance_alive = false;
+                        m_connect_req_notified = false;
                     }
                     break;
                     case CONTROLLER_START_STREAMING:
@@ -1748,6 +1760,7 @@ void MiracastController::notify_ConnectionRequest(std::string device_name,std::s
     MIRACASTLOG_INFO("#### MCAST-TRIAGE-OK-CONNECT-REQ DEVICE[%s - %s] CONNECT REQUEST RECEIVED ####",
                         m_current_device_name.c_str(), 
                         m_current_device_mac_addr.c_str());
+    m_connect_req_notified = true;
     if (nullptr != m_notify_handler)
     {
         m_notify_handler->onMiracastServiceClientConnectionRequest(device_mac, device_name);

--- a/Miracast/MiracastService/MiracastService.cpp
+++ b/Miracast/MiracastService/MiracastService.cpp
@@ -401,15 +401,36 @@ namespace WPEFramework
 			std::string requestedStatus = "";
 
 			MIRACASTLOG_INFO("Entering..!!!");
-
 			if (parameters.HasLabel("requestStatus"))
 			{
 				requestedStatus = parameters["requestStatus"].String();
 				if (("Accept" == requestedStatus) || ("Reject" == requestedStatus))
 				{
-					m_miracast_ctrler_obj->accept_client_connection(requestedStatus);
 					success = true;
-					m_eService_state = MIRACAST_SERVICE_STATE_CONNECTION_ACCEPTED;
+					if ( MIRACAST_SERVICE_STATE_DIRECT_LAUCH_REQUESTED == m_eService_state )
+					{
+						if ("Accept" == requestedStatus)
+						{
+							MIRACASTLOG_INFO("#### Notifying Launch Request ####");
+							onMiracastServiceLaunchRequest(m_src_dev_ip, m_src_dev_mac, m_src_dev_name, m_sink_dev_ip , true );
+							m_src_dev_ip.clear();
+							m_src_dev_mac.clear();
+							m_src_dev_name.clear();
+							m_sink_dev_ip.clear();
+						}
+						else
+						{
+							m_miracast_ctrler_obj->restart_session_discovery();
+							m_miracast_ctrler_obj->m_ePlayer_state = MIRACAST_PLAYER_STATE_IDLE;
+							m_eService_state = MIRACAST_SERVICE_STATE_DISCOVERABLE;
+							MIRACASTLOG_INFO("#### Refreshing the Session ####");
+						}
+					}
+					else
+					{
+						m_miracast_ctrler_obj->accept_client_connection(requestedStatus);
+						m_eService_state = MIRACAST_SERVICE_STATE_CONNECTION_ACCEPTED;
+					}
 				}
 				else
 				{
@@ -845,8 +866,8 @@ namespace WPEFramework
 				is_another_connect_request = true;
 				MIRACASTLOG_WARNING("Another Connect Request received while casting\n");
 			}
-
-			if (0 == access("/opt/miracast_autoconnect", F_OK))
+			if ((MIRACAST_SERVICE_STATE_DIRECT_LAUCH_REQUESTED != m_eService_state) &&
+				(0 == access("/opt/miracast_autoconnect", F_OK)))
 			{
 				std::string system_command = "";
 
@@ -995,11 +1016,21 @@ namespace WPEFramework
 			return timer_retry_state;
 		}
 
-		void MiracastService::onMiracastServiceLaunchRequest(string src_dev_ip, string src_dev_mac, string src_dev_name, string sink_dev_ip)
+		void MiracastService::onMiracastServiceLaunchRequest(string src_dev_ip, string src_dev_mac, string src_dev_name, string sink_dev_ip, bool is_connect_req_reported )
 		{
-			MIRACASTLOG_INFO("Entering..!!!");
+			MIRACASTLOG_INFO("Entering[%u]..!!!",is_connect_req_reported);
 
-			if ( MIRACAST_SERVICE_STATE_APP_REQ_TO_ABORT_CONNECTION == m_eService_state )
+			if ( !is_connect_req_reported )
+			{
+				m_eService_state = MIRACAST_SERVICE_STATE_DIRECT_LAUCH_REQUESTED;
+				m_src_dev_ip = src_dev_ip;
+				m_src_dev_mac = src_dev_mac;
+				m_src_dev_name = src_dev_name;
+				m_sink_dev_ip = sink_dev_ip;
+				MIRACASTLOG_INFO("Direct Launch request has received. So need to notify connect Request");
+				onMiracastServiceClientConnectionRequest( src_dev_mac, src_dev_name );
+			}
+			else if ( MIRACAST_SERVICE_STATE_APP_REQ_TO_ABORT_CONNECTION == m_eService_state )
 			{
 				MIRACASTLOG_INFO("APP_REQ_TO_ABORT_CONNECTION has requested. So no need to notify Launch Request..!!!");
 				//m_miracast_ctrler_obj->restart_session_discovery();

--- a/Miracast/MiracastService/MiracastService.h
+++ b/Miracast/MiracastService/MiracastService.h
@@ -74,7 +74,7 @@ namespace WPEFramework
 
             virtual void onMiracastServiceClientConnectionRequest(string client_mac, string client_name) override;
             virtual void onMiracastServiceClientConnectionError(string client_mac, string client_name , eMIRACAST_SERVICE_ERR_CODE error_code ) override;
-            virtual void onMiracastServiceLaunchRequest(string src_dev_ip, string src_dev_mac, string src_dev_name, string sink_dev_ip) override;
+            virtual void onMiracastServiceLaunchRequest(string src_dev_ip, string src_dev_mac, string src_dev_name, string sink_dev_ip, bool is_connect_req_reported ) override;
 
             BEGIN_INTERFACE_MAP(MiracastService)
             INTERFACE_ENTRY(PluginHost::IPlugin)
@@ -90,6 +90,10 @@ namespace WPEFramework
             bool m_isServiceEnabled;
             guint m_FriendlyNameMonitorTimerID{0};
             eMIRA_SERVICE_STATES m_eService_state;
+            std::string m_src_dev_ip;
+            std::string m_src_dev_mac;
+            std::string m_src_dev_name;
+            std::string m_sink_dev_ip;
             WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement> *m_SystemPluginObj = NULL;
             uint32_t setEnable(const JsonObject &parameters, JsonObject &response);
             uint32_t getEnable(const JsonObject &parameters, JsonObject &response);

--- a/Miracast/P2P/MiracastP2P.cpp
+++ b/Miracast/P2P/MiracastP2P.cpp
@@ -437,8 +437,8 @@ MiracastError MiracastP2P::set_WFDParameters(void)
         command = "SET p2p_ssid_postfix -Element-Xumo-TV";
         executeCommand(command, NON_GLOBAL_INTERFACE, retBuffer);
 
-        /* Set p2p_go_intent to 15 */
-        command = "SET p2p_go_intent 15";
+        /* Set p2p_go_intent to 14 */
+        command = "SET p2p_go_intent 14";
         executeCommand(command, NON_GLOBAL_INTERFACE, retBuffer);
 
         m_isWiFiDisplayParamsEnabled = true;

--- a/Miracast/RTSP/MiracastRtspMsg.cpp
+++ b/Miracast/RTSP/MiracastRtspMsg.cpp
@@ -1024,6 +1024,13 @@ MiracastError MiracastRTSPMsg::initiate_TCP(std::string goIP)
             MIRACASTLOG_ERROR("TCP Socket creation error %s", strerror(errno));
             continue;
         }
+        // Set SO_REUSEADDR option
+        int optval = 1;
+        if (setsockopt(m_tcpSockfd, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval)) == -1)
+        {
+            MIRACASTLOG_ERROR("Failed to set SO_REUSEADDR: %s", strerror(errno));
+            continue;
+        }
     #if 0
         /* Bind socket */
         if (bind(m_tcpSockfd, (struct sockaddr *)&addr, sizeof(addr)) < 0)

--- a/Miracast/include/MiracastCommon.h
+++ b/Miracast/include/MiracastCommon.h
@@ -160,7 +160,8 @@ typedef enum emira_service_states_e
     MIRACAST_SERVICE_STATE_CONNECTION_ACCEPTED,
     MIRACAST_SERVICE_STATE_CONNECTION_ERROR,
     MIRACAST_SERVICE_STATE_PLAYER_LAUNCHED,
-    MIRACAST_SERVICE_STATE_APP_REQ_TO_ABORT_CONNECTION
+    MIRACAST_SERVICE_STATE_APP_REQ_TO_ABORT_CONNECTION,
+    MIRACAST_SERVICE_STATE_DIRECT_LAUCH_REQUESTED
 } eMIRA_SERVICE_STATES;
 
 typedef enum miracast_player_states_e
@@ -338,7 +339,7 @@ class MiracastServiceNotifier
 public:
     virtual void onMiracastServiceClientConnectionRequest(string client_mac, string client_name) = 0;
     virtual void onMiracastServiceClientConnectionError(string client_mac, string client_name , eMIRACAST_SERVICE_ERR_CODE error_code ) = 0;
-    virtual void onMiracastServiceLaunchRequest(string src_dev_ip, string src_dev_mac, string src_dev_name, string sink_dev_ip) = 0;
+    virtual void onMiracastServiceLaunchRequest(string src_dev_ip, string src_dev_mac, string src_dev_name, string sink_dev_ip, bool is_connect_req_reported ) = 0;
 };
 
 /**

--- a/Miracast/include/MiracastController.h
+++ b/Miracast/include/MiracastController.h
@@ -142,6 +142,7 @@ private:
     bool m_connectionStatus;
     bool m_p2p_backend_discovery{false};
     bool m_start_discovering_enabled{false};
+    bool m_connect_req_notified{false};
     std::string  m_current_device_name;
     std::string  m_current_device_mac_addr;
 

--- a/Miracast/include/MiracastController.h
+++ b/Miracast/include/MiracastController.h
@@ -32,6 +32,8 @@
 #include <arpa/inet.h>
 #include <sys/epoll.h>
 #include <fstream>
+#include <ifaddrs.h>
+#include <netdb.h>
 #include <MiracastCommon.h>
 #include "MiracastP2P.h"
 #include "MiracastLogger.h"
@@ -41,6 +43,7 @@ using namespace std;
 using namespace MIRACAST;
 
 #define THUNDER_REQ_THREAD_CLIENT_CONNECTION_WAITTIME (30)
+#define MAX_IFACE_NAME_LEN 16
 
 class MiracastController
 {
@@ -124,6 +127,7 @@ private:
     MiracastError create_ControllerFramework(std::string p2p_ctrl_iface);
     MiracastError destroy_ControllerFramework(void);
     void checkAndInitiateP2PBackendDiscovery(void);
+    std::string getifNameByIPv4(std::string ip_address);
 
     void set_localIp(std::string ipAddr);
 


### PR DESCRIPTION
RDKTV-30016 - [miracast] Connection fails with "ENT-32203/ENT-32102/ENT-32103" after Thunder restart
RDKTV-29983 - [Element-X3] ENT-32102 Error observed when trying to connect through Miracast using Redmi Device