### PR TITLE
RDK-49198 RDK Thunder provide API to install and clear bootloader splash

### DIFF
--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -400,6 +400,7 @@ namespace WPEFramework {
             registerMethod("updateFirmware", &SystemServices::updateFirmware, this);
             registerMethod("setMode", &SystemServices::setMode, this);
             registerMethod("setBootLoaderPattern", &SystemServices::setBootLoaderPattern, this);
+	    registerMethod("setBootLoaderSplashScreen", &SystemServices::setBootLoaderSplashScreen, this);
             registerMethod("getFirmwareUpdateInfo",
                     &SystemServices::getFirmwareUpdateInfo, this);
             registerMethod("setDeepSleepTimer", &SystemServices::setDeepSleepTimer,
@@ -1321,6 +1322,50 @@ namespace WPEFramework {
                         status = false;
                    }
                 }
+                returnResponse(status);
+        }
+
+        /***
+         * @brief : To update bootloader splash screen.
+         * @param1[in]  : {"path":"<string>"}
+         * @param2[out] : {"result":{"success":<bool>}}
+         * @return              : Core::<StatusCode>
+         */
+        uint32_t SystemServices::setBootLoaderSplashScreen(const JsonObject& parameters,
+                JsonObject& response)
+        {
+                returnIfParamNotFound(parameters, "path");
+                bool status = false;
+                string strBLSplashScreenPath = parameters["path"].String();
+		bool fileExists = Utils::fileExists(strBLSplashScreenPath.c_str());
+                if((strBLSplashScreenPath != "") && fileExists)
+		{
+			IARM_Bus_MFRLib_SetBLSplashScreen_Param_t mfrparam;
+			std::strcpy(mfrparam.path, strBLSplashScreenPath.c_str());
+			IARM_Result_t result = IARM_Bus_Call(IARM_BUS_MFRLIB_NAME, IARM_BUS_MFRLIB_API_SetBlSplashScreen, (void *)&mfrparam, sizeof(mfrparam));
+			if (result != IARM_RESULT_SUCCESS){
+				LOGERR("Update failed. path: %s, fileExists %s, IARM result %d ",strBLSplashScreenPath.c_str(),fileExists ? "true" : "false",result);
+				JsonObject error;
+				error["message"] = "Update failed";
+				error["code"] = "-32002";
+				response["error"] = error;
+				status = false;
+			}
+			else 
+			{
+				LOGINFO("BootLoaderSplashScreen updated successfully");
+				status =true;
+			}
+		}
+		else
+		{
+			LOGERR("Invalid path. path: %s, fileExists %s ",strBLSplashScreenPath.c_str(),fileExists ? "true" : "false");
+			JsonObject error;
+			error["message"] = "Invalid path";
+			error["code"] = "-32001";
+			response["error"] = error;
+			status = false;
+		}
                 returnResponse(status);
         }
 

--- a/SystemServices/SystemServices.h
+++ b/SystemServices/SystemServices.h
@@ -234,6 +234,7 @@ namespace WPEFramework {
                 uint32_t updateFirmware(const JsonObject& parameters, JsonObject& response);
                 uint32_t setMode(const JsonObject& parameters, JsonObject& response);
                 uint32_t setBootLoaderPattern(const JsonObject& parameters, JsonObject& response);
+		uint32_t setBootLoaderSplashScreen(const JsonObject& parameters, JsonObject& response);
                 static void firmwareUpdateInfoReceived(void);
                 uint32_t getFirmwareUpdateInfo(const JsonObject& parameters, JsonObject& response);
                 void reportFirmwareUpdateInfoReceived(string firmwareUpdateVersion,

--- a/Tests/L1Tests/tests/test_SystemServices.cpp
+++ b/Tests/L1Tests/tests/test_SystemServices.cpp
@@ -734,6 +734,78 @@ TEST_F(SystemServicesTest, SystemVersions)
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getSystemVersions"), _T("{}"), response));
     EXPECT_EQ(response, string("{\"stbVersion\":\"PX051AEI_VBN_2203_sprint_20220331225312sdy_NG\",\"receiverVersion\":\"000.36.0.0\",\"stbTimestamp\":\"Fri 05 Aug 2022 16:14:54 UTC\",\"success\":true}"));
 }
+/*******************************************************************************************************************
+ * Test function for :setBootLoaderSplashScreen
+ * @brief : To update bootloader splash screen.
+ * @param1[in]  : {"path":"<string>"}
+ * @param2[out] : {"result":{"success":<bool>}}
+ * @return              : Core::<StatusCode>
+ * Use case coverage:
+ *                @Success :1
+ *                @Failure :3
+ ********************************************************************************************************************/
+
+
+TEST_F(SystemServicesTest, setBootLoaderSplashScreen_IARM_fail)
+{
+    ofstream file("/tmp/osd1");
+    file << "testing setBootLoaderSplashScreen";
+    file.close();
+    EXPECT_CALL(*p_iarmBusImplMock, IARM_Bus_Call)
+            .Times(::testing::AnyNumber())
+            .WillRepeatedly(
+                            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                            EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_MFRLIB_NAME)));
+                            EXPECT_EQ(string(methodName), string(_T(IARM_BUS_MFRLIB_API_SetBlSplashScreen)));
+                            auto param = static_cast<IARM_Bus_MFRLib_SetBLSplashScreen_Param_t*>(arg);
+                            EXPECT_EQ(param->path, "/tmp/osd1");
+                            return IARM_RESULT_OOM;
+                            });
+
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("setBootLoaderSplashScreen"), _T("{\"path\": \"/tmp/osd1\"}"), response));
+
+    EXPECT_EQ(response, string("{\"error\":{\"message\":\"Update failed\",\"code\":\"-32002\"},\"success\":false}"));
+}
+
+TEST_F(SystemServicesTest, setBootLoaderSplashScreen_IARM_success)
+{
+    ofstream file("/tmp/osd1");
+    file << "testing setBootLoaderSplashScreen";
+    file.close();
+
+    EXPECT_CALL(*p_iarmBusImplMock, IARM_Bus_Call)
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_MFRLIB_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_MFRLIB_API_SetBootLoaderPattern)));
+                auto param = static_cast<IARM_Bus_MFRLib_SetBLSplashScreen_Param_t*>(arg);
+                EXPECT_EQ(param->path, "/tmp/osd1");
+                return IARM_RESULT_SUCCESS;
+            });
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("setBootLoaderSplashScreen"), _T("{\"path\": \"/tmp/osd1\"}"), response));
+    EXPECT_EQ(response, string("{\"success\":true}"));
+}
+
+TEST_F(SystemServicesTest, setBootLoaderSplashScreen_empty_path)
+{
+    EXPECT_CALL(*p_iarmBusImplMock, IARM_Bus_Call)
+        .Times(0);
+
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("setBootLoaderSplashScreen"), _T("{\"path\": \"\"}"), response));
+    EXPECT_EQ(response, string("{\"error\":{\"message\":\"Invalid path\",\"code\":\"-32001\"},\"success\":false}"));
+}
+
+TEST_F(SystemServicesTest, setBootLoaderSplashScreen_invalid_path)
+{
+    EXPECT_CALL(*p_iarmBusImplMock, IARM_Bus_Call)
+        .Times(0);
+
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("setBootLoaderSplashScreen"), _T("{\"path\": \"/tmp/osd2\"}"), response));
+
+    EXPECT_EQ(response, string("{\"error\":{\"message\":\"Invalid path\",\"code\":\"-32001\"},\"success\":false}"));
+}
+
 
 TEST_F(SystemServicesTest, MocaStatus)
 {

--- a/Tests/L2Tests/L2TestsPlugin/tests/SystemService_L2Test.cpp
+++ b/Tests/L2Tests/L2TestsPlugin/tests/SystemService_L2Test.cpp
@@ -441,3 +441,94 @@ TEST_F(SystemService_L2Test,SystemServiceUploadLogsAndSystemPowerStateChange)
     jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("onSystemPowerStateChanged"));
 
 }
+/********************************************************
+************Test case Details **************************
+** 1. setBootLoaderSplashScreen success
+** 2. setBootLoaderSplashScreen fail
+** 3. setBootLoaderSplashScreen invalid path
+** 4. setBootLoaderSplashScreen empty path
+*******************************************************/
+
+TEST_F(SystemService_L2Test,setBootLoaderSplashScreen)
+{
+    JSONRPC::LinkType<Core::JSON::IElement> jsonrpc(SYSTEM_CALLSIGN,L2TEST_CALLSIGN);
+    StrictMock<AsyncHandlerMock> async_handler;
+    uint32_t status = Core::ERROR_GENERAL;
+    JsonObject params;
+    JsonObject result;
+    uint32_t signalled = SYSTEMSERVICEL2TEST_STATE_INVALID;
+    std::string message;
+    JsonObject expected_status;
+    params["path"] = "/tmp/osd1";
+
+
+    std::ofstream file("/tmp/osd1");
+    file << "testing setBootLoaderSplashScreen";
+    file.close();
+
+    EXPECT_CALL(*p_iarmBusImplMock, IARM_Bus_Call)
+	    .Times(::testing::AnyNumber())
+	    .WillRepeatedly(
+			    [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+			    EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_MFRLIB_NAME)));
+			    EXPECT_EQ(string(methodName), string(_T(IARM_BUS_MFRLIB_API_SetBlSplashScreen)));
+			    auto param = static_cast<IARM_Bus_MFRLib_SetBLSplashScreen_Param_t*>(arg);
+			    EXPECT_EQ(param->path, "/tmp/osd1");
+			    return IARM_RESULT_SUCCESS;
+			    });
+
+    status = InvokeServiceMethod("org.rdk.System.1", "setBootLoaderSplashScreen", params, result);
+    EXPECT_EQ(Core::ERROR_NONE, status);
+    EXPECT_TRUE(result["success"].Boolean());
+//    EXPECT_STREQ("{\"message\":\"Update failed\",\"code\":\"-32002\"}", result["error"].String().c_str());
+
+
+    EXPECT_CALL(*p_iarmBusImplMock, IARM_Bus_Call)
+	    .Times(::testing::AnyNumber())
+	    .WillRepeatedly(
+			    [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+			    EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_MFRLIB_NAME)));
+			    EXPECT_EQ(string(methodName), string(_T(IARM_BUS_MFRLIB_API_SetBlSplashScreen)));
+			    auto param = static_cast<IARM_Bus_MFRLib_SetBLSplashScreen_Param_t*>(arg);
+			    EXPECT_EQ(param->path, "/tmp/osd1");
+			    return IARM_RESULT_OOM;
+			    });
+
+    status = InvokeServiceMethod("org.rdk.System.1", "setBootLoaderSplashScreen", params, result);
+    EXPECT_EQ(Core::ERROR_GENERAL, status);
+    EXPECT_FALSE(result["success"].Boolean());
+
+    params["path"] = "/tmp/osd2";
+    EXPECT_CALL(*p_iarmBusImplMock, IARM_Bus_Call)
+	    .Times(::testing::AnyNumber())
+	    .WillRepeatedly(
+			    [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+			    EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_MFRLIB_NAME)));
+			    EXPECT_EQ(string(methodName), string(_T(IARM_BUS_MFRLIB_API_SetBlSplashScreen)));
+			    auto param = static_cast<IARM_Bus_MFRLib_SetBLSplashScreen_Param_t*>(arg);
+			    EXPECT_EQ(param->path, "/tmp/osd2");
+			    return IARM_RESULT_OOM;
+			    });
+
+    status = InvokeServiceMethod("org.rdk.System.1", "setBootLoaderSplashScreen", params, result);
+    EXPECT_EQ(Core::ERROR_GENERAL, status);
+    EXPECT_FALSE(result["success"].Boolean());
+
+
+    params["path"] = "";
+    EXPECT_CALL(*p_iarmBusImplMock, IARM_Bus_Call)
+	    .Times(::testing::AnyNumber())
+	    .WillRepeatedly(
+			    [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+			    EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_MFRLIB_NAME)));
+			    EXPECT_EQ(string(methodName), string(_T(IARM_BUS_MFRLIB_API_SetBlSplashScreen)));
+			    auto param = static_cast<IARM_Bus_MFRLib_SetBLSplashScreen_Param_t*>(arg);
+			    EXPECT_EQ(param->path, "/tmp/osd2");
+			    return IARM_RESULT_OOM;
+			    });
+
+    status = InvokeServiceMethod("org.rdk.System.1", "setBootLoaderSplashScreen", params, result);
+    EXPECT_EQ(Core::ERROR_GENERAL, status);
+    EXPECT_FALSE(result["success"].Boolean());
+   
+}

--- a/Tests/mocks/Iarm.h
+++ b/Tests/mocks/Iarm.h
@@ -210,6 +210,7 @@ typedef struct _DeepSleepMgr_WakeupKeyCode_Param_t {
 
 #define IARM_BUS_MFRLIB_NAME "MFRLib"
 #define IARM_BUS_MFRLIB_API_SetBootLoaderPattern "mfrSetBootloaderPattern"
+#define IARM_BUS_MFRLIB_API_SetBlSplashScreen       "mfrSetBlSplashScreen"
 #define IARM_BUS_MFRLIB_API_GetSerializedData "mfrGetManufacturerData"
 
 typedef enum _mfrSerializedType_t {
@@ -918,6 +919,10 @@ typedef struct _IARM_Bus_CECMgr_Status_Updated_Param_t
 {
     int logicalAddress;
 }IARM_Bus_CECMgr_Status_Updated_Param_t;
+
+typedef struct _IARM_Bus_MFRLib_SetBLSplashScreen_Param{
+	char path[255];
+} IARM_Bus_MFRLib_SetBLSplashScreen_Param_t;
 
 #define IARM_BUS_CECMGR_API_isAvailable "isAvailable"
 #define IARM_BUS_DSMGR_API_dsHdmiInGetNumberOfInputs    "dsHdmiInGetNumberOfInputs"


### PR DESCRIPTION
Reason for change: Adding System.setBootLoaderSplashScreen API
Test Procedure: verify build success and basic test
Risks: Low
Priority: P1
Signed-off-by: ramkumar_prabaharan@comcast.com