### PR TITLE
RDKTV-30678,RDKTV-30706: Changes for file system corruption hang

### DIFF
--- a/MaintenanceManager/CHANGELOG.md
+++ b/MaintenanceManager/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.0.24] - 2024-06-18
+### Fixed
+- Added change for file system corruption hang
+
 ## [1.0.23] - 2023-10-04
 ### Added
 - Implement Thunder Plugin Configuration for Kirkstone builds(CMake-3.20 & above)

--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -36,6 +36,7 @@
 #include <iomanip>
 #include <bits/stdc++.h>
 #include <algorithm>
+#include <unistd.h>
 
 #include "MaintenanceManager.h"
 
@@ -66,7 +67,7 @@ using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 22
+#define API_VERSION_NUMBER_PATCH 24
 #define SERVER_DETAILS  "127.0.0.1:9998"
 
 
@@ -246,6 +247,19 @@ namespace WPEFramework {
             :PluginHost::JSONRPC()
         {
             MaintenanceManager::_instance = this;
+	    if (Utils::directoryExists(MAINTENANCE_MGR_RECORD_FILE))
+            {
+                std::cout << "File " << MAINTENANCE_MGR_RECORD_FILE << " detected as folder, deleting.." << std::endl;
+                if (rmdir(MAINTENANCE_MGR_RECORD_FILE) == 0)
+                {
+		    cSettings mtemp(MAINTENANCE_MGR_RECORD_FILE);
+		    MaintenanceManager::m_setting = mtemp;
+                }
+                else
+                {
+                     std::cout << "Unable to delete folder: " << MAINTENANCE_MGR_RECORD_FILE << std::endl;
+                }
+            }
 
             /**
              * @brief Invoking Plugin API register to WPEFRAMEWORK.

--- a/SystemServices/CHANGELOG.md
+++ b/SystemServices/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.8.1] - 2024-06-18
+### Fixed
+- Added change for file system corruption hang
+
 ## [1.8.0] - 2024-02-29
 ### Added
 - Added API to get Thunder start reason

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -67,7 +67,7 @@ using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 8
-#define API_VERSION_NUMBER_PATCH 0
+#define API_VERSION_NUMBER_PATCH 1
 
 #define MAX_REBOOT_DELAY 86400 /* 24Hr = 86400 sec */
 #define TR181_FW_DELAY_REBOOT "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.AutoReboot.fwDelayReboot"
@@ -349,6 +349,20 @@ namespace WPEFramework {
               , m_cacheService(SYSTEM_SERVICE_SETTINGS_FILE)
         {
             SystemServices::_instance = this;
+            if (Utils::directoryExists(SYSTEM_SERVICE_SETTINGS_FILE))
+            {
+                std::cout << "File " << SYSTEM_SERVICE_SETTINGS_FILE << " detected as folder, deleting.." << std::endl;
+                if (rmdir(SYSTEM_SERVICE_SETTINGS_FILE) == 0)
+                {
+                    cSettings stemp(SYSTEM_SERVICE_SETTINGS_FILE);
+                    SystemServices::m_cacheService = stemp;
+                }
+                else
+                {
+                     std::cout << "Unable to delete folder: " << SYSTEM_SERVICE_SETTINGS_FILE << std::endl;
+                }
+            }
+
 	    //Updating the standard territory
             m_strStandardTerritoryList =   "ABW AFG AGO AIA ALA ALB AND ARE ARG ARM ASM ATA ATF ATG AUS AUT AZE BDI BEL BEN BES BFA BGD BGR BHR BHS BIH BLM BLR BLZ BMU BOL                BRA BRB BRN BTN BVT BWA CAF CAN CCK CHE CHL CHN CIV CMR COD COG COK COL COM CPV CRI CUB Cuba CUW CXR CYM CYP CZE DEU DJI DMA DNK DOM DZA ECU EGY ERI ESH ESP                EST ETH FIN FJI FLK FRA FRO FSM GAB GBR GEO GGY GHA GIB GIN GLP GMB GNB GNQ GRC GRD GRL GTM GUF GUM GUY HKG HMD HND HRV HTI HUN IDN IMN IND IOT IRL IRN IRQ                 ISL ISR ITA JAM JEY JOR JPN KAZ KEN KGZ KHM KIR KNA KOR KWT LAO LBN LBR LBY LCA LIE LKA LSO LTU LUX LVA MAC MAF MAR MCO MDA MDG MDV MEX MHL MKD MLI MLT MMR                 MNE MNG MNP MOZ MRT MSR MTQ MUS MWI MYS MYT NAM NCL NER NFK NGA NIC NIU NLD NOR NPL NRU NZL OMN PAK PAN PCN PER PHL PLW PNG POL PRI PRK PRT PRY PSE PYF QAT                 REU ROU RUS RWA SAU SDN SEN SGP SGS SHN SJM SLB SLE SLV SMR SOM SPM SRB SSD STP SUR SVK SVN SWE SWZ SXM SYC SYR TCA TCD TGO THA TJK TKL TKM TLS TON TTO TUN                 TUR TUV TWN TZA UGA UKR UMI URY USA UZB VAT VCT VEN VGB VIR VNM VUT WLF WSM YEM ZAF ZMB ZWE";
 

--- a/helpers/UtilsfileExists.h
+++ b/helpers/UtilsfileExists.h
@@ -6,6 +6,11 @@ namespace Utils {
 inline bool fileExists(const char* pFileName)
 {
     struct stat fileStat;
-    return 0 == stat(pFileName, &fileStat);
+    return 0 == stat(pFileName, &fileStat) && S_IFREG == (fileStat.st_mode & S_IFMT);
+}
+inline bool directoryExists(const char* pDirName)
+{
+    struct stat dirStat;
+    return 0 == stat(pDirName, &dirStat) && S_ISDIR(dirStat.st_mode);
 }
 }


### PR DESCRIPTION
Reason for change: Changes for file system corruption for xumo_2 branch.
Test Procedure: Test multiple reboots and abrupt power plug reboot.
Risks: Medium