### PR TITLE
RDKTV-30981 - Devices went to offline plui state

### DIFF
--- a/NetworkManager/LegacyPlugin_NetworkAPIs.cpp
+++ b/NetworkManager/LegacyPlugin_NetworkAPIs.cpp
@@ -106,7 +106,7 @@ namespace WPEFramework
 
             string callsign(NETWORK_MANAGER_CALLSIGN);
 
-            string token;
+            string token = "";
 
             // TODO: use interfaces and remove token
             auto security = m_service->QueryInterfaceByCallsign<PluginHost::IAuthenticate>("SecurityAgent");

--- a/NetworkManager/LegacyPlugin_NetworkAPIs.cpp
+++ b/NetworkManager/LegacyPlugin_NetworkAPIs.cpp
@@ -68,6 +68,7 @@ namespace WPEFramework
        {
            _gNWInstance = this;
            m_defaultInterface = "wlan0";
+           m_timer.connect(std::bind(&Network::subscribeToEvents, this));
            RegisterLegacyMethods();
        }
 
@@ -105,6 +106,28 @@ namespace WPEFramework
 
             string callsign(NETWORK_MANAGER_CALLSIGN);
 
+            string token;
+
+            // TODO: use interfaces and remove token
+            auto security = m_service->QueryInterfaceByCallsign<PluginHost::IAuthenticate>("SecurityAgent");
+            if (security != nullptr) {
+                string payload = "http://localhost";
+                if (security->CreateToken(
+                            static_cast<uint16_t>(payload.length()),
+                            reinterpret_cast<const uint8_t*>(payload.c_str()),
+                            token)
+                        == Core::ERROR_NONE) {
+                    std::cout << "DisplaySettings got security token" << std::endl;
+                } else {
+                    std::cout << "DisplaySettings failed to get security token" << std::endl;
+                }
+                security->Release();
+            } else {
+                std::cout << "No security agent" << std::endl;
+            }
+
+            string query = "token=" + token;
+
             auto interface = m_service->QueryInterfaceByCallsign<PluginHost::IShell>(callsign);
             if (interface != nullptr)
             {
@@ -123,16 +146,10 @@ namespace WPEFramework
             }
         
             Core::SystemInfo::SetEnvironment(_T("THUNDER_ACCESS"), (_T("127.0.0.1:9998")));
-            string query="token=";
-            m_networkmanager = make_shared<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement> >("org.rdk.NetworkManager", "");
+            m_networkmanager = make_shared<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement> >(_T(NETWORK_MANAGER_CALLSIGN), _T(NETWORK_MANAGER_CALLSIGN), false, query);
 
-            /* Wait for Proxy stuff to be established */
-            sleep(3);
-    
-            if (Core::ERROR_NONE != subscribeToEvents())
-                return string("Failed to Subscribe");
-            else
-                return string();
+            m_timer.start(5000);
+            return string();
         }
 
         void Network::Deinitialize(PluginHost::IShell* /* service */)
@@ -754,7 +771,7 @@ const string CIDR_PREFIXES[CIDR_NETMASK_IP_LEN] = {
         }
 
         /** Private */
-        uint32_t Network::subscribeToEvents(void)
+        void Network::subscribeToEvents(void)
         {
             uint32_t errCode = Core::ERROR_GENERAL;
             if (m_networkmanager)
@@ -781,7 +798,8 @@ const string CIDR_PREFIXES[CIDR_NETMASK_IP_LEN] = {
                     NMLOG_ERROR("Subscribe to onInternetStatusChange failed, errCode: %u", errCode);
                 }
             }
-            return errCode;
+            if (errCode == Core::ERROR_NONE)
+                m_timer.stop();
         }
 
         string Network::getInterfaceMapping(const string & interface)

--- a/NetworkManager/LegacyPlugin_NetworkAPIs.h
+++ b/NetworkManager/LegacyPlugin_NetworkAPIs.h
@@ -5,10 +5,10 @@
 
 #include "Module.h"
 #include "core/Link.h"
+#include "NetworkManagerTimer.h"
 
 namespace WPEFramework {
     namespace Plugin {
-
         // This is a server for a JSONRPC communication channel.
         // For a plugin to be capable to handle JSONRPC, inherit from PluginHost::JSONRPC.
         // By inheriting from this class, the plugin realizes the interface PluginHost::IDispatcher.
@@ -30,7 +30,7 @@ namespace WPEFramework {
 
             void RegisterLegacyMethods();
             void UnregisterLegacyMethods();
-            uint32_t subscribeToEvents(void);
+            void subscribeToEvents(void);
             static std::string getInterfaceMapping(const std::string &interface);
             void activatePrimaryPlugin();
 
@@ -84,6 +84,7 @@ namespace WPEFramework {
             PluginHost::IShell* m_service;
             std::shared_ptr<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>> m_networkmanager;
             string m_defaultInterface;
+            NetworkManagerTimer m_timer;
         };
     } // namespace Plugin
 } // namespace WPEFramework

--- a/NetworkManager/LegacyPlugin_WiFiManagerAPIs.cpp
+++ b/NetworkManager/LegacyPlugin_WiFiManagerAPIs.cpp
@@ -105,7 +105,7 @@ namespace WPEFramework
             m_service->AddRef();
 
             string callsign(NETWORK_MANAGER_CALLSIGN);
-            string token;
+            string token = "";
 
             // TODO: use interfaces and remove token
             auto security = m_service->QueryInterfaceByCallsign<PluginHost::IAuthenticate>("SecurityAgent");

--- a/NetworkManager/LegacyPlugin_WiFiManagerAPIs.h
+++ b/NetworkManager/LegacyPlugin_WiFiManagerAPIs.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "Module.h"
+#include "NetworkManagerTimer.h"
 
 namespace WPEFramework {
 
@@ -84,13 +85,14 @@ namespace WPEFramework {
         private:
             void RegisterLegacyMethods();
             void UnregisterLegacyMethods();
-            uint32_t subscribeToEvents(void);
+            void subscribeToEvents(void);
             static std::string getInterfaceMapping(const std::string &interface);
             void activatePrimaryPlugin();
 
         private:
             PluginHost::IShell* m_service;
             std::shared_ptr<WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>> m_networkmanager;
+            NetworkManagerTimer m_timer;
         };
     } // namespace Plugin
 } // namespace WPEFramework

--- a/NetworkManager/NetworkManagerJsonRpc.cpp
+++ b/NetworkManager/NetworkManagerJsonRpc.cpp
@@ -217,7 +217,7 @@ namespace WPEFramework
             LOGINFOMETHOD();
             uint32_t rc = Core::ERROR_GENERAL;
             string interface = parameters["interface"].String();
-            bool enabled = parameters["enable"].Boolean();
+            bool enabled = parameters["enabled"].Boolean();
             if (_NetworkManager)
                 rc = _NetworkManager->SetInterfaceState(interface, enabled);
             else

--- a/NetworkManager/NetworkManagerLogger.cpp
+++ b/NetworkManager/NetworkManagerLogger.cpp
@@ -83,7 +83,7 @@ namespace NetworkManagerLogger {
         gettimeofday(&tv, NULL);
         lt = localtime(&tv.tv_sec);
 
-        printf("%.2d:%.2d:%.2d.%.6lld %-10s %s:%d : %s\n", lt->tm_hour, lt->tm_min, lt->tm_sec, (long long int)tv.tv_usec, levelMap[level], func, line, formattedLog);
+        printf("%.2d:%.2d:%.2d.%.6lld %-10s %s:%d : %s\n", lt->tm_hour, lt->tm_min, lt->tm_sec, (long long int)tv.tv_usec, levelMap[level], basename(file), line, formattedLog);
         fflush(stdout);
 #endif
     }

--- a/NetworkManager/NetworkManagerRDKProxy.cpp
+++ b/NetworkManager/NetworkManagerRDKProxy.cpp
@@ -657,7 +657,7 @@ namespace WPEFramework
                 return rc;
             }
 
-            iarmData.isInterfaceEnabled = true;
+            iarmData.isInterfaceEnabled = enable;
             iarmData.persist = true;
             if (IARM_RESULT_SUCCESS == IARM_Bus_Call (IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_NETSRVMGR_API_setInterfaceEnabled, (void *)&iarmData, sizeof(iarmData)))
             {
@@ -671,7 +671,7 @@ namespace WPEFramework
             return rc;
         }
 
-        uint32_t NetworkManagerImplementation::GetInterfaceState(const string& interface/* @in */, bool& isEnabled /* @out */)
+        uint32_t NetworkManagerImplementation::GetInterfaceState(const string& interface/* @in */, bool &isEnabled /* @out */)
         {
             LOG_ENTRY_FUNCTION();
             uint32_t rc = Core::ERROR_RPC_CALL_FAILED;
@@ -689,11 +689,10 @@ namespace WPEFramework
                 return rc;
             }
 
-            iarmData.isInterfaceEnabled = false;
-            iarmData.persist = true;
-            if (IARM_RESULT_SUCCESS == IARM_Bus_Call (IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_NETSRVMGR_API_setInterfaceEnabled, (void *)&iarmData, sizeof(iarmData)))
+            if (IARM_RESULT_SUCCESS == IARM_Bus_Call (IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_NETSRVMGR_API_isInterfaceEnabled, (void *)&iarmData, sizeof(iarmData)))
             {
-                NMLOG_INFO ("Call to %s for %s success", IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_NETSRVMGR_API_setInterfaceEnabled);
+                NMLOG_TRACE("Call to %s for %s success", IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_NETSRVMGR_API_isInterfaceEnabled);
+                isEnabled = iarmData.isInterfaceEnabled;
                 rc = Core::ERROR_NONE;
             }
             else

--- a/NetworkManager/NetworkManagerTimer.h
+++ b/NetworkManager/NetworkManagerTimer.h
@@ -58,7 +58,7 @@ namespace WPEFramework {
 
             public:
                 NetworkManagerTimer()
-                    : baseTimer(64 * 1024, "ThunderPluginBaseTimer")
+                    : baseTimer(64 * 1024, "TimerUtility")
                       , m_timerJob(this)
                       , m_isActive(false)
                       , m_isSingleShot(false)

--- a/NetworkManager/NetworkManagerTimer.h
+++ b/NetworkManager/NetworkManagerTimer.h
@@ -1,0 +1,132 @@
+/**
+* If not stated otherwise in this file or this component's LICENSE
+* file the following copyright and licenses apply:
+*
+* Copyright 2020 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+namespace WPEFramework {
+
+    namespace Plugin {
+        class NetworkManagerTimer {
+            private:
+                class NetworkManagerTimerJob {
+                    private:
+                        NetworkManagerTimerJob() = delete;
+                        NetworkManagerTimerJob& operator=(const NetworkManagerTimerJob& RHS) = delete;
+
+                    public:
+                        NetworkManagerTimerJob(NetworkManagerTimer* tpt)
+                            : m_tptimer(tpt)
+                        {
+                        }
+                        NetworkManagerTimerJob(const NetworkManagerTimerJob& copy)
+                            : m_tptimer(copy.m_tptimer)
+                        {
+                        }
+                        ~NetworkManagerTimerJob() {}
+
+                        inline bool operator==(const NetworkManagerTimerJob& RHS) const
+                        {
+                            return (m_tptimer == RHS.m_tptimer);
+                        }
+
+                    public:
+                        uint64_t Timed(const uint64_t scheduledTime)
+                        {
+                            if (m_tptimer) {
+                                m_tptimer->Timed();
+                            }
+                            return 0;
+                        }
+
+                    private:
+                        NetworkManagerTimer* m_tptimer;
+                };
+
+            public:
+                NetworkManagerTimer()
+                    : baseTimer(64 * 1024, "ThunderPluginBaseTimer")
+                      , m_timerJob(this)
+                      , m_isActive(false)
+                      , m_isSingleShot(false)
+                      , m_intervalInMs(-1)
+            {
+            }
+                ~NetworkManagerTimer()
+                {
+                    stop();
+                }
+
+                bool isActive()
+                {
+                    return m_isActive;
+                }
+                void stop()
+                {
+                    baseTimer.Revoke(m_timerJob);
+                    m_isActive = false;
+                }
+                void start()
+                {
+                    baseTimer.Revoke(m_timerJob);
+                    baseTimer.Schedule(Core::Time::Now().Add(m_intervalInMs), m_timerJob);
+                    m_isActive = true;
+                }
+                void start(int msec)
+                {
+                    setInterval(msec);
+                    start();
+                }
+                void setSingleShot(bool val)
+                {
+                    m_isSingleShot = val;
+                }
+                void setInterval(int msec)
+                {
+                    m_intervalInMs = msec;
+                }
+
+                void connect(std::function<void()> callback)
+                {
+                    onTimeoutCallback = callback;
+                }
+
+            private:
+                void Timed()
+                {
+                    if (onTimeoutCallback != nullptr) {
+                        onTimeoutCallback();
+                    }
+
+                    if (m_isActive) {
+                        if (m_isSingleShot) {
+                            stop();
+                        } else {
+                            start();
+                        }
+                    }
+                }
+
+                WPEFramework::Core::TimerType<NetworkManagerTimerJob> baseTimer;
+                NetworkManagerTimerJob m_timerJob;
+                bool m_isActive;
+                bool m_isSingleShot;
+                int m_intervalInMs;
+
+                std::function<void()> onTimeoutCallback;
+        };
+    }
+}

--- a/docs/api/NetworkManagerPlugin.md
+++ b/docs/api/NetworkManagerPlugin.md
@@ -247,6 +247,112 @@ Sets the primary/default interface for the device. This call fails if the interf
 }
 ```
 
+<a name="method.SetInterfaceState"></a>
+## *SetInterfaceState [<sup>method</sup>](#head.Methods)*
+
+Enable or Disable the specified interface.
+
+### Events
+
+| Event | Description |
+| :-------- | :-------- |
+| [onInterfaceStateChange](#event.onInterfaceStateChange) | Triggered when interface’s status changes to enabled or disabled. |
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.interface | string | An interface, such as `eth0` or `wlan0`, depending upon availability of the given interface in `GetAvailableInterfaces` |
+| params.enabled | boolean | Set the state of the interface to be Enabled or Disabled |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.success | boolean | Whether the request succeeded |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.NetworkManager.SetInterfaceState",
+    "params": {
+        "interface": "wlan0",
+        "enabled": true
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "success": true
+    }
+}
+```
+
+<a name="method.GetInterfaceState"></a>
+## *GetInterfaceState [<sup>method</sup>](#head.Methods)*
+
+Disable the specified interface.
+
+### Events
+
+No Events
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.interface | string | An interface, such as `eth0` or `wlan0`, depending upon availability of the given interface in `GetAvailableInterfaces` |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | object |  |
+| result.isEnabled | boolean | Whether the Interface is enabled or disabled |
+| result.success | boolean | Whether the request succeeded |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.NetworkManager.GetInterfaceState",
+    "params": {
+        "interface": "wlan0"
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "isEnabled": true,
+        "success": true
+    }
+}
+```
+
 <a name="method.GetIPSettings"></a>
 ## *GetIPSettings [<sup>method</sup>](#head.Methods)*
 
@@ -1691,112 +1797,6 @@ No Events
     "jsonrpc": "2.0",
     "id": 42,
     "result": {
-        "success": true
-    }
-}
-```
-
-<a name="method.SetInterfaceState"></a>
-## *SetInterfaceState [<sup>method</sup>](#head.Methods)*
-
-Enable or Disable the specified interface.
-
-### Events
-
-| Event | Description |
-| :-------- | :-------- |
-| [onInterfaceStateChange](#event.onInterfaceStateChange) | Triggered when interface’s status changes to enabled. |
-
-### Parameters
-
-| Name | Type | Description |
-| :-------- | :-------- | :-------- |
-| params | object |  |
-| params.interface | string | An interface, such as `eth0` or `wlan0`, depending upon availability of the given interface in `GetAvailableInterfaces` |
-| params.enabled | boolean | Set the state of the interface to be Enabled or Disabled |
-
-### Result
-
-| Name | Type | Description |
-| :-------- | :-------- | :-------- |
-| result | object |  |
-| result.success | boolean | Whether the request succeeded |
-
-### Example
-
-#### Request
-
-```json
-{
-    "jsonrpc": "2.0",
-    "id": 42,
-    "method": "org.rdk.NetworkManager.SetInterfaceState",
-    "params": {
-        "interface": "wlan0",
-        "enabled": true
-    }
-}
-```
-
-#### Response
-
-```json
-{
-    "jsonrpc": "2.0",
-    "id": 42,
-    "result": {
-        "success": true
-    }
-}
-```
-
-<a name="method.GetInterfaceState"></a>
-## *GetInterfaceState [<sup>method</sup>](#head.Methods)*
-
-Disable the specified interface.
-
-### Events
-
-No Events
-
-### Parameters
-
-| Name | Type | Description |
-| :-------- | :-------- | :-------- |
-| params | object |  |
-| params.interface | string | An interface, such as `eth0` or `wlan0`, depending upon availability of the given interface in `GetAvailableInterfaces` |
-
-### Result
-
-| Name | Type | Description |
-| :-------- | :-------- | :-------- |
-| result | object |  |
-| result.isEnabled | boolean | Whether the Interface is enabled or disabled |
-| result.success | boolean | Whether the request succeeded |
-
-### Example
-
-#### Request
-
-```json
-{
-    "jsonrpc": "2.0",
-    "id": 42,
-    "method": "org.rdk.NetworkManager.GetInterfaceState",
-    "params": {
-        "interface": "wlan0"
-    }
-}
-```
-
-#### Response
-
-```json
-{
-    "jsonrpc": "2.0",
-    "id": 42,
-    "result": {
-        "isEnabled": true,
         "success": true
     }
 }

--- a/docs/api/NetworkManagerPlugin.md
+++ b/docs/api/NetworkManagerPlugin.md
@@ -2,7 +2,7 @@
 <a name="head.NetworkManager_Plugin"></a>
 # NetworkManager Plugin
 
-**Version: [0.1.0]()**
+**Version: [0.2.0]()**
 
 A NetworkManager plugin for Thunder framework.
 

--- a/docs/api/NetworkManagerPlugin.md
+++ b/docs/api/NetworkManagerPlugin.md
@@ -58,6 +58,8 @@ NetworkManager interface methods:
 | [GetAvailableInterfaces](#method.GetAvailableInterfaces) | Get device supported list of available interface including their state |
 | [GetPrimaryInterface](#method.GetPrimaryInterface) | Gets the primary/default network interface for the device |
 | [SetPrimaryInterface](#method.SetPrimaryInterface) | Sets the primary/default interface for the device |
+| [SetInterfaceState](#method.SetInterfaceState) | Enable the interface |
+| [GetInterfaceState](#method.GetInterfaceState) | Disable the interface |
 | [GetIPSettings](#method.GetIPSettings) | Gets the IP setting for the given interface |
 | [SetIPSettings](#method.SetIPSettings) | Sets the IP settings for the given interface |
 | [GetStunEndpoint](#method.GetStunEndpoint) | Get the STUN Endpoint that is used to identify public IP of the device |
@@ -84,8 +86,6 @@ NetworkManager interface methods:
 | [GetWiFiSignalStrength](#method.GetWiFiSignalStrength) | Get WiFiSignalStrength of connected SSID |
 | [GetSupportedSecurityModes](#method.GetSupportedSecurityModes) | Returns the Wifi security modes that the device supports |
 | [SetLogLevel](#method.SetLogLevel) | Set Log level for more information |
-| [EnableInterface](#method.EnableInterface) | Enable the interface |
-| [DisableInterface](#method.DisableInterface) | Disable the interface |
 | [GetWifiState](#method.GetWifiState) | Returns the current Wifi State |
 
 
@@ -1696,10 +1696,10 @@ No Events
 }
 ```
 
-<a name="method.EnableInterface"></a>
-## *EnableInterface [<sup>method</sup>](#head.Methods)*
+<a name="method.SetInterfaceState"></a>
+## *SetInterfaceState [<sup>method</sup>](#head.Methods)*
 
-Enable the specified interface.
+Enable or Disable the specified interface.
 
 ### Events
 
@@ -1713,6 +1713,7 @@ Enable the specified interface.
 | :-------- | :-------- | :-------- |
 | params | object |  |
 | params.interface | string | An interface, such as `eth0` or `wlan0`, depending upon availability of the given interface in `GetAvailableInterfaces` |
+| params.enabled | boolean | Set the state of the interface to be Enabled or Disabled |
 
 ### Result
 
@@ -1729,9 +1730,10 @@ Enable the specified interface.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.NetworkManager.EnableInterface",
+    "method": "org.rdk.NetworkManager.SetInterfaceState",
     "params": {
-        "interface": "wlan0"
+        "interface": "wlan0",
+        "enabled": true
     }
 }
 ```
@@ -1748,16 +1750,14 @@ Enable the specified interface.
 }
 ```
 
-<a name="method.DisableInterface"></a>
-## *DisableInterface [<sup>method</sup>](#head.Methods)*
+<a name="method.GetInterfaceState"></a>
+## *GetInterfaceState [<sup>method</sup>](#head.Methods)*
 
 Disable the specified interface.
 
 ### Events
 
-| Event | Description |
-| :-------- | :-------- |
-| [onInterfaceStateChange](#event.onInterfaceStateChange) | Triggered when interface’s status changes to disabled. |
+No Events
 
 ### Parameters
 
@@ -1771,6 +1771,7 @@ Disable the specified interface.
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
 | result | object |  |
+| result.isEnabled | boolean | Whether the Interface is enabled or disabled |
 | result.success | boolean | Whether the request succeeded |
 
 ### Example
@@ -1781,7 +1782,7 @@ Disable the specified interface.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.NetworkManager.DisableInterface",
+    "method": "org.rdk.NetworkManager.GetInterfaceState",
     "params": {
         "interface": "wlan0"
     }
@@ -1795,6 +1796,7 @@ Disable the specified interface.
     "jsonrpc": "2.0",
     "id": 42,
     "result": {
+        "isEnabled": true,
         "success": true
     }
 }


### PR DESCRIPTION
Reason for change: 
Created authorization token and passed the same for json RPC call to networkmanager from network plugin. 
Also added timer logic to subscribe for events.
Corrected SetInterfaceState and GetInterfaceState function calls. 
Updated logger to print file name instead of function name. Test Procedure: Do CDL and confirm the device boots up in online state Risks: Low
Priority: P1
Signed-off-by: Gururaaja ESR <Gururaja_ErodeSriranganRamlingham@comcast.com>