### PR TITLE
RDKDEV-988 - Upstream PlayerInfo dolby audio mode changes

### DIFF
--- a/PlayerInfo/CHANGELOG.md
+++ b/PlayerInfo/CHANGELOG.md
@@ -16,6 +16,11 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+
+## [1.1.0] - 2024-06-04
+### Fixed
+- Added support for PlayerInfo dolby audio mode
+
 ## [1.0.9] - 2024-05-30
 ### Fixed
 - Added exception handling for device::manager

--- a/PlayerInfo/DeviceSettings/PlatformImplementation.cpp
+++ b/PlayerInfo/DeviceSettings/PlatformImplementation.cpp
@@ -274,6 +274,8 @@ public:
             else if(amode == device::AudioStereoMode::kStereo) mode = STEREO;
             else if(amode == device::AudioStereoMode::kMono) mode = MONO;
             else if(amode == device::AudioStereoMode::kPassThru) mode = PASSTHRU;
+           else if(amode == device::AudioStereoMode::kDD) mode = DOLBYDIGITAL;
+           else if(amode == device::AudioStereoMode::kDDPlus) mode = DOLBYDIGITALPLUS;
             else mode = UNKNOWN;
             PlayerInfoImplementation::_instance->audiomodeChanged(mode, true);
         }

--- a/PlayerInfo/PlayerInfo.cpp
+++ b/PlayerInfo/PlayerInfo.cpp
@@ -20,8 +20,8 @@
 #include "PlayerInfo.h"
 
 #define API_VERSION_NUMBER_MAJOR 1
-#define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 9
+#define API_VERSION_NUMBER_MINOR 1
+#define API_VERSION_NUMBER_PATCH 0
 
 namespace WPEFramework {
 


### PR DESCRIPTION
Reason for change: Added missing audio modes for dolby_audiomodechanged event in PlayerInfo plugin. otherwise 'client.events.1.dolby_audiomodechanged' event will return with unknown for DOLBYDIGITAL and DOLBYDIGITALPLUS audio modes.

Risks: Low

Test Procedure:
TDK PlayerInfo test cases: Check_Dolby_AudioMode_Changed_Event