### PR TITLE
DELIA-65168 - Observed telemetry marker "SYST_ERR_ThunderSrvNotReady"

### DIFF
--- a/NetworkManager/service/NetworkManagerLogger.cpp
+++ b/NetworkManager/service/NetworkManagerLogger.cpp
@@ -35,12 +35,6 @@
 namespace NetworkManagerLogger {
     static LogLevel gDefaultLogLevel = TRACE_LEVEL;
 
-    static inline void sync_stdout()
-    {
-        if (getenv("SYNC_STDOUT"))
-            setvbuf(stdout, NULL, _IOLBF, 0);
-    }
-
     const char* methodName(const std::string& prettyFunction)
     {
         size_t colons = prettyFunction.find("::");
@@ -52,7 +46,6 @@ namespace NetworkManagerLogger {
 
     void Init()
     {
-        sync_stdout();
 #ifdef USE_RDK_LOGGER
         rdk_logger_init(0 == access("/opt/debug.ini", R_OK) ? "/opt/debug.ini" : "/etc/debug.ini");
 #endif


### PR DESCRIPTION
Reason for change: Removed the getenv from NetworkManagerLogger as it is not required
Test Procedure: Build and verified
Risks: Low
Priority: P1
Signed-off-by: Gururaaja ESR <Gururaja_ErodeSriranganRamlingham@comcast.com>