### PR TITLE
RDKDEV-1008: Upstream change to keep the system time consistent with the serial port

### DIFF
--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -2447,6 +2447,7 @@ namespace WPEFramework {
 		if (parameters.HasLabel("timeZone")) {
 			std::string dir = dirnameOf(TZ_FILE);
 			std::string timeZone = "";
+			std::string command = "";
 			try {
 				timeZone = parameters["timeZone"].String();
 				size_t pos = timeZone.find("/");
@@ -2475,10 +2476,12 @@ namespace WPEFramework {
 					if( dirExists(path+country)  && Utils::fileExists(city.c_str()) ) 
 					{
 						if (!dirExists(dir)) {
-							std::string command = "mkdir -p " + dir + " \0";
+							command = "mkdir -p " + dir + " \0";
 							Utils::cRunScript(command.c_str());
 						} else {
 							//Do nothing//
+							command = "cat /usr/share/zoneinfo/" +timeZone +" > /usr/share/zoneinfo/Universal" +" \0";
+							Utils::cRunScript(command.c_str());
 						}
 						std::string oldTimeZoneDST = getTimeZoneDSTHelper();
 						


### PR DESCRIPTION
Reason for change: Force the log time of the serial port to be consistent with the actual time

Test Procedure: Test and confirm that curl command return expected responses

Risks: Low

Signed-off-by: yangkang [yangkang@skyworth.com](mailto:yangkang@skyworth.com)