### PR TITLE
RDK-48604: New UserSettings Thunder Plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,10 @@ if(PLUGIN_CONTROLSERVICE)
     add_subdirectory(ControlService)
 endif()
 
+if(PLUGIN_USERSETTINGS)
+    add_subdirectory(UserSettings)
+endif()
+
 if(PLUGIN_VOICECONTROL)
     add_subdirectory(VoiceControl)
 endif()

--- a/UserSettings/CHANGELOG.md
+++ b/UserSettings/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this RDK Service will be documented in this file.
+
+* Each RDK Service has a CHANGELOG file that contains all changes done so far. When version is updated, add a entry in the CHANGELOG.md at the top with user friendly information on what was changed with the new version. Please don't mention JIRA tickets in CHANGELOG.
+
+* Please Add entry in the CHANGELOG for each version change and indicate the type of change with these labels:
+    * **Added** for new features.
+    * **Changed** for changes in existing functionality.
+    * **Deprecated** for soon-to-be removed features.
+    * **Removed** for now removed features.
+    * **Fixed** for any bug fixes.
+    * **Security** in case of vulnerabilities.
+
+* Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development.
+
+* For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+## [1.0.0] - 2024-05-08
+### Added
+- Add CHANGELOG
+
+### Change
+- Reset API version to 1.0.0
+- Change README to inform how to update changelog and API version

--- a/UserSettings/CMakeLists.txt
+++ b/UserSettings/CMakeLists.txt
@@ -1,0 +1,68 @@
+# If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2024 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set(PLUGIN_NAME UserSettings)
+set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
+set(PLUGIN_IMPLEMENTATION ${MODULE_NAME}Implementation)
+
+set(PLUGIN_USERSETTINGS_AUTOSTART "true" CACHE STRING "Automatically start UserSettings plugin")
+set(PLUGIN_USERSETTINGS_STARTUPORDER "51" CACHE STRING "To configure startup order of UserSettings plugin")
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+find_package(${NAMESPACE}Plugins REQUIRED)
+find_package(${NAMESPACE}Definitions REQUIRED)
+find_package(CompileSettingsDebug CONFIG REQUIRED)
+
+add_library(${MODULE_NAME} SHARED
+    UserSettings.cpp
+    Module.cpp)
+
+set_target_properties(${MODULE_NAME} PROPERTIES
+        CXX_STANDARD 11
+        CXX_STANDARD_REQUIRED YES)
+
+target_link_libraries(${MODULE_NAME}
+    PRIVATE
+        CompileSettingsDebug::CompileSettingsDebug
+        ${NAMESPACE}Plugins::${NAMESPACE}Plugins
+        ${NAMESPACE}Definitions::${NAMESPACE}Definitions)
+
+install(TARGETS ${MODULE_NAME}
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/${STORAGE_DIRECTORY}/plugins)
+
+add_library(${PLUGIN_IMPLEMENTATION} SHARED
+    UserSettingsImplementation.cpp
+    Module.cpp)
+
+include_directories(
+   ../helpers)
+
+set_target_properties(${PLUGIN_IMPLEMENTATION} PROPERTIES
+        CXX_STANDARD 11
+        CXX_STANDARD_REQUIRED YES)
+
+target_link_libraries(${PLUGIN_IMPLEMENTATION}
+    PRIVATE
+        CompileSettingsDebug::CompileSettingsDebug
+        ${NAMESPACE}Plugins::${NAMESPACE}Plugins)
+
+install(TARGETS ${PLUGIN_IMPLEMENTATION}
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/${STORAGE_DIRECTORY}/plugins)
+
+write_config(${PLUGIN_NAME})
+

--- a/UserSettings/Module.cpp
+++ b/UserSettings/Module.cpp
@@ -1,0 +1,22 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2024 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "Module.h"
+
+MODULE_NAME_DECLARATION(BUILD_REFERENCE)

--- a/UserSettings/Module.h
+++ b/UserSettings/Module.h
@@ -1,0 +1,29 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2024 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#pragma once
+#ifndef MODULE_NAME
+#define MODULE_NAME Plugin_UserSettings
+#endif
+
+#include <plugins/plugins.h>
+#include <tracing/tracing.h>
+
+#undef EXTERNAL
+#define EXTERNAL

--- a/UserSettings/UserSettings.conf.in
+++ b/UserSettings/UserSettings.conf.in
@@ -1,0 +1,12 @@
+autostart = "@PLUGIN_USERSETTINGS_AUTOSTART@"
+precondition = ["Platform"]
+callsign = "org.rdk.UserSettings"
+startuporder = "@PLUGIN_USERSETTINGS_STARTUPORDER@"
+
+configuration = JSON()
+rootobject = JSON()
+
+rootobject.add("mode", "@PLUGIN_USERSETTINGS_MODE@")
+rootobject.add("locator", "lib@PLUGIN_IMPLEMENTATION@.so")
+configuration.add("root", rootobject)
+

--- a/UserSettings/UserSettings.config
+++ b/UserSettings/UserSettings.config
@@ -1,0 +1,15 @@
+set(autostart ${PLUGIN_USERSETTINGS_AUTOSTART})
+
+if(PLUGIN_USERSETTINGS_STARTUPORDER)
+set (startuporder ${PLUGIN_USERSETTINGS_STARTUPORDER})
+endif()
+
+map()
+   key(root)
+   map()
+       kv(mode ${PLUGIN_USERSETTINGS_MODE})
+       kv(locator lib${PLUGIN_IMPLEMENTATION}.so)
+   end()
+end()
+ans(configuration)
+

--- a/UserSettings/UserSettings.cpp
+++ b/UserSettings/UserSettings.cpp
@@ -1,0 +1,155 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2024 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "UserSettings.h"
+
+#define API_VERSION_NUMBER_MAJOR 1
+#define API_VERSION_NUMBER_MINOR 0
+#define API_VERSION_NUMBER_PATCH 0
+
+namespace WPEFramework
+{
+
+    namespace {
+
+        static Plugin::Metadata<Plugin::UserSettings> metadata(
+            // Version (Major, Minor, Patch)
+            API_VERSION_NUMBER_MAJOR, API_VERSION_NUMBER_MINOR, API_VERSION_NUMBER_PATCH,
+            // Preconditions
+            {},
+            // Terminations
+            {},
+            // Controls
+            {}
+        );
+    }
+
+    namespace Plugin
+    {
+
+    /*
+     *Register UserSettings module as wpeframework plugin
+     **/
+    SERVICE_REGISTRATION(UserSettings, API_VERSION_NUMBER_MAJOR, API_VERSION_NUMBER_MINOR, API_VERSION_NUMBER_PATCH);
+
+    UserSettings::UserSettings() : _service(nullptr), _connectionId(0), _userSetting(nullptr), _usersettingsNotification(this)
+    {
+        SYSLOG(Logging::Startup, (_T("UserSettings Constructor")));
+    }
+
+    UserSettings::~UserSettings()
+    {
+        SYSLOG(Logging::Shutdown, (string(_T("UserSettings Destructor"))));
+    }
+
+    const string UserSettings::Initialize(PluginHost::IShell* service)
+    {
+        string message="";
+
+        ASSERT(nullptr != service);
+        ASSERT(nullptr == _service);
+        ASSERT(nullptr == _userSetting);
+        ASSERT(0 == _connectionId);
+
+        SYSLOG(Logging::Startup, (_T("UserSettings::Initialize: PID=%u"), getpid()));
+
+        _service = service;
+        _service->AddRef();
+        _service->Register(&_usersettingsNotification);
+        _userSetting = _service->Root<Exchange::IUserSettings>(_connectionId, 5000, _T("UserSettingsImplementation"));
+
+        if(nullptr != _userSetting)
+        {
+            // Register for notifications
+            _userSetting->Register(&_usersettingsNotification);
+            // Invoking Plugin API register to wpeframework
+            Exchange::JUserSettings::Register(*this, _userSetting);
+        }
+        else
+        {
+            SYSLOG(Logging::Startup, (_T("UserSettings::Initialize: Failed to initialise UserSettings plugin")));
+            message = _T("UserSettings plugin could not be initialised");
+        }
+
+        if (0 != message.length())
+        {
+           Deinitialize(service);
+        }
+
+        return message;
+    }
+
+    void UserSettings::Deinitialize(PluginHost::IShell* service)
+    {
+        ASSERT(_service == service);
+
+        SYSLOG(Logging::Shutdown, (string(_T("UserSettings::Deinitialize"))));
+
+        // Make sure the Activated and Deactivated are no longer called before we start cleaning up..
+        _service->Unregister(&_usersettingsNotification);
+
+        if (nullptr != _userSetting)
+        {
+            _userSetting->Unregister(&_usersettingsNotification);
+            Exchange::JUserSettings::Unregister(*this);
+
+            // Stop processing:
+            RPC::IRemoteConnection* connection = service->RemoteConnection(_connectionId);
+            VARIABLE_IS_NOT_USED uint32_t result = _userSetting->Release();
+
+            _userSetting = nullptr;
+
+            // It should have been the last reference we are releasing,
+            // so it should endup in a DESTRUCTION_SUCCEEDED, if not we
+            // are leaking...
+            ASSERT(result == Core::ERROR_DESTRUCTION_SUCCEEDED);
+
+            // If this was running in a (container) process...
+            if (nullptr != connection)
+            {
+               // Lets trigger the cleanup sequence for
+               // out-of-process code. Which will guard
+               // that unwilling processes, get shot if
+               // not stopped friendly :-)
+               connection->Terminate();
+               connection->Release();
+            }
+        }
+
+        _connectionId = 0;
+        _service->Release();
+        _service = nullptr;
+        SYSLOG(Logging::Shutdown, (string(_T("UserSettings de-initialised"))));
+    }
+
+    string UserSettings::Information() const
+    {
+       // No additional info to report
+       return (string());
+    }
+
+    void UserSettings::Deactivated(RPC::IRemoteConnection* connection)
+    {
+        if (connection->Id() == _connectionId) {
+            ASSERT(nullptr != _service);
+            Core::IWorkerPool::Instance().Submit(PluginHost::IShell::Job::Create(_service, PluginHost::IShell::DEACTIVATED, PluginHost::IShell::FAILURE));
+        }
+    }
+} // namespace Plugin
+} // namespace WPEFramework

--- a/UserSettings/UserSettings.h
+++ b/UserSettings/UserSettings.h
@@ -1,0 +1,142 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2024 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#pragma once
+
+#include "Module.h"
+#include <interfaces/json/JsonData_UserSettings.h>
+#include <interfaces/json/JUserSettings.h>
+#include <interfaces/IUserSettings.h>
+#include "UtilsLogging.h"
+#include "tracing/Logging.h"
+#include <mutex>
+
+namespace WPEFramework {
+namespace Plugin {
+
+    class UserSettings: public PluginHost::IPlugin, public PluginHost::JSONRPC
+    {
+     private:
+        class Notification : public RPC::IRemoteConnection::INotification,
+                             public Exchange::IUserSettings::INotification
+        {
+            private:
+                Notification() = delete;
+                Notification(const Notification&) = delete;
+                Notification& operator=(const Notification&) = delete;
+
+            public:
+            explicit Notification(UserSettings* parent)
+                : _parent(*parent)
+                {
+                    ASSERT(parent != nullptr);
+                }
+
+                virtual ~Notification()
+                {
+                }
+
+                BEGIN_INTERFACE_MAP(Notification)
+                INTERFACE_ENTRY(Exchange::IUserSettings::INotification)
+                INTERFACE_ENTRY(RPC::IRemoteConnection::INotification)
+                END_INTERFACE_MAP
+
+                void Activated(RPC::IRemoteConnection*) override
+                {
+                    LOGINFO("UserSettings Notification Activated");
+                }
+
+                void Deactivated(RPC::IRemoteConnection *connection) override
+                {
+                   LOGINFO("UserSettings Notification Deactivated");
+                   _parent.Deactivated(connection);
+                }
+
+                void OnAudioDescriptionChanged(const bool enabled) override
+                {
+                    LOGINFO("AudioDescriptionChanged: %d\n", enabled);
+                    Exchange::JUserSettings::Event::OnAudioDescriptionChanged(_parent, enabled);
+                }
+
+                void OnPreferredAudioLanguagesChanged(const string& preferredLanguages) override
+                {
+                    LOGINFO("PreferredAudioLanguagesChanged: %s\n", preferredLanguages.c_str());
+                    Exchange::JUserSettings::Event::OnPreferredAudioLanguagesChanged(_parent, preferredLanguages);
+                }
+
+                void OnPresentationLanguageChanged(const string& presentationLanguages) override
+                {
+                    LOGINFO("PresentationLanguageChanged: %s\n", presentationLanguages.c_str());
+                    Exchange::JUserSettings::Event::OnPresentationLanguageChanged(_parent, presentationLanguages);
+                }
+
+                void OnCaptionsChanged(bool enabled) override
+                {
+                    LOGINFO("CaptionsChanged: %d\n", enabled);
+                    Exchange::JUserSettings::Event::OnCaptionsChanged(_parent, enabled);
+                }
+
+                void OnPreferredCaptionsLanguagesChanged(const string& preferredLanguages) override
+                {
+                    LOGINFO("PreferredCaptionsLanguagesChanged: %s\n", preferredLanguages.c_str());
+                    Exchange::JUserSettings::Event::OnPreferredCaptionsLanguagesChanged(_parent, preferredLanguages);
+                }
+
+                void OnPreferredClosedCaptionServiceChanged(const string& service) override
+                {
+                    LOGINFO("PreferredClosedCaptionServiceChanged: %s\n", service.c_str());
+                    Exchange::JUserSettings::Event::OnPreferredClosedCaptionServiceChanged(_parent, service);
+                }
+
+            private:
+                UserSettings& _parent;
+        };
+
+        public:
+            // We do not allow this plugin to be copied !!
+            UserSettings(const UserSettings&) = delete;
+            UserSettings& operator=(const UserSettings&) = delete;
+
+            UserSettings();
+            virtual ~UserSettings();
+
+            BEGIN_INTERFACE_MAP(UserSettings)
+            INTERFACE_ENTRY(PluginHost::IPlugin)
+            INTERFACE_ENTRY(PluginHost::IDispatcher)
+            INTERFACE_AGGREGATE(Exchange::IUserSettings, _userSetting)
+            END_INTERFACE_MAP
+
+            //  IPlugin methods
+            // -------------------------------------------------------------------------------------------------------
+            const string Initialize(PluginHost::IShell* service) override;
+            void Deinitialize(PluginHost::IShell* service) override;
+            string Information() const override;
+
+        private:
+            void Deactivated(RPC::IRemoteConnection* connection);
+
+        private:
+            PluginHost::IShell* _service{};
+            uint32_t _connectionId{};
+            Exchange::IUserSettings* _userSetting{};
+            Core::Sink<Notification> _usersettingsNotification;
+    };
+
+} // namespace Plugin
+} // namespace WPEFramework

--- a/UserSettings/UserSettings.json
+++ b/UserSettings/UserSettings.json
@@ -1,0 +1,302 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rdkcentral/rdkservices/main/Tools/json_generator/schemas/interface.schema.json",
+    "jsonrpc": "2.0",
+    "info": {
+        "title": "UserSettings API",
+        "class": "UserSettings",
+        "description": "The `UserSettings`, that is responsible for persisting and notifying listeners of any change of these settings.."
+    },
+    "common": {
+        "$ref": "../common/common.json"
+    },
+    "definitions": {
+        "enabled": {
+            "summary": "Enabled (`true`) or disabled (`false`)",
+            "type": "boolean",
+            "example": false
+        },
+        "preferredLanguages": {
+            "summary": "A prioritized list of ISO 639-2/B codes for the preferred audio languages",
+            "type": "string",
+            "example": "eng"
+        },
+        "preferredCaptionsLanguages": {
+            "summary": "A prioritized list of ISO 639-2/B codes for the preferred captions languages",
+            "type": "string",
+            "example": "eng"
+        },
+        "preferredClosedCaptionService": {
+            "summary": "A string for the preferred closed captions service.  Valid values are AUTO, CC[1-4], TEXT[1-4], SERVICE[1-64] where CC and TEXT is CTA-608 and SERVICE is CTA-708.  AUTO indicates that the choice is left to the player",
+            "type": "string",
+            "example": "CC3"
+        },
+        "presentationLanguage": {
+            "summary": "The preferred presentationLanguages in a full BCP 47 value, including script, * region, variant The language set and used by Immerse UI",
+            "type": "string",
+            "example": "en-US"
+        }
+    },
+    "methods": {
+        "setaudiodescription": {
+            "summary": "Setting Audio Description.",
+            "params": {
+                "summary": "Audio Description Enabled: true/false",
+                "type": "boolean",
+                "example": true
+            },
+            "result": {
+                "summary": "Null string will display",
+                "type": "string",
+                "example": "null"
+            }
+        },
+        "setpreferredaudiolanguages": {
+            "summary": "Setting Preferred Audio Languages.",
+            "params": {
+                "summary": "Preferred Audio Languages: eng, wel",
+                "type": "string",
+                "example": "eng"
+            },
+            "result": {
+                "summary": "Null string will display",
+                "type": "string",
+                "example": "null"
+            }
+        },
+        "setpresentationlanguages": {
+            "summary": "Setting Presentation Languages.",
+            "params": {
+                "summary": "Presentation Languages: en-US, es-US",
+                "type": "string",
+                "example": "en-US"
+            },
+            "result": {
+                "summary": "Null string will display",
+                "type": "string",
+                "example": "null"
+            }
+        },
+        "setcaptionsenabled": {
+            "summary": "Setting Captions.",
+            "params": {
+                "summary": "Captions Enabled: true/false",
+                "type": "boolean",
+                "example": true
+            },
+            "result": {
+                "summary": "Null string will display ",
+                "type": "string",
+                "example": "null"
+            }
+        },
+        "setpreferredcaptionlanguages": {
+            "summary": "Setting PreferredCaption Languages.",
+            "params": {
+                "summary": "PreferredCaption Languages: eng, fra",
+                "type": "string",
+                "example": "eng"
+            },
+            "result": {
+                "summary": "Null string will display",
+                "type": "string",
+                "example": "null"
+            }
+        },
+        "setpreferredclosedcaptionservice": {
+            "summary": "Setting Preferred Closed Caption Service.",
+            "params": {
+                "summary": "Preferred Closed Caption Service: CC3",
+                "type": "string",
+                "example": "CC3"
+            },
+            "result": {
+                "summary": "Null string will display",
+                "type": "string",
+                "example": "null"
+            }
+        },
+        "getaudiodescription":{
+            "summary": "Returns Audio Description.",
+            "result": {
+                "type": "object",
+                "properties": {
+                    "enabled": {
+                        "$ref": "#/definitions/enabled"
+                    }
+                },
+                "required": [
+                    "enabled"
+                    ]
+            }
+        },
+        "getpreferredaudiolanguages":{
+            "summary": "Returns Audio Description.",
+            "result": {
+                "type": "object",
+                "properties": {
+                    "preferredLanguages": {
+                        "$ref": "#/definitions/preferredLanguages"
+                    }
+                },
+                "required": [
+                    "preferredLanguages"
+                ]
+            }
+        },
+        "getpresentationlanguages":{
+            "summary": "Getting Presentation Languages.",
+            "result": {
+                "type": "object",
+                "properties": {
+                    "presentationlanguages": {
+                        "$ref": "#/definitions/presentationLanguage"
+                    }
+                },
+                "required": [
+                    "presentationlanguages"
+                ]
+            }
+        },
+        "getcaptionsenabled":{
+            "summary": "Getting Captions Enabled.",
+            "result": {
+                "type": "object",
+                "properties": {
+                    "enabled": {
+                        "$ref": "#/definitions/enabled"
+                    }
+                },
+                "required": [
+                    "enabled"
+                ]
+            }
+        },
+        "GetPreferredCaptionLanguages":{
+            "summary": "Getting Preferred Caption Languages.",
+            "result": {
+                "type": "object",
+                "properties": {
+                    "preferredLanguages": {
+                        "$ref": "#/definitions/preferredCaptionsLanguages"
+                    }
+                },
+                "required": [
+                    "preferredLanguages"
+                ]
+            }
+        },
+        "GetPreferredClosedCaptionService":{
+            "summary": "Getting Preferred ClosedCaption Service.",
+            "result": {
+                "type": "object",
+                "properties": {
+                    "preferredClosedCaptionService": {
+                        "$ref": "#/definitions/preferredClosedCaptionService"
+                    }
+                },
+                "required": [
+                    "preferredClosedCaptionService"
+                ]
+            }
+        }
+    },
+    "events": {
+        "OnAudioDescriptionChanged": {
+            "summary": "Triggered after the audio description changes (see `setaudiodescription`)",
+            "params": {
+                "type": "object",
+                "properties": {
+                    "enabled":{
+                        "summary": "Receive audio description changes enable or not",
+                        "type": "boolean",
+                        "example": true
+                    }
+                },
+                "required": [
+                    "enabled"
+                ]
+            }
+        },
+        "OnPreferredAudioLanguagesChanged": {
+            "summary": "Triggered after the audio preferred Audio languages changes (see `setpreferredaudiolanguages`)",
+            "params": {
+                "type": "object",
+                "properties": {
+                    "PreferredAudioLanguagesChanged":{
+                        "summary": "Receive preferred Audio languages changes",
+                        "type": "string",
+                        "example": "eng"
+                    }
+                },
+                "required": [
+                    "PreferredAudioLanguagesChanged"
+                ]
+            }
+        },
+        "OnPresentationLanguageChanged": {
+            "summary": "Triggered after the Presentation Language changes (see `setpresentationlanguages`)",
+            "params": {
+                "type": "object",
+                "properties": {
+                    "PresentationLanguageChanged":{
+                        "summary": "Receive Presentation Language changes",
+                        "type": "string",
+                        "example": "en-US"
+                    }
+                },
+                "required": [
+                    "PresentationLanguageChanged"
+                ]
+            }
+        },
+        "OnCaptionsChanged": {
+            "summary": "Triggered after the captions changes (see `setcaptionsenabled`)",
+            "params": {
+                "type": "object",
+                "properties": {
+                    "enabled":{
+                        "summary": "",
+                        "type": "boolean",
+                        "example": true
+                    }
+                },
+                "required": [
+                    "enabled"
+                ]
+            }
+        },
+        "OnPreferredCaptionsLanguagesChanged": {
+            "summary": "Triggered after the PreferredCaption Languages changes (see `setpreferredcaptionlanguages`)",
+            "params": {
+                "type": "object",
+                "properties": {
+                    "PreferredCaptionsLanguagesChanged":{
+                        "summary": "Receive PreferredCaption Languages changes",
+                        "type": "string",
+                        "example": "eng"
+                    }
+                },
+                "required": [
+                    "PreferredCaptionsLanguagesChanged"
+                ]
+            }
+        },
+        "OnPreferredClosedCaptionServiceChanged": {
+            "summary": "Triggered after the Preferred Closed Caption changes (see `setpreferredclosedcaptionservice`)",
+            "params": {
+                "type": "object",
+                "properties": {
+                    "PreferredClosedCaptionServiceChanged":{
+                        "summary": "Receive Preferred Closed Caption changes",
+                        "type": "string",
+                        "example": "eng"
+                    }
+                },
+                "required": [
+                    "PreferredClosedCaptionServiceChanged"
+                ]
+            }
+        }
+    }
+}
+

--- a/UserSettings/UserSettingsImplementation.cpp
+++ b/UserSettings/UserSettingsImplementation.cpp
@@ -336,7 +336,7 @@ uint32_t UserSettingsImplementation::GetAudioDescription(bool &enabled) const
     return status;
 }
 
-uint32_t UserSettingsImplementation::SetPreferredAudioLanguages(const string preferredLanguages)
+uint32_t UserSettingsImplementation::SetPreferredAudioLanguages(const string& preferredLanguages)
 {
     uint32_t status = Core::ERROR_GENERAL;
 
@@ -376,7 +376,7 @@ uint32_t UserSettingsImplementation::GetPreferredAudioLanguages(string &preferre
     return status;
 }
 
-uint32_t UserSettingsImplementation::SetPresentationLanguage(const string presentationLanguages)
+uint32_t UserSettingsImplementation::SetPresentationLanguage(const string& presentationLanguages)
 {
     uint32_t status = Core::ERROR_GENERAL;
 
@@ -468,7 +468,7 @@ uint32_t UserSettingsImplementation::GetCaptions(bool &enabled) const
     return status;
 }
 
-uint32_t UserSettingsImplementation::SetPreferredCaptionsLanguages(const string preferredLanguages)
+uint32_t UserSettingsImplementation::SetPreferredCaptionsLanguages(const string& preferredLanguages)
 {
     uint32_t status = Core::ERROR_GENERAL;
 
@@ -508,7 +508,7 @@ uint32_t UserSettingsImplementation::GetPreferredCaptionsLanguages(string &prefe
     return status;
 }
 
-uint32_t UserSettingsImplementation::SetPreferredClosedCaptionService(const string service)
+uint32_t UserSettingsImplementation::SetPreferredClosedCaptionService(const string& service)
 {
     uint32_t status = Core::ERROR_GENERAL;
 

--- a/UserSettings/UserSettingsImplementation.cpp
+++ b/UserSettings/UserSettingsImplementation.cpp
@@ -1,0 +1,551 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2024 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "UserSettingsImplementation.h"
+#include <sys/prctl.h>
+#include "UtilsJsonRpc.h"
+#include <mutex>
+#include "tracing/Logging.h"
+
+#define USERSETTINGS_NAMESPACE "UserSettings"
+
+#define USERSETTINGS_AUDIO_DESCRIPTION_KEY                    "audioDescription"
+#define USERSETTINGS_PREFERRED_AUDIO_LANGUAGES_KEY            "preferredAudioLanguages"
+#define USERSETTINGS_PRESENTATION_LANGUAGE_KEY                "presentationLanguage"
+#define USERSETTINGS_CAPTIONS_KEY                             "captions"
+#define USERSETTINGS_PREFERRED_CAPTIONS_LANGUAGES_KEY         "preferredCaptionsLanguages"
+#define USERSETTINGS_PREFERRED_CLOSED_CAPTIONS_SERVICE_KEY    "preferredClosedCaptionsService"
+
+namespace WPEFramework {
+namespace Plugin {
+
+SERVICE_REGISTRATION(UserSettingsImplementation, 1, 0);
+
+UserSettingsImplementation::UserSettingsImplementation()
+: _adminLock()
+, _engine(Core::ProxyType<RPC::InvokeServerType<1, 0, 4>>::Create())
+, _communicatorClient(Core::ProxyType<RPC::CommunicatorClient>::Create(Core::NodeId("/tmp/communicator"), Core::ProxyType<Core::IIPCServer>(_engine)))
+, _controller(nullptr)
+, _remotStoreObject(nullptr)
+, _storeNotification(*this)
+, _registeredEventHandlers(false)
+{
+    LOGINFO("Create UserSettingsImplementation Instance");
+
+    UserSettingsImplementation::instance(this);
+
+     if (!_communicatorClient.IsValid())
+     {
+         LOGWARN("Invalid _communicatorClient\n");
+    }
+    else
+    {
+        _engine->Announcements(_communicatorClient->Announcement());
+
+        LOGINFO("Connect the COM-RPC socket\n");
+        _controller = _communicatorClient->Open<PluginHost::IShell>(_T("org.rdk.PersistentStore"), ~0, 3000);
+
+        if (_controller)
+        {
+             _remotStoreObject = _controller->QueryInterface<Exchange::IStore2>();
+
+             if(_remotStoreObject)
+             {
+                 _remotStoreObject->AddRef();
+             }
+        }
+        else
+        {
+            LOGERR("Failed to create PersistentStore Controller\n");
+        }
+
+        registerEventHandlers();
+    }
+}
+
+UserSettingsImplementation* UserSettingsImplementation::instance(UserSettingsImplementation *UserSettingsImpl)
+{
+   static UserSettingsImplementation *UserSettingsImpl_instance = nullptr;
+
+   ASSERT ((nullptr == UserSettingsImpl_instance) || (nullptr == UserSettingsImpl));
+
+   if (UserSettingsImpl != nullptr)
+   {
+      UserSettingsImpl_instance = UserSettingsImpl;
+   }
+
+   return(UserSettingsImpl_instance);
+}
+
+UserSettingsImplementation::~UserSettingsImplementation()
+{
+    if (_controller)
+    {
+        _controller->Release();
+	 _controller = nullptr;
+    }
+
+    LOGINFO("Disconnect from the COM-RPC socket\n");
+    // Disconnect from the COM-RPC socket
+    _communicatorClient->Close(RPC::CommunicationTimeOut);
+    if (_communicatorClient.IsValid())
+    {
+        _communicatorClient.Release();
+    }
+
+    if(_engine.IsValid())
+    {
+        _engine.Release();
+    }
+
+    if(_remotStoreObject)
+    {
+        _remotStoreObject->Release();
+    }
+    _registeredEventHandlers = false;
+}
+
+void UserSettingsImplementation::registerEventHandlers()
+{
+    ASSERT (nullptr != _remotStoreObject);
+
+    if(!_registeredEventHandlers && _remotStoreObject) {
+        _registeredEventHandlers = true;
+        _remotStoreObject->Register(&_storeNotification);
+    }
+}
+
+/**
+ * Register a notification callback
+ */
+uint32_t UserSettingsImplementation::Register(Exchange::IUserSettings::INotification *notification)
+{
+    ASSERT (nullptr != notification);
+
+    _adminLock.Lock();
+
+    // Make sure we can't register the same notification callback multiple times
+    if (std::find(_userSettingNotification.begin(), _userSettingNotification.end(), notification) == _userSettingNotification.end())
+    {
+        LOGINFO("Register notification");
+        _userSettingNotification.push_back(notification);
+        notification->AddRef();
+    }
+
+    _adminLock.Unlock();
+
+    return Core::ERROR_NONE;
+}
+
+/**
+ * Unregister a notification callback
+ */
+uint32_t UserSettingsImplementation::Unregister(Exchange::IUserSettings::INotification *notification )
+{
+    uint32_t status = Core::ERROR_GENERAL;
+
+    ASSERT (nullptr != notification);
+
+    _adminLock.Lock();
+
+    // Make sure we can't unregister the same notification callback multiple times
+    auto itr = std::find(_userSettingNotification.begin(), _userSettingNotification.end(), notification);
+    if (itr != _userSettingNotification.end())
+    {
+        (*itr)->Release();
+        LOGINFO("Unregister notification");
+        _userSettingNotification.erase(itr);
+        status = Core::ERROR_NONE;
+    }
+    else
+    {
+        LOGERR("notification not found");
+    }
+
+    _adminLock.Unlock();
+
+    return status;
+}
+
+void UserSettingsImplementation::dispatchEvent(Event event, const JsonValue &params)
+{
+    Core::IWorkerPool::Instance().Submit(Job::Create(this, event, params));
+}
+
+void UserSettingsImplementation::Dispatch(Event event, const JsonValue params)
+{
+     _adminLock.Lock();
+
+     std::list<Exchange::IUserSettings::INotification*>::const_iterator index(_userSettingNotification.begin());
+
+     switch(event) {
+         case AUDIO_DESCRIPTION_CHANGED:
+             while (index != _userSettingNotification.end())
+             {
+                 (*index)->OnAudioDescriptionChanged(params.Boolean());
+                 ++index;
+             }
+		break;
+
+         case PREFERRED_AUDIO_CHANGED:
+             while (index != _userSettingNotification.end())
+             {
+                 (*index)->OnPreferredAudioLanguagesChanged(params.String());
+                 ++index;
+             }
+		break;
+
+         case PRESENTATION_LANGUAGE_CHANGED:
+             while (index != _userSettingNotification.end())
+             {
+                 (*index)->OnPresentationLanguageChanged(params.String());
+                 ++index;
+             }
+		break;
+
+         case CAPTIONS_CHANGED:
+             while (index != _userSettingNotification.end())
+             {
+                 (*index)->OnCaptionsChanged(params.Boolean());
+                 ++index;
+             }
+		break;
+
+         case PREFERRED_CAPTIONS_LANGUAGE_CHANGED:
+             while (index != _userSettingNotification.end())
+             {
+                 (*index)->OnPreferredCaptionsLanguagesChanged(params.String());
+                 ++index;
+             }
+		break;
+
+         case PREFERRED_CLOSED_CAPTIONS_SERVICE_CHANGED:
+             while (index != _userSettingNotification.end())
+             {
+                 (*index)->OnPreferredClosedCaptionServiceChanged(params.String());
+                 ++index;
+             }
+		break;
+
+         default:
+             break;
+     }
+
+     _adminLock.Unlock();
+}
+
+void UserSettingsImplementation::ValueChanged(const Exchange::IStore2::ScopeType scope, const string& ns, const string& key, const string& value)
+{
+    LOGINFO("ns:%s key:%s value:%s", ns.c_str(), key.c_str(), value.c_str());
+
+    if((ns.compare(USERSETTINGS_NAMESPACE) == 0) && (key.compare(USERSETTINGS_AUDIO_DESCRIPTION_KEY) == 0))
+    {
+        dispatchEvent(AUDIO_DESCRIPTION_CHANGED, JsonValue((bool)(value.compare("true")==0)?true:false));
+    }
+    else if((ns.compare(USERSETTINGS_NAMESPACE) == 0) && (key.compare(USERSETTINGS_PREFERRED_AUDIO_LANGUAGES_KEY) == 0))
+    {
+        dispatchEvent(PREFERRED_AUDIO_CHANGED, JsonValue((string)value));
+    }
+    else if((ns.compare(USERSETTINGS_NAMESPACE) == 0) && (key.compare(USERSETTINGS_PRESENTATION_LANGUAGE_KEY) == 0))
+    {
+        dispatchEvent(PRESENTATION_LANGUAGE_CHANGED, JsonValue((string)value));
+    }
+    else if((ns.compare(USERSETTINGS_NAMESPACE) == 0) && (key.compare(USERSETTINGS_CAPTIONS_KEY) == 0))
+    {
+        dispatchEvent(CAPTIONS_CHANGED, JsonValue((bool)(value.compare("true")==0)?true:false));
+    }
+    else if((ns.compare(USERSETTINGS_NAMESPACE) == 0) && (key.compare(USERSETTINGS_PREFERRED_CAPTIONS_LANGUAGES_KEY) == 0))
+    {
+        dispatchEvent(PREFERRED_CAPTIONS_LANGUAGE_CHANGED, JsonValue((string)value));
+    }
+    else if((ns.compare(USERSETTINGS_NAMESPACE) == 0) && (key.compare(USERSETTINGS_PREFERRED_CLOSED_CAPTIONS_SERVICE_KEY) == 0))
+    {
+        dispatchEvent(PREFERRED_CLOSED_CAPTIONS_SERVICE_CHANGED, JsonValue((string)value));
+    }
+    else
+    {
+        LOGERR("Not supported");
+    }
+}
+
+uint32_t UserSettingsImplementation::SetAudioDescription(const bool enabled)
+{
+    uint32_t status = Core::ERROR_GENERAL;
+
+    LOGINFO("enabled: %d", enabled);
+
+    _adminLock.Lock();
+
+    ASSERT (nullptr != _remotStoreObject);
+
+    if (nullptr != _remotStoreObject)
+    {
+        status = _remotStoreObject->SetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_AUDIO_DESCRIPTION_KEY, (enabled)?"true":"false", 0);
+    }
+
+    _adminLock.Unlock();
+
+    return status;
+}
+
+uint32_t UserSettingsImplementation::GetAudioDescription(bool &enabled) const
+{
+    uint32_t status = Core::ERROR_GENERAL;
+    std::string value = "";
+    uint32_t ttl = 0;
+
+    _adminLock.Lock();
+
+    ASSERT (nullptr != _remotStoreObject);
+
+    if (nullptr != _remotStoreObject)
+    {
+        status = _remotStoreObject->GetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_AUDIO_DESCRIPTION_KEY, value, ttl);
+
+        if(Core::ERROR_NONE == status)
+        {
+            if (0 == value.compare("true"))
+            {
+                enabled = true;
+            }
+            else
+            {
+                enabled = false;
+            }
+        }
+    }
+
+    _adminLock.Unlock();
+
+    return status;
+}
+
+uint32_t UserSettingsImplementation::SetPreferredAudioLanguages(const string preferredLanguages)
+{
+    uint32_t status = Core::ERROR_GENERAL;
+
+    LOGINFO("preferredLanguages: %s", preferredLanguages.c_str());
+
+    _adminLock.Lock();
+
+    ASSERT (nullptr != _remotStoreObject);
+
+    if (nullptr != _remotStoreObject)
+    {
+        status = _remotStoreObject->SetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_PREFERRED_AUDIO_LANGUAGES_KEY, preferredLanguages, 0);
+    }
+
+    _adminLock.Unlock();
+
+    return status;
+}
+
+uint32_t UserSettingsImplementation::GetPreferredAudioLanguages(string &preferredLanguages) const
+{
+    uint32_t status = Core::ERROR_GENERAL;
+    std::string value = "";
+    uint32_t ttl = 0;
+
+    _adminLock.Lock();
+
+    ASSERT (nullptr != _remotStoreObject);
+
+    if (nullptr != _remotStoreObject)
+    {
+        status = _remotStoreObject->GetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_PREFERRED_AUDIO_LANGUAGES_KEY, preferredLanguages, ttl);
+    }
+
+    _adminLock.Unlock();
+
+    return status;
+}
+
+uint32_t UserSettingsImplementation::SetPresentationLanguage(const string presentationLanguages)
+{
+    uint32_t status = Core::ERROR_GENERAL;
+
+    LOGINFO("presentationLanguages: %s", presentationLanguages.c_str());
+
+    _adminLock.Lock();
+
+    ASSERT (nullptr != _remotStoreObject);
+
+    if (nullptr != _remotStoreObject)
+    {
+        status = _remotStoreObject->SetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_PRESENTATION_LANGUAGE_KEY, presentationLanguages, 0);
+    }
+
+    _adminLock.Unlock();
+
+    return status;
+}
+
+uint32_t UserSettingsImplementation::GetPresentationLanguage(string &presentationLanguages) const
+{
+    uint32_t status = Core::ERROR_GENERAL;
+    std::string value = "";
+    uint32_t ttl = 0;
+
+    _adminLock.Lock();
+
+    ASSERT (nullptr != _remotStoreObject);
+
+    if (nullptr != _remotStoreObject)
+    {
+        status = _remotStoreObject->GetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_PRESENTATION_LANGUAGE_KEY, presentationLanguages, ttl);
+    }
+
+    _adminLock.Unlock();
+
+    return status;
+}
+
+uint32_t UserSettingsImplementation::SetCaptions(const bool enabled)
+{
+    uint32_t status = Core::ERROR_GENERAL;
+
+    LOGINFO("enabled: %d", enabled);
+
+    _adminLock.Lock();
+
+    ASSERT (nullptr != _remotStoreObject);
+
+    if (nullptr != _remotStoreObject)
+    {
+        status = _remotStoreObject->SetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_CAPTIONS_KEY, (enabled)?"true":"false", 0);
+    }
+
+    _adminLock.Unlock();
+
+    return status;
+}
+
+uint32_t UserSettingsImplementation::GetCaptions(bool &enabled) const
+{
+    uint32_t status = Core::ERROR_GENERAL;
+    std::string value = "";
+    uint32_t ttl = 0;
+
+    _adminLock.Lock();
+
+    ASSERT (nullptr != _remotStoreObject);
+
+    if (nullptr != _remotStoreObject)
+    {
+        status = _remotStoreObject->GetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_CAPTIONS_KEY, value, ttl);
+
+        if(Core::ERROR_NONE == status)
+        {
+            if (0 == value.compare("true"))
+            {
+                enabled = true;
+            }
+            else
+            {
+                enabled = false;
+            }
+        }
+    }
+
+    _adminLock.Unlock();
+
+    return status;
+}
+
+uint32_t UserSettingsImplementation::SetPreferredCaptionsLanguages(const string preferredLanguages)
+{
+    uint32_t status = Core::ERROR_GENERAL;
+
+    LOGINFO("preferredLanguages: %s", preferredLanguages.c_str());
+
+    _adminLock.Lock();
+
+    ASSERT (nullptr != _remotStoreObject);
+
+    if (nullptr != _remotStoreObject)
+    {
+        status = _remotStoreObject->SetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_PREFERRED_CAPTIONS_LANGUAGES_KEY, preferredLanguages, 0);
+    }
+
+    _adminLock.Unlock();
+
+    return status;
+}
+
+uint32_t UserSettingsImplementation::GetPreferredCaptionsLanguages(string &preferredLanguages) const
+{
+    uint32_t status = Core::ERROR_GENERAL;
+    std::string value = "";
+    uint32_t ttl = 0;
+
+    _adminLock.Lock();
+
+    ASSERT (nullptr != _remotStoreObject);
+
+    if (nullptr != _remotStoreObject)
+    {
+        status = _remotStoreObject->GetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_PREFERRED_CAPTIONS_LANGUAGES_KEY, preferredLanguages, ttl);
+    }
+
+    _adminLock.Unlock();
+
+    return status;
+}
+
+uint32_t UserSettingsImplementation::SetPreferredClosedCaptionService(const string service)
+{
+    uint32_t status = Core::ERROR_GENERAL;
+
+    LOGINFO("service: %s", service.c_str());
+
+    _adminLock.Lock();
+
+    ASSERT (nullptr != _remotStoreObject);
+
+    if (nullptr != _remotStoreObject)
+    {
+        status = _remotStoreObject->SetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_PREFERRED_CLOSED_CAPTIONS_SERVICE_KEY, service, 0);
+    }
+
+    _adminLock.Unlock();
+
+    return status;
+}
+
+uint32_t UserSettingsImplementation::GetPreferredClosedCaptionService(string &service) const
+{
+    uint32_t status = Core::ERROR_GENERAL;
+    std::string value = "";
+    uint32_t ttl = 0;
+
+    _adminLock.Lock();
+
+    ASSERT (nullptr != _remotStoreObject);
+
+    if (nullptr != _remotStoreObject)
+    {
+        status = _remotStoreObject->GetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_PREFERRED_CLOSED_CAPTIONS_SERVICE_KEY, service, ttl);
+    }
+
+    _adminLock.Unlock();
+
+    return status;
+}
+} // namespace Plugin
+} // namespace WPEFramework

--- a/UserSettings/UserSettingsImplementation.h
+++ b/UserSettings/UserSettingsImplementation.h
@@ -1,0 +1,162 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2024 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#pragma once
+
+#include "Module.h"
+#include <interfaces/Ids.h>
+#include <interfaces/IUserSettings.h>
+#include <interfaces/IStore2.h>
+#include "tracing/Logging.h"
+#include <vector>
+
+#include <com/com.h>
+#include <core/core.h>
+#include <plugins/plugins.h>
+
+namespace WPEFramework {
+namespace Plugin {
+    class UserSettingsImplementation : public Exchange::IUserSettings{
+    private:
+        class Store2Notification : public Exchange::IStore2::INotification {
+        private:
+            Store2Notification(const Store2Notification&) = delete;
+            Store2Notification& operator=(const Store2Notification&) = delete;
+
+        public:
+            explicit Store2Notification(UserSettingsImplementation& parent)
+                : _parent(parent)
+            {
+            }
+            ~Store2Notification() override = default;
+
+        public:
+            void ValueChanged(const Exchange::IStore2::ScopeType scope, const string& ns, const string& key, const string& value) override
+            {
+                _parent.ValueChanged(scope, ns, key, value);
+            }
+
+            BEGIN_INTERFACE_MAP(Store2Notification)
+            INTERFACE_ENTRY(Exchange::IStore2::INotification)
+            END_INTERFACE_MAP
+
+        private:
+            UserSettingsImplementation& _parent;
+        };
+
+    public:
+        // We do not allow this plugin to be copied !!
+        UserSettingsImplementation();
+        ~UserSettingsImplementation() override;
+
+        static UserSettingsImplementation* instance(UserSettingsImplementation *UserSettingsImpl = nullptr);
+
+        // We do not allow this plugin to be copied !!
+        UserSettingsImplementation(const UserSettingsImplementation&) = delete;
+        UserSettingsImplementation& operator=(const UserSettingsImplementation&) = delete;
+
+        BEGIN_INTERFACE_MAP(UserSettingsImplementation)
+        INTERFACE_ENTRY(Exchange::IUserSettings)
+        END_INTERFACE_MAP
+
+    public:
+        enum Event {
+                AUDIO_DESCRIPTION_CHANGED,
+                PREFERRED_AUDIO_CHANGED,
+                PRESENTATION_LANGUAGE_CHANGED,
+                CAPTIONS_CHANGED,
+                PREFERRED_CAPTIONS_LANGUAGE_CHANGED,
+                PREFERRED_CLOSED_CAPTIONS_SERVICE_CHANGED
+            };
+
+        class EXTERNAL Job : public Core::IDispatch {
+        protected:
+             Job(UserSettingsImplementation *usersettingImplementation, Event event, JsonValue &params)
+                : _userSettingImplementation(usersettingImplementation)
+                , _event(event)
+                , _params(params) {
+                if (_userSettingImplementation != nullptr) {
+                    _userSettingImplementation->AddRef();
+                }
+            }
+
+       public:
+            Job() = delete;
+            Job(const Job&) = delete;
+            Job& operator=(const Job&) = delete;
+            ~Job() {
+                if (_userSettingImplementation != nullptr) {
+                    _userSettingImplementation->Release();
+                }
+            }
+
+       public:
+            static Core::ProxyType<Core::IDispatch> Create(UserSettingsImplementation *usersettingImplementation, Event event, JsonValue params) {
+#ifndef USE_THUNDER_R4
+                return (Core::proxy_cast<Core::IDispatch>(Core::ProxyType<Job>::Create(usersettingImplementation, event, params)));
+#else
+                return (Core::ProxyType<Core::IDispatch>(Core::ProxyType<Job>::Create(usersettingImplementation, event, params)));
+#endif
+            }
+
+            virtual void Dispatch() {
+                _userSettingImplementation->Dispatch(_event, _params);
+            }
+        private:
+            UserSettingsImplementation *_userSettingImplementation;
+            const Event _event;
+            const JsonValue _params;
+        };
+
+    public:
+        virtual uint32_t Register(Exchange::IUserSettings::INotification *notification ) override ;
+        virtual uint32_t Unregister(Exchange::IUserSettings::INotification *notification ) override ;
+        uint32_t SetAudioDescription(const bool enabled) override;
+        uint32_t GetAudioDescription(bool &enabled) const override;
+        uint32_t SetPreferredAudioLanguages(const string preferredLanguages) override;
+        uint32_t GetPreferredAudioLanguages(string &preferredLanguages) const override;
+        uint32_t SetPresentationLanguage(const string presentationLanguages) override;
+        uint32_t GetPresentationLanguage(string &presentationLanguages) const override;
+        uint32_t SetCaptions(const bool enabled) override;
+        uint32_t GetCaptions(bool &enabled) const override;
+        uint32_t SetPreferredCaptionsLanguages(const string preferredLanguages) override;
+        uint32_t GetPreferredCaptionsLanguages(string &preferredLanguages) const override;
+        uint32_t SetPreferredClosedCaptionService(const string service) override;
+        uint32_t GetPreferredClosedCaptionService(string &service) const override;
+
+        void registerEventHandlers();
+        void ValueChanged(const Exchange::IStore2::ScopeType scope, const string& ns, const string& key, const string& value);
+
+    private:
+        mutable Core::CriticalSection _adminLock;
+        Core::ProxyType<RPC::InvokeServerType<1, 0, 4>> _engine;
+        Core::ProxyType<RPC::CommunicatorClient> _communicatorClient;
+        PluginHost::IShell *_controller;
+        Exchange::IStore2* _remotStoreObject;
+        std::list<Exchange::IUserSettings::INotification*> _userSettingNotification;
+        Core::Sink<Store2Notification> _storeNotification;
+        bool _registeredEventHandlers;
+
+        void dispatchEvent(Event, const JsonValue &params);
+        void Dispatch(Event event, const JsonValue params);
+
+        friend class Job;
+    };
+} // namespace Plugin
+} // namespace WPEFramework

--- a/UserSettings/UserSettingsImplementation.h
+++ b/UserSettings/UserSettingsImplementation.h
@@ -129,15 +129,15 @@ namespace Plugin {
         virtual uint32_t Unregister(Exchange::IUserSettings::INotification *notification ) override ;
         uint32_t SetAudioDescription(const bool enabled) override;
         uint32_t GetAudioDescription(bool &enabled) const override;
-        uint32_t SetPreferredAudioLanguages(const string preferredLanguages) override;
+        uint32_t SetPreferredAudioLanguages(const string& preferredLanguages) override;
         uint32_t GetPreferredAudioLanguages(string &preferredLanguages) const override;
-        uint32_t SetPresentationLanguage(const string presentationLanguages) override;
+        uint32_t SetPresentationLanguage(const string& presentationLanguages) override;
         uint32_t GetPresentationLanguage(string &presentationLanguages) const override;
         uint32_t SetCaptions(const bool enabled) override;
         uint32_t GetCaptions(bool &enabled) const override;
-        uint32_t SetPreferredCaptionsLanguages(const string preferredLanguages) override;
+        uint32_t SetPreferredCaptionsLanguages(const string& preferredLanguages) override;
         uint32_t GetPreferredCaptionsLanguages(string &preferredLanguages) const override;
-        uint32_t SetPreferredClosedCaptionService(const string service) override;
+        uint32_t SetPreferredClosedCaptionService(const string& service) override;
         uint32_t GetPreferredClosedCaptionService(string &service) const override;
 
         void registerEventHandlers();

--- a/UserSettings/UserSettingsPlugin.json
+++ b/UserSettings/UserSettingsPlugin.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rdkcentral/rdkservices/main/Tools/json_generator/schemas/plugin.schema.json",
+    "info": {
+        "title": "UserSettings Plugin",
+        "callsign": "org.rdk.UserSettings",
+        "locator": "libWPEFrameworkUserSettings.so",
+        "status": "production",
+        "description": "The `UserSettings` that is responsible for persisting and notifying listeners of any change of these settings"
+   },
+    "interface": {
+        "$ref": "UserSettings.json#"
+    }
+}

--- a/docs/api/UserSettingsPlugin.md
+++ b/docs/api/UserSettingsPlugin.md
@@ -1,0 +1,754 @@
+<!-- Generated automatically, DO NOT EDIT! -->
+<a name="head.UserSettings_Plugin"></a>
+# UserSettings Plugin
+
+**Version: [1.0.0](https://github.com/rdkcentral/rdkservices/blob/main/UserSettings/CHANGELOG.md)**
+
+A org.rdk.UserSettings plugin for Thunder framework.
+
+### Table of Contents
+
+- [Abbreviation, Acronyms and Terms](#head.Abbreviation,_Acronyms_and_Terms)
+- [Description](#head.Description)
+- [Configuration](#head.Configuration)
+- [Methods](#head.Methods)
+- [Notifications](#head.Notifications)
+
+<a name="head.Abbreviation,_Acronyms_and_Terms"></a>
+# Abbreviation, Acronyms and Terms
+
+[[Refer to this link](userguide/aat.md)]
+
+<a name="head.Description"></a>
+# Description
+
+The `UserSettings` that is responsible for persisting and notifying listeners of any change of these settings.
+
+The plugin is designed to be loaded and executed within the Thunder framework. For more information about the framework refer to [[Thunder](#ref.Thunder)].
+
+<a name="head.Configuration"></a>
+# Configuration
+
+The table below lists configuration options of the plugin.
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| callsign | string | Plugin instance name (default: *org.rdk.UserSettings*) |
+| classname | string | Class name: *org.rdk.UserSettings* |
+| locator | string | Library name: *libWPEFrameworkUserSettings.so* |
+| autostart | boolean | Determines if the plugin shall be started automatically along with the framework |
+
+<a name="head.Methods"></a>
+# Methods
+
+The following methods are provided by the org.rdk.UserSettings plugin:
+
+UserSettings interface methods:
+
+| Method | Description |
+| :-------- | :-------- |
+| [setaudiodescription](#method.setaudiodescription) | Setting Audio Description |
+| [setpreferredaudiolanguages](#method.setpreferredaudiolanguages) | Setting Preferred Audio Languages |
+| [setpresentationlanguages](#method.setpresentationlanguages) | Setting Presentation Languages |
+| [setcaptionsenabled](#method.setcaptionsenabled) | Setting Captions |
+| [setpreferredcaptionlanguages](#method.setpreferredcaptionlanguages) | Setting PreferredCaption Languages |
+| [setpreferredclosedcaptionservice](#method.setpreferredclosedcaptionservice) | Setting Preferred Closed Caption Service |
+| [getaudiodescription](#method.getaudiodescription) | Returns Audio Description |
+| [getpreferredaudiolanguages](#method.getpreferredaudiolanguages) | Returns Audio Description |
+| [getpresentationlanguages](#method.getpresentationlanguages) | Getting Presentation Languages |
+| [getcaptionsenabled](#method.getcaptionsenabled) | Getting Captions Enabled |
+| [GetPreferredCaptionLanguages](#method.GetPreferredCaptionLanguages) | Getting Preferred Caption Languages |
+| [GetPreferredClosedCaptionService](#method.GetPreferredClosedCaptionService) | Getting Preferred ClosedCaption Service |
+
+
+<a name="method.setaudiodescription"></a>
+## *setaudiodescription [<sup>method</sup>](#head.Methods)*
+
+Setting Audio Description.
+
+### Events
+
+No Events
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | boolean | Audio Description Enabled: true/false |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | string | Null string will display |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.UserSettings.setaudiodescription",
+    "params": true
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": "null"
+}
+```
+
+<a name="method.setpreferredaudiolanguages"></a>
+## *setpreferredaudiolanguages [<sup>method</sup>](#head.Methods)*
+
+Setting Preferred Audio Languages.
+
+### Events
+
+No Events
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | string | Preferred Audio Languages: eng, wel |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | string | Null string will display |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.UserSettings.setpreferredaudiolanguages",
+    "params": "eng"
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": "null"
+}
+```
+
+<a name="method.setpresentationlanguages"></a>
+## *setpresentationlanguages [<sup>method</sup>](#head.Methods)*
+
+Setting Presentation Languages.
+
+### Events
+
+No Events
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | string | Presentation Languages: en-US, es-US |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | string | Null string will display |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.UserSettings.setpresentationlanguages",
+    "params": "en-US"
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": "null"
+}
+```
+
+<a name="method.setcaptionsenabled"></a>
+## *setcaptionsenabled [<sup>method</sup>](#head.Methods)*
+
+Setting Captions.
+
+### Events
+
+No Events
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | boolean | Captions Enabled: true/false |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | string | Null string will display  |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.UserSettings.setcaptionsenabled",
+    "params": true
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": "null"
+}
+```
+
+<a name="method.setpreferredcaptionlanguages"></a>
+## *setpreferredcaptionlanguages [<sup>method</sup>](#head.Methods)*
+
+Setting PreferredCaption Languages.
+
+### Events
+
+No Events
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | string | PreferredCaption Languages: eng, fra |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | string | Null string will display |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.UserSettings.setpreferredcaptionlanguages",
+    "params": "eng"
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": "null"
+}
+```
+
+<a name="method.setpreferredclosedcaptionservice"></a>
+## *setpreferredclosedcaptionservice [<sup>method</sup>](#head.Methods)*
+
+Setting Preferred Closed Caption Service.
+
+### Events
+
+No Events
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | string | Preferred Closed Caption Service: CC3 |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | string | Null string will display |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.UserSettings.setpreferredclosedcaptionservice",
+    "params": "CC3"
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": "null"
+}
+```
+
+<a name="method.getaudiodescription"></a>
+## *getaudiodescription [<sup>method</sup>](#head.Methods)*
+
+Returns Audio Description.
+
+### Events
+
+No Events
+
+### Parameters
+
+This method takes no parameters.
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.enabled | boolean | Enabled (`true`) or disabled (`false`) |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.UserSettings.getaudiodescription"
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "enabled": false
+    }
+}
+```
+
+<a name="method.getpreferredaudiolanguages"></a>
+## *getpreferredaudiolanguages [<sup>method</sup>](#head.Methods)*
+
+Returns Audio Description.
+
+### Events
+
+No Events
+
+### Parameters
+
+This method takes no parameters.
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.preferredLanguages | string | A prioritized list of ISO 639-2/B codes for the preferred audio languages |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.UserSettings.getpreferredaudiolanguages"
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "preferredLanguages": "eng"
+    }
+}
+```
+
+<a name="method.getpresentationlanguages"></a>
+## *getpresentationlanguages [<sup>method</sup>](#head.Methods)*
+
+Getting Presentation Languages.
+
+### Events
+
+No Events
+
+### Parameters
+
+This method takes no parameters.
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.presentationlanguages | string | The preferred presentationLanguages in a full BCP 47 value, including script, * region, variant The language set and used by Immerse UI |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.UserSettings.getpresentationlanguages"
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "presentationlanguages": "en-US"
+    }
+}
+```
+
+<a name="method.getcaptionsenabled"></a>
+## *getcaptionsenabled [<sup>method</sup>](#head.Methods)*
+
+Getting Captions Enabled.
+
+### Events
+
+No Events
+
+### Parameters
+
+This method takes no parameters.
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.enabled | boolean | Enabled (`true`) or disabled (`false`) |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.UserSettings.getcaptionsenabled"
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "enabled": false
+    }
+}
+```
+
+<a name="method.GetPreferredCaptionLanguages"></a>
+## *GetPreferredCaptionLanguages [<sup>method</sup>](#head.Methods)*
+
+Getting Preferred Caption Languages.
+
+### Events
+
+No Events
+
+### Parameters
+
+This method takes no parameters.
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.preferredLanguages | string | A prioritized list of ISO 639-2/B codes for the preferred captions languages |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.UserSettings.GetPreferredCaptionLanguages"
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "preferredLanguages": "eng"
+    }
+}
+```
+
+<a name="method.GetPreferredClosedCaptionService"></a>
+## *GetPreferredClosedCaptionService [<sup>method</sup>](#head.Methods)*
+
+Getting Preferred ClosedCaption Service.
+
+### Events
+
+No Events
+
+### Parameters
+
+This method takes no parameters.
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.preferredClosedCaptionService | string | A string for the preferred closed captions service.  Valid values are AUTO, CC[1-4], TEXT[1-4], SERVICE[1-64] where CC and TEXT is CTA-608 and SERVICE is CTA-708.  AUTO indicates that the choice is left to the player |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.UserSettings.GetPreferredClosedCaptionService"
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "preferredClosedCaptionService": "CC3"
+    }
+}
+```
+
+<a name="head.Notifications"></a>
+# Notifications
+
+Notifications are autonomous events, triggered by the internals of the implementation, and broadcasted via JSON-RPC to all registered observers. Refer to [[Thunder](#ref.Thunder)] for information on how to register for a notification.
+
+The following events are provided by the org.rdk.UserSettings plugin:
+
+UserSettings interface events:
+
+| Event | Description |
+| :-------- | :-------- |
+| [OnAudioDescriptionChanged](#event.OnAudioDescriptionChanged) | Triggered after the audio description changes (see `setaudiodescription`) |
+| [OnPreferredAudioLanguagesChanged](#event.OnPreferredAudioLanguagesChanged) | Triggered after the audio preferred Audio languages changes (see `setpreferredaudiolanguages`) |
+| [OnPresentationLanguageChanged](#event.OnPresentationLanguageChanged) | Triggered after the Presentation Language changes (see `setpresentationlanguages`) |
+| [OnCaptionsChanged](#event.OnCaptionsChanged) | Triggered after the captions changes (see `setcaptionsenabled`) |
+| [OnPreferredCaptionsLanguagesChanged](#event.OnPreferredCaptionsLanguagesChanged) | Triggered after the PreferredCaption Languages changes (see `setpreferredcaptionlanguages`) |
+| [OnPreferredClosedCaptionServiceChanged](#event.OnPreferredClosedCaptionServiceChanged) | Triggered after the Preferred Closed Caption changes (see `setpreferredclosedcaptionservice`) |
+
+
+<a name="event.OnAudioDescriptionChanged"></a>
+## *OnAudioDescriptionChanged [<sup>event</sup>](#head.Notifications)*
+
+Triggered after the audio description changes (see `setaudiodescription`).
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.enabled | boolean | Receive audio description changes enable or not |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.OnAudioDescriptionChanged",
+    "params": {
+        "enabled": true
+    }
+}
+```
+
+<a name="event.OnPreferredAudioLanguagesChanged"></a>
+## *OnPreferredAudioLanguagesChanged [<sup>event</sup>](#head.Notifications)*
+
+Triggered after the audio preferred Audio languages changes (see `setpreferredaudiolanguages`).
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.PreferredAudioLanguagesChanged | string | Receive preferred Audio languages changes |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.OnPreferredAudioLanguagesChanged",
+    "params": {
+        "PreferredAudioLanguagesChanged": "eng"
+    }
+}
+```
+
+<a name="event.OnPresentationLanguageChanged"></a>
+## *OnPresentationLanguageChanged [<sup>event</sup>](#head.Notifications)*
+
+Triggered after the Presentation Language changes (see `setpresentationlanguages`).
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.PresentationLanguageChanged | string | Receive Presentation Language changes |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.OnPresentationLanguageChanged",
+    "params": {
+        "PresentationLanguageChanged": "en-US"
+    }
+}
+```
+
+<a name="event.OnCaptionsChanged"></a>
+## *OnCaptionsChanged [<sup>event</sup>](#head.Notifications)*
+
+Triggered after the captions changes (see `setcaptionsenabled`).
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.enabled | boolean |  |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.OnCaptionsChanged",
+    "params": {
+        "enabled": true
+    }
+}
+```
+
+<a name="event.OnPreferredCaptionsLanguagesChanged"></a>
+## *OnPreferredCaptionsLanguagesChanged [<sup>event</sup>](#head.Notifications)*
+
+Triggered after the PreferredCaption Languages changes (see `setpreferredcaptionlanguages`).
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.PreferredCaptionsLanguagesChanged | string | Receive PreferredCaption Languages changes |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.OnPreferredCaptionsLanguagesChanged",
+    "params": {
+        "PreferredCaptionsLanguagesChanged": "eng"
+    }
+}
+```
+
+<a name="event.OnPreferredClosedCaptionServiceChanged"></a>
+## *OnPreferredClosedCaptionServiceChanged [<sup>event</sup>](#head.Notifications)*
+
+Triggered after the Preferred Closed Caption changes (see `setpreferredclosedcaptionservice`).
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.PreferredClosedCaptionServiceChanged | string | Receive Preferred Closed Caption changes |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.OnPreferredClosedCaptionServiceChanged",
+    "params": {
+        "PreferredClosedCaptionServiceChanged": "eng"
+    }
+}
+```
+


### PR DESCRIPTION
Reason for change: Added new UserSettings Plugin

Added implementation functions for all IUserSettings interface functions
Created IStore2 object using comrpc and calling the IStore2 interface functions for set and get values
Added UserSettings.json and UserSettingsPlugin.json schema file for generating the
docs/api/UserSettingsPlugin.md file
UserSettings plugin startup order set as 51 because persistonestore startup order is default value that is 50
Priority: P1

Test Procedure: Execute curl command and verifY the methods in full stack build