### PR TITLE
RDKDEV-985 - Upstream dobby amazon container changes

### DIFF
--- a/RDKShell/CHANGELOG.md
+++ b/RDKShell/CHANGELOG.md
@@ -16,6 +16,11 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+
+## [1.5.2] - 2024-06-04
+### Changed
+- Added support for dobby amazon container
+
 ## [1.5.1] - 2024-05-31
 ### Changed
 - RDK-45345: Upgrade Sky Glass devices to use Thunder R4.4.1

--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -55,7 +55,7 @@
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 5
-#define API_VERSION_NUMBER_PATCH 0
+#define API_VERSION_NUMBER_PATCH 2
 
 const string WPEFramework::Plugin::RDKShell::SERVICE_NAME = "org.rdk.RDKShell";
 //methods

--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -4334,6 +4334,36 @@ namespace WPEFramework {
 #endif
                 }
 
+		if (!type.empty() && type == "Amazon")
+		{
+#ifdef RFC_ENABLED
+			RFC_ParamData_t param;
+			if (Utils::getRFCConfig("Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.Dobby.Amazon.Enable", param))
+			{
+				JsonObject root;
+				if (strncasecmp(param.value, "true", 4) == 0)
+				{
+					std::cout << "dobby rfc true - launching amazon in container mode " << std::endl;
+					root = configSet["root"].Object();
+					root["mode"] = JsonValue("Container");
+				}
+				else
+				{
+					std::cout << "dobby rfc false - launching amazon in local mode " << std::endl;
+					root = configSet["root"].Object();
+					root["mode"] = JsonValue("Local");
+				}
+				configSet["root"] = root;
+			}
+			else
+			{
+				std::cout << "reading amazon dobby rfc failed " << std::endl;
+			}
+#else
+			std::cout << "rfc is disabled and unable to check for amazon container mode " << std::endl;
+#endif
+		}
+
                 string configSetAsString;
                 configSet.ToString(configSetAsString);
                 Core::JSON::String configSetAsJsonString;


### PR DESCRIPTION
Reason for change: Upstream Rdkshell-Amazon-Container.patch patch changes into github , as dobby support has available on AML and RTK upstreaming the changes instead of keeping as a patch

Risks: Low

Test Procedure: Amazon launched in container mode