### PR TITLE
RDKCOM-4733- RDKDEV-1034 Make rdkservices plugin(SystemServices) autostart configurable from recipe

### DIFF
--- a/SystemServices/CHANGELOG.md
+++ b/SystemServices/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+## [2.1.5] - 2024-05-14
+### Fixed
+- Fixed the autostart configurable from recipe
+
 ## [2.1.4] - 2024-05-02
 ### Fixed
 - Fixed the WPEFramework crash issue

--- a/SystemServices/CMakeLists.txt
+++ b/SystemServices/CMakeLists.txt
@@ -18,6 +18,7 @@
 set(PLUGIN_NAME SystemServices)
 set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
 
+set(PLUGIN_SYSTEM_AUTOSTART false CACHE STRING "To automatically start System plugin.")
 set(PLUGIN_SYSTEMSERVICE_STARTUPORDER "" CACHE STRING "To configure startup order of SystemServices plugin")
 
 find_package(${NAMESPACE}Plugins REQUIRED)

--- a/SystemServices/SystemServices.conf.in
+++ b/SystemServices/SystemServices.conf.in
@@ -1,4 +1,4 @@
 precondition = ["Platform"]
 callsign = "org.rdk.System"
-autostart = "false"
+autostart = "@PLUGIN_SYSTEM_AUTOSTART@"
 startuporder = "@PLUGIN_SYSTEMSERVICE_STARTUPORDER@"

--- a/SystemServices/SystemServices.config
+++ b/SystemServices/SystemServices.config
@@ -1,4 +1,4 @@
-set (autostart false)
+set (autostart ${PLUGIN_SYSTEM_AUTOSTART})
 set (preconditions Platform)
 set (callsign "org.rdk.System")
 

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -67,7 +67,7 @@ using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 2
 #define API_VERSION_NUMBER_MINOR 1
-#define API_VERSION_NUMBER_PATCH 4
+#define API_VERSION_NUMBER_PATCH 5
 
 #define MAX_REBOOT_DELAY 86400 /* 24Hr = 86400 sec */
 #define TR181_FW_DELAY_REBOOT "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.AutoReboot.fwDelayReboot"

--- a/docs/api/SystemPlugin.md
+++ b/docs/api/SystemPlugin.md
@@ -2,7 +2,7 @@
 <a name="System_Plugin"></a>
 # System Plugin
 
-**Version: [2.1.4](https://github.com/rdkcentral/rdkservices/blob/main/SystemServices/CHANGELOG.md)**
+**Version: [2.1.5](https://github.com/rdkcentral/rdkservices/blob/main/SystemServices/CHANGELOG.md)**
 
 A org.rdk.System plugin for Thunder framework.
 


### PR DESCRIPTION
Reason for change: Need SystemServices plugin to be made autostart true to reduce the startup delay and aid resident UI for user input handling

Test Procedure: Build and verify.

Risks: Low

Signed-off-by: Selva Kumar MR selvakumar_mr@comcast.com