### PR TITLE
ES1-1055 : Increase spawn process timeout

### DIFF
--- a/PersistentStore/PersistentStore.cpp
+++ b/PersistentStore/PersistentStore.cpp
@@ -93,7 +93,7 @@ namespace Plugin {
 
         uint32_t connectionId;
 
-        _deviceStore2 = service->Root<Exchange::IStore2>(connectionId, 2000, _T("SqliteStore2"));
+        _deviceStore2 = service->Root<Exchange::IStore2>(connectionId, RPC::CommunicationTimeOut, _T("SqliteStore2"));
         if (_deviceStore2 != nullptr) {
             _deviceStore2->Register(&_store2Sink);
             _deviceStore2->Register(_store);
@@ -102,7 +102,7 @@ namespace Plugin {
             _deviceStoreLimit = _deviceStore2->QueryInterface<Exchange::IStoreLimit>();
         }
 
-        _accountStore2 = service->Root<Exchange::IStore2>(connectionId, 2000, _T("GrpcStore2"));
+        _accountStore2 = service->Root<Exchange::IStore2>(connectionId, RPC::CommunicationTimeOut, _T("GrpcStore2"));
         if (_accountStore2 != nullptr) {
             _accountStore2->Register(&_store2Sink);
         }

--- a/PersistentStore/l0test/ServiceMock.h
+++ b/PersistentStore/l0test/ServiceMock.h
@@ -23,6 +23,7 @@ public:
     MOCK_METHOD(WPEFramework::PluginHost::ISubSystem*, SubSystems, (), (override));
     MOCK_METHOD(uint32_t, Submit, (const uint32_t, const WPEFramework::Core::ProxyType<WPEFramework::Core::JSON::IElement>&), (override));
     MOCK_METHOD(void, Notify, (const string&), (override));
+    MOCK_METHOD(void, Notify, (const string&, const string&), (override));
     MOCK_METHOD(void*, QueryInterfaceByCallsign, (const uint32_t, const string&), (override));
     MOCK_METHOD(void, Register, (WPEFramework::PluginHost::IPlugin::INotification*), (override));
     MOCK_METHOD(void, Unregister, (WPEFramework::PluginHost::IPlugin::INotification*), (override));

--- a/PersistentStore/l1test/ServiceMock.h
+++ b/PersistentStore/l1test/ServiceMock.h
@@ -23,6 +23,7 @@ public:
     MOCK_METHOD(WPEFramework::PluginHost::ISubSystem*, SubSystems, (), (override));
     MOCK_METHOD(uint32_t, Submit, (const uint32_t, const WPEFramework::Core::ProxyType<WPEFramework::Core::JSON::IElement>&), (override));
     MOCK_METHOD(void, Notify, (const string&), (override));
+    MOCK_METHOD(void, Notify, (const string&, const string&), (override));
     MOCK_METHOD(void*, QueryInterfaceByCallsign, (const uint32_t, const string&), (override));
     MOCK_METHOD(void, Register, (WPEFramework::PluginHost::IPlugin::INotification*), (override));
     MOCK_METHOD(void, Unregister, (WPEFramework::PluginHost::IPlugin::INotification*), (override));


### PR DESCRIPTION
Reason for change: Increase timeout from 2s to
RPC::CommunicationTimeOut (3s default, 20s in RDK).
Test Procedure: None
Risks: None
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>