### PR TITLE
RDK-45352: Upgrade Xumo TV to use Thunder R4.4.1

### DIFF
--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -1455,7 +1455,7 @@ namespace WPEFramework {
         }
 
 #ifdef USE_THUNDER_R4
-	void RDKShell::MonitorClients::Initialize(VARIABLE_IS_NOT_USED const string& callsign, VARIABLE_IS_NOT_USED PluginHost::IShell* service)
+       void RDKShell::MonitorClients::Initialize(const string& callsign, PluginHost::IShell* service)
        {
              handleInitialize(service);
        }
@@ -1472,10 +1472,10 @@ namespace WPEFramework {
             //StateChange(service);
             handleDeactivated(service);
        }
-        void RDKShell::MonitorClients::Deinitialized(VARIABLE_IS_NOT_USED const string& callsign, VARIABLE_IS_NOT_USED PluginHost::IShell* service)
-        {
+       void RDKShell::MonitorClients::Deinitialized(const string& callsign, PluginHost::IShell* service)
+       {
             handleDeinitialized(service);
-        }
+       }
        void RDKShell::MonitorClients::Unavailable(const string& callsign, PluginHost::IShell* service)
        {}
 #endif /* USE_THUNDER_R4 */

--- a/RDKShell/RDKShell.h
+++ b/RDKShell/RDKShell.h
@@ -401,7 +401,13 @@ namespace WPEFramework {
                   RDKShell& mShell;
             };
 
-            class MonitorClients : public PluginHost::IPlugin::INotification {
+#if ((THUNDER_VERSION >= 4) && (THUNDER_VERSION_MINOR >= 4))
+            class MonitorClients
+            : public PluginHost::IPlugin::INotification
+            ,  public PluginHost::IPlugin::ILifeTime {
+#else
+	    class MonitorClients : public PluginHost::IPlugin::INotification {
+#endif
               private:
                   MonitorClients() = delete;
                   MonitorClients(const MonitorClients&) = delete;
@@ -419,6 +425,9 @@ namespace WPEFramework {
               public:
                   BEGIN_INTERFACE_MAP(MonitorClients)
                   INTERFACE_ENTRY(PluginHost::IPlugin::INotification)
+#if ((THUNDER_VERSION >= 4) && (THUNDER_VERSION_MINOR >= 4))
+		  INTERFACE_ENTRY(PluginHost::IPlugin::ILifeTime)
+#endif
                   END_INTERFACE_MAP
 
               private:
@@ -427,13 +436,14 @@ namespace WPEFramework {
                   void handleActivated(PluginHost::IShell* shell);
                   void handleDeactivated(PluginHost::IShell* shell);
                   void handleDeinitialized(PluginHost::IShell* shell);
+
 #ifdef USE_THUNDER_R4
-		  virtual void Initialize(VARIABLE_IS_NOT_USED const string& callsign, VARIABLE_IS_NOT_USED PluginHost::IShell* plugin);
+                  virtual void Initialize(const string& callsign, PluginHost::IShell* plugin);
                   virtual void Activation(const string& name, PluginHost::IShell* plugin);
                   virtual void Deactivation(const string& name, PluginHost::IShell* plugin);
                   virtual void  Activated(const string& callSign,  PluginHost::IShell* plugin);
                   virtual void  Deactivated(const string& callSign,  PluginHost::IShell* plugin);
-		  virtual void Deinitialized(VARIABLE_IS_NOT_USED const string& callsign, VARIABLE_IS_NOT_USED PluginHost::IShell* plugin);
+		  virtual void Deinitialized(const string& callsign, PluginHost::IShell* plugin);
                   virtual void  Unavailable(const string& callSign,  PluginHost::IShell* plugin);
 #endif /* USE_THUNDER_R4 */
               private:

--- a/RDKShell/RDKShell.h
+++ b/RDKShell/RDKShell.h
@@ -401,13 +401,11 @@ namespace WPEFramework {
                   RDKShell& mShell;
             };
 
+            class MonitorClients : public PluginHost::IPlugin::INotification
 #if ((THUNDER_VERSION >= 4) && (THUNDER_VERSION_MINOR >= 4))
-            class MonitorClients
-            : public PluginHost::IPlugin::INotification
-            ,  public PluginHost::IPlugin::ILifeTime {
-#else
-	    class MonitorClients : public PluginHost::IPlugin::INotification {
+            ,  public PluginHost::IPlugin::ILifeTime 
 #endif
+	   {
               private:
                   MonitorClients() = delete;
                   MonitorClients(const MonitorClients&) = delete;


### PR DESCRIPTION
Reason for change: ResidentApp plugin unable to activate due to unable to get the Initialize/activating Notification from Thunder(R4.4.1)
Test Procedure: Verify in Jenkin Build
Risks: High
Signed-off-by: Thamim Razith tabbas651@cable.comcast.com