### PR TITLE
RDK-46636 - NetworkManager backward compatibility

### DIFF
--- a/NetworkManager/service/NetworkManagerLegacy.cpp
+++ b/NetworkManager/service/NetworkManagerLegacy.cpp
@@ -73,6 +73,7 @@ namespace WPEFramework
             Register("getCurrentState",                   &NetworkManager::GetWifiState, this);
             GetHandler(2)->Register<JsonObject, JsonObject>("setIPSettings", &NetworkManager::setIPSettings, this);
             GetHandler(2)->Register<JsonObject, JsonObject>("getIPSettings", &NetworkManager::getIPSettings, this);
+            GetHandler(2)->Register<JsonObject, JsonObject>("initiateWPSPairing", &NetworkManager::initiateWPSPairing, this);
         }
 
         /**


### PR DESCRIPTION
Reason for change: Added handler2 support for initiateWPSPairing
Test Procedure: Build and verified
Risks: Low
Priority: P1
Signed-off-by: Gururaaja ESR <Gururaja_ErodeSriranganRamlingham@comcast.com>