### PR TITLE
RDKDEV-1011: Upstream change to support HdmiCecSink plugin and add se…

### DIFF
--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -60,6 +60,7 @@
 #define HDMICECSINK_METHOD_SETUP_ARC              "setupARCRouting"
 #define HDMICECSINK_METHOD_REQUEST_SHORT_AUDIO_DESCRIPTOR  "requestShortAudioDescriptor"
 #define HDMICECSINK_METHOD_SEND_STANDBY_MESSAGE            "sendStandbyMessage"
+#define HDMICECSINK_METHOD_SEND_WAKEUP_MESSAGE            "sendWakeupMessage"
 #define HDMICECSINK_METHOD_SEND_AUDIO_DEVICE_POWER_ON "sendAudioDevicePowerOnMessage"
 #define HDMICECSINK_METHOD_SEND_KEY_PRESS                          "sendKeyPressEvent"
 #define HDMICECSINK_METHOD_SEND_USER_CONTROL_PRESSED          "sendUserControlPressed"
@@ -718,6 +719,7 @@ namespace WPEFramework
 		   Register(HDMICECSINK_METHOD_SET_MENU_LANGUAGE, &HdmiCecSink::setMenuLanguageWrapper, this);
                    Register(HDMICECSINK_METHOD_REQUEST_SHORT_AUDIO_DESCRIPTOR, &HdmiCecSink::requestShortAudioDescriptorWrapper, this);
                    Register(HDMICECSINK_METHOD_SEND_STANDBY_MESSAGE, &HdmiCecSink::sendStandbyMessageWrapper, this);
+                   Register(HDMICECSINK_METHOD_SEND_WAKEUP_MESSAGE, &HdmiCecSink::sendWakeupMessageWrapper, this);
 		   Register(HDMICECSINK_METHOD_SEND_AUDIO_DEVICE_POWER_ON, &HdmiCecSink::sendAudioDevicePowerOnMsgWrapper, this);
 		   Register(HDMICECSINK_METHOD_SEND_KEY_PRESS,&HdmiCecSink::sendRemoteKeyPressWrapper,this);
 		   Register(HDMICECSINK_METHOD_SEND_USER_CONTROL_PRESSED,&HdmiCecSink::sendUserControlPressedWrapper,this);
@@ -873,7 +875,7 @@ namespace WPEFramework
                 IARM_Result_t res;
                 IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_CECMGR_NAME, IARM_BUS_CECMGR_EVENT_DAEMON_INITIALIZED,cecMgrEventHandler) );
                 IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_CECMGR_NAME, IARM_BUS_CECMGR_EVENT_STATUS_UPDATED,cecMgrEventHandler) );
-                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_IN_HOTPLUG, dsHdmiEventHandler) );
+                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_HOTPLUG, dsHdmiEventHandler) );
                 IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_PWRMGR_NAME,IARM_BUS_PWRMGR_EVENT_MODECHANGED, pwrMgrModeChangeEventHandler) );
            }
        }
@@ -885,7 +887,7 @@ namespace WPEFramework
                 IARM_Result_t res;
                 IARM_CHECK( IARM_Bus_RemoveEventHandler(IARM_BUS_CECMGR_NAME, IARM_BUS_CECMGR_EVENT_DAEMON_INITIALIZED, cecMgrEventHandler) );
                 IARM_CHECK( IARM_Bus_RemoveEventHandler(IARM_BUS_CECMGR_NAME, IARM_BUS_CECMGR_EVENT_STATUS_UPDATED, cecMgrEventHandler) );
-                IARM_CHECK( IARM_Bus_RemoveEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_IN_HOTPLUG, dsHdmiEventHandler) );
+                IARM_CHECK( IARM_Bus_RemoveEventHandler(IARM_BUS_DSMGR_NAME,IARM_BUS_DSMGR_EVENT_HDMI_HOTPLUG, dsHdmiEventHandler) );
                 IARM_CHECK( IARM_Bus_RemoveEventHandler(IARM_BUS_PWRMGR_NAME,IARM_BUS_PWRMGR_EVENT_MODECHANGED, pwrMgrModeChangeEventHandler) );
             }
        }
@@ -926,13 +928,12 @@ namespace WPEFramework
        {
             if(!HdmiCecSink::_instance)
                 return;
-
-            if (IARM_BUS_DSMGR_EVENT_HDMI_IN_HOTPLUG == eventId)
+            if (IARM_BUS_DSMGR_EVENT_HDMI_HOTPLUG == eventId)
             {
                 IARM_Bus_DSMgr_EventData_t *eventData = (IARM_Bus_DSMgr_EventData_t *)data;
                 bool isHdmiConnected = eventData->data.hdmi_in_connect.isPortConnected;
                 dsHdmiInPort_t portId = eventData->data.hdmi_in_connect.port;
-                LOGINFO("Received IARM_BUS_DSMGR_EVENT_HDMI_IN_HOTPLUG event port: %d data:%d \r\n",portId,  isHdmiConnected);
+                LOGINFO("Received IARM_BUS_DSMGR_EVENT_HDMI_HOTPLUG event port: %d data:%d \r\n",portId,  isHdmiConnected);
                 HdmiCecSink::_instance->onHdmiHotPlug(portId,isHdmiConnected);
             }
        }
@@ -999,7 +1000,21 @@ namespace WPEFramework
 			}
 
 			_instance->smConnection->sendTo(LogicalAddress(LogicalAddress::BROADCAST), MessageEncoder().encode(Standby()), 1000);
-       } 
+       }
+
+    	 void HdmiCecSink::sendWakeupMessage()
+    	 {
+        	if(!HdmiCecSink::_instance)
+            			return;
+        	if(!(HdmiCecSink::_instance->smConnection))
+            		  	return;
+        	if ( _instance->m_logicalAddressAllocated == LogicalAddress::UNREGISTERED){
+            			LOGERR("Logical Address NOT Allocated Or its not valid");
+            			return;
+        		}
+
+        	_instance->smConnection->sendTo(LogicalAddress(LogicalAddress::TV), MessageEncoder().encode(ImageViewOn()), 100);
+    	 } 
 
 	   void HdmiCecSink::wakeupFromStandby()
 	   {
@@ -1561,6 +1576,7 @@ namespace WPEFramework
                 LOGINFO("setOSDNameWrapper osdName: %s",osd.c_str());
                 osdName = osd.c_str();
                 Utils::persistJsonSettings (CEC_SETTING_ENABLED_FILE, CEC_SETTING_OSD_NAME, JsonValue(osd.c_str()));
+                _instance->smConnection->sendTo(LogicalAddress(LogicalAddress::BROADCAST), MessageEncoder().encode(GiveOSDName()), 200);
             }
             else
             {
@@ -1790,6 +1806,12 @@ namespace WPEFramework
 	  returnResponse(true);
         }
 
+    	uint32_t HdmiCecSink::sendWakeupMessageWrapper(const JsonObject& parameters, JsonObject& response)
+    	{
+          sendWakeupMessage();
+          returnResponse(true);
+        }
+
         uint32_t HdmiCecSink::sendAudioDevicePowerOnMsgWrapper(const JsonObject& parameters, JsonObject& response)
         {
 	    LOGINFO("%s invoked. \n",__FUNCTION__);
@@ -1901,10 +1923,10 @@ namespace WPEFramework
                 }
                 else
                 {
-                    parameters[CEC_SETTING_OTP_ENABLED] = true;
-                    cecOTPSettingEnabled = true;
+                    parameters[CEC_SETTING_OTP_ENABLED] = false;
+                    cecOTPSettingEnabled = false;
                     isConfigAdded = true;
-                    LOGINFO("CEC_SETTING_OTP_ENABLED not present set dafult true:\n ");
+                    LOGINFO("CEC_SETTING_OTP_ENABLED not present set dafult false:\n ");
                 }
                 if( parameters.HasLabel(CEC_SETTING_OSD_NAME))
                 {
@@ -1955,11 +1977,11 @@ namespace WPEFramework
 
                 JsonObject parameters;
                 unsigned int  vendorId = (defaultVendorId.at(0) <<16) | ( defaultVendorId.at(1) << 8 ) | defaultVendorId.at(2);
-                parameters[CEC_SETTING_ENABLED] = true;
+                parameters[CEC_SETTING_ENABLED] = false;
                 parameters[CEC_SETTING_OSD_NAME] = osdName.toString();
                 parameters[CEC_SETTING_VENDOR_ID] = vendorId;
 
-                cecSettingEnabled = true;
+                cecSettingEnabled = false;
                 cecOTPSettingEnabled = true;
                 parameters.IElement::ToFile(file);
 
@@ -2133,6 +2155,9 @@ namespace WPEFramework
 				LOGERR("Logical Address NOT Allocated");
 				return;
 			}
+
+			_instance->smConnection->sendTo(LogicalAddress(LogicalAddress::TV), 
+										MessageEncoder().encode(ImageViewOn()), 1000);
 
 			_instance->smConnection->sendTo(LogicalAddress::BROADCAST, 
 										MessageEncoder().encode(RequestActiveSource()), 500);
@@ -2881,14 +2906,14 @@ namespace WPEFramework
 				case POLL_THREAD_STATE_POLL :
 				{
 					//LOGINFO("POLL_THREAD_STATE_POLL");
-					_instance->allocateLogicalAddress(DeviceType::TV);
+					_instance->allocateLogicalAddress(DeviceType::PLAYBACK_DEVICE);
 					if ( _instance->m_logicalAddressAllocated != LogicalAddress::UNREGISTERED)
 					{
 						logicalAddress = LogicalAddress(_instance->m_logicalAddressAllocated);
 						LibCCEC::getInstance().addLogicalAddress(logicalAddress);
 						_instance->smConnection->setSource(logicalAddress);
 						_instance->m_numberOfDevices = 0;
-						_instance->deviceList[_instance->m_logicalAddressAllocated].m_deviceType = DeviceType::TV;
+						_instance->deviceList[_instance->m_logicalAddressAllocated].m_deviceType = DeviceType::PLAYBACK_DEVICE;
 						_instance->deviceList[_instance->m_logicalAddressAllocated].m_isDevicePresent = true;
                         			_instance->deviceList[_instance->m_logicalAddressAllocated].update(physical_addr);
 						_instance->deviceList[_instance->m_logicalAddressAllocated].m_cecVersion = Version::V_1_4;
@@ -3078,31 +3103,15 @@ namespace WPEFramework
             if (!(_instance->smConnection))
                 return;
 
-            for (i = 0; i< HDMICECSINK_NUMBER_TV_ADDR; i++)
+            try{
+                addr = LibCCEC::getInstance().getLogicalAddress(DeviceType::PLAYBACK_DEVICE);
+                std::string logicalAddrDeviceType = DeviceType(LogicalAddress(addr).getType()).toString().c_str();
+                gotLogicalAddress = true;
+                LOGWARN("logical address obtained is %d , saved logical address is %s ", addr, logicalAddress.toString().c_str());
+            }
+            catch (const std::exception &e)
             {
-                /* poll for TV logical address - retry 5 times*/
-                for (j = 0; j < 5; j++)
-                {
-                    try {
-                        smConnection->poll(LogicalAddress(addr), Throw_e());
-                    }
-                    catch(CECNoAckException &e )
-                    {
-                        LOGWARN("Poll caught %s \r\n",e.what());
-                        gotLogicalAddress = true;
-                        break;
-                    }
-                    catch(Exception &e)
-                    {
-                        LOGWARN("Poll caught %s \r\n",e.what());
-                        usleep(250000);
-                    }
-                }
-                if (gotLogicalAddress)
-                {
-                    break;
-                }
-                addr = LogicalAddress::SPECIFIC_USE;
+                LOGWARN("CEC exception caught from getLogicalAddress ");
             }
 
             if ( gotLogicalAddress )

--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -3099,7 +3099,6 @@ namespace WPEFramework
         {
             bool gotLogicalAddress = false;
             int addr = LogicalAddress::TV;
-            int i, j;
             if (!(_instance->smConnection))
                 return;
 

--- a/HdmiCecSink/HdmiCecSink.h
+++ b/HdmiCecSink/HdmiCecSink.h
@@ -542,6 +542,7 @@ private:
 			void sendPowerOFFCommand(const PhysicalAddress &physical_addr);
 			void sendPowerONCommand(const PhysicalAddress &physical_addr); 
 			void sendStandbyMessage();
+			void sendWakeupMessage();
 			void setCurrentLanguage(const Language &lang);
 			void sendMenuLanguage();
 			void setActiveSource(bool isResponse);
@@ -603,6 +604,7 @@ private:
 			uint32_t setMenuLanguageWrapper(const JsonObject& parameters, JsonObject& response);
                         uint32_t requestShortAudioDescriptorWrapper(const JsonObject& parameters, JsonObject& response);
                         uint32_t sendStandbyMessageWrapper(const JsonObject& parameters, JsonObject& response);
+                        uint32_t sendWakeupMessageWrapper(const JsonObject& parameters, JsonObject& response);
 			uint32_t sendAudioDevicePowerOnMsgWrapper(const JsonObject& parameters, JsonObject& response);
                         uint32_t sendRemoteKeyPressWrapper(const JsonObject& parameters, JsonObject& response);
 			uint32_t sendUserControlPressedWrapper(const JsonObject& parameters, JsonObject& response);


### PR DESCRIPTION
…ndWakeupMessage method

Reason for change: Fix the HdmiCecSink one-click wake up issue.

Test Procedure: Ensure that the curl commands return expected responses

Risks: Low