### PR TITLE
RDKVREFPLT-2104 - [RPI][memcr][6.1] Integrate thunder 4.4 memcr patch…

### DIFF
--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -782,7 +782,7 @@ namespace WPEFramework {
                     bool l2s = (gLaunchedToSuspended.find(mCallSign) != gLaunchedToSuspended.end());
                     gLaunchedToSuspendedMutex.unlock();
 
-                    if (!l2s && (mCallSign.find("Netflix") != std::string::npos || mCallSign.find("Cobalt") != std::string::npos))
+                    if (!l2s && (mCallSign.find("Netflix") != std::string::npos || mCallSign.find("Cobalt") != std::string::npos || mCallSign.find("Amazon") != std::string::npos || mCallSign.find("YouTube") != std::string::npos))
                     {
                         // call RDKShell.hibernate
                         std::thread requestsThread =
@@ -6562,7 +6562,7 @@ namespace WPEFramework {
                     returnResponse(status);
                 }
 
-                if( callsign.find("Netflix") != string::npos || callsign.find("Cobalt") != string::npos )
+                if( callsign.find("Netflix") != string::npos || callsign.find("Cobalt") != string::npos || callsign.find("Amazon") != string::npos || callsign.find("YouTube") != string::npos )
                 {
                     //Check if native app is suspended
                     WPEFramework::Core::JSON::String stateString;


### PR DESCRIPTION
…es to thunder 4.2, RDKShell memcr patches, datamodel & validation

Reason for change: Added callsign for Amazon and YouTube

Test Procedure: Build and verified

Risks: High