### PR TITLE
Workaround for the race condition in bmalloc's BMScavenger caused by …

### DIFF
--- a/WebKitBrowser/CMakeLists.txt
+++ b/WebKitBrowser/CMakeLists.txt
@@ -254,6 +254,8 @@ if(NOT WEBKIT_GLIB_API)
     target_sources(${PLUGIN_WEBKITBROWSER_IMPLEMENTATION} PRIVATE InjectedBundle/Utils.cpp)
 endif()
 
+# This is a temporary solution. Normally we should leave this to the framework.
+# Do not replicate for other plugins.
 target_link_options(${PLUGIN_WEBKITBROWSER_IMPLEMENTATION} PRIVATE "-Wl,-z,nodelete")
 
 target_link_libraries(${PLUGIN_WEBKITBROWSER_IMPLEMENTATION}

--- a/WebKitBrowser/CMakeLists.txt
+++ b/WebKitBrowser/CMakeLists.txt
@@ -254,6 +254,8 @@ if(NOT WEBKIT_GLIB_API)
     target_sources(${PLUGIN_WEBKITBROWSER_IMPLEMENTATION} PRIVATE InjectedBundle/Utils.cpp)
 endif()
 
+target_link_options(${PLUGIN_WEBKITBROWSER_IMPLEMENTATION} PRIVATE "-Wl,-z,nodelete")
+
 target_link_libraries(${PLUGIN_WEBKITBROWSER_IMPLEMENTATION}
     PRIVATE
         ${NAMESPACE}Plugins::${NAMESPACE}Plugins


### PR DESCRIPTION
…WebKitBrowser plugin implementation unloading.

Sometimes BMScavenger crashes with a SIGSEGV  in __pthread_cond_timedwait after WebKitBrowserPlugin implementation is unloaded, as it  retains an invalidated condition variable.

The crashed thread callstack usually looks like:
```
5|0|libpthread-2.31.so|__condvar_dec_grefs|/usr/src/debug/glibc/2.31+gitAUTOINC+1094741224-r0/git/nptl/pthread_cond_wait.c|153|0x0
5|1|libpthread-2.31.so|__pthread_cond_timedwait|/usr/src/debug/glibc/2.31+gitAUTOINC+1094741224-r0/git/nptl/pthread_cond_wait.c|530|0x3
5|2|||||0xb21504e9
5|3|libstdc++.so.6.0.28|std::execute_native_thread_routine|/usr/src/debug/gcc-runtime/9.3.0-r0/arm-rdk-linux-gnueabi/libstdc++-v3/src/c++11/../../../../../../../../../../work-shared/gcc-9.3.0-r0/gcc-9.3.0/libstdc++-v3/src/c++11/thread.cc|80|0x3
5|4|libpthread-2.31.so|start_thread|/usr/src/debug/glibc/2.31+gitAUTOINC+1094741224-r0/git/nptl/pthread_create.c|477|0x1

```

This workaround is to prevent the plugin implementation unloading.