### PR TITLE
DELIA-62842 org.rdk.System.getSystemVersions API has wrong stbTimestamp

### DIFF
--- a/SystemServices/CHANGELOG.md
+++ b/SystemServices/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+## [2.1.6] - 2024-05-16
+### Fixed
+- getSystemVersions API has wrong stbTimestamp format
+
 ## [2.1.5] - 2024-05-14
 ### Fixed
 - Fixed the autostart configurable from recipe

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -67,7 +67,7 @@ using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 2
 #define API_VERSION_NUMBER_MINOR 1
-#define API_VERSION_NUMBER_PATCH 5
+#define API_VERSION_NUMBER_PATCH 6
 
 #define MAX_REBOOT_DELAY 86400 /* 24Hr = 86400 sec */
 #define TR181_FW_DELAY_REBOOT "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.AutoReboot.fwDelayReboot"

--- a/SystemServices/SystemServicesHelper.cpp
+++ b/SystemServices/SystemServicesHelper.cpp
@@ -546,7 +546,7 @@ std::string stringTodate(char *pBuffer)
     } else {
         char tempBuff[128] = {'\0'};
 
-        strftime(tempBuff, sizeof(tempBuff), "%a %d %b %Y %H:%M:%S AP UTC", &result);
+        strftime(tempBuff, sizeof(tempBuff), "%a %d %b %Y %H:%M:%S UTC", &result);
         str = tempBuff;
     }
     return str;

--- a/Tests/L1Tests/tests/test_SystemServices.cpp
+++ b/Tests/L1Tests/tests/test_SystemServices.cpp
@@ -732,7 +732,7 @@ TEST_F(SystemServicesTest, SystemVersions)
     file.close();
 
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getSystemVersions"), _T("{}"), response));
-    EXPECT_EQ(response, string("{\"stbVersion\":\"PX051AEI_VBN_2203_sprint_20220331225312sdy_NG\",\"receiverVersion\":\"000.36.0.0\",\"stbTimestamp\":\"Fri 05 Aug 2022 16:14:54 AP UTC\",\"success\":true}"));
+    EXPECT_EQ(response, string("{\"stbVersion\":\"PX051AEI_VBN_2203_sprint_20220331225312sdy_NG\",\"receiverVersion\":\"000.36.0.0\",\"stbTimestamp\":\"Fri 05 Aug 2022 16:14:54 UTC\",\"success\":true}"));
 }
 
 TEST_F(SystemServicesTest, MocaStatus)


### PR DESCRIPTION
Reason for change:  Remove the junk string AP
Test Procedure: verify build success and basic test
Risks: Low
Priority: P1
Signed-off-by: ramkumar_prabaharan@comcast.com