### PR TITLE
DELIA-65244 : Add support for error 5 (NOT_FOUND)

### DIFF
--- a/PersistentStore/grpc/Store2.h
+++ b/PersistentStore/grpc/Store2.h
@@ -241,6 +241,8 @@ namespace Plugin {
                     OnError(__FUNCTION__, status);
                     if (status.error_code() == grpc::StatusCode::INVALID_ARGUMENT) {
                         result = Core::ERROR_INVALID_INPUT_LENGTH;
+                    } else if (status.error_code() == grpc::StatusCode::NOT_FOUND) {
+                        result = Core::ERROR_UNKNOWN_KEY;
                     } else {
                         result = Core::ERROR_GENERAL;
                     }

--- a/PersistentStore/grpc/l2test/StubTest.cpp
+++ b/PersistentStore/grpc/l2test/StubTest.cpp
@@ -24,10 +24,12 @@ using ::testing::Le;
 using ::testing::Test;
 
 const auto kUri = "ss.eu.prod.developer.comcast.com:443";
+const auto kDevUri = "ss.dev.developer.comcast.com:443";
 const auto kValue = "value_1";
 const auto kKey = "key_1";
 const auto kAppId = "app_id_1";
 const auto kTtl = 2;
+const auto kTtlFault = 1;
 const auto kScope = Scope::SCOPE_ACCOUNT;
 const auto kEmpty = "";
 const auto kUnknown = "unknown";
@@ -39,6 +41,17 @@ protected:
     AStub()
         : stub(SecureStorageService::NewStub(grpc::CreateChannel(
               kUri,
+              grpc::SslCredentials(grpc::SslCredentialsOptions()))))
+    {
+    }
+};
+
+class ADevStub : public Test {
+protected:
+    std::unique_ptr<SecureStorageService::Stub> stub;
+    ADevStub()
+        : stub(SecureStorageService::NewStub(grpc::CreateChannel(
+              kDevUri,
               grpc::SslCredentials(grpc::SslCredentialsOptions()))))
     {
     }
@@ -217,6 +230,23 @@ TEST_F(AStub, DoesNotGetValueWhenAppIdUnknown)
     EXPECT_THAT(response.has_value(), IsFalse());
 }
 
+TEST_F(ADevStub, DoesNotGetValueWhenAppIdUnknown)
+{
+    grpc::ClientContext context;
+    context.AddMetadata("authorization", std::string(kToken));
+    GetValueRequest request;
+    auto k = new Key();
+    k->set_app_id(kUnknown);
+    k->set_key(kKey);
+    k->set_scope(kScope);
+    request.set_allocated_key(k);
+    GetValueResponse response;
+    auto status = stub->GetValue(&context, request, &response);
+    ASSERT_THAT(status.ok(), IsFalse());
+    EXPECT_THAT(status.error_code(), Eq(5));
+    EXPECT_THAT(status.error_message(), Eq("requested key scope does not exist"));
+}
+
 TEST_F(AStub, DoesNotGetValueWhenKeyUnknown)
 {
     {
@@ -248,6 +278,41 @@ TEST_F(AStub, DoesNotGetValueWhenKeyUnknown)
         auto status = stub->GetValue(&context, request, &response);
         ASSERT_THAT(status.ok(), IsTrue());
         EXPECT_THAT(response.has_value(), IsFalse());
+    }
+}
+
+TEST_F(ADevStub, DoesNotGetValueWhenKeyUnknown)
+{
+    {
+        grpc::ClientContext context;
+        context.AddMetadata("authorization", std::string(kToken));
+        UpdateValueRequest request;
+        auto v = new Value();
+        v->set_value(kValue);
+        auto k = new Key();
+        k->set_app_id(kAppId);
+        k->set_key(kKey);
+        k->set_scope(kScope);
+        v->set_allocated_key(k);
+        request.set_allocated_value(v);
+        UpdateValueResponse response;
+        auto status = stub->UpdateValue(&context, request, &response);
+        ASSERT_THAT(status.ok(), IsTrue());
+    }
+    {
+        grpc::ClientContext context;
+        context.AddMetadata("authorization", std::string(kToken));
+        GetValueRequest request;
+        auto k = new Key();
+        k->set_app_id(kAppId);
+        k->set_key(kUnknown);
+        k->set_scope(kScope);
+        request.set_allocated_key(k);
+        GetValueResponse response;
+        auto status = stub->GetValue(&context, request, &response);
+        ASSERT_THAT(status.ok(), IsFalse());
+        EXPECT_THAT(status.error_code(), Eq(5));
+        EXPECT_THAT(status.error_message(), Eq("requested key scope does not exist"));
     }
 }
 
@@ -352,7 +417,7 @@ TEST_F(AStub, GetsValueWhenTtlDidNotExpire)
         now.set_seconds(time(nullptr));
         now.set_nanos(0);
         EXPECT_THAT(response.value().expire_time().seconds(), Gt(now.seconds()));
-        EXPECT_THAT(response.value().expire_time().seconds(), Le(now.seconds() + kTtl));
+        EXPECT_THAT(response.value().expire_time().seconds(), Le(now.seconds() + kTtl + kTtlFault));
     }
 }
 
@@ -377,7 +442,7 @@ TEST_F(AStub, DoesNotGetValueWhenTtlExpired)
         auto status = stub->UpdateValue(&context, request, &response);
         ASSERT_THAT(status.ok(), IsTrue());
     }
-    sleep(kTtl + 1);
+    sleep(kTtl + kTtlFault);
     {
         grpc::ClientContext context;
         context.AddMetadata("authorization", std::string(kToken));
@@ -391,5 +456,44 @@ TEST_F(AStub, DoesNotGetValueWhenTtlExpired)
         auto status = stub->GetValue(&context, request, &response);
         ASSERT_THAT(status.ok(), IsTrue());
         EXPECT_THAT(response.has_value(), IsFalse());
+    }
+}
+
+TEST_F(ADevStub, DoesNotGetValueWhenTtlExpired)
+{
+    {
+        grpc::ClientContext context;
+        context.AddMetadata("authorization", std::string(kToken));
+        UpdateValueRequest request;
+        auto v = new Value();
+        v->set_value(kValue);
+        auto t = new ::google::protobuf::Duration();
+        t->set_seconds(kTtl);
+        v->set_allocated_ttl(t);
+        auto k = new Key();
+        k->set_app_id(kAppId);
+        k->set_key(kKey);
+        k->set_scope(kScope);
+        v->set_allocated_key(k);
+        request.set_allocated_value(v);
+        UpdateValueResponse response;
+        auto status = stub->UpdateValue(&context, request, &response);
+        ASSERT_THAT(status.ok(), IsTrue());
+    }
+    sleep(kTtl + kTtlFault);
+    {
+        grpc::ClientContext context;
+        context.AddMetadata("authorization", std::string(kToken));
+        GetValueRequest request;
+        auto k = new Key();
+        k->set_app_id(kAppId);
+        k->set_key(kKey);
+        k->set_scope(kScope);
+        request.set_allocated_key(k);
+        GetValueResponse response;
+        auto status = stub->GetValue(&context, request, &response);
+        ASSERT_THAT(status.ok(), IsFalse());
+        EXPECT_THAT(status.error_code(), Eq(5));
+        EXPECT_THAT(status.error_message(), Eq("requested key scope does not exist"));
     }
 }


### PR DESCRIPTION
Reason for change: Add support for error 5 (NOT_FOUND) returned from SecureStore endpoint.
Corresponding L0, L2 tests.
Test Procedure: None
Risks: None
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>