### PR TITLE
RDKTV-31166 posting internet event when interface connection changes

### DIFF
--- a/Network/Network.cpp
+++ b/Network/Network.cpp
@@ -1461,15 +1461,11 @@ typedef struct _IARM_BUS_NetSrvMgr_Iface_EventData_t {
             m_defInterfaceCache = "";
 
             sendNotify("onConnectionStatusChanged", params);
-            if(connected)
+            connectivityMonitor.doInitialConnectivityMonitoring(30);
+            if(!connected)
             {
-                connectivityMonitor.doInitialConnectivityMonitoring(30);
-            }
-            else
-            {
-               /*run the thread again to notify no_internet state*/
-               connectivityMonitor.doInitialConnectivityMonitoring(30);
-               connectivityMonitor.stopInitialConnectivityMonitoring();
+                /* if disconnectd need to stop the thread after one event */
+                connectivityMonitor.stopInitialConnectivityMonitoring();
             }
         }
 

--- a/Network/Network.cpp
+++ b/Network/Network.cpp
@@ -1467,12 +1467,9 @@ typedef struct _IARM_BUS_NetSrvMgr_Iface_EventData_t {
             }
             else
             {
-                if (!connectivityMonitor.isMonitorThreadRunning())
-                {
-                    /*run the thread again to notify no_internet state*/
-                    connectivityMonitor.doInitialConnectivityMonitoring(30);
-                }
-                connectivityMonitor.stopInitialConnectivityMonitoring();
+               /*run the thread again to notify no_internet state*/
+               connectivityMonitor.doInitialConnectivityMonitoring(30);
+               connectivityMonitor.stopInitialConnectivityMonitoring();
             }
         }
 

--- a/Network/NetworkConnectivity.cpp
+++ b/Network/NetworkConnectivity.cpp
@@ -492,6 +492,7 @@ namespace WPEFramework {
         if (isMonitorThreadRunning() && stopFlag == false)
         {
             LOGINFO("Connectivity Monitor Thread is active so notify");
+            g_internetState = nsm_internetState::UNKNOWN;
             cv_.notify_all();
         }
         else

--- a/NetworkManager/NetworkManagerConnectivity.cpp
+++ b/NetworkManager/NetworkManagerConnectivity.cpp
@@ -425,6 +425,7 @@ namespace WPEFramework {
         if (isMonitorThreadRunning() && stopFlag == false)
         {
             NMLOG_INFO("Connectivity Monitor Thread is active so notify");
+            g_internetState = nsm_internetState::UNKNOWN;
             cv_.notify_all();
         }
         else

--- a/NetworkManager/NetworkManagerRDKProxy.cpp
+++ b/NetworkManager/NetworkManagerRDKProxy.cpp
@@ -425,8 +425,12 @@ namespace WPEFramework
                         {
                             if (e->status)
                                 ::_instance->ReportInterfaceStateChangedEvent(Exchange::INetworkManager::INTERFACE_LINK_UP, interface);
-                            else
-                                ::_instance->ReportInterfaceStateChangedEvent(Exchange::INetworkManager::INTERFACE_LINK_DOWN, interface);
+                            else {
+                               ::_instance->ReportInterfaceStateChangedEvent(Exchange::INetworkManager::INTERFACE_LINK_DOWN, interface);
+                               /* when ever interface down we start connectivity monitor to post noInternet event */
+                               ::_instance->connectivityMonitor.doInitialConnectivityMonitoring(5);
+                               ::_instance->connectivityMonitor.stopInitialConnectivityMonitoring();
+                            }
                         }
                         break;
                     }
@@ -436,8 +440,14 @@ namespace WPEFramework
                         interface = e->interface;
                         NMLOG_INFO ("IARM_BUS_NETWORK_MANAGER_EVENT_INTERFACE_IPADDRESS :: %s -- %s", interface.c_str(), e->ip_address);
 
-                        if(interface == "eth0" || interface == "wlan0")
+                        if(interface == "eth0" || interface == "wlan0") {
                             ::_instance->ReportIPAddressChangedEvent(interface, e->acquired, e->is_ipv6, string(e->ip_address));
+                            if(e->acquired)
+                            {
+                                /* if ip address acquired we start connectivity monitor */
+                                ::_instance->connectivityMonitor.doInitialConnectivityMonitoring(5);
+                            }
+                        }
                         break;
                     }
                     case IARM_BUS_NETWORK_MANAGER_EVENT_DEFAULT_INTERFACE:


### PR DESCRIPTION
Fix for RDKTV-31166 Wi-Fi - Getting "Your internet connection was interrupted" error message while switching different network connection.