### PR TITLE
Fix to get Active Source Status when we put TV into HdmiCec Standby mode.

### DIFF
--- a/HdmiCecSource/HdmiCecSource.cpp
+++ b/HdmiCecSource/HdmiCecSource.cpp
@@ -787,8 +787,16 @@ namespace WPEFramework
                         powerState = 0; 
                     }
                     else
+		    {
                         powerState = 1;
-
+		    }
+	            if(param->data.state.newState == IARM_BUS_PWRMGR_POWERSTATE_STANDBY)
+                    {
+                        // Handled standby event logic here
+                        isDeviceActiveSource = false;
+                        LOGINFO("ActiveSource isDeviceActiveSource status: %d \n", isDeviceActiveSource);
+                        HdmiCec_2::_instance->sendActiveSourceEvent();
+                    }
                 }
            }
        }


### PR DESCRIPTION
Reason for change: Added fix to get status of "getActiveSourceStatus" when we put TV into org.rdk.HdmiCec_2.sendStandbyMessage.

Test Procedure: Build and verify. Use curl commands to verify the working using the methods getEnabled, getActiveSourceStatus & sendStandbyMessage of HdmiCec_2.

Risks: Low

Signed-off-by: Kumari Priyanka kumari_priyanka@comcast.com