### PR TITLE
RDKDEV-1034 Make rdkservices plugin(SystemServices) autostart configurable from recipe

### DIFF
--- a/SystemServices/CMakeLists.txt
+++ b/SystemServices/CMakeLists.txt
@@ -18,6 +18,7 @@
 set(PLUGIN_NAME SystemServices)
 set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
 
+set(PLUGIN_SYSTEM_AUTOSTART false CACHE STRING "To automatically start System plugin.")
 set(PLUGIN_SYSTEMSERVICE_STARTUPORDER "" CACHE STRING "To configure startup order of SystemServices plugin")
 
 find_package(${NAMESPACE}Plugins REQUIRED)

--- a/SystemServices/SystemServices.conf.in
+++ b/SystemServices/SystemServices.conf.in
@@ -1,4 +1,4 @@
 precondition = ["Platform"]
 callsign = "org.rdk.System"
-autostart = "false"
+autostart = "@PLUGIN_SYSTEM_AUTOSTART@"
 startuporder = "@PLUGIN_SYSTEMSERVICE_STARTUPORDER@"

--- a/SystemServices/SystemServices.config
+++ b/SystemServices/SystemServices.config
@@ -1,4 +1,4 @@
-set (autostart false)
+set (autostart ${PLUGIN_SYSTEM_AUTOSTART})
 set (preconditions Platform)
 set (callsign "org.rdk.System")
 


### PR DESCRIPTION
Reason for change: Need SystemServices plugin to be made autostart true to reduce the startup delay and aid resident UI for user input handling

Test Procedure: Build and verify.

Risks: Low

Signed-off-by: Selva Kumar MR <selvakumar_mr@comcast.com>