### PR TITLE
RDKCOM-4633 RDKDEV-990 - Upstream onApplicationFocusChanged event cha…

### DIFF
--- a/RDKShell/RDKShell.json
+++ b/RDKShell/RDKShell.json
@@ -1253,6 +1253,28 @@
                 ]
             }
         },
+	"getFocus": {
+            "summary": "Gets focus to the specified client.",
+            "params": {
+                "type":"object",
+                "properties": {
+                    "client": {
+                        "$ref": "#/definitions/client"
+                    },
+                    "callsign": {
+                        "summary": "The application callsign",
+                        "type": "string",
+                        "example": "org.rdk.Netflix"
+                    }
+                },
+                "required": [
+                    "client"
+                ]
+            },
+            "result": {
+                "$ref": "#/common/result"
+            }
+        },
         "hideAllClients": {
             "summary": "Hides/Unhides all the clients.",
             "params": {
@@ -2358,6 +2380,20 @@
     "events": {
         "onApplicationActivated":{
             "summary": "Triggered when an application is activated",
+            "params": {
+                "type": "object",
+                "properties": {
+                    "client":{
+                        "$ref": "#/definitions/client" 
+                    }
+                },
+                "required": [
+                    "client"
+                ]
+            }
+        },
+        "onApplicationFocusChanged":{
+            "summary": "Triggered when an application focus is changed",
             "params": {
                 "type": "object",
                 "properties": {


### PR DESCRIPTION
RDKCOM-4633 RDKDEV-990 - Upstream onApplicationFocusChanged event change handling

Reason for change: onApplicationFocusChanged event handling not done , so added those changes for getFocus , getFocused and corresponding event handlings

Risks: Low

Test Procedure: Getting onApplicationFocusChanged events on in ResidentUI , switch to Youtube , back to main UI in all cases

Signed-off-by: Dhivya Priya M [dhivyapriya_murugesan@comcast.com](mailto:dhivyapriya_murugesan@comcast.com)