### PR TITLE
RDKTV-30490 - [miracast] Intermittently, "ENT-32203" error is observed when miracast is connected using first source for 2-3 times and then attempt to connect using second source

### DIFF
--- a/Miracast/MiracastService/MiracastController.h
+++ b/Miracast/MiracastService/MiracastController.h
@@ -123,8 +123,11 @@ private:
     void checkAndInitiateP2PBackendDiscovery(void);
     std::string getifNameByIPv4(std::string ip_address);
     bool getConnectionStatusByARPING( const char* remote_address, const char* interface );
-
+    void remove_ARPEntry(std::string& ipAddress);
+    void create_DeviceCacheData(std::string deviceMAC,std::string authType,std::string modelName,std::string deviceType, bool force_overwrite);
     void set_localIp(std::string ipAddr);
+    void set_SourcePeerIface(std::string& devMac, std::string peer_iface_mac);
+    std::string get_SourcePeerIface(std::string& devMac);
 
     MiracastServiceNotifier *m_notify_handler;
     std::string m_connected_mac_addr;

--- a/Miracast/common/MiracastCommon.h
+++ b/Miracast/common/MiracastCommon.h
@@ -208,6 +208,7 @@ typedef struct d_info
     string deviceMAC;
     string deviceType;
     string modelName;
+    string peer_iface;
     string authType;
     bool isCPSupported;
     enum DEVICEROLE deviceRole;
@@ -358,6 +359,7 @@ class MiracastCommon
     public:
         static std::string parse_opt_flag( std::string file_name , bool integer_check = false, bool debugStats = true );
         static int execute_SystemCommand( const char* system_command_buffer );
+        static bool execute_PopenCommand( const char* popen_command, const char* expected_char, unsigned int retry_count, std::string& popen_buffer, unsigned int interval_micro_sec );
 };
 
 #endif

--- a/Tests/L1Tests/tests/test_MiracastService.cpp
+++ b/Tests/L1Tests/tests/test_MiracastService.cpp
@@ -370,9 +370,13 @@ TEST_F(MiracastServiceEventTest, P2P_GOMode_onClientConnectionAndLaunchRequest)
 					[&](const char* command, const char* type)
 					{
 					char buffer[1024] = {0};
-					if ( 0 == strncmp(command,"awk '$6 == ",strlen("awk '$6 == ")))
+					if ( 0 == strncmp(command,"awk '$4 == ",strlen("awk '$4 == ")))
 					{
 						strncpy(buffer, "192.168.59.165",sizeof(buffer));
+					}
+					else if ( 0 == strncmp(command,"awk '$1 == ",strlen("awk '$1 == ")))
+					{
+						// Need to return as empty
 					}
 					else if ( 0 == strncmp(command,"arping",strlen("arping")))
 					{
@@ -507,8 +511,11 @@ TEST_F(MiracastServiceEventTest, P2P_GOMode_onClientConnectionAndLaunchRequest)
 	EXPECT_EQ(Core::ERROR_NONE, P2PGrpStart.Lock(10000));
 
 	EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("updatePlayerState"), _T("{\"mac\": \"96:52:44:b6:7d:14\",\"state\":\"INITIATED\"}"), response));
+	sleep(1);
 	EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("updatePlayerState"), _T("{\"mac\": \"96:52:44:b6:7d:14\",\"state\":\"INPROGRESS\"}"), response));
+	sleep(1);
 	EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("updatePlayerState"), _T("{\"mac\": \"96:52:44:b6:7d:14\",\"state\":\"PLAYING\"}"), response));
+	sleep(1);
 
 	/* @return      :  {"message":"Failed as MiracastPlayer already Launched.","success":false}*/
 	EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("setEnable"), _T("{\"enabled\": false}"), response));
@@ -1692,9 +1699,13 @@ TEST_F(MiracastServiceEventTest, P2P_GOMode_GENERIC_FAILURE)
 					[&](const char* command, const char* type)
 					{
 					char buffer[1024] = {0};
-					if ( 0 == strncmp(command,"awk '$6 == ",strlen("awk '$6 == ")))
+					if ( 0 == strncmp(command,"awk '$4 == ",strlen("awk '$4 == ")))
 					{
 						strncpy(buffer, "192.168.59.165",sizeof(buffer));
+					}
+					else if ( 0 == strncmp(command,"awk '$1 == ",strlen("awk '$1 == ")))
+					{
+						// Need to return as empty
 					}
 					else if ( 0 == strncmp(command,"arping",strlen("arping")))
 					{
@@ -1828,9 +1839,13 @@ TEST_F(MiracastServiceEventTest, P2P_GOMode_AutoConnect)
 					[&](const char* command, const char* type)
 					{
 					char buffer[1024] = {0};
-					if ( 0 == strncmp(command,"awk '$6 == ",strlen("awk '$6 == ")))
+					if ( 0 == strncmp(command,"awk '$4 == ",strlen("awk '$4 == ")))
 					{
 						strncpy(buffer, "192.168.59.165",sizeof(buffer));
+					}
+					else if ( 0 == strncmp(command,"awk '$1 == ",strlen("awk '$1 == ")))
+					{
+						// Need to return as empty
 					}
 					else if ( 0 == strncmp(command,"arping",strlen("arping")))
 					{

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -31,6 +31,8 @@
   - [MaintenanceManager](api/MaintenanceManagerPlugin.md)
   - [MediaEngineRMF](api/MediaEngineRMFPlugin.md)
   - [Messenger](api/MessengerPlugin.md)
+  - [MiracastService](api/MiracastServicePlugin.md)
+  - [MiracastPlayer](api/MiracastPlayerPlugin.md)
   - [Monitor](api/MonitorPlugin.md)
   - [MotionDetection](api/MotionDetectionPlugin.md)
   - [Network](api/NetworkPlugin.md)

--- a/docs/api/_sidebar.md
+++ b/docs/api/_sidebar.md
@@ -31,6 +31,8 @@
   - [MaintenanceManager](api/MaintenanceManagerPlugin.md)
   - [MediaEngineRMF](api/MediaEngineRMFPlugin.md)
   - [Messenger](api/MessengerPlugin.md)
+  - [MiracastService](api/MiracastServicePlugin.md)
+  - [MiracastPlayer](api/MiracastPlayerPlugin.md)
   - [Monitor](api/MonitorPlugin.md)
   - [MotionDetection](api/MotionDetectionPlugin.md)
   - [Network](api/NetworkPlugin.md)


### PR DESCRIPTION
RDKTV-30490 - [miracast] Intermittently, "ENT-32203" error is observed when miracast is connected using first source for 2-3 times and then attempt to connect using second source

- Fetched the ip table from ARP using peer_iface MacAddress which is received in P2P-GO-NEG-SUCCESS event
- Added the retry to check ARP properly removed or not while exiting the session