### PR TITLE
Merge pull request #5174 from dautapankumardora/sprint/24Q2_28858

### DIFF
--- a/DisplaySettings/CHANGELOG.md
+++ b/DisplaySettings/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+## [1.4.2] - 2024-04-29
+### Added
+- Fail safe check for CEC enable.
+
 ## [1.4.1] - 2024-03-29
 ### Security
 - Resolved security vulnerabilities

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -85,7 +85,7 @@ using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 4
-#define API_VERSION_NUMBER_PATCH 1
+#define API_VERSION_NUMBER_PATCH 2
 
 static bool isCecEnabled = false;
 static bool isResCacheUpdated = false;
@@ -5557,6 +5557,15 @@ void DisplaySettings::sendMsgThread()
                     m_timer.stop();
                 }
             }
+	    
+	    if(!isCecEnabled){
+		try {
+		    isCecEnabled = getHdmiCecSinkCecEnableStatus();
+		}
+		catch (const device::Exception& err){
+		    LOG_DEVICE_EXCEPTION1(string("HDMI_ARC0"));
+		}
+	    }
 
             if(m_subscribed) {
          	//Need to send power on request as this timer might have started based on standby out or boot up scenario


### PR DESCRIPTION
RDKTV-28858: Getting audio output when on mute/ 0 vol when AVR was connected.

Reason for change:getHdmiCecSinkCecEnableStatus when plugin becomes active.
Test Procedure: check the ticket for test procedure.
Risks: Low
Priority: P1
Signed-off-by: bp-tdora114 [dautapankumar.dora@sky.uk](mailto:dautapankumar.dora@sky.uk)