### PR TITLE
[RDKCOM-4703] SGMM393-104: update common resolution list for getSupportedResolutions

### DIFF
--- a/DisplaySettings/CHANGELOG.md
+++ b/DisplaySettings/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+## [1.4.5] - 2024-06-03
+### Added
+- update common resolution list for getSupportedResolutions.
+
 ## [1.4.4] - 2024-05-23
 ### Added
 - Fixed thread timing issues.

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -85,7 +85,7 @@ using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 4
-#define API_VERSION_NUMBER_PATCH 4
+#define API_VERSION_NUMBER_PATCH 5
 
 static bool isCecEnabled = false;
 static bool isResCacheUpdated = false;
@@ -1160,20 +1160,23 @@ namespace WPEFramework {
                 vPort.getSupportedTvResolutions(&tvResolutions);
                 if(!tvResolutions)supportedTvResolutions.emplace_back("none");
                 if(tvResolutions & dsTV_RESOLUTION_480i)supportedTvResolutions.emplace_back("480i");
+                if(tvResolutions & dsTV_RESOLUTION_480i)supportedTvResolutions.emplace_back("480i60");
                 if(tvResolutions & dsTV_RESOLUTION_480p)supportedTvResolutions.emplace_back("480p");
-                if(tvResolutions & dsTV_RESOLUTION_576i)supportedTvResolutions.emplace_back("576i");
-                if(tvResolutions & dsTV_RESOLUTION_576p)supportedTvResolutions.emplace_back("576p");
-		if(tvResolutions & dsTV_RESOLUTION_576p50)supportedTvResolutions.emplace_back("576p50");
-                if(tvResolutions & dsTV_RESOLUTION_720p)supportedTvResolutions.emplace_back("720p");
+                if(tvResolutions & dsTV_RESOLUTION_480p)supportedTvResolutions.emplace_back("480p60");
+                if(tvResolutions & dsTV_RESOLUTION_576i)supportedTvResolutions.emplace_back("576i50");
+                if(tvResolutions & dsTV_RESOLUTION_576p)supportedTvResolutions.emplace_back("576p50");
 		if(tvResolutions & dsTV_RESOLUTION_720p50)supportedTvResolutions.emplace_back("720p50");
-                if(tvResolutions & dsTV_RESOLUTION_1080i)supportedTvResolutions.emplace_back("1080i");
-                if(tvResolutions & dsTV_RESOLUTION_1080p)supportedTvResolutions.emplace_back("1080p");
+                if(tvResolutions & dsTV_RESOLUTION_720p)supportedTvResolutions.emplace_back("720p");
+                if(tvResolutions & dsTV_RESOLUTION_720p)supportedTvResolutions.emplace_back("720p60");
 		if(tvResolutions & dsTV_RESOLUTION_1080p24)supportedTvResolutions.emplace_back("1080p24");
 		if(tvResolutions & dsTV_RESOLUTION_1080p25)supportedTvResolutions.emplace_back("1080p25");
-		if(tvResolutions & dsTV_RESOLUTION_1080i25)supportedTvResolutions.emplace_back("1080i25");
 		if(tvResolutions & dsTV_RESOLUTION_1080p30)supportedTvResolutions.emplace_back("1080p30");
 		if(tvResolutions & dsTV_RESOLUTION_1080i50)supportedTvResolutions.emplace_back("1080i50");
 		if(tvResolutions & dsTV_RESOLUTION_1080p50)supportedTvResolutions.emplace_back("1080p50");
+                if(tvResolutions & dsTV_RESOLUTION_1080i)supportedTvResolutions.emplace_back("1080i");
+                if(tvResolutions & dsTV_RESOLUTION_1080i)supportedTvResolutions.emplace_back("1080i60");
+                if(tvResolutions & dsTV_RESOLUTION_1080p)supportedTvResolutions.emplace_back("1080p");
+                if(tvResolutions & dsTV_RESOLUTION_1080p)supportedTvResolutions.emplace_back("1080p60");
                 if(tvResolutions & dsTV_RESOLUTION_1080p60)supportedTvResolutions.emplace_back("1080p60");
 		if(tvResolutions & dsTV_RESOLUTION_2160p24)supportedTvResolutions.emplace_back("2160p24");
 		if(tvResolutions & dsTV_RESOLUTION_2160p25)supportedTvResolutions.emplace_back("2160p25");


### PR DESCRIPTION
getSupportedResolutions expects to return the common resolution in both the TV and Settop resolutions list, Before the change, getSupportedResolutions returns some other resolution which is not commint in TV and Settop api. getSupportedResolutions,
["480i","480i60","480p","480p60","576i50","576p50","720p50","720p","720p60","1080p24","1080i50","1080p50","1080i","1080i60","1080p","1080p60"] supportedTvResolutions,
["480i","480p","576i","576p","720p","1080i","1080p"] supportedSettopResolutions,
["480i","480i60","480p","480p60","576i50","576p50","720p50","720p","720p60","1080p24","1080p25","1080p30","1080i50","1080p50","1080i","1080i60","1080p","1080p60","2160p24","2160p25","2160p30","2160p50","2160p60"]

After the change, the three calling are returning as below, supportedResolutions,
["480i","480i60","480p","480p60","576i50","576p50","720p50","720p","720p60","1080p24","1080p25","1080p30","1080i50","1080p50","1080i","1080i60","1080p","1080p60","2160p24","2160p25","2160p30","2160p50","2160p60"] supportedTvResolutions,
["480i","480i60","480p","480p60","576i50","576p50","720p50","720p","720p60","1080p24","1080p25","1080p30","1080i50","1080p50","1080i","1080i60","1080p","1080p60","2160p24","2160p25","2160p30","2160p50","2160p60"] supportedSettopResolutions,
["480i","480i60","480p","480p60","576i50","576p50","720p50","720p","720p60","1080p24","1080p25","1080p30","1080i50","1080p50","1080i","1080i60","1080p","1080p60","2160p24","2160p25","2160p30","2160p50","2160p60"]

Signed-off-by: JWang@freewheel.com