### PR TITLE
RDKTV-29977: GetConnectedDevice and getPairedDevices should both retu…

### DIFF
--- a/Bluetooth/Bluetooth.cpp
+++ b/Bluetooth/Bluetooth.cpp
@@ -40,7 +40,7 @@
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 9
+#define API_VERSION_NUMBER_PATCH 10
 
 const string WPEFramework::Plugin::Bluetooth::SERVICE_NAME = "org.rdk.Bluetooth";
 const string WPEFramework::Plugin::Bluetooth::METHOD_START_SCAN = "startScan";
@@ -438,6 +438,9 @@ namespace WPEFramework
                     deviceDetails["name"] = string(pairedDevices->m_deviceProperty[i].m_name);
                     deviceDetails["deviceType"] = string(BTRMGR_GetDeviceTypeAsString(pairedDevices->m_deviceProperty[i].m_deviceType));
                     deviceDetails["connected"] = pairedDevices->m_deviceProperty[i].m_isConnected?true:false;
+                    deviceDetails["rawDeviceType"] = std::to_string(pairedDevices->m_deviceProperty[i].m_ui32DevClassBtSpec);
+                    deviceDetails["rawBleDeviceType"] = std::to_string(pairedDevices->m_deviceProperty[i].m_ui16DevAppearanceBleSpec);
+
                     deviceArray.Add(deviceDetails);
                 }
             }
@@ -472,6 +475,9 @@ namespace WPEFramework
                     deviceDetails["name"] = string(connectedDevices->m_deviceProperty[i].m_name);
                     deviceDetails["deviceType"] = string(BTRMGR_GetDeviceTypeAsString(connectedDevices->m_deviceProperty[i].m_deviceType));
                     deviceDetails["activeState"] = std::to_string(connectedDevices->m_deviceProperty[i].m_powerStatus);
+                    deviceDetails["rawDeviceType"] = std::to_string(connectedDevices->m_deviceProperty[i].m_ui32DevClassBtSpec);
+                    deviceDetails["rawBleDeviceType"] = std::to_string(connectedDevices->m_deviceProperty[i].m_ui16DevAppearanceBleSpec);
+
                     deviceArray.Add(deviceDetails);
                 }
             }
@@ -493,7 +499,10 @@ namespace WPEFramework
                     rc = BTRMGR_ConnectToDevice(0, deviceHandle, stream_pref);
                 }
             }
-            else if (Utils::String::equal(deviceType, "HUMAN INTERFACE DEVICE")) {
+            else if (Utils::String::equal(deviceType, "HUMAN INTERFACE DEVICE") ||
+                     Utils::String::contains(deviceType, "KEYBOARD") ||
+                     Utils::String::contains(deviceType, "MOUSE") ||
+                     Utils::String::contains(deviceType, "JOYSTICK")) {
                 if (Utils::String::equal(enable, "DISCONNECT")) {
                     rc = BTRMGR_DisconnectFromDevice(0, deviceHandle);
                 }

--- a/Bluetooth/Bluetooth.json
+++ b/Bluetooth/Bluetooth.json
@@ -395,13 +395,21 @@
                                 },
                                 "activeState":{
                                     "$ref": "#/definitions/activeState"
+                                },
+                                "rawDeviceType": {
+                                    "$ref": "#/definitions/rawDeviceType"
+                                },
+                                "rawBleDeviceType": {
+                                    "$ref": "#/definitions/rawBleDeviceType"
                                 }
                             },
                             "required": [
                                 "deviceID",
                                 "name",
                                 "deviceType",
-                                "activeState"
+                                "activeState",
+                                "rawDeviceType",
+                                "rawBleDeviceType"
                             ]
                         }
                     },
@@ -515,6 +523,12 @@
                                 },
                                 "paired":{
                                     "$ref": "#/definitions/paired"
+                                }, 
+                                "rawDeviceType": {
+                                    "$ref": "#/definitions/rawDeviceType"
+                                },
+                                "rawBleDeviceType": {
+                                    "$ref": "#/definitions/rawBleDeviceType"
                                 }
                             },
                             "required": [
@@ -522,7 +536,9 @@
                                 "name",
                                 "deviceType",
                                 "connected",
-                                "paired"
+                                "paired",
+                                "rawDeviceType",
+                                "rawBleDeviceType"
                             ]
                         }
                     },
@@ -580,13 +596,21 @@
                                     "summary": "Whether the device is connected",
                                     "type": "boolean",
                                     "example": "true"
+                                }, 
+                                "rawDeviceType": {
+                                    "$ref": "#/definitions/rawDeviceType"
+                                },
+                                "rawBleDeviceType": {
+                                    "$ref": "#/definitions/rawBleDeviceType"
                                 }
                             },
                             "required": [
                                 "deviceID",
                                 "name",
                                 "deviceType",
-                                "connected"
+                                "connected",
+                                "rawDeviceType",
+                                "rawBleDeviceType"
                             ]
                         }
                     },

--- a/Bluetooth/CHANGELOG.md
+++ b/Bluetooth/CHANGELOG.md
@@ -15,6 +15,11 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+## [1.0.10] - 2024-03-29
+### Added
+- Device class and appearance to all "get Devices" functions
+- Connect call when JOYSTICK specified should not start streaming out
+
 ## [1.0.9] - 2024-03-29
 ### Security
 - Resolved security vulnerabilities

--- a/Bluetooth/README.md
+++ b/Bluetooth/README.md
@@ -63,10 +63,10 @@ getDiscoveredDevices:
 {"jsonrpc":"2.0","id":3,"result":{"discoveredDevices":[{"deviceID":"61579454946360","name":"[TV] UE32J5530","deviceType":"TV","rawDeviceType": "2360344","rawBleDeviceType": "180","connected":false,"paired":false}],"success":true}}
 
 getPairedDevices:
-{"jsonrpc":"2.0","id":3,"result":{"pairedDevices":[{"deviceID":"256168644324480","name":"Eleven","deviceType":"SMARTPHONE","connected":true},{"deviceID":"26499258260618","name":"Little Big","deviceType":"SMARTPHONE","connected":false}],"success":true}}
+{"jsonrpc":"2.0","id":3,"result":{"pairedDevices":[{"deviceID":"256168644324480","name":"Eleven","deviceType":"SMARTPHONE","rawDeviceType": "2360344","rawBleDeviceType": "180","connected":true},{"deviceID":"26499258260618","name":"Little Big","deviceType":"SMARTPHONE","rawDeviceType": "2360344","rawBleDeviceType": "180,"connected":false}],"success":true}}
 
 getConnectedDevices:
-{"jsonrpc":"2.0","id":3,"result":{"connectedDevices":[{"deviceID":"256168644324480","name":"Eleven","deviceType":"SMARTPHONE","activeState":"0"}],"success":true}}
+{"jsonrpc":"2.0","id":3,"result":{"connectedDevices":[{"deviceID":"256168644324480","name":"Eleven","deviceType":"SMARTPHONE","rawDeviceType": "2360344","rawBleDeviceType": "180,"activeState":"0""}],"success":true}}
 
 pair:
 {"jsonrpc":"2.0","id":3,"result":{"success":true}}

--- a/docs/api/BluetoothPlugin.md
+++ b/docs/api/BluetoothPlugin.md
@@ -2,7 +2,7 @@
 <a name="Bluetooth_Plugin"></a>
 # Bluetooth Plugin
 
-**Version: [1.0.9](https://github.com/rdkcentral/rdkservices/blob/main/Bluetooth/CHANGELOG.md)**
+**Version: [1.0.10](https://github.com/rdkcentral/rdkservices/blob/main/Bluetooth/CHANGELOG.md)**
 
 A org.rdk.Bluetooth plugin for Thunder framework.
 


### PR DESCRIPTION
…rn device class and appearance for rdkservices

Reason for change: Add device class and appearance to getPairedDevices, getConnectedDevices, and getDiscoveredDevices
Test Procedure: A valid device class and appearance should appear in the return to getPairedDevices, getConnectedDevices, and getDiscoveredDevices
Risks: Low
Signed-off-by: Jack O'Gorman <jack.ogorman@sky.uk>