### PR TITLE
DELIA-65238 - Network failure retry logic timeout remains as 5 sec

### DIFF
--- a/Network/CHANGELOG.md
+++ b/Network/CHANGELOG.md
@@ -16,6 +16,11 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+README
+## [1.3.6] - 2024-05-10
+### Fixed
+- Fixed connectivity monitor retry logic
+
 ## [1.3.5] - 2024-04-19
 ### Added
 - added retry logic for connectivity monitor

--- a/Network/Network.cpp
+++ b/Network/Network.cpp
@@ -35,7 +35,7 @@ using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 3
-#define API_VERSION_NUMBER_PATCH 5
+#define API_VERSION_NUMBER_PATCH 6
 
 /* Netsrvmgr Based Macros & Structures */
 #define IARM_BUS_NM_SRV_MGR_NAME "NET_SRV_MGR"

--- a/Network/NetworkConnectivity.cpp
+++ b/Network/NetworkConnectivity.cpp
@@ -539,6 +539,11 @@ namespace WPEFramework {
                     LOGINFO("notification count change to default %d ...", notifyWaitCount);
                 }
             }
+            else
+            {
+                notifyWaitCount = DEFAULT_MONITOR_RETRY_COUNT;
+                tempTimeout = timeout.load();
+            }
 
             if(stopFlag)
                 break;


### PR DESCRIPTION
Reason for change: Added logic to change the notification count and timeout to default value, when the global internet state is equal to InternetConnectionState Test Procedure: Build and verified
Risks: Low
Priority: P1
Signed-off-by: Gururaaja ESR <Gururaja_ErodeSriranganRamlingham@comcast.com>