### PR TITLE
RDKTV-31102: Cropped Video Display with Auto Zoom settings

### DIFF
--- a/AVOutput/AVOutputTV.h
+++ b/AVOutput/AVOutputTV.h
@@ -232,7 +232,7 @@ class AVOutputTV : public AVOutputBase {
 
 		void broadcastLowLatencyModeChangeEvent(bool lowLatencyMode);
 		tvError_t setAspectRatioZoomSettings(tvDisplayMode_t mode);
-		tvError_t setDefaultAspectRatio(std::string pqmode="all",std::string format="all",std::string source="all");
+		tvError_t setDefaultAspectRatio(std::string pqmode="none",std::string format="none",std::string source="none");
 
 	public:
 		int m_currentHdmiInResoluton;


### PR DESCRIPTION
Reason for change: Cropped Video Display with Auto Zoom settings
Test Procedure:  refer ticket
Risks: None
Priority: P1
Signed-off-by: bp-tarumu252 <tamilselvan.arumugamkesavan@sky.uk>