### PR TITLE
RDKCOM-4805 RDKDEV-1023: Make plugin autostart configurable from recipe

### DIFF
--- a/Bluetooth/Bluetooth.conf.in
+++ b/Bluetooth/Bluetooth.conf.in
@@ -1,4 +1,4 @@
 precondition = ["Platform"]
 callsign = "org.rdk.Bluetooth"
-autostart = "false"
+autostart = "@PLUGIN_BLUETOOTH_AUTOSTART@"
 startuporder = "@PLUGIN_BLUETOOTH_STARTUPORDER@"

--- a/Bluetooth/Bluetooth.config
+++ b/Bluetooth/Bluetooth.config
@@ -1,4 +1,4 @@
-set (autostart false)
+set (autostart ${PLUGIN_BLUETOOTH_AUTOSTART})
 set (preconditions Platform)
 set (callsign "org.rdk.Bluetooth")
 

--- a/Bluetooth/CMakeLists.txt
+++ b/Bluetooth/CMakeLists.txt
@@ -19,6 +19,7 @@ set(PLUGIN_NAME Bluetooth)
 set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
 
 set(PLUGIN_BLUETOOTH_STARTUPORDER "" CACHE STRING "To configure startup order of Bluetooth plugin")
+set(PLUGIN_BLUETOOTH_AUTOSTART false CACHE STRING "To automatically start Bluetooth plugin.")
 
 find_package(${NAMESPACE}Plugins REQUIRED)
 

--- a/DataCapture/CMakeLists.txt
+++ b/DataCapture/CMakeLists.txt
@@ -19,6 +19,7 @@ set(PLUGIN_NAME DataCapture)
 set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
 
 set(PLUGIN_DATACAPTURE_STARTUPORDER "" CACHE STRING "To configure startup order of DataCapture plugin")
+set(PLUGIN_DATACAPTURE_AUTOSTART false CACHE STRING "To automatically start DataCapture plugin.")
 
 find_package(${NAMESPACE}Plugins REQUIRED)
 

--- a/DataCapture/DataCapture.conf.in
+++ b/DataCapture/DataCapture.conf.in
@@ -1,4 +1,4 @@
 precondition = ["Platform"]
 callsign = "org.rdk.dataCapture"
-autostart = "false"
+autostart = "@PLUGIN_DATACAPTURE_AUTOSTART@"
 startuporder = "@PLUGIN_DATACAPTURE_STARTUPORDER@"

--- a/DataCapture/DataCapture.config
+++ b/DataCapture/DataCapture.config
@@ -1,4 +1,4 @@
-set (autostart false)
+set (autostart ${PLUGIN_DATACAPTURE_AUTOSTART})
 set (preconditions Platform)
 set (callsign org.rdk.dataCapture)
 

--- a/DeviceDiagnostics/CMakeLists.txt
+++ b/DeviceDiagnostics/CMakeLists.txt
@@ -19,6 +19,7 @@ set(PLUGIN_NAME DeviceDiagnostics)
 set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
 
 set(PLUGIN_DEVICEDIAGNOSTICS_STARTUPORDER "" CACHE STRING "To configure startup order of DeviceDiagnostics plugin")
+set(PLUGIN_DEVICEDIAGNOSTICS_AUTOSTART false CACHE STRING "To automatically start DeviceDiagnostics plugin.")
 
 find_package(${NAMESPACE}Plugins REQUIRED)
 

--- a/DeviceDiagnostics/DeviceDiagnostics.conf.in
+++ b/DeviceDiagnostics/DeviceDiagnostics.conf.in
@@ -1,4 +1,4 @@
 precondition = ["Platform"]
 callsign = "org.rdk.DeviceDiagnostics"
-autostart = "false"
+autostart = "@PLUGIN_DEVICEDIAGNOSTICS_AUTOSTART@"
 startuporder = "@PLUGIN_DEVICEDIAGNOSTICS_STARTUPORDER@"

--- a/DeviceDiagnostics/DeviceDiagnostics.config
+++ b/DeviceDiagnostics/DeviceDiagnostics.config
@@ -1,4 +1,4 @@
-set (autostart false)
+set (autostart ${PLUGIN_DEVICEDIAGNOSTICS_AUTOSTART})
 set (preconditions Platform)
 set (callsign "org.rdk.DeviceDiagnostics")
 

--- a/FrameRate/CMakeLists.txt
+++ b/FrameRate/CMakeLists.txt
@@ -19,6 +19,7 @@ set(PLUGIN_NAME FrameRate)
 set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
 
 set(PLUGIN_FRAMERATE_STARTUPORDER "" CACHE STRING "To configure startup order of FrameRate plugin")
+set(PLUGIN_FRAMERATE_AUTOSTART false CACHE STRING "To automatically start FrameRate plugin.")
 
 find_package(${NAMESPACE}Plugins REQUIRED)
 

--- a/FrameRate/FrameRate.conf.in
+++ b/FrameRate/FrameRate.conf.in
@@ -1,4 +1,4 @@
 precondition = ["Platform"]
 callsign = "org.rdk.FrameRate"
-autostart = "false"
+autostart = "@PLUGIN_FRAMERATE_AUTOSTART@"
 startuporder = "@PLUGIN_FRAMERATE_STARTUPORDER@"

--- a/FrameRate/FrameRate.config
+++ b/FrameRate/FrameRate.config
@@ -1,4 +1,4 @@
-set (autostart false)
+set (autostart ${PLUGIN_FRAMERATE_AUTOSTART})
 set (preconditions Platform)
 set (callsign "org.rdk.FrameRate")
 

--- a/FrontPanel/CMakeLists.txt
+++ b/FrontPanel/CMakeLists.txt
@@ -19,6 +19,7 @@ set(PLUGIN_NAME FrontPanel)
 set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
 
 set(PLUGIN_FRONTPANEL_STARTUPORDER "" CACHE STRING "To configure startup order of FrontPanel plugin")
+set(PLUGIN_FRONTPANEL_AUTOSTART false CACHE STRING "To automatically start FrontPanel plugin.")
 
 find_package(${NAMESPACE}Plugins REQUIRED)
 

--- a/FrontPanel/FrontPanel.conf.in
+++ b/FrontPanel/FrontPanel.conf.in
@@ -1,4 +1,4 @@
 precondition = ["Platform"]
 callsign = "org.rdk.FrontPanel"
-autostart = "false"
+autostart = "@PLUGIN_FRONTPANEL_AUTOSTART@"
 startuporder = "@PLUGIN_FRONTPANEL_STARTUPORDER@"

--- a/FrontPanel/FrontPanel.config
+++ b/FrontPanel/FrontPanel.config
@@ -1,4 +1,4 @@
-set (autostart false)
+set (autostart ${PLUGIN_FRONTPANEL_AUTOSTART})
 set (preconditions Platform)
 set (callsign "org.rdk.FrontPanel")
 

--- a/HdmiCec_2/CMakeLists.txt
+++ b/HdmiCec_2/CMakeLists.txt
@@ -18,6 +18,7 @@ set(PLUGIN_NAME HdmiCec_2)
 set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
 
 set(PLUGIN_HDMICEC2_STARTUPORDER "" CACHE STRING "To configure startup order of HdmiCec_2 plugin")
+set(PLUGIN_HDMICEC2_AUTOSTART false CACHE STRING "To automatically start HdmiCec_2 plugin.")
 set_source_files_properties(HdmiCec_2.cpp PROPERTIES COMPILE_FLAGS "-fexceptions")
 
 find_package(${NAMESPACE}Plugins REQUIRED)

--- a/HdmiCec_2/HdmiCec_2.conf.in
+++ b/HdmiCec_2/HdmiCec_2.conf.in
@@ -1,4 +1,4 @@
 precondition = ["Platform"]
 callsign = "org.rdk.HdmiCec_2"
-autostart = "false"
+autostart = "@PLUGIN_HDMICEC2_AUTOSTART@"
 startuporder = "@PLUGIN_HDMICEC2_STARTUPORDER@"

--- a/HdmiCec_2/HdmiCec_2.config
+++ b/HdmiCec_2/HdmiCec_2.config
@@ -1,4 +1,4 @@
-set (autostart false)
+set (autostart ${PLUGIN_HDMICEC2_AUTOSTART})
 set (preconditions Platform)
 set (callsign "org.rdk.HdmiCec_2")
 

--- a/LoggingPreferences/CMakeLists.txt
+++ b/LoggingPreferences/CMakeLists.txt
@@ -19,6 +19,7 @@ set(PLUGIN_NAME LoggingPreferences)
 set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
 
 set(PLUGIN_LOGGINGPREFERENCE_STARTUPORDER "" CACHE STRING "To configure startup order of LoggingPreferences plugin")
+set(PLUGIN_LOGGINGPREFERENCES_AUTOSTART false CACHE STRING "To automatically start LoggingPreferences plugin.")
 
 find_package(${NAMESPACE}Plugins REQUIRED)
 

--- a/LoggingPreferences/LoggingPreferences.conf.in
+++ b/LoggingPreferences/LoggingPreferences.conf.in
@@ -1,4 +1,4 @@
 precondition = ["Platform"]
 callsign = "org.rdk.LoggingPreferences"
-autostart = "false"
+autostart = "@PLUGIN_LOGGINGPREFERENCES_AUTOSTART@"
 startuporder = "@PLUGIN_LOGGINGPREFERENCE_STARTUPORDER@"

--- a/LoggingPreferences/LoggingPreferences.config
+++ b/LoggingPreferences/LoggingPreferences.config
@@ -1,4 +1,4 @@
-set (autostart false)
+set (autostart ${PLUGIN_LOGGINGPREFERENCES_AUTOSTART})
 set (preconditions Platform)
 set (callsign "org.rdk.LoggingPreferences")
 

--- a/ScreenCapture/CMakeLists.txt
+++ b/ScreenCapture/CMakeLists.txt
@@ -19,6 +19,7 @@ set(PLUGIN_NAME ScreenCapture)
 set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
 
 set(PLUGIN_SCREENCAPTURE_STARTUPORDER "" CACHE STRING "To configure startup order of ScreenCapture plugin")
+set(PLUGIN_SCREENCAPTURE_AUTOSTART false CACHE STRING "To automatically start ScreenCapture plugin.")
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 

--- a/ScreenCapture/ScreenCapture.conf.in
+++ b/ScreenCapture/ScreenCapture.conf.in
@@ -1,4 +1,4 @@
 precondition = ["Platform"]
 callsign = "org.rdk.ScreenCapture"
-autostart = "false"
+autostart = "@PLUGIN_SCREENCAPTURE_AUTOSTART@"
 startuporder = "@PLUGIN_SCREENCAPTURE_STARTUPORDER@"

--- a/ScreenCapture/ScreenCapture.config
+++ b/ScreenCapture/ScreenCapture.config
@@ -1,4 +1,4 @@
-set (autostart false)
+set (autostart ${PLUGIN_SCREENCAPTURE_AUTOSTART})
 set (preconditions Platform)
 set (callsign "org.rdk.ScreenCapture")
 

--- a/Timer/CMakeLists.txt
+++ b/Timer/CMakeLists.txt
@@ -19,6 +19,7 @@ set(PLUGIN_NAME Timer)
 set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
 
 set(PLUGIN_TIMER_STARTUPORDER "" CACHE STRING "To configure startup order of Timer plugin")
+set(PLUGIN_TIMER_AUTOSTART false CACHE STRING "To automatically start Timer plugin.")
 
 find_package(${NAMESPACE}Plugins REQUIRED)
 

--- a/Timer/Timer.conf.in
+++ b/Timer/Timer.conf.in
@@ -1,4 +1,4 @@
 precondition = ["Platform"]
 callsign = "org.rdk.Timer"
-autostart = "false"
+autostart = "@PLUGIN_TIMER_AUTOSTART@"
 startuporder = "@PLUGIN_TIMER_STARTUPORDER@"

--- a/Timer/Timer.config
+++ b/Timer/Timer.config
@@ -1,4 +1,4 @@
-set (autostart false)
+set (autostart ${PLUGIN_TIMER_AUTOSTART})
 set (preconditions Platform)
 set (callsign "org.rdk.Timer")
 

--- a/UsbAccess/CMakeLists.txt
+++ b/UsbAccess/CMakeLists.txt
@@ -2,6 +2,7 @@ set(PLUGIN_NAME UsbAccess)
 set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
 
 set(PLUGIN_USBACCESS_STARTUPORDER "" CACHE STRING "To configure startup order of UsbAccess plugin")
+set(PLUGIN_USBACCESS_AUTOSTART false CACHE STRING "To automatically start UsbAccess plugin.")
 
 find_package(${NAMESPACE}Plugins REQUIRED)
 

--- a/UsbAccess/UsbAccess.conf.in
+++ b/UsbAccess/UsbAccess.conf.in
@@ -1,4 +1,4 @@
 precondition = ["Platform"]
 callsign = "org.rdk.UsbAccess"
-autostart = "false"
+autostart = "@PLUGIN_USBACCESS_AUTOSTART@"
 startuporder = "@PLUGIN_USBACCESS_STARTUPORDER@"

--- a/UsbAccess/UsbAccess.config
+++ b/UsbAccess/UsbAccess.config
@@ -1,4 +1,4 @@
-set (autostart false)
+set (autostart ${PLUGIN_USBACCESS_AUTOSTART})
 set (preconditions Platform)
 set (callsign "org.rdk.UsbAccess")
 

--- a/UserPreferences/CMakeLists.txt
+++ b/UserPreferences/CMakeLists.txt
@@ -19,6 +19,7 @@ set(PLUGIN_NAME UserPreferences)
 set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
 
 set(PLUGIN_USERPREFERENCE_STARTUPORDER "" CACHE STRING "To configure startup order of UserPreferences plugin")
+set(PLUGIN_USERPREFERENCES_AUTOSTART false CACHE STRING "To automatically start UserPreferences plugin.")
 
 find_package(${NAMESPACE}Plugins REQUIRED)
 find_package(DS)

--- a/UserPreferences/UserPreferences.conf.in
+++ b/UserPreferences/UserPreferences.conf.in
@@ -1,4 +1,4 @@
 precondition = ["Platform"]
 callsign = "org.rdk.UserPreferences"
-autostart = "false"
+autostart = "@PLUGIN_USERPREFERENCES_AUTOSTART@"
 startuporder = "@PLUGIN_USERPREFERENCE_STARTUPORDER@"

--- a/UserPreferences/UserPreferences.config
+++ b/UserPreferences/UserPreferences.config
@@ -1,4 +1,4 @@
-set (autostart false)
+set (autostart ${PLUGIN_USERPREFERENCES_AUTOSTART})
 set (preconditions Platform)
 set (callsign "org.rdk.UserPreferences")
 

--- a/Warehouse/CMakeLists.txt
+++ b/Warehouse/CMakeLists.txt
@@ -19,6 +19,7 @@ set(PLUGIN_NAME Warehouse)
 set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
 
 set(PLUGIN_WAREHOUSE_STARTUPORDER "" CACHE STRING "To configure startup order of Warehouse plugin")
+set(PLUGIN_WAREHOUSE_AUTOSTART false CACHE STRING "To automatically start Warehouse plugin.")
 
 find_package(${NAMESPACE}Plugins REQUIRED)
 

--- a/Warehouse/Warehouse.conf.in
+++ b/Warehouse/Warehouse.conf.in
@@ -1,4 +1,4 @@
 precondition = ["Platform"]
 callsign = "org.rdk.Warehouse"
-autostart = "false"
+autostart = "@PLUGIN_WAREHOUSE_AUTOSTART@"
 startuporder = "@PLUGIN_WAREHOUSE_STARTUPORDER@"

--- a/Warehouse/Warehouse.config
+++ b/Warehouse/Warehouse.config
@@ -1,4 +1,4 @@
-set (autostart false)
+set (autostart ${PLUGIN_WAREHOUSE_AUTOSTART})
 set (preconditions Platform)
 set (callsign "org.rdk.Warehouse")
 


### PR DESCRIPTION
RDKCOM-4805 RDKDEV-1023: Make plugin autostart configurable from recipe

Reason for change: Platform specific autostart configurations to be set in platform layers

Test Procedure: Build and verify.

Risks: Low

Signed-off-by: Jitha James [jitha_james@comcast.com](mailto:jitha_james@comcast.com)
(cherry picked from commit https://github.com/rdkcentral/rdkservices/commit/75760eac159bfb7e04d0a2d84901afdbf5bcbc31)