### PR TITLE
RDK-45352: Upgrade Xumo TV to use Thunder R4.4.1

### DIFF
--- a/RDKShell/CHANGELOG.md
+++ b/RDKShell/CHANGELOG.md
@@ -17,6 +17,10 @@ All notable changes to this RDK Service will be documented in this file.
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
 
+## [1.5.3] - 2024-06-10
+### Fixed
+- ResidentApp plugin unable to activate due to unable to get the Initialize/activating Notification from Thunder(R4.4.1)
+
 ## [1.5.2] - 2024-06-04
 ### Changed
 - Added support for dobby amazon container

--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -1452,13 +1452,8 @@ namespace WPEFramework {
             }
         }
 
-#if (THUNDER_VERSION >= 4)
-
-#if(THUNDER_VERSION_MINOR >= 4)
+#ifdef USE_THUNDER_R4
        void RDKShell::MonitorClients::Initialize(const string& callsign, PluginHost::IShell* service)
-#else
-       void RDKShell::MonitorClients::Initialize(VARIABLE_IS_NOT_USED const string& callsign, VARIABLE_IS_NOT_USED PluginHost::IShell* service)
-#endif
        {
              handleInitialize(service);
        }
@@ -1475,17 +1470,13 @@ namespace WPEFramework {
             //StateChange(service);
             handleDeactivated(service);
        }
-#if(THUNDER_VERSION_MINOR >= 4)
        void RDKShell::MonitorClients::Deinitialized(const string& callsign, PluginHost::IShell* service)
-#else
-       void RDKShell::MonitorClients::Deinitialized(VARIABLE_IS_NOT_USED const string& callsign, VARIABLE_IS_NOT_USED PluginHost::IShell* service)
-#endif
        {
             handleDeinitialized(service);
        }
        void RDKShell::MonitorClients::Unavailable(const string& callsign, PluginHost::IShell* service)
        {}
-#endif
+#endif /* USE_THUNDER_R4 */
 
         bool RDKShell::ScreenCapture::Capture(ICapture::IStore& storer)
         {

--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -1452,8 +1452,13 @@ namespace WPEFramework {
             }
         }
 
-#ifdef USE_THUNDER_R4
-	void RDKShell::MonitorClients::Initialize(VARIABLE_IS_NOT_USED const string& callsign, VARIABLE_IS_NOT_USED PluginHost::IShell* service)
+#if (THUNDER_VERSION >= 4)
+
+#if(THUNDER_VERSION_MINOR >= 4)
+       void RDKShell::MonitorClients::Initialize(const string& callsign, PluginHost::IShell* service)
+#else
+       void RDKShell::MonitorClients::Initialize(VARIABLE_IS_NOT_USED const string& callsign, VARIABLE_IS_NOT_USED PluginHost::IShell* service)
+#endif
        {
              handleInitialize(service);
        }
@@ -1470,13 +1475,17 @@ namespace WPEFramework {
             //StateChange(service);
             handleDeactivated(service);
        }
-        void RDKShell::MonitorClients::Deinitialized(VARIABLE_IS_NOT_USED const string& callsign, VARIABLE_IS_NOT_USED PluginHost::IShell* service)
-        {
+#if(THUNDER_VERSION_MINOR >= 4)
+       void RDKShell::MonitorClients::Deinitialized(const string& callsign, PluginHost::IShell* service)
+#else
+       void RDKShell::MonitorClients::Deinitialized(VARIABLE_IS_NOT_USED const string& callsign, VARIABLE_IS_NOT_USED PluginHost::IShell* service)
+#endif
+       {
             handleDeinitialized(service);
-        }
+       }
        void RDKShell::MonitorClients::Unavailable(const string& callsign, PluginHost::IShell* service)
        {}
-#endif /* USE_THUNDER_R4 */
+#endif
 
         bool RDKShell::ScreenCapture::Capture(ICapture::IStore& storer)
         {

--- a/RDKShell/RDKShell.h
+++ b/RDKShell/RDKShell.h
@@ -432,20 +432,13 @@ namespace WPEFramework {
                   void handleDeactivated(PluginHost::IShell* shell);
                   void handleDeinitialized(PluginHost::IShell* shell);
 
-#if (THUNDER_VERSION >= 4)
-
-#if(THUNDER_VERSION_MINOR >= 4)
+#ifdef USE_THUNDER_R4
                   virtual void Initialize(const string& callsign, PluginHost::IShell* plugin);
-                  virtual void Deinitialized(const string& callsign, PluginHost::IShell* plugin);
-#else
-                  virtual void Initialize(VARIABLE_IS_NOT_USED const string& callsign, VARIABLE_IS_NOT_USED PluginHost::IShell* plugin);
-                  virtual void Deinitialized(VARIABLE_IS_NOT_USED const string& callsign, VARIABLE_IS_NOT_USED PluginHost::IShell* plugin);
-#endif
                   virtual void Activation(const string& name, PluginHost::IShell* plugin);
                   virtual void Deactivation(const string& name, PluginHost::IShell* plugin);
                   virtual void  Activated(const string& callSign,  PluginHost::IShell* plugin);
                   virtual void  Deactivated(const string& callSign,  PluginHost::IShell* plugin);
-		  virtual void Deinitialized(VARIABLE_IS_NOT_USED const string& callsign, VARIABLE_IS_NOT_USED PluginHost::IShell* plugin);
+                  virtual void Deinitialized(const string& callsign, PluginHost::IShell* plugin);
                   virtual void  Unavailable(const string& callSign,  PluginHost::IShell* plugin);
 #endif /* USE_THUNDER_R4 */
               private:

--- a/RDKShell/RDKShell.h
+++ b/RDKShell/RDKShell.h
@@ -396,7 +396,13 @@ namespace WPEFramework {
                   RDKShell& mShell;
             };
 
-            class MonitorClients : public PluginHost::IPlugin::INotification {
+#if ((THUNDER_VERSION >= 4) && (THUNDER_VERSION_MINOR >= 4))
+            class MonitorClients
+            : public PluginHost::IPlugin::INotification
+            ,  public PluginHost::IPlugin::ILifeTime {
+#else
+	    class MonitorClients : public PluginHost::IPlugin::INotification {
+#endif
               private:
                   MonitorClients() = delete;
                   MonitorClients(const MonitorClients&) = delete;
@@ -414,6 +420,9 @@ namespace WPEFramework {
               public:
                   BEGIN_INTERFACE_MAP(MonitorClients)
                   INTERFACE_ENTRY(PluginHost::IPlugin::INotification)
+#if ((THUNDER_VERSION >= 4) && (THUNDER_VERSION_MINOR >= 4))
+		  INTERFACE_ENTRY(PluginHost::IPlugin::ILifeTime)
+#endif
                   END_INTERFACE_MAP
 
               private:
@@ -422,8 +431,16 @@ namespace WPEFramework {
                   void handleActivated(PluginHost::IShell* shell);
                   void handleDeactivated(PluginHost::IShell* shell);
                   void handleDeinitialized(PluginHost::IShell* shell);
-#ifdef USE_THUNDER_R4
-		  virtual void Initialize(VARIABLE_IS_NOT_USED const string& callsign, VARIABLE_IS_NOT_USED PluginHost::IShell* plugin);
+
+#if (THUNDER_VERSION >= 4)
+
+#if(THUNDER_VERSION_MINOR >= 4)
+                  virtual void Initialize(const string& callsign, PluginHost::IShell* plugin);
+                  virtual void Deinitialized(const string& callsign, PluginHost::IShell* plugin);
+#else
+                  virtual void Initialize(VARIABLE_IS_NOT_USED const string& callsign, VARIABLE_IS_NOT_USED PluginHost::IShell* plugin);
+                  virtual void Deinitialized(VARIABLE_IS_NOT_USED const string& callsign, VARIABLE_IS_NOT_USED PluginHost::IShell* plugin);
+#endif
                   virtual void Activation(const string& name, PluginHost::IShell* plugin);
                   virtual void Deactivation(const string& name, PluginHost::IShell* plugin);
                   virtual void  Activated(const string& callSign,  PluginHost::IShell* plugin);


### PR DESCRIPTION
Reason for change: ResidentApp plugin unable to activate due to unable to get the Initialize/activating Notification from Thunder(R4.4.1)
Test Procedure: Verify in Jenkin Build
Risks: High
Signed-off-by: Thamim Razith tabbas651@cable.comcast.com