### PR TITLE
RDKTV-30016 - [Miracast] Connection fails with ENT-32203 when alternatively trying connect from different mobiles devices

### DIFF
--- a/Miracast/RTSP/MiracastRtspMsg.cpp
+++ b/Miracast/RTSP/MiracastRtspMsg.cpp
@@ -953,6 +953,14 @@ MiracastError MiracastRTSPMsg::initiate_TCP(std::string goIP)
             MIRACASTLOG_ERROR("Failed to set SO_REUSEADDR: %s", strerror(errno));
             continue;
         }
+        // Set SO_LINGER option with a timeout of 5
+        struct linger ling;
+        ling.l_onoff = 1;  // Enable lingering
+        ling.l_linger = 5; // Timeout of 5 seconds
+        if (setsockopt(m_tcpSockfd, SOL_SOCKET, SO_LINGER, &ling, sizeof(ling)) == -1) {
+            MIRACASTLOG_ERROR("Failed to set SO_LINGER: %s", strerror(errno));
+            continue;
+        }
 
         /*---Add socket to epoll---*/
         m_epollfd = epoll_create(1);

--- a/Miracast/RTSP/MiracastRtspMsg.cpp
+++ b/Miracast/RTSP/MiracastRtspMsg.cpp
@@ -945,7 +945,7 @@ MiracastError MiracastRTSPMsg::initiate_TCP(std::string goIP)
             MIRACASTLOG_ERROR("TCP Socket creation error %s", strerror(errno));
             continue;
         }
-
+#if 0
         // Set SO_REUSEADDR option
         int optval = 1;
         if (setsockopt(m_tcpSockfd, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval)) == -1)
@@ -961,7 +961,7 @@ MiracastError MiracastRTSPMsg::initiate_TCP(std::string goIP)
             MIRACASTLOG_ERROR("Failed to set SO_LINGER: %s", strerror(errno));
             continue;
         }
-
+#endif
         /*---Add socket to epoll---*/
         m_epollfd = epoll_create(1);
         struct epoll_event event;


### PR DESCRIPTION
RDKTV-30016 - [Miracast] Connection fails with ENT-32203 when alternatively trying connect from different mobiles devices

- Commented out the SO_REUSEADDR socket flag

Signed-off-by: yuvaramachandran_gurusamy <yuvaramachandran_gurusamy@comcast.com>
