### PR TITLE
RDKTV-29964,DELIA-64899,DELIA-65238: Implement Retry logic in Connectivity Monitoring

### DIFF
--- a/Network/CHANGELOG.md
+++ b/Network/CHANGELOG.md
@@ -22,6 +22,8 @@ All notable changes to this RDK Service will be documented in this file.
 - Removed connectivity monitor from InterfaceConnectionStatusChanged
 ### Fixed
 - Fixed the L1 test case failure
+### Changed
+- Changed the connectivity monitor retry count from 2 to 4
 
 ## [1.3.10] - 2024-04-17
 ### Added

--- a/Network/NetworkConnectivity.h
+++ b/Network/NetworkConnectivity.h
@@ -14,7 +14,7 @@
 #define DEFAULT_MONITOR_TIMEOUT 60 // in seconds
 #define MONITOR_TIMEOUT_INTERVAL_MIN 5
 #define TEST_CONNECTIVITY_DEFAULT_TIMEOUT_MS    10000
-#define DEFAULT_MONITOR_RETRY_COUNT 2
+#define DEFAULT_MONITOR_RETRY_COUNT 4
 
 enum nsm_ipversion {
     NSM_IPRESOLVE_WHATEVER  = 0, /* default, resolves addresses to all IP*/


### PR DESCRIPTION
Reason for change: Increased the DEFAULT_MONITOR_RETRY_COUNT from 2 to 4
Test Procedure: Build and verified
Risks: Low
Priority: P1
Signed-off-by: Gururaaja ESR <Gururaja_ErodeSriranganRamlingham@comcast.com>