### PR TITLE
RDKTV-30141 : Switch for account scope feature

### DIFF
--- a/PersistentStore/CMakeLists.txt
+++ b/PersistentStore/CMakeLists.txt
@@ -33,6 +33,7 @@ set(PLUGIN_PERSISTENTSTORE_MAXVALUE "3000" CACHE STRING "For single text data, i
 set(PLUGIN_PERSISTENTSTORE_LIMIT "10000" CACHE STRING "Default for all text data in namespace, in bytes")
 set(PLUGIN_PERSISTENTSTORE_TOKEN_COMMAND "" CACHE STRING "Shell command to get the service access token")
 set(PLUGIN_PERSISTENTSTORE_STARTUPORDER "" CACHE STRING "To configure startup order of PersistentStore plugin")
+set(PLUGIN_PERSISTENTSTORE_WITH_ACCOUNT_SCOPE true CACHE BOOL "Enable account scope")
 
 add_library(${MODULE_NAME} SHARED
         PersistentStore.cpp
@@ -82,26 +83,29 @@ if (IARMBUS_LIBRARIES)
     target_compile_definitions(${PLUGIN_IMPLEMENTATION} PRIVATE WITH_SYSMGR)
 endif ()
 
-find_package(Protobuf REQUIRED)
-target_link_libraries(${PLUGIN_IMPLEMENTATION} PRIVATE ${Protobuf_LIBRARIES})
+if (PLUGIN_PERSISTENTSTORE_WITH_ACCOUNT_SCOPE)
+    find_package(Protobuf REQUIRED)
+    target_link_libraries(${PLUGIN_IMPLEMENTATION} PRIVATE ${Protobuf_LIBRARIES})
 
-add_custom_target(protoc
-        ${Protobuf_PROTOC_EXECUTABLE} --cpp_out ${CMAKE_CURRENT_BINARY_DIR} -I ${CMAKE_CURRENT_SOURCE_DIR}/grpc/secure_storage ${CMAKE_CURRENT_SOURCE_DIR}/grpc/secure_storage/secure_storage.proto
-)
-add_dependencies(${PLUGIN_IMPLEMENTATION} protoc)
+    add_custom_target(protoc
+            ${Protobuf_PROTOC_EXECUTABLE} --cpp_out ${CMAKE_CURRENT_BINARY_DIR} -I ${CMAKE_CURRENT_SOURCE_DIR}/grpc/secure_storage ${CMAKE_CURRENT_SOURCE_DIR}/grpc/secure_storage/secure_storage.proto
+    )
+    add_dependencies(${PLUGIN_IMPLEMENTATION} protoc)
 
-target_link_libraries(${PLUGIN_IMPLEMENTATION} PRIVATE grpc++)
-find_program(GRPC_CPP_PLUGIN grpc_cpp_plugin REQUIRED)
+    target_link_libraries(${PLUGIN_IMPLEMENTATION} PRIVATE grpc++)
+    find_program(GRPC_CPP_PLUGIN grpc_cpp_plugin REQUIRED)
 
-add_custom_target(protoc-gen-grpc
-        ${Protobuf_PROTOC_EXECUTABLE} --grpc_out ${CMAKE_CURRENT_BINARY_DIR} --plugin=protoc-gen-grpc=${GRPC_CPP_PLUGIN} -I ${CMAKE_CURRENT_SOURCE_DIR}/grpc/secure_storage ${CMAKE_CURRENT_SOURCE_DIR}/grpc/secure_storage/secure_storage.proto
-)
-add_dependencies(${PLUGIN_IMPLEMENTATION} protoc-gen-grpc)
+    add_custom_target(protoc-gen-grpc
+            ${Protobuf_PROTOC_EXECUTABLE} --grpc_out ${CMAKE_CURRENT_BINARY_DIR} --plugin=protoc-gen-grpc=${GRPC_CPP_PLUGIN} -I ${CMAKE_CURRENT_SOURCE_DIR}/grpc/secure_storage ${CMAKE_CURRENT_SOURCE_DIR}/grpc/secure_storage/secure_storage.proto
+    )
+    add_dependencies(${PLUGIN_IMPLEMENTATION} protoc-gen-grpc)
 
-set(PROTO_SRCS secure_storage.pb.cc secure_storage.grpc.pb.cc)
-target_sources(${PLUGIN_IMPLEMENTATION} PRIVATE ${PROTO_SRCS})
-set_property(SOURCE ${PROTO_SRCS} PROPERTY GENERATED 1)
-target_include_directories(${PLUGIN_IMPLEMENTATION} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+    set(PROTO_SRCS secure_storage.pb.cc secure_storage.grpc.pb.cc)
+    target_sources(${PLUGIN_IMPLEMENTATION} PRIVATE ${PROTO_SRCS})
+    set_property(SOURCE ${PROTO_SRCS} PROPERTY GENERATED 1)
+    target_include_directories(${PLUGIN_IMPLEMENTATION} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+    target_compile_definitions(${PLUGIN_IMPLEMENTATION} PRIVATE WITH_ACCOUNT_SCOPE)
+endif ()
 
 install(TARGETS ${PLUGIN_IMPLEMENTATION}
         DESTINATION lib/${STORAGE_DIRECTORY}/plugins)

--- a/PersistentStore/PersistentStoreImplementation.cpp
+++ b/PersistentStore/PersistentStoreImplementation.cpp
@@ -18,7 +18,9 @@
  */
 
 #include "PersistentStoreImplementation.h"
+#ifdef WITH_ACCOUNT_SCOPE
 #include "grpc/Store2.h"
+#endif
 #include "sqlite/Store2.h"
 
 namespace WPEFramework {
@@ -31,7 +33,7 @@ namespace Plugin {
         , _deviceStoreCache(nullptr)
         , _deviceStoreInspector(nullptr)
         , _deviceStoreLimit(nullptr)
-        , _accountStore2(Core::Service<Grpc::Store2>::Create<Exchange::IStore2>())
+        , _accountStore2(nullptr)
         , _store2Sink(*this)
     {
         if (_deviceStore2 != nullptr) {
@@ -45,7 +47,10 @@ namespace Plugin {
         ASSERT(_deviceStoreCache != nullptr);
         ASSERT(_deviceStoreInspector != nullptr);
         ASSERT(_deviceStoreLimit != nullptr);
+#ifdef WITH_ACCOUNT_SCOPE
+        _accountStore2 = Core::Service<Grpc::Store2>::Create<Exchange::IStore2>();
         ASSERT(_accountStore2 != nullptr);
+#endif
     }
 
     PersistentStoreImplementation::~PersistentStoreImplementation()


### PR DESCRIPTION
Reason for change: Make it easy to turn off
part of the functionality via cmake variable.
Test Procedure: None
Risks: None
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>