### PR TITLE
DELIA-65017 : Out-of-process improvements to PersistentStore

### DIFF
--- a/.github/workflows/L2-PersistentStore-grpc.yml
+++ b/.github/workflows/L2-PersistentStore-grpc.yml
@@ -27,3 +27,9 @@ jobs:
         run: |
           cmake -S ${GITHUB_REPOSITORY}/PersistentStore/grpc/l2test -B build/grpcl2test -DCMAKE_INSTALL_PREFIX="install/usr" -DCMAKE_CXX_FLAGS="-Wall -Werror"
           cmake --build build/grpcl2test --target install
+
+# (Optional)
+# Rebuild with real token (here: kToken = "Bearer TOKEN"):
+# cmake --build build/grpcl2test --target install
+# Run:
+# PATH=${PWD}/install/usr/bin:${PATH} LD_LIBRARY_PATH=${PWD}/install/usr/lib:${LD_LIBRARY_PATH} valgrind --tool=memcheck --log-file=valgrind_log --leak-check=yes --show-reachable=yes --track-fds=yes --fair-sched=try grpcl2test

--- a/.github/workflows/L2-PersistentStore.yml
+++ b/.github/workflows/L2-PersistentStore.yml
@@ -1,0 +1,45 @@
+name: L2-PersistentStore
+
+on:
+  push:
+    paths:
+      - PersistentStore/**
+  pull_request:
+    paths:
+      - PersistentStore/**
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: ${{github.repository}}
+
+      - name: Install cmake, sqlite, protoc, grpc_cpp_plugin, grpc
+        run: |
+          sudo apt update
+          sudo apt install -y cmake libsqlite3-dev protobuf-compiler protobuf-compiler-grpc libgrpc++-dev
+
+      - name: Build Thunder
+        working-directory: ${{github.workspace}}
+        run: sh +x ${GITHUB_REPOSITORY}/.github/workflows/BuildThunder.sh
+
+      - name: Build
+        working-directory: ${{github.workspace}}
+        run: |
+          cmake -S ${GITHUB_REPOSITORY}/PersistentStore -B build/PersistentStore -DCMAKE_INSTALL_PREFIX="install/usr" -DCMAKE_CXX_FLAGS="-Wall -Werror" -DPLUGIN_PERSISTENTSTORE_PATH="/tmp/persistentstore/l2test/test"
+          cmake --build build/PersistentStore --target install
+
+# (Optional)
+# Thunder startup:
+# PATH=${PWD}/install/usr/bin:${PATH} LD_LIBRARY_PATH=${PWD}/install/usr/lib:${LD_LIBRARY_PATH} valgrind --tool=memcheck --log-file=valgrind_log --leak-check=yes --show-reachable=yes --track-fds=yes --fair-sched=try WPEFramework -f -c ${PWD}/install/etc/WPEFramework/config.json
+# (to stop press q & enter)
+# API test:
+# curl -d '{"jsonrpc":"2.0","id":0,"method":"org.rdk.PersistentStore.setValue","params":{"namespace":"test","key":"key1","value":"1","ttl":100}}' http://localhost:55555/jsonrpc
+# curl -d '{"jsonrpc":"2.0","id":0,"method":"org.rdk.PersistentStore.getValue","params":{"namespace":"test","key":"key1"}}' http://localhost:55555/jsonrpc
+# Crash test:
+# kill -SIGFPE $(pidof WPEProcess)
+# Deactivate test:
+# curl -d '{"jsonrpc":"2.0","id":0,"method":"Controller.1.deactivate", "params":{"callsign":"org.rdk.PersistentStore"}}' http://localhost:55555/jsonrpc

--- a/PersistentStore/CMakeLists.txt
+++ b/PersistentStore/CMakeLists.txt
@@ -60,9 +60,8 @@ install(TARGETS ${MODULE_NAME}
 
 set(PLUGIN_IMPLEMENTATION ${MODULE_NAME}Implementation)
 add_library(${PLUGIN_IMPLEMENTATION} SHARED
-        sqlite/Store2.cpp
-        grpc/Store2.cpp
         Module.cpp
+        PersistentStoreImplementation.cpp
 )
 
 target_link_libraries(${PLUGIN_IMPLEMENTATION} PRIVATE

--- a/PersistentStore/PersistentStore.cpp
+++ b/PersistentStore/PersistentStore.cpp
@@ -51,8 +51,20 @@ namespace Plugin {
         string result;
 
         ASSERT(service != nullptr);
+        ASSERT(_store == nullptr);
+        ASSERT(_store2 == nullptr);
+        ASSERT(_storeCache == nullptr);
+        ASSERT(_storeInspector == nullptr);
+        ASSERT(_storeLimit == nullptr);
+        ASSERT(_service == nullptr);
+        ASSERT(_connectionId == 0);
 
-        auto configLine = service->ConfigLine();
+        SYSLOG(Logging::Startup, (_T("PersistentStore::Initialize: PID=%u"), getpid()));
+
+        _service = service;
+        _service->AddRef();
+
+        auto configLine = _service->ConfigLine();
         _config.FromString(configLine);
 
         {
@@ -91,50 +103,70 @@ namespace Plugin {
         Core::SystemInfo::SetEnvironment(MAXVALUE_ENV, std::to_string(_config.MaxValue.Value()));
         Core::SystemInfo::SetEnvironment(LIMIT_ENV, std::to_string(_config.Limit.Value()));
 
-        uint32_t connectionId;
+        _service->Register(&_notification);
 
-        _deviceStore2 = service->Root<Exchange::IStore2>(connectionId, RPC::CommunicationTimeOut, _T("SqliteStore2"));
-        if (_deviceStore2 != nullptr) {
-            _deviceStore2->Register(&_store2Sink);
-            _deviceStore2->Register(_store);
-            _deviceStoreCache = _deviceStore2->QueryInterface<Exchange::IStoreCache>();
-            _deviceStoreInspector = _deviceStore2->QueryInterface<Exchange::IStoreInspector>();
-            _deviceStoreLimit = _deviceStore2->QueryInterface<Exchange::IStoreLimit>();
-        }
+        _store = _service->Root<Exchange::IStore>(_connectionId, RPC::CommunicationTimeOut, _T("PersistentStoreImplementation"));
+        if (_store != nullptr) {
+            _store2 = _store->QueryInterface<Exchange::IStore2>();
+            if (_store2 != nullptr) {
+                _store2->Register(&_store2Sink);
+            }
+            _storeCache = _store->QueryInterface<Exchange::IStoreCache>();
+            _storeInspector = _store->QueryInterface<Exchange::IStoreInspector>();
+            _storeLimit = _store->QueryInterface<Exchange::IStoreLimit>();
 
-        _accountStore2 = service->Root<Exchange::IStore2>(connectionId, RPC::CommunicationTimeOut, _T("GrpcStore2"));
-        if (_accountStore2 != nullptr) {
-            _accountStore2->Register(&_store2Sink);
+            ASSERT(_store2 != nullptr);
+            ASSERT(_storeCache != nullptr);
+            ASSERT(_storeInspector != nullptr);
+            ASSERT(_storeLimit != nullptr);
+        } else {
+            result = _T("Couldn't create implementation instance");
         }
 
         return result;
     }
 
-    void PersistentStore::Deinitialize(PluginHost::IShell* /* service */)
+    void PersistentStore::Deinitialize(PluginHost::IShell* service)
     {
-        if (_deviceStore2 != nullptr) {
-            _deviceStore2->Unregister(&_store2Sink);
-            _deviceStore2->Unregister(_store);
-            _deviceStore2->Release();
-            _deviceStore2 = nullptr;
+        ASSERT(_service == service);
+
+        SYSLOG(Logging::Shutdown, (string(_T("DTV::Deinitialize"))));
+
+        _service->Unregister(&_notification);
+
+        if (_store != nullptr) {
+            if (_store2 != nullptr) {
+                _store2->Unregister(&_store2Sink);
+                _store2->Release();
+                _store2 = nullptr;
+            }
+            if (_storeCache != nullptr) {
+                _storeCache->Release();
+                _storeCache = nullptr;
+            }
+            if (_storeInspector != nullptr) {
+                _storeInspector->Release();
+                _storeInspector = nullptr;
+            }
+            if (_storeLimit != nullptr) {
+                _storeLimit->Release();
+                _storeLimit = nullptr;
+            }
+
+            auto connection = _service->RemoteConnection(_connectionId);
+            VARIABLE_IS_NOT_USED auto result = _store->Release();
+            _store = nullptr;
+            ASSERT(result == Core::ERROR_DESTRUCTION_SUCCEEDED);
+            if (connection != nullptr) {
+                connection->Terminate();
+                connection->Release();
+            }
         }
-        if (_deviceStoreCache != nullptr) {
-            _deviceStoreCache->Release();
-            _deviceStoreCache = nullptr;
-        }
-        if (_deviceStoreInspector != nullptr) {
-            _deviceStoreInspector->Release();
-            _deviceStoreInspector = nullptr;
-        }
-        if (_deviceStoreLimit != nullptr) {
-            _deviceStoreLimit->Release();
-            _deviceStoreLimit = nullptr;
-        }
-        if (_accountStore2 != nullptr) {
-            _accountStore2->Unregister(&_store2Sink);
-            _accountStore2->Release();
-            _accountStore2 = nullptr;
-        }
+
+        _connectionId = 0;
+        _service->Release();
+        _service = nullptr;
+        SYSLOG(Logging::Shutdown, (string(_T("PersistentStore de-initialised"))));
     }
 
     string PersistentStore::Information() const

--- a/PersistentStore/PersistentStoreImplementation.cpp
+++ b/PersistentStore/PersistentStoreImplementation.cpp
@@ -1,0 +1,77 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "PersistentStoreImplementation.h"
+#include "grpc/Store2.h"
+#include "sqlite/Store2.h"
+
+namespace WPEFramework {
+namespace Plugin {
+
+    SERVICE_REGISTRATION(PersistentStoreImplementation, 1, 0);
+
+    PersistentStoreImplementation::PersistentStoreImplementation()
+        : _deviceStore2(Core::Service<Sqlite::Store2>::Create<Exchange::IStore2>())
+        , _deviceStoreCache(nullptr)
+        , _deviceStoreInspector(nullptr)
+        , _deviceStoreLimit(nullptr)
+        , _accountStore2(Core::Service<Grpc::Store2>::Create<Exchange::IStore2>())
+        , _store2Sink(*this)
+    {
+        if (_deviceStore2 != nullptr) {
+            _deviceStore2->Register(&_store2Sink);
+            _deviceStoreCache = _deviceStore2->QueryInterface<Exchange::IStoreCache>();
+            _deviceStoreInspector = _deviceStore2->QueryInterface<Exchange::IStoreInspector>();
+            _deviceStoreLimit = _deviceStore2->QueryInterface<Exchange::IStoreLimit>();
+        }
+
+        ASSERT(_deviceStore2 != nullptr);
+        ASSERT(_deviceStoreCache != nullptr);
+        ASSERT(_deviceStoreInspector != nullptr);
+        ASSERT(_deviceStoreLimit != nullptr);
+        ASSERT(_accountStore2 != nullptr);
+    }
+
+    PersistentStoreImplementation::~PersistentStoreImplementation()
+    {
+        if (_deviceStore2 != nullptr) {
+            _deviceStore2->Unregister(&_store2Sink);
+            _deviceStore2->Release();
+            _deviceStore2 = nullptr;
+        }
+        if (_deviceStoreCache != nullptr) {
+            _deviceStoreCache->Release();
+            _deviceStoreCache = nullptr;
+        }
+        if (_deviceStoreInspector != nullptr) {
+            _deviceStoreInspector->Release();
+            _deviceStoreInspector = nullptr;
+        }
+        if (_deviceStoreLimit != nullptr) {
+            _deviceStoreLimit->Release();
+            _deviceStoreLimit = nullptr;
+        }
+        if (_accountStore2 != nullptr) {
+            _accountStore2->Release();
+            _accountStore2 = nullptr;
+        }
+    }
+
+} // namespace Plugin
+} // namespace WPEFramework

--- a/PersistentStore/PersistentStoreImplementation.h
+++ b/PersistentStore/PersistentStoreImplementation.h
@@ -1,0 +1,262 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "Module.h"
+#include <interfaces/IStore.h>
+#include <interfaces/IStore2.h>
+#include <interfaces/IStoreCache.h>
+
+namespace WPEFramework {
+namespace Plugin {
+
+    class PersistentStoreImplementation : public Exchange::IStore,
+                                          public Exchange::IStore2,
+                                          public Exchange::IStoreCache,
+                                          public Exchange::IStoreInspector,
+                                          public Exchange::IStoreLimit {
+    private:
+        class Store2Notification : public IStore2::INotification {
+        private:
+            Store2Notification(const Store2Notification&) = delete;
+            Store2Notification& operator=(const Store2Notification&) = delete;
+
+        public:
+            explicit Store2Notification(PersistentStoreImplementation& parent)
+                : _parent(parent)
+            {
+            }
+            ~Store2Notification() override = default;
+
+        public:
+            void ValueChanged(const IStore2::ScopeType scope, const string& ns, const string& key, const string& value) override
+            {
+                ASSERT(scope == IStore2::ScopeType::DEVICE);
+
+                Core::SafeSyncType<Core::CriticalSection> lock(_parent._clientLock);
+
+                std::list<IStore::INotification*>::iterator
+                    index(_parent._clients.begin());
+
+                while (index != _parent._clients.end()) {
+                    (*index)->ValueChanged(ns, key, value);
+                    index++;
+                }
+            }
+
+            BEGIN_INTERFACE_MAP(Store)
+            INTERFACE_ENTRY(IStore2::INotification)
+            END_INTERFACE_MAP
+
+        private:
+            PersistentStoreImplementation& _parent;
+        };
+
+    private:
+        PersistentStoreImplementation(const PersistentStoreImplementation&) = delete;
+        PersistentStoreImplementation& operator=(const PersistentStoreImplementation&) = delete;
+
+    public:
+        PersistentStoreImplementation();
+        ~PersistentStoreImplementation() override;
+
+        BEGIN_INTERFACE_MAP(PersistentStoreImplementation)
+        INTERFACE_ENTRY(IStore)
+        INTERFACE_ENTRY(IStore2)
+        INTERFACE_ENTRY(IStoreCache)
+        INTERFACE_ENTRY(IStoreInspector)
+        INTERFACE_ENTRY(IStoreLimit)
+        END_INTERFACE_MAP
+
+    private:
+        uint32_t Register(IStore::INotification* notification) override
+        {
+            Core::SafeSyncType<Core::CriticalSection> lock(_clientLock);
+
+            ASSERT(std::find(_clients.begin(), _clients.end(), notification) == _clients.end());
+
+            notification->AddRef();
+            _clients.push_back(notification);
+
+            return Core::ERROR_NONE;
+        }
+        uint32_t Unregister(IStore::INotification* notification) override
+        {
+            Core::SafeSyncType<Core::CriticalSection> lock(_clientLock);
+
+            std::list<IStore::INotification*>::iterator
+                index(std::find(_clients.begin(), _clients.end(), notification));
+
+            ASSERT(index != _clients.end());
+
+            if (index != _clients.end()) {
+                notification->Release();
+                _clients.erase(index);
+            }
+
+            return Core::ERROR_NONE;
+        }
+        uint32_t SetValue(const string& ns, const string& key, const string& value) override
+        {
+            return SetValue(IStore2::ScopeType::DEVICE, ns, key, value, 0);
+        }
+        uint32_t GetValue(const string& ns, const string& key, string& value) override
+        {
+            uint32_t ttl;
+            return GetValue(IStore2::ScopeType::DEVICE, ns, key, value, ttl);
+        }
+        uint32_t DeleteKey(const string& ns, const string& key) override
+        {
+            return DeleteKey(IStore2::ScopeType::DEVICE, ns, key);
+        }
+        uint32_t DeleteNamespace(const string& ns) override
+        {
+            return DeleteNamespace(IStore2::ScopeType::DEVICE, ns);
+        }
+        uint32_t Register(IStore2::INotification* notification) override
+        {
+            if (_deviceStore2 != nullptr) {
+                _deviceStore2->Register(notification);
+            }
+            if (_accountStore2 != nullptr) {
+                _accountStore2->Register(notification);
+            }
+            return Core::ERROR_NONE;
+        }
+        uint32_t Unregister(IStore2::INotification* notification) override
+        {
+            if (_deviceStore2 != nullptr) {
+                _deviceStore2->Unregister(notification);
+            }
+            if (_accountStore2 != nullptr) {
+                _accountStore2->Unregister(notification);
+            }
+            return Core::ERROR_NONE;
+        }
+        uint32_t SetValue(const IStore2::ScopeType scope, const string& ns, const string& key, const string& value, const uint32_t ttl) override
+        {
+            if (scope == IStore2::ScopeType::ACCOUNT) {
+                if (_accountStore2 != nullptr) {
+                    return _accountStore2->SetValue(scope, ns, key, value, ttl);
+                }
+            } else if (_deviceStore2 != nullptr) {
+                return _deviceStore2->SetValue(scope, ns, key, value, ttl);
+            }
+            return Core::ERROR_NOT_SUPPORTED;
+        }
+        uint32_t GetValue(const IStore2::ScopeType scope, const string& ns, const string& key, string& value, uint32_t& ttl) override
+        {
+            if (scope == IStore2::ScopeType::ACCOUNT) {
+                if (_accountStore2 != nullptr) {
+                    return _accountStore2->GetValue(scope, ns, key, value, ttl);
+                }
+            } else if (_deviceStore2 != nullptr) {
+                return _deviceStore2->GetValue(scope, ns, key, value, ttl);
+            }
+            return Core::ERROR_NOT_SUPPORTED;
+        }
+        uint32_t DeleteKey(const IStore2::ScopeType scope, const string& ns, const string& key) override
+        {
+            if (scope == IStore2::ScopeType::ACCOUNT) {
+                if (_accountStore2 != nullptr) {
+                    return _accountStore2->DeleteKey(scope, ns, key);
+                }
+            } else if (_deviceStore2 != nullptr) {
+                return _deviceStore2->DeleteKey(scope, ns, key);
+            }
+            return Core::ERROR_NOT_SUPPORTED;
+        }
+        uint32_t DeleteNamespace(const IStore2::ScopeType scope, const string& ns) override
+        {
+            if (scope == IStore2::ScopeType::ACCOUNT) {
+                if (_accountStore2 != nullptr) {
+                    return _accountStore2->DeleteNamespace(scope, ns);
+                }
+            } else if (_deviceStore2 != nullptr) {
+                return _deviceStore2->DeleteNamespace(scope, ns);
+            }
+            return Core::ERROR_NOT_SUPPORTED;
+        }
+        uint32_t FlushCache() override
+        {
+            if (_deviceStoreCache != nullptr) {
+                return _deviceStoreCache->FlushCache();
+            }
+            return Core::ERROR_NOT_SUPPORTED;
+        }
+        uint32_t GetKeys(const IStoreInspector::ScopeType scope, const string& ns, RPC::IStringIterator*& keys) override
+        {
+            if (scope == IStoreInspector::ScopeType::DEVICE) {
+                if (_deviceStoreInspector != nullptr) {
+                    return _deviceStoreInspector->GetKeys(scope, ns, keys);
+                }
+            }
+            return Core::ERROR_NOT_SUPPORTED;
+        }
+        uint32_t GetNamespaces(const IStoreInspector::ScopeType scope, RPC::IStringIterator*& namespaces) override
+        {
+            if (scope == IStoreInspector::ScopeType::DEVICE) {
+                if (_deviceStoreInspector != nullptr) {
+                    return _deviceStoreInspector->GetNamespaces(scope, namespaces);
+                }
+            }
+            return Core::ERROR_NOT_SUPPORTED;
+        }
+        uint32_t GetStorageSizes(const IStoreInspector::ScopeType scope, INamespaceSizeIterator*& storageList) override
+        {
+            if (scope == IStoreInspector::ScopeType::DEVICE) {
+                if (_deviceStoreInspector != nullptr) {
+                    return _deviceStoreInspector->GetStorageSizes(scope, storageList);
+                }
+            }
+            return Core::ERROR_NOT_SUPPORTED;
+        }
+        uint32_t SetNamespaceStorageLimit(const IStoreLimit::ScopeType scope, const string& ns, const uint32_t size) override
+        {
+            if (scope == IStoreLimit::ScopeType::DEVICE) {
+                if (_deviceStoreLimit != nullptr) {
+                    return _deviceStoreLimit->SetNamespaceStorageLimit(scope, ns, size);
+                }
+            }
+            return Core::ERROR_NOT_SUPPORTED;
+        }
+        uint32_t GetNamespaceStorageLimit(const IStoreLimit::ScopeType scope, const string& ns, uint32_t& size) override
+        {
+            if (scope == IStoreLimit::ScopeType::DEVICE) {
+                if (_deviceStoreLimit != nullptr) {
+                    return _deviceStoreLimit->GetNamespaceStorageLimit(scope, ns, size);
+                }
+            }
+            return Core::ERROR_NOT_SUPPORTED;
+        }
+
+    private:
+        IStore2* _deviceStore2;
+        IStoreCache* _deviceStoreCache;
+        IStoreInspector* _deviceStoreInspector;
+        IStoreLimit* _deviceStoreLimit;
+        IStore2* _accountStore2;
+        Core::Sink<Store2Notification> _store2Sink;
+        std::list<IStore::INotification*> _clients;
+        Core::CriticalSection _clientLock;
+    };
+
+} // namespace Plugin
+} // namespace WPEFramework

--- a/PersistentStore/PersistentStoreJsonRpc.cpp
+++ b/PersistentStore/PersistentStoreJsonRpc.cpp
@@ -118,7 +118,7 @@ namespace Plugin {
     uint32_t PersistentStore::endpoint_getKeys(const DeleteNamespaceParamsInfo& params, GetKeysResultData& response)
     {
         RPC::IStringIterator* it;
-        auto result = _store2->GetKeys(
+        auto result = _storeInspector->GetKeys(
             Exchange::IStoreInspector::ScopeType(params.Scope.Value()),
             params.Namespace.Value(),
             it);
@@ -137,7 +137,7 @@ namespace Plugin {
     uint32_t PersistentStore::endpoint_getNamespaces(const GetNamespacesParamsInfo& params, GetNamespacesResultData& response)
     {
         RPC::IStringIterator* it;
-        auto result = _store2->GetNamespaces(
+        auto result = _storeInspector->GetNamespaces(
             Exchange::IStoreInspector::ScopeType(params.Scope.Value()),
             it);
         if (result == Core::ERROR_NONE) {
@@ -156,7 +156,7 @@ namespace Plugin {
     uint32_t PersistentStore::endpoint_getStorageSize(const GetNamespacesParamsInfo& params, JsonObject& response)
     {
         Exchange::IStoreInspector::INamespaceSizeIterator* it;
-        auto result = _store2->GetStorageSizes(
+        auto result = _storeInspector->GetStorageSizes(
             Exchange::IStoreInspector::ScopeType(params.Scope.Value()),
             it);
         if (result == Core::ERROR_NONE) {
@@ -176,7 +176,7 @@ namespace Plugin {
     uint32_t PersistentStore::endpoint_getStorageSizes(const GetNamespacesParamsInfo& params, GetStorageSizesResultData& response)
     {
         Exchange::IStoreInspector::INamespaceSizeIterator* it;
-        auto result = _store2->GetStorageSizes(
+        auto result = _storeInspector->GetStorageSizes(
             Exchange::IStoreInspector::ScopeType(params.Scope.Value()),
             it);
         if (result == Core::ERROR_NONE) {
@@ -194,7 +194,7 @@ namespace Plugin {
 
     uint32_t PersistentStore::endpoint_flushCache(DeleteKeyResultInfo& response)
     {
-        auto result = _store2->FlushCache();
+        auto result = _storeCache->FlushCache();
         if (result == Core::ERROR_NONE) {
             response.Success = true;
         }
@@ -205,7 +205,7 @@ namespace Plugin {
     uint32_t PersistentStore::endpoint_getNamespaceStorageLimit(const DeleteNamespaceParamsInfo& params, GetNamespaceStorageLimitResultData& response)
     {
         uint32_t size;
-        auto result = _store2->GetNamespaceStorageLimit(
+        auto result = _storeLimit->GetNamespaceStorageLimit(
             Exchange::IStoreLimit::ScopeType(params.Scope.Value()),
             params.Namespace.Value(),
             size);
@@ -218,7 +218,7 @@ namespace Plugin {
 
     uint32_t PersistentStore::endpoint_setNamespaceStorageLimit(const SetNamespaceStorageLimitParamsData& params)
     {
-        return _store2->SetNamespaceStorageLimit(
+        return _storeLimit->SetNamespaceStorageLimit(
             Exchange::IStoreLimit::ScopeType(params.Scope.Value()),
             params.Namespace.Value(),
             params.StorageLimit.Value());

--- a/PersistentStore/grpc/Store2.cpp
+++ b/PersistentStore/grpc/Store2.cpp
@@ -1,8 +1,0 @@
-#include "Store2.h"
-
-namespace WPEFramework {
-namespace Plugin {
-    class GrpcStore2 : public Grpc::Store2 {};
-    SERVICE_REGISTRATION(GrpcStore2, 1, 0);
-} // namespace Plugin
-} // namespace WPEFramework

--- a/PersistentStore/grpc/l2test/StubTest.cpp
+++ b/PersistentStore/grpc/l2test/StubTest.cpp
@@ -61,7 +61,7 @@ TEST_F(AStub, DoesNotUpdateValueWhenAppIdEmpty)
     auto status = stub->UpdateValue(&context, request, &response);
     ASSERT_THAT(status.ok(), IsFalse());
     EXPECT_THAT(status.error_code(), Eq(3));
-    EXPECT_THAT(status.error_message(), Eq("app_id is mandatory"));
+    EXPECT_THAT(status.error_message(), Eq("key's key and app_id fields are required"));
 }
 
 TEST_F(AStub, DoesNotUpdateValueWhenKeyEmpty)
@@ -98,7 +98,7 @@ TEST_F(AStub, DoesNotGetValueWhenAppIdEmpty)
     auto status = stub->GetValue(&context, request, &response);
     ASSERT_THAT(status.ok(), IsFalse());
     EXPECT_THAT(status.error_code(), Eq(3));
-    EXPECT_THAT(status.error_message(), Eq("app_id is mandatory"));
+    EXPECT_THAT(status.error_message(), Eq("key's key and app_id fields are required"));
 }
 
 TEST_F(AStub, DoesNotGetValueWhenKeyEmpty)
@@ -132,7 +132,7 @@ TEST_F(AStub, DoesNotDeleteValueWhenAppIdEmpty)
     auto status = stub->DeleteValue(&context, request, &response);
     ASSERT_THAT(status.ok(), IsFalse());
     EXPECT_THAT(status.error_code(), Eq(3));
-    EXPECT_THAT(status.error_message(), Eq("app_id is mandatory"));
+    EXPECT_THAT(status.error_message(), Eq("key's key and app_id fields are required"));
 }
 
 TEST_F(AStub, DoesNotDeleteValueWhenKeyEmpty)
@@ -197,8 +197,7 @@ TEST_F(AStub, GetsValueWhenValueEmpty)
         ASSERT_THAT(response.has_value(), IsTrue());
         EXPECT_THAT(response.value().value(), Eq(kEmpty));
         EXPECT_THAT(response.value().has_ttl(), IsFalse());
-        ASSERT_THAT(response.value().has_expire_time(), IsTrue());
-        EXPECT_THAT(response.value().expire_time().seconds(), Eq(0));
+        EXPECT_THAT(response.value().has_expire_time(), IsFalse());
     }
 }
 
@@ -378,7 +377,7 @@ TEST_F(AStub, DoesNotGetValueWhenTtlExpired)
         auto status = stub->UpdateValue(&context, request, &response);
         ASSERT_THAT(status.ok(), IsTrue());
     }
-    sleep(kTtl);
+    sleep(kTtl + 1);
     {
         grpc::ClientContext context;
         context.AddMetadata("authorization", std::string(kToken));

--- a/PersistentStore/l0test/PersistentStoreImplementationMock.h
+++ b/PersistentStore/l0test/PersistentStoreImplementationMock.h
@@ -1,17 +1,26 @@
 #pragma once
 
 #include <gmock/gmock.h>
+#include <interfaces/IStore.h>
 #include <interfaces/IStore2.h>
 #include <interfaces/IStoreCache.h>
 
-class Store2Mock : public WPEFramework::Exchange::IStore2,
-                   public WPEFramework::Exchange::IStoreCache,
-                   public WPEFramework::Exchange::IStoreInspector,
-                   public WPEFramework::Exchange::IStoreLimit {
+class PersistentStoreImplementationMock
+    : public WPEFramework::Exchange::IStore,
+      public WPEFramework::Exchange::IStore2,
+      public WPEFramework::Exchange::IStoreCache,
+      public WPEFramework::Exchange::IStoreInspector,
+      public WPEFramework::Exchange::IStoreLimit {
 public:
-    ~Store2Mock() override = default;
-    MOCK_METHOD(uint32_t, Register, (INotification*), (override));
-    MOCK_METHOD(uint32_t, Unregister, (INotification*), (override));
+    ~PersistentStoreImplementationMock() override = default;
+    MOCK_METHOD(uint32_t, Register, (IStore::INotification * notification), (override));
+    MOCK_METHOD(uint32_t, Unregister, (IStore::INotification * notification), (override));
+    MOCK_METHOD(uint32_t, SetValue, (const string& ns, const string& key, const string& value), (override));
+    MOCK_METHOD(uint32_t, GetValue, (const string& ns, const string& key, string& value), (override));
+    MOCK_METHOD(uint32_t, DeleteKey, (const string& ns, const string& key), (override));
+    MOCK_METHOD(uint32_t, DeleteNamespace, (const string& ns), (override));
+    MOCK_METHOD(uint32_t, Register, (IStore2::INotification*), (override));
+    MOCK_METHOD(uint32_t, Unregister, (IStore2::INotification*), (override));
     MOCK_METHOD(uint32_t, SetValue, (const IStore2::ScopeType scope, const string& ns, const string& key, const string& value, const uint32_t ttl), (override));
     MOCK_METHOD(uint32_t, GetValue, (const IStore2::ScopeType scope, const string& ns, const string& key, string& value, uint32_t& ttl), (override));
     MOCK_METHOD(uint32_t, DeleteKey, (const IStore2::ScopeType scope, const string& ns, const string& key), (override));
@@ -22,7 +31,8 @@ public:
     MOCK_METHOD(uint32_t, GetStorageSizes, (const IStoreInspector::ScopeType scope, INamespaceSizeIterator*& storageList), (override));
     MOCK_METHOD(uint32_t, GetNamespaceStorageLimit, (const IStoreLimit::ScopeType scope, const string& ns, uint32_t& size), (override));
     MOCK_METHOD(uint32_t, SetNamespaceStorageLimit, (const IStoreLimit::ScopeType scope, const string& ns, const uint32_t size), (override));
-    BEGIN_INTERFACE_MAP(Store2Mock)
+    BEGIN_INTERFACE_MAP(PersistentStoreImplementationMock)
+    INTERFACE_ENTRY(IStore)
     INTERFACE_ENTRY(IStore2)
     INTERFACE_ENTRY(IStoreCache)
     INTERFACE_ENTRY(IStoreInspector)

--- a/PersistentStore/l0test/PersistentStoreTest.cpp
+++ b/PersistentStore/l0test/PersistentStoreTest.cpp
@@ -2,8 +2,8 @@
 #include <gtest/gtest.h>
 
 #include "../PersistentStore.h"
+#include "PersistentStoreImplementationMock.h"
 #include "ServiceMock.h"
-#include "Store2Mock.h"
 
 using ::testing::_;
 using ::testing::Eq;
@@ -61,9 +61,9 @@ protected:
 
 TEST_F(APersistentStore, GetsValueInDeviceScopeViaJsonRpc)
 {
-    class SqliteStore2 : public NiceMock<Store2Mock> {
+    class PersistentStoreImplementation : public NiceMock<PersistentStoreImplementationMock> {
     public:
-        SqliteStore2()
+        PersistentStoreImplementation()
         {
             EXPECT_CALL(*this, GetValue(_, _, _, _, _))
                 .WillRepeatedly(Invoke(
@@ -77,7 +77,7 @@ TEST_F(APersistentStore, GetsValueInDeviceScopeViaJsonRpc)
                     }));
         }
     };
-    PublishedServiceType<SqliteStore2> metadata(WPEFramework::Core::System::MODULE_NAME, 1, 0, 0);
+    PublishedServiceType<PersistentStoreImplementation> metadata(WPEFramework::Core::System::MODULE_NAME, 1, 0, 0);
     ASSERT_THAT(plugin->Initialize(service), Eq(""));
     auto jsonRpc = plugin->QueryInterface<ILocalDispatcher>();
     ASSERT_THAT(jsonRpc, NotNull());
@@ -98,9 +98,9 @@ TEST_F(APersistentStore, GetsValueInDeviceScopeViaJsonRpc)
 
 TEST_F(APersistentStore, GetsValueInAccountScopeViaJsonRpc)
 {
-    class GrpcStore2 : public NiceMock<Store2Mock> {
+    class PersistentStoreImplementation : public NiceMock<PersistentStoreImplementationMock> {
     public:
-        GrpcStore2()
+        PersistentStoreImplementation()
         {
             EXPECT_CALL(*this, GetValue(_, _, _, _, _))
                 .WillRepeatedly(Invoke(
@@ -114,7 +114,7 @@ TEST_F(APersistentStore, GetsValueInAccountScopeViaJsonRpc)
                     }));
         }
     };
-    PublishedServiceType<GrpcStore2> metadata(WPEFramework::Core::System::MODULE_NAME, 1, 0, 0);
+    PublishedServiceType<PersistentStoreImplementation> metadata(WPEFramework::Core::System::MODULE_NAME, 1, 0, 0);
     ASSERT_THAT(plugin->Initialize(service), Eq(""));
     auto jsonRpc = plugin->QueryInterface<ILocalDispatcher>();
     ASSERT_THAT(jsonRpc, NotNull());
@@ -136,9 +136,9 @@ TEST_F(APersistentStore, GetsValueInAccountScopeViaJsonRpc)
 
 TEST_F(APersistentStore, SetsValueInDeviceScopeViaJsonRpc)
 {
-    class SqliteStore2 : public NiceMock<Store2Mock> {
+    class PersistentStoreImplementation : public NiceMock<PersistentStoreImplementationMock> {
     public:
-        SqliteStore2()
+        PersistentStoreImplementation()
         {
             EXPECT_CALL(*this, SetValue(_, _, _, _, _))
                 .WillRepeatedly(Invoke(
@@ -152,7 +152,7 @@ TEST_F(APersistentStore, SetsValueInDeviceScopeViaJsonRpc)
                     }));
         }
     };
-    PublishedServiceType<SqliteStore2> metadata(WPEFramework::Core::System::MODULE_NAME, 1, 0, 0);
+    PublishedServiceType<PersistentStoreImplementation> metadata(WPEFramework::Core::System::MODULE_NAME, 1, 0, 0);
     ASSERT_THAT(plugin->Initialize(service), Eq(""));
     auto jsonRpc = plugin->QueryInterface<ILocalDispatcher>();
     ASSERT_THAT(jsonRpc, NotNull());
@@ -171,9 +171,9 @@ TEST_F(APersistentStore, SetsValueInDeviceScopeViaJsonRpc)
 
 TEST_F(APersistentStore, SetsValueInAccountScopeViaJsonRpc)
 {
-    class GrpcStore2 : public NiceMock<Store2Mock> {
+    class PersistentStoreImplementation : public NiceMock<PersistentStoreImplementationMock> {
     public:
-        GrpcStore2()
+        PersistentStoreImplementation()
         {
             EXPECT_CALL(*this, SetValue(_, _, _, _, _))
                 .WillRepeatedly(Invoke(
@@ -187,7 +187,7 @@ TEST_F(APersistentStore, SetsValueInAccountScopeViaJsonRpc)
                     }));
         }
     };
-    PublishedServiceType<GrpcStore2> metadata(WPEFramework::Core::System::MODULE_NAME, 1, 0, 0);
+    PublishedServiceType<PersistentStoreImplementation> metadata(WPEFramework::Core::System::MODULE_NAME, 1, 0, 0);
     ASSERT_THAT(plugin->Initialize(service), Eq(""));
     auto jsonRpc = plugin->QueryInterface<ILocalDispatcher>();
     ASSERT_THAT(jsonRpc, NotNull());
@@ -207,9 +207,9 @@ TEST_F(APersistentStore, SetsValueInAccountScopeViaJsonRpc)
 
 TEST_F(APersistentStore, DeletesKeyInDeviceScopeViaJsonRpc)
 {
-    class SqliteStore2 : public NiceMock<Store2Mock> {
+    class PersistentStoreImplementation : public NiceMock<PersistentStoreImplementationMock> {
     public:
-        SqliteStore2()
+        PersistentStoreImplementation()
         {
             EXPECT_CALL(*this, DeleteKey(_, _, _))
                 .WillRepeatedly(Invoke(
@@ -221,7 +221,7 @@ TEST_F(APersistentStore, DeletesKeyInDeviceScopeViaJsonRpc)
                     }));
         }
     };
-    PublishedServiceType<SqliteStore2> metadata(WPEFramework::Core::System::MODULE_NAME, 1, 0, 0);
+    PublishedServiceType<PersistentStoreImplementation> metadata(WPEFramework::Core::System::MODULE_NAME, 1, 0, 0);
     ASSERT_THAT(plugin->Initialize(service), Eq(""));
     auto jsonRpc = plugin->QueryInterface<ILocalDispatcher>();
     ASSERT_THAT(jsonRpc, NotNull());
@@ -238,9 +238,9 @@ TEST_F(APersistentStore, DeletesKeyInDeviceScopeViaJsonRpc)
 
 TEST_F(APersistentStore, DeletesKeyInAccountScopeViaJsonRpc)
 {
-    class GrpcStore2 : public NiceMock<Store2Mock> {
+    class PersistentStoreImplementation : public NiceMock<PersistentStoreImplementationMock> {
     public:
-        GrpcStore2()
+        PersistentStoreImplementation()
         {
             EXPECT_CALL(*this, DeleteKey(_, _, _))
                 .WillRepeatedly(Invoke(
@@ -252,7 +252,7 @@ TEST_F(APersistentStore, DeletesKeyInAccountScopeViaJsonRpc)
                     }));
         }
     };
-    PublishedServiceType<GrpcStore2> metadata(WPEFramework::Core::System::MODULE_NAME, 1, 0, 0);
+    PublishedServiceType<PersistentStoreImplementation> metadata(WPEFramework::Core::System::MODULE_NAME, 1, 0, 0);
     ASSERT_THAT(plugin->Initialize(service), Eq(""));
     auto jsonRpc = plugin->QueryInterface<ILocalDispatcher>();
     ASSERT_THAT(jsonRpc, NotNull());
@@ -270,9 +270,9 @@ TEST_F(APersistentStore, DeletesKeyInAccountScopeViaJsonRpc)
 
 TEST_F(APersistentStore, DeletesNamespaceInDeviceScopeViaJsonRpc)
 {
-    class SqliteStore2 : public NiceMock<Store2Mock> {
+    class PersistentStoreImplementation : public NiceMock<PersistentStoreImplementationMock> {
     public:
-        SqliteStore2()
+        PersistentStoreImplementation()
         {
             EXPECT_CALL(*this, DeleteNamespace(_, _))
                 .WillRepeatedly(Invoke(
@@ -283,7 +283,7 @@ TEST_F(APersistentStore, DeletesNamespaceInDeviceScopeViaJsonRpc)
                     }));
         }
     };
-    PublishedServiceType<SqliteStore2> metadata(WPEFramework::Core::System::MODULE_NAME, 1, 0, 0);
+    PublishedServiceType<PersistentStoreImplementation> metadata(WPEFramework::Core::System::MODULE_NAME, 1, 0, 0);
     ASSERT_THAT(plugin->Initialize(service), Eq(""));
     auto jsonRpc = plugin->QueryInterface<ILocalDispatcher>();
     ASSERT_THAT(jsonRpc, NotNull());
@@ -299,9 +299,9 @@ TEST_F(APersistentStore, DeletesNamespaceInDeviceScopeViaJsonRpc)
 
 TEST_F(APersistentStore, DeletesNamespaceInAccountScopeViaJsonRpc)
 {
-    class GrpcStore2 : public NiceMock<Store2Mock> {
+    class PersistentStoreImplementation : public NiceMock<PersistentStoreImplementationMock> {
     public:
-        GrpcStore2()
+        PersistentStoreImplementation()
         {
             EXPECT_CALL(*this, DeleteNamespace(_, _))
                 .WillRepeatedly(Invoke(
@@ -312,7 +312,7 @@ TEST_F(APersistentStore, DeletesNamespaceInAccountScopeViaJsonRpc)
                     }));
         }
     };
-    PublishedServiceType<GrpcStore2> metadata(WPEFramework::Core::System::MODULE_NAME, 1, 0, 0);
+    PublishedServiceType<PersistentStoreImplementation> metadata(WPEFramework::Core::System::MODULE_NAME, 1, 0, 0);
     ASSERT_THAT(plugin->Initialize(service), Eq(""));
     auto jsonRpc = plugin->QueryInterface<ILocalDispatcher>();
     ASSERT_THAT(jsonRpc, NotNull());
@@ -329,15 +329,15 @@ TEST_F(APersistentStore, DeletesNamespaceInAccountScopeViaJsonRpc)
 
 TEST_F(APersistentStore, FlushesCacheViaJsonRpc)
 {
-    class SqliteStore2 : public NiceMock<Store2Mock> {
+    class PersistentStoreImplementation : public NiceMock<PersistentStoreImplementationMock> {
     public:
-        SqliteStore2()
+        PersistentStoreImplementation()
         {
             EXPECT_CALL(*this, FlushCache())
                 .WillRepeatedly(Return(WPEFramework::Core::ERROR_NONE));
         }
     };
-    PublishedServiceType<SqliteStore2> metadata(WPEFramework::Core::System::MODULE_NAME, 1, 0, 0);
+    PublishedServiceType<PersistentStoreImplementation> metadata(WPEFramework::Core::System::MODULE_NAME, 1, 0, 0);
     ASSERT_THAT(plugin->Initialize(service), Eq(""));
     auto jsonRpc = plugin->QueryInterface<ILocalDispatcher>();
     ASSERT_THAT(jsonRpc, NotNull());
@@ -349,9 +349,9 @@ TEST_F(APersistentStore, FlushesCacheViaJsonRpc)
 
 TEST_F(APersistentStore, GetsKeysInDeviceScopeViaJsonRpc)
 {
-    class SqliteStore2 : public NiceMock<Store2Mock> {
+    class PersistentStoreImplementation : public NiceMock<PersistentStoreImplementationMock> {
     public:
-        SqliteStore2()
+        PersistentStoreImplementation()
         {
             EXPECT_CALL(*this, GetKeys(_, _, _))
                 .WillRepeatedly(Invoke(
@@ -363,7 +363,7 @@ TEST_F(APersistentStore, GetsKeysInDeviceScopeViaJsonRpc)
                     }));
         }
     };
-    PublishedServiceType<SqliteStore2> metadata(WPEFramework::Core::System::MODULE_NAME, 1, 0, 0);
+    PublishedServiceType<PersistentStoreImplementation> metadata(WPEFramework::Core::System::MODULE_NAME, 1, 0, 0);
     ASSERT_THAT(plugin->Initialize(service), Eq(""));
     auto jsonRpc = plugin->QueryInterface<ILocalDispatcher>();
     ASSERT_THAT(jsonRpc, NotNull());
@@ -385,27 +385,11 @@ TEST_F(APersistentStore, GetsKeysInDeviceScopeViaJsonRpc)
     plugin->Deinitialize(service);
 }
 
-TEST_F(APersistentStore, DoesNotGetKeysInAccountScopeViaJsonRpc)
-{
-    ASSERT_THAT(plugin->Initialize(service), Eq(""));
-    auto jsonRpc = plugin->QueryInterface<ILocalDispatcher>();
-    ASSERT_THAT(jsonRpc, NotNull());
-    DeleteNamespaceParamsInfo params;
-    params.Scope = WPEFramework::JsonData::PersistentStore::ScopeType::ACCOUNT;
-    params.Namespace = kAppId;
-    string paramsJsonStr;
-    params.ToString(paramsJsonStr);
-    string resultJsonStr;
-    EXPECT_THAT(jsonRpc->Invoke(0, 0, "", "getKeys", paramsJsonStr, resultJsonStr), Eq(WPEFramework::Core::ERROR_NOT_SUPPORTED));
-    jsonRpc->Release();
-    plugin->Deinitialize(service);
-}
-
 TEST_F(APersistentStore, GetsNamespacesInDeviceScopeViaJsonRpc)
 {
-    class SqliteStore2 : public NiceMock<Store2Mock> {
+    class PersistentStoreImplementation : public NiceMock<PersistentStoreImplementationMock> {
     public:
-        SqliteStore2()
+        PersistentStoreImplementation()
         {
             EXPECT_CALL(*this, GetNamespaces(_, _))
                 .WillRepeatedly(Invoke(
@@ -416,7 +400,7 @@ TEST_F(APersistentStore, GetsNamespacesInDeviceScopeViaJsonRpc)
                     }));
         }
     };
-    PublishedServiceType<SqliteStore2> metadata(WPEFramework::Core::System::MODULE_NAME, 1, 0, 0);
+    PublishedServiceType<PersistentStoreImplementation> metadata(WPEFramework::Core::System::MODULE_NAME, 1, 0, 0);
     ASSERT_THAT(plugin->Initialize(service), Eq(""));
     auto jsonRpc = plugin->QueryInterface<ILocalDispatcher>();
     ASSERT_THAT(jsonRpc, NotNull());
@@ -434,26 +418,11 @@ TEST_F(APersistentStore, GetsNamespacesInDeviceScopeViaJsonRpc)
     plugin->Deinitialize(service);
 }
 
-TEST_F(APersistentStore, DoesNotGetNamespacesInAccountScopeViaJsonRpc)
-{
-    ASSERT_THAT(plugin->Initialize(service), Eq(""));
-    auto jsonRpc = plugin->QueryInterface<ILocalDispatcher>();
-    ASSERT_THAT(jsonRpc, NotNull());
-    GetNamespacesParamsInfo params;
-    params.Scope = WPEFramework::JsonData::PersistentStore::ScopeType::ACCOUNT;
-    string paramsJsonStr;
-    params.ToString(paramsJsonStr);
-    string resultJsonStr;
-    EXPECT_THAT(jsonRpc->Invoke(0, 0, "", "getNamespaces", paramsJsonStr, resultJsonStr), Eq(WPEFramework::Core::ERROR_NOT_SUPPORTED));
-    jsonRpc->Release();
-    plugin->Deinitialize(service);
-}
-
 TEST_F(APersistentStore, GetsStorageSizesInDeviceScopeViaJsonRpc)
 {
-    class SqliteStore2 : public NiceMock<Store2Mock> {
+    class PersistentStoreImplementation : public NiceMock<PersistentStoreImplementationMock> {
     public:
-        SqliteStore2()
+        PersistentStoreImplementation()
         {
             EXPECT_CALL(*this, GetStorageSizes(_, _))
                 .WillRepeatedly(Invoke(
@@ -464,7 +433,7 @@ TEST_F(APersistentStore, GetsStorageSizesInDeviceScopeViaJsonRpc)
                     }));
         }
     };
-    PublishedServiceType<SqliteStore2> metadata(WPEFramework::Core::System::MODULE_NAME, 1, 0, 0);
+    PublishedServiceType<PersistentStoreImplementation> metadata(WPEFramework::Core::System::MODULE_NAME, 1, 0, 0);
     ASSERT_THAT(plugin->Initialize(service), Eq(""));
     auto jsonRpc = plugin->QueryInterface<ILocalDispatcher>();
     ASSERT_THAT(jsonRpc, NotNull());
@@ -484,26 +453,11 @@ TEST_F(APersistentStore, GetsStorageSizesInDeviceScopeViaJsonRpc)
     plugin->Deinitialize(service);
 }
 
-TEST_F(APersistentStore, DoesNotGetStorageSizesInAccountScopeViaJsonRpc)
-{
-    ASSERT_THAT(plugin->Initialize(service), Eq(""));
-    auto jsonRpc = plugin->QueryInterface<ILocalDispatcher>();
-    ASSERT_THAT(jsonRpc, NotNull());
-    GetNamespacesParamsInfo params;
-    params.Scope = WPEFramework::JsonData::PersistentStore::ScopeType::ACCOUNT;
-    string paramsJsonStr;
-    params.ToString(paramsJsonStr);
-    string resultJsonStr;
-    EXPECT_THAT(jsonRpc->Invoke(0, 0, "", "getStorageSizes", paramsJsonStr, resultJsonStr), Eq(WPEFramework::Core::ERROR_NOT_SUPPORTED));
-    jsonRpc->Release();
-    plugin->Deinitialize(service);
-}
-
 TEST_F(APersistentStore, GetsNamespaceStorageLimitInDeviceScopeViaJsonRpc)
 {
-    class SqliteStore2 : public NiceMock<Store2Mock> {
+    class PersistentStoreImplementation : public NiceMock<PersistentStoreImplementationMock> {
     public:
-        SqliteStore2()
+        PersistentStoreImplementation()
         {
             EXPECT_CALL(*this, GetNamespaceStorageLimit(_, _, _))
                 .WillRepeatedly(Invoke(
@@ -515,7 +469,7 @@ TEST_F(APersistentStore, GetsNamespaceStorageLimitInDeviceScopeViaJsonRpc)
                     }));
         }
     };
-    PublishedServiceType<SqliteStore2> metadata(WPEFramework::Core::System::MODULE_NAME, 1, 0, 0);
+    PublishedServiceType<PersistentStoreImplementation> metadata(WPEFramework::Core::System::MODULE_NAME, 1, 0, 0);
     ASSERT_THAT(plugin->Initialize(service), Eq(""));
     auto jsonRpc = plugin->QueryInterface<ILocalDispatcher>();
     ASSERT_THAT(jsonRpc, NotNull());
@@ -532,27 +486,11 @@ TEST_F(APersistentStore, GetsNamespaceStorageLimitInDeviceScopeViaJsonRpc)
     plugin->Deinitialize(service);
 }
 
-TEST_F(APersistentStore, DoesNotGetNamespaceStorageLimitInAccountScopeViaJsonRpc)
-{
-    ASSERT_THAT(plugin->Initialize(service), Eq(""));
-    auto jsonRpc = plugin->QueryInterface<ILocalDispatcher>();
-    ASSERT_THAT(jsonRpc, NotNull());
-    DeleteNamespaceParamsInfo params;
-    params.Scope = WPEFramework::JsonData::PersistentStore::ScopeType::ACCOUNT;
-    params.Namespace = kAppId;
-    string paramsJsonStr;
-    params.ToString(paramsJsonStr);
-    string resultJsonStr;
-    EXPECT_THAT(jsonRpc->Invoke(0, 0, "", "getNamespaceStorageLimit", paramsJsonStr, resultJsonStr), Eq(WPEFramework::Core::ERROR_NOT_SUPPORTED));
-    jsonRpc->Release();
-    plugin->Deinitialize(service);
-}
-
 TEST_F(APersistentStore, SetsNamespaceStorageLimitInDeviceScopeViaJsonRpc)
 {
-    class SqliteStore2 : public NiceMock<Store2Mock> {
+    class PersistentStoreImplementation : public NiceMock<PersistentStoreImplementationMock> {
     public:
-        SqliteStore2()
+        PersistentStoreImplementation()
         {
             EXPECT_CALL(*this, SetNamespaceStorageLimit(_, _, _))
                 .WillRepeatedly(Invoke(
@@ -564,7 +502,7 @@ TEST_F(APersistentStore, SetsNamespaceStorageLimitInDeviceScopeViaJsonRpc)
                     }));
         }
     };
-    PublishedServiceType<SqliteStore2> metadata(WPEFramework::Core::System::MODULE_NAME, 1, 0, 0);
+    PublishedServiceType<PersistentStoreImplementation> metadata(WPEFramework::Core::System::MODULE_NAME, 1, 0, 0);
     ASSERT_THAT(plugin->Initialize(service), Eq(""));
     auto jsonRpc = plugin->QueryInterface<ILocalDispatcher>();
     ASSERT_THAT(jsonRpc, NotNull());
@@ -579,33 +517,15 @@ TEST_F(APersistentStore, SetsNamespaceStorageLimitInDeviceScopeViaJsonRpc)
     plugin->Deinitialize(service);
 }
 
-TEST_F(APersistentStore, DoesNotSetNamespaceStorageLimitInAccountScopeViaJsonRpc)
-{
-    ASSERT_THAT(plugin->Initialize(service), Eq(""));
-    auto jsonRpc = plugin->QueryInterface<ILocalDispatcher>();
-    ASSERT_THAT(jsonRpc, NotNull());
-    SetNamespaceStorageLimitParamsData params;
-    params.Scope = WPEFramework::JsonData::PersistentStore::ScopeType::ACCOUNT;
-    params.Namespace = kAppId;
-    params.StorageLimit = kSize;
-    string paramsJsonStr;
-    params.ToString(paramsJsonStr);
-    string resultJsonStr;
-    EXPECT_THAT(jsonRpc->Invoke(0, 0, "", "setNamespaceStorageLimit", paramsJsonStr, resultJsonStr), Eq(WPEFramework::Core::ERROR_NOT_SUPPORTED));
-    jsonRpc->Release();
-    plugin->Deinitialize(service);
-}
-
 TEST_F(APersistentStore, GetsValueInDeviceScopeViaIStore)
 {
-    class SqliteStore2 : public NiceMock<Store2Mock> {
+    class PersistentStoreImplementation : public NiceMock<PersistentStoreImplementationMock> {
     public:
-        SqliteStore2()
+        PersistentStoreImplementation()
         {
-            EXPECT_CALL(*this, GetValue(_, _, _, _, _))
+            EXPECT_CALL(*this, GetValue(_, _, _))
                 .WillRepeatedly(Invoke(
-                    [](const IStore2::ScopeType scope, const string& ns, const string& key, string& value, uint32_t& ttl) {
-                        EXPECT_THAT(scope, Eq(IStore2::ScopeType::DEVICE));
+                    [](const string& ns, const string& key, string& value) {
                         EXPECT_THAT(ns, Eq(kAppId));
                         EXPECT_THAT(key, Eq(kKey));
                         value = kValue;
@@ -613,7 +533,7 @@ TEST_F(APersistentStore, GetsValueInDeviceScopeViaIStore)
                     }));
         }
     };
-    PublishedServiceType<SqliteStore2> metadata(WPEFramework::Core::System::MODULE_NAME, 1, 0, 0);
+    PublishedServiceType<PersistentStoreImplementation> metadata(WPEFramework::Core::System::MODULE_NAME, 1, 0, 0);
     ASSERT_THAT(plugin->Initialize(service), Eq(""));
     auto store = plugin->QueryInterface<IStore>();
     ASSERT_THAT(store, NotNull());
@@ -626,23 +546,21 @@ TEST_F(APersistentStore, GetsValueInDeviceScopeViaIStore)
 
 TEST_F(APersistentStore, SetsValueInDeviceScopeViaIStore)
 {
-    class SqliteStore2 : public NiceMock<Store2Mock> {
+    class PersistentStoreImplementation : public NiceMock<PersistentStoreImplementationMock> {
     public:
-        SqliteStore2()
+        PersistentStoreImplementation()
         {
-            EXPECT_CALL(*this, SetValue(_, _, _, _, _))
+            EXPECT_CALL(*this, SetValue(_, _, _))
                 .WillRepeatedly(Invoke(
-                    [](const IStore2::ScopeType scope, const string& ns, const string& key, const string& value, const uint32_t ttl) {
-                        EXPECT_THAT(scope, Eq(IStore2::ScopeType::DEVICE));
+                    [](const string& ns, const string& key, const string& value) {
                         EXPECT_THAT(ns, Eq(kAppId));
                         EXPECT_THAT(key, Eq(kKey));
                         EXPECT_THAT(value, Eq(kValue));
-                        EXPECT_THAT(ttl, Eq(0));
                         return WPEFramework::Core::ERROR_NONE;
                     }));
         }
     };
-    PublishedServiceType<SqliteStore2> metadata(WPEFramework::Core::System::MODULE_NAME, 1, 0, 0);
+    PublishedServiceType<PersistentStoreImplementation> metadata(WPEFramework::Core::System::MODULE_NAME, 1, 0, 0);
     ASSERT_THAT(plugin->Initialize(service), Eq(""));
     auto store = plugin->QueryInterface<IStore>();
     ASSERT_THAT(store, NotNull());
@@ -653,21 +571,20 @@ TEST_F(APersistentStore, SetsValueInDeviceScopeViaIStore)
 
 TEST_F(APersistentStore, DeletesKeyInDeviceScopeViaIStore)
 {
-    class SqliteStore2 : public NiceMock<Store2Mock> {
+    class PersistentStoreImplementation : public NiceMock<PersistentStoreImplementationMock> {
     public:
-        SqliteStore2()
+        PersistentStoreImplementation()
         {
-            EXPECT_CALL(*this, DeleteKey(_, _, _))
+            EXPECT_CALL(*this, DeleteKey(_, _))
                 .WillRepeatedly(Invoke(
-                    [](const IStore2::ScopeType scope, const string& ns, const string& key) {
-                        EXPECT_THAT(scope, Eq(IStore2::ScopeType::DEVICE));
+                    [](const string& ns, const string& key) {
                         EXPECT_THAT(ns, Eq(kAppId));
                         EXPECT_THAT(key, Eq(kKey));
                         return WPEFramework::Core::ERROR_NONE;
                     }));
         }
     };
-    PublishedServiceType<SqliteStore2> metadata(WPEFramework::Core::System::MODULE_NAME, 1, 0, 0);
+    PublishedServiceType<PersistentStoreImplementation> metadata(WPEFramework::Core::System::MODULE_NAME, 1, 0, 0);
     ASSERT_THAT(plugin->Initialize(service), Eq(""));
     auto store = plugin->QueryInterface<IStore>();
     ASSERT_THAT(store, NotNull());
@@ -678,20 +595,19 @@ TEST_F(APersistentStore, DeletesKeyInDeviceScopeViaIStore)
 
 TEST_F(APersistentStore, DeletesNamespaceInDeviceScopeViaIStore)
 {
-    class SqliteStore2 : public NiceMock<Store2Mock> {
+    class PersistentStoreImplementation : public NiceMock<PersistentStoreImplementationMock> {
     public:
-        SqliteStore2()
+        PersistentStoreImplementation()
         {
-            EXPECT_CALL(*this, DeleteNamespace(_, _))
+            EXPECT_CALL(*this, DeleteNamespace(_))
                 .WillRepeatedly(Invoke(
-                    [](const IStore2::ScopeType scope, const string& ns) {
-                        EXPECT_THAT(scope, Eq(IStore2::ScopeType::DEVICE));
+                    [](const string& ns) {
                         EXPECT_THAT(ns, Eq(kAppId));
                         return WPEFramework::Core::ERROR_NONE;
                     }));
         }
     };
-    PublishedServiceType<SqliteStore2> metadata(WPEFramework::Core::System::MODULE_NAME, 1, 0, 0);
+    PublishedServiceType<PersistentStoreImplementation> metadata(WPEFramework::Core::System::MODULE_NAME, 1, 0, 0);
     ASSERT_THAT(plugin->Initialize(service), Eq(""));
     auto store = plugin->QueryInterface<IStore>();
     ASSERT_THAT(store, NotNull());

--- a/PersistentStore/l0test/ServiceMock.h
+++ b/PersistentStore/l0test/ServiceMock.h
@@ -3,7 +3,8 @@
 #include "../Module.h"
 #include <gmock/gmock.h>
 
-class ServiceMock : public WPEFramework::PluginHost::IShell {
+class ServiceMock : public WPEFramework::PluginHost::IShell,
+                    public WPEFramework::PluginHost::IShell::ICOMLink {
 public:
     ~ServiceMock() override = default;
     MOCK_METHOD(string, Versions, (), (const, override));
@@ -33,22 +34,28 @@ public:
     MOCK_METHOD(string, ProxyStubPath, (), (const, override));
     MOCK_METHOD(string, HashKey, (), (const, override));
     MOCK_METHOD(string, Substitute, (const string&), (const, override));
-    MOCK_METHOD(WPEFramework::PluginHost::IShell::ICOMLink*, COMLink, (), (override));
     MOCK_METHOD(uint32_t, Activate, (const reason), (override));
     MOCK_METHOD(uint32_t, Deactivate, (const reason), (override));
     MOCK_METHOD(uint32_t, Unavailable, (const reason), (override));
     MOCK_METHOD(reason, Reason, (), (const, override));
-    MOCK_METHOD(uint32_t, ConfigLine, (const string& config), (override));
+    MOCK_METHOD(uint32_t, ConfigLine, (const string&), (override));
     MOCK_METHOD(string, SystemRootPath, (), (const, override));
-    MOCK_METHOD(uint32_t, SystemRootPath, (const string& systemRootPath), (override));
+    MOCK_METHOD(uint32_t, SystemRootPath, (const string&), (override));
     MOCK_METHOD(string, SystemPath, (), (const, override));
     MOCK_METHOD(string, PluginPath, (), (const, override));
     MOCK_METHOD(WPEFramework::PluginHost::IShell::startmode, StartMode, (), (const, override));
-    MOCK_METHOD(WPEFramework::Core::hresult, StartMode, (const startmode value), (override));
-    MOCK_METHOD(WPEFramework::Core::hresult, Resumed, (const bool value), (override));
-    MOCK_METHOD(WPEFramework::Core::hresult, Metadata, (string & info /* @out */), (const, override));
-    MOCK_METHOD(WPEFramework::Core::hresult, Hibernate, (const uint32_t timeout), (override));
+    MOCK_METHOD(WPEFramework::Core::hresult, StartMode, (const startmode), (override));
+    MOCK_METHOD(WPEFramework::Core::hresult, Resumed, (const bool), (override));
+    MOCK_METHOD(WPEFramework::Core::hresult, Metadata, (string&), (const, override));
+    MOCK_METHOD(WPEFramework::Core::hresult, Hibernate, (const uint32_t), (override));
+    MOCK_METHOD(void, Register, (WPEFramework::RPC::IRemoteConnection::INotification*), (override));
+    MOCK_METHOD(void, Unregister, (const WPEFramework::RPC::IRemoteConnection::INotification*), (override));
+    MOCK_METHOD(void, Register, (IShell::ICOMLink::INotification*), (override));
+    MOCK_METHOD(void, Unregister, (const IShell::ICOMLink::INotification*), (override));
+    MOCK_METHOD(WPEFramework::RPC::IRemoteConnection*, RemoteConnection, (const uint32_t), (override));
+    MOCK_METHOD(void*, Instantiate, (const WPEFramework::RPC::Object&, const uint32_t, uint32_t&), (override));
     BEGIN_INTERFACE_MAP(ServiceMock)
     INTERFACE_ENTRY(IShell)
+    INTERFACE_ENTRY(IShell::ICOMLink)
     END_INTERFACE_MAP
 };

--- a/PersistentStore/l1test/PersistentStoreTest.cpp
+++ b/PersistentStore/l1test/PersistentStoreTest.cpp
@@ -50,7 +50,7 @@ TEST_F(APersistentStore, MovesFileWhenInitializedWithNewAndPreviousPath)
     config.ToString(configJsonStr);
     ON_CALL(*service, ConfigLine())
         .WillByDefault(Return(configJsonStr));
-    ASSERT_THAT(plugin->Initialize(service), Eq(""));
+    plugin->Initialize(service);
     plugin->Deinitialize(service);
     ASSERT_THAT(WPEFramework::Core::File(kFile1).Exists(), IsFalse());
     ASSERT_THAT(file2.Open(true), IsTrue());

--- a/PersistentStore/l1test/ServiceMock.h
+++ b/PersistentStore/l1test/ServiceMock.h
@@ -3,7 +3,8 @@
 #include "../Module.h"
 #include <gmock/gmock.h>
 
-class ServiceMock : public WPEFramework::PluginHost::IShell {
+class ServiceMock : public WPEFramework::PluginHost::IShell,
+                    public WPEFramework::PluginHost::IShell::ICOMLink {
 public:
     ~ServiceMock() override = default;
     MOCK_METHOD(string, Versions, (), (const, override));
@@ -33,22 +34,28 @@ public:
     MOCK_METHOD(string, ProxyStubPath, (), (const, override));
     MOCK_METHOD(string, HashKey, (), (const, override));
     MOCK_METHOD(string, Substitute, (const string&), (const, override));
-    MOCK_METHOD(WPEFramework::PluginHost::IShell::ICOMLink*, COMLink, (), (override));
     MOCK_METHOD(uint32_t, Activate, (const reason), (override));
     MOCK_METHOD(uint32_t, Deactivate, (const reason), (override));
     MOCK_METHOD(uint32_t, Unavailable, (const reason), (override));
     MOCK_METHOD(reason, Reason, (), (const, override));
-    MOCK_METHOD(uint32_t, ConfigLine, (const string& config), (override));
+    MOCK_METHOD(uint32_t, ConfigLine, (const string&), (override));
     MOCK_METHOD(string, SystemRootPath, (), (const, override));
-    MOCK_METHOD(uint32_t, SystemRootPath, (const string& systemRootPath), (override));
+    MOCK_METHOD(uint32_t, SystemRootPath, (const string&), (override));
     MOCK_METHOD(string, SystemPath, (), (const, override));
     MOCK_METHOD(string, PluginPath, (), (const, override));
     MOCK_METHOD(WPEFramework::PluginHost::IShell::startmode, StartMode, (), (const, override));
-    MOCK_METHOD(WPEFramework::Core::hresult, StartMode, (const startmode value), (override));
-    MOCK_METHOD(WPEFramework::Core::hresult, Resumed, (const bool value), (override));
-    MOCK_METHOD(WPEFramework::Core::hresult, Metadata, (string & info /* @out */), (const, override));
-    MOCK_METHOD(WPEFramework::Core::hresult, Hibernate, (const uint32_t timeout), (override));
+    MOCK_METHOD(WPEFramework::Core::hresult, StartMode, (const startmode), (override));
+    MOCK_METHOD(WPEFramework::Core::hresult, Resumed, (const bool), (override));
+    MOCK_METHOD(WPEFramework::Core::hresult, Metadata, (string&), (const, override));
+    MOCK_METHOD(WPEFramework::Core::hresult, Hibernate, (const uint32_t), (override));
+    MOCK_METHOD(void, Register, (WPEFramework::RPC::IRemoteConnection::INotification*), (override));
+    MOCK_METHOD(void, Unregister, (const WPEFramework::RPC::IRemoteConnection::INotification*), (override));
+    MOCK_METHOD(void, Register, (IShell::ICOMLink::INotification*), (override));
+    MOCK_METHOD(void, Unregister, (const IShell::ICOMLink::INotification*), (override));
+    MOCK_METHOD(WPEFramework::RPC::IRemoteConnection*, RemoteConnection, (const uint32_t), (override));
+    MOCK_METHOD(void*, Instantiate, (const WPEFramework::RPC::Object&, const uint32_t, uint32_t&), (override));
     BEGIN_INTERFACE_MAP(ServiceMock)
     INTERFACE_ENTRY(IShell)
+    INTERFACE_ENTRY(IShell::ICOMLink)
     END_INTERFACE_MAP
 };

--- a/PersistentStore/sqlite/Store2.cpp
+++ b/PersistentStore/sqlite/Store2.cpp
@@ -1,8 +1,0 @@
-#include "Store2.h"
-
-namespace WPEFramework {
-namespace Plugin {
-    class SqliteStore2 : public Sqlite::Store2 {};
-    SERVICE_REGISTRATION(SqliteStore2, 1, 0);
-} // namespace Plugin
-} // namespace WPEFramework


### PR DESCRIPTION
Reason for change: PersistentStore spawns 1 process. If spawning times out, activation should fail.
If process crashes, plugin should deactivate.
Test Procedure: None
Risks: None
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>