### PR TITLE
SERXIONE-5242: After CDL, reboot device and stuck

### DIFF
--- a/MaintenanceManager/CHANGELOG.md
+++ b/MaintenanceManager/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.0.36] - 2024-06-06
+### Fixed
+- Potential initialization assert due to uninitialized variable
+
 ## [1.0.35] - 2024-05-27
 ### Fixed
 - Delay Unsolicited Maintenance start event in WAI-enabled case

--- a/MaintenanceManager/MaintenanceManager.h
+++ b/MaintenanceManager/MaintenanceManager.h
@@ -148,7 +148,7 @@ namespace WPEFramework {
                 std::map<string, string> m_param_map;
                 std::map<string, DATA_TYPE> m_paramType_map;
 
-                PluginHost::IShell* m_service;
+                PluginHost::IShell* m_service = nullptr;
 
                 bool isDeviceOnline();
                 void task_execution_thread();


### PR DESCRIPTION
Reason for change: Crash on init due to ASSERT and uninitialized variable
Test Procedure: Test latest and reboot
Risks: Low
Signed-off-by: Chris Buchter