### PR TITLE
DELIA-65343 - Fixing the trace method of network manager

### DIFF
--- a/NetworkManager/NetworkManagerJsonRpc.cpp
+++ b/NetworkManager/NetworkManagerJsonRpc.cpp
@@ -671,7 +671,10 @@ namespace WPEFramework
 
             if (Core::ERROR_NONE == rc)
             {
-                response["success"] = true;
+                JsonObject reply;
+                reply.FromString(result);
+                reply["success"] = true;
+                response = reply;
             }
             LOGTRACEMETHODFIN();
             return rc;


### PR DESCRIPTION
Reason for change: Added the trace ouput details in the Json response object
Test Procedure: Run Trace method curl and check
Risks: Low
Priority: P1
Signed-off-by: Gururaaja ESR <Gururaja_ErodeSriranganRamlingham@comcast.com>