### PR TITLE
DELIA-65419, RDKTV-31166: Delay in providing 'oninternetstatuschange'

### DIFF
--- a/Network/CHANGELOG.md
+++ b/Network/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.3.11] - 2024-06-19
+### Fixed
+- onInternetStatus event not posting error fix
+
 ## [1.3.10] - 2024-04-17
 ### Added
 - added retry logic for connectivity monitor

--- a/Network/Network.cpp
+++ b/Network/Network.cpp
@@ -35,7 +35,7 @@ using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 3
-#define API_VERSION_NUMBER_PATCH 10
+#define API_VERSION_NUMBER_PATCH 11
 
 /* Netsrvmgr Based Macros & Structures */
 #define IARM_BUS_NM_SRV_MGR_NAME "NET_SRV_MGR"
@@ -1461,17 +1461,10 @@ typedef struct _IARM_BUS_NetSrvMgr_Iface_EventData_t {
             m_defInterfaceCache = "";
 
             sendNotify("onConnectionStatusChanged", params);
-            if(connected)
+            connectivityMonitor.doInitialConnectivityMonitoring(30);
+            if(!connected)
             {
-                connectivityMonitor.doInitialConnectivityMonitoring(30);
-            }
-            else
-            {
-                if (!connectivityMonitor.isMonitorThreadRunning())
-                {
-                    /*run the thread again to notify no_internet state*/
-                    connectivityMonitor.doInitialConnectivityMonitoring(30);
-                }
+                /* if disconnectd need to stop the thread after one event */
                 connectivityMonitor.stopInitialConnectivityMonitoring();
             }
         }

--- a/Network/NetworkConnectivity.cpp
+++ b/Network/NetworkConnectivity.cpp
@@ -493,6 +493,7 @@ namespace WPEFramework {
         if (isMonitorThreadRunning() && stopFlag == false)
         {
             LOGINFO("Connectivity Monitor Thread is active so notify");
+            g_internetState = nsm_internetState::UNKNOWN;
             cv_.notify_all();
         }
         else
@@ -578,7 +579,8 @@ namespace WPEFramework {
             if(g_internetState.load() != InternetConnectionState)
             {
                 LOGINFO("notification count %d ...", notifyWaitCount);
-                if(InternetConnectionState == nsm_internetState::NO_INTERNET && notifyWaitCount > 0)
+                /* Retry logic only need when continuous monitor is running, otherwise post notification immediately */
+                if(InternetConnectionState == nsm_internetState::NO_INTERNET && isContinuesMonitoringNeeded && notifyWaitCount > 0)
                 {
                     /* Decrease the notification count to create a delay in posting the 'no internet' state. */
                     notifyWaitCount--;

--- a/NetworkManager/service/NetworkConnectivity.cpp
+++ b/NetworkManager/service/NetworkConnectivity.cpp
@@ -486,6 +486,7 @@ namespace WPEFramework {
         if (isMonitorThreadRunning())
         {
             NMLOG_INFO("Connectivity Monitor Thread is active so notify");
+            g_internetState = nsm_internetState::UNKNOWN;
             cv_.notify_all();
         }
         else


### PR DESCRIPTION
… (#5374)(#5407) (#5433)

RDKTV-31166 posting internet event when interface connection changes (#5407)
* Update no internet event logic in  Network

RDKTV-31166 posting internet event when interface connection changes (#5407)

* RDKTV-31166 internetStatus Event posting updated
* modefiy the same change in network manager

(cherry picked from commit 3237958d5fdeda4ea721605ba7f5691a6379cb8e) (cherry picked from commit 00a6207857901d35e6cf6dfba0f38f8574004a13) (cherry picked from commit 156a6b9132aad50870d4edc4640f1c1a61f551d8)