### PR TITLE
RDKCOM-4611 RDKDEV-985 - Upstream dobby amazon container changes

### DIFF
--- a/RDKShell/CHANGELOG.md
+++ b/RDKShell/CHANGELOG.md
@@ -15,6 +15,11 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+
+## [1.4.17] - 2024-04-13
+### Added
+- Added Upstream dobby amazon container changes
+
 ## [1.4.16] - 2024-03-13
 ### Addded
 - Added long key press support

--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -53,7 +53,7 @@
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 4
-#define API_VERSION_NUMBER_PATCH 16
+#define API_VERSION_NUMBER_PATCH 17
 
 const string WPEFramework::Plugin::RDKShell::SERVICE_NAME = "org.rdk.RDKShell";
 //methods
@@ -4210,6 +4210,36 @@ namespace WPEFramework {
                     std::cout << "rfc is disabled and unable to check for cobalt container mode " << std::endl;
 #endif
                 }
+
+		if (!type.empty() && type == "Amazon")
+		{
+#ifdef RFC_ENABLED
+                    RFC_ParamData_t param;
+                    if (Utils::getRFCConfig("Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.Dobby.Amazon.Enable", param))
+		    {
+			JsonObject root;
+			if (strncasecmp(param.value, "true", 4) == 0)
+	                {
+			    std::cout << "dobby rfc true - launching amazon in container mode " << std::endl;
+			    root = configSet["root"].Object();
+			    root["mode"] = JsonValue("Container");
+			}
+			else
+		        {
+		            std::cout << "dobby rfc false - launching amazon in local mode " << std::endl;
+                            root = configSet["root"].Object();
+			     root["mode"] = JsonValue("Local");
+			}
+			configSet["root"] = root;
+		     }
+		     else
+	             {
+			 std::cout << "reading amazon dobby rfc failed " << std::endl;
+	             }
+#else
+		     std::cout << "rfc is disabled and unable to check for amazon container mode " << std::endl;
+#endif
+		}
 
                 // One RFC controls all WPE-based apps
                 if (!type.empty() && (type == "HtmlApp" || type == "LightningApp"))


### PR DESCRIPTION
RDKCOM-4611 RDKDEV-985 - Upstream dobby amazon container changes

Reason for change: Upstream Rdkshell-Amazon-Container.patch patch changes into github , as dobby support has available on AML and RTK upstreaming the changes instead of keeping as a patch

Risks: Low

Test Procedure: Amazon launched in container mode

Signed-off-by: Dhivya Priya M <dhivyapriya_murugesan@comcast.com>
(cherry picked from commit b5d2f4c54313912d7b781d9ac4f743ca0e65c69f)