### PR TITLE
DELIA-64977 : Remove the R4 WPEFramework-Interfaces patches and address the corresponding changes in the SystemServicesPlugin.

### DIFF
--- a/SystemServices/CHANGELOG.md
+++ b/SystemServices/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [2.3.2] - 2024-06-26
+### Fixed
+- Remove the R4 WPEFramework-Interfaces patches and added corresponding code fix
+
 ## [2.3.1] - 2024-06-06
 ### Fixed
 - Added change for file system corruption hang

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -67,7 +67,7 @@ using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 2
 #define API_VERSION_NUMBER_MINOR 3
-#define API_VERSION_NUMBER_PATCH 1
+#define API_VERSION_NUMBER_PATCH 2
 
 #define MAX_REBOOT_DELAY 86400 /* 24Hr = 86400 sec */
 #define TR181_FW_DELAY_REBOOT "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.AutoReboot.fwDelayReboot"

--- a/SystemServices/platformcaps/platformcaps.cpp
+++ b/SystemServices/platformcaps/platformcaps.cpp
@@ -117,7 +117,7 @@ bool PlatformCaps::DeviceInfo::Load(PluginHost::IShell* service, const string &q
   }
 
   if (query.empty() || query == _T("mimeTypeExclusions")) {
-    mimeTypeExclusions.Reset();
+    mimeTypeExclusions.Clear();
     std::map <string, std::list<string>> hash;
     data.AddDashExclusionList(hash);
     if (!hash.empty()) {
@@ -133,7 +133,7 @@ bool PlatformCaps::DeviceInfo::Load(PluginHost::IShell* service, const string &q
   }
 
   if (query.empty() || query == _T("features")) {
-    features.Reset();
+    features.Clear();
     auto hash = data.DeviceCapsFeatures();
     if (!hash.empty()) {
       for (auto &it: hash) {


### PR DESCRIPTION
Reason for change:  Removed the JSONObject.Reset removal patch
Test Procedure: verify using Jenkins build
Risks: Medium
Signed-off-by: Karunakaran A <karunakaran_amirthalingam@cable.comcast.com>