### PR TITLE
RDKTV-31210 RDKTV-30775 RDKTV-31401 - Miracast Fixes

### DIFF
--- a/Miracast/MiracastService/MiracastController.cpp
+++ b/Miracast/MiracastService/MiracastController.cpp
@@ -487,12 +487,12 @@ void MiracastController::checkAndInitiateP2PBackendDiscovery(void)
     {
         MIRACASTLOG_INFO("!!! BACKEND P2P DISCOVERY HAS BEEN STARTED !!!");
         /* Enabled the Device Discovery to allow other device to cast */
-        discover_devices();
+        discover_devices(false);
     }
     else
     {
         MIRACASTLOG_INFO("!!! BACKEND P2P DISCOVERY HAS DISABLED !!!");
-        stop_discover_devices();
+        stop_discover_devices(false);
     }
 }
 
@@ -538,23 +538,31 @@ MiracastError MiracastController::set_WFDParameters(void)
     return ret;
 }
 
-MiracastError MiracastController::discover_devices(void)
+MiracastError MiracastController::discover_devices(bool isNotificationRequired)
 {
     MIRACASTLOG_TRACE("Entering...");
     MiracastError ret = MIRACAST_FAIL;
     if (nullptr != m_p2p_ctrl_obj){
         ret = m_p2p_ctrl_obj->discover_devices();
+        if ((nullptr != m_notify_handler) && (isNotificationRequired))
+        {
+            m_notify_handler->onStateChange(MIRACAST_SERVICE_STATE_DISCOVERABLE);
+        }
     }
     MIRACASTLOG_TRACE("Exiting...");
     return ret;
 }
 
-MiracastError MiracastController::stop_discover_devices(void)
+MiracastError MiracastController::stop_discover_devices(bool isNotificationRequired)
 {
     MIRACASTLOG_TRACE("Entering...");
     MiracastError ret = MIRACAST_FAIL;
     if (nullptr != m_p2p_ctrl_obj){
         ret = m_p2p_ctrl_obj->stop_discover_devices();
+        if ((nullptr != m_notify_handler) && (isNotificationRequired))
+        {
+            m_notify_handler->onStateChange(MIRACAST_SERVICE_STATE_IDLE);
+        }
     }
     MIRACASTLOG_TRACE("Exiting...");
     return ret;
@@ -929,7 +937,8 @@ void MiracastController::Controller_Thread(void *args)
                                         sink_dev_ip = "";
                             std::string modelName = "Miracast-Source",
                                         authType = "pbc",
-                                        deviceType = "unknown";
+                                        deviceType = "unknown",
+                                        result     = "";
                             m_groupInfo = new GroupInfo;
                             size_t found = event_buffer.find("client");
                             size_t found_space = event_buffer.find(" ");
@@ -952,7 +961,7 @@ void MiracastController::Controller_Thread(void *args)
                                     std::size_t secondDash = m_groupInfo->SSID.find("-", firstDash + 1);
                                     if (secondDash != std::string::npos)
                                     {
-                                        std::string result = m_groupInfo->SSID.substr(secondDash + 1);
+                                        result = m_groupInfo->SSID.substr(secondDash + 1);
                                         if (!result.empty())
                                         {
                                             modelName.clear();
@@ -1184,38 +1193,39 @@ void MiracastController::Controller_Thread(void *args)
                 MIRACASTLOG_TRACE("CONTRLR_FW_MSG type received");
                 switch (controller_msgq_data.state)
                 {
-                // Start and Stop Discovering initiated directly from Thunder request. So this is unused and commenting out here
-                #if 0
                     case CONTROLLER_START_DISCOVERING:
-                    {
-                        MIRACASTLOG_INFO("CONTROLLER_START_DISCOVERING Received\n");
-                        set_WFDParameters();
-                        discover_devices();
-                        m_start_discovering_enabled = true;
-                    }
-                    break;
                     case CONTROLLER_STOP_DISCOVERING:
-                    {
-                        MIRACASTLOG_INFO("CONTROLLER_STOP_DISCOVERING Received\n");
-                        stop_session(true);
-                        m_start_discovering_enabled = false;
-                    }
-                    break;
-                #endif
                     case CONTROLLER_RESTART_DISCOVERING:
                     {
-                        std::string cached_mac_address = get_NewSourceMACAddress(),
-                                    mac_address = controller_msgq_data.source_dev_mac;
-                        MIRACASTLOG_INFO("CONTROLLER_RESTART_DISCOVERING Received\n");
-                        m_connectionStatus = false;
-
-                        if ((!cached_mac_address.empty()) && ( 0 == mac_address.compare(cached_mac_address)))
+                        if (CONTROLLER_START_DISCOVERING == controller_msgq_data.state)
                         {
-                            reset_NewSourceMACAddress();
-                            reset_NewSourceName();
-                            MIRACASTLOG_INFO("[%s] Cached Device info removed...",cached_mac_address.c_str());
+                            MIRACASTLOG_INFO("CONTROLLER_START_DISCOVERING Received\n");
+                            set_WFDParameters();
+                            discover_devices();
+                            m_start_discovering_enabled = true;
                         }
-                        restart_session(m_start_discovering_enabled);
+                        else if (CONTROLLER_STOP_DISCOVERING == controller_msgq_data.state)
+                        {
+                            MIRACASTLOG_INFO("CONTROLLER_STOP_DISCOVERING Received\n");
+                            stop_session(true);
+                            m_start_discovering_enabled = false;
+                            sleep(2);
+                        }
+                        else
+                        {
+                            std::string cached_mac_address = get_NewSourceMACAddress(),
+                            mac_address = controller_msgq_data.source_dev_mac;
+                            MIRACASTLOG_INFO("CONTROLLER_RESTART_DISCOVERING Received\n");
+                            m_connectionStatus = false;
+
+                            if ((!cached_mac_address.empty()) && ( 0 == mac_address.compare(cached_mac_address)))
+                            {
+                                reset_NewSourceMACAddress();
+                                reset_NewSourceName();
+                                MIRACASTLOG_INFO("[%s] Cached Device info removed...",cached_mac_address.c_str());
+                            }
+                            restart_session(m_start_discovering_enabled);
+                        }
                         new_thunder_req_client_connection_sent = false;
                         another_thunder_req_client_connection_sent = false;
                         session_restart_required = true;
@@ -1419,6 +1429,38 @@ void MiracastController::switch_launch_request_context(std::string& source_dev_i
         controller_msgq_data.state = CONTROLLER_SWITCH_LAUNCH_REQ_CTX;
         send_thundermsg_to_controller_thread(controller_msgq_data);
     }
+    MIRACASTLOG_TRACE("Exiting...");
+}
+
+void MiracastController::start_discoveryAsync(void)
+{
+    CONTROLLER_MSGQ_STRUCT controller_msgq_data = {0};
+    MIRACASTLOG_TRACE("Entering...");
+    MIRACASTLOG_INFO("MIRACAST_SERVICE_WFD_START");
+    controller_msgq_data.state = CONTROLLER_START_DISCOVERING;
+    send_thundermsg_to_controller_thread(controller_msgq_data);
+    MIRACASTLOG_TRACE("Exiting...");
+}
+
+void MiracastController::stop_discoveryAsync(void)
+{
+    CONTROLLER_MSGQ_STRUCT controller_msgq_data = {0};
+    MIRACASTLOG_TRACE("Entering...");
+    MIRACASTLOG_INFO("MIRACAST_SERVICE_WFD_STOP");
+    controller_msgq_data.state = CONTROLLER_STOP_DISCOVERING;
+    send_thundermsg_to_controller_thread(controller_msgq_data);
+    MIRACASTLOG_TRACE("Exiting...");
+}
+
+void MiracastController::restart_discoveryAsync(void)
+{
+    CONTROLLER_MSGQ_STRUCT controller_msgq_data = {0};
+    MIRACASTLOG_TRACE("Entering...");
+    MIRACASTLOG_INFO("MIRACAST_SERVICE_WFD_RESTART");
+    controller_msgq_data.state = CONTROLLER_STOP_DISCOVERING;
+    send_thundermsg_to_controller_thread(controller_msgq_data);
+    controller_msgq_data.state = CONTROLLER_START_DISCOVERING;
+    send_thundermsg_to_controller_thread(controller_msgq_data);
     MIRACASTLOG_TRACE("Exiting...");
 }
 

--- a/Miracast/MiracastService/MiracastController.h
+++ b/Miracast/MiracastService/MiracastController.h
@@ -52,7 +52,7 @@ public:
 
     void event_handler(P2P_EVENTS eventId, void *data, size_t len );
 
-    MiracastError discover_devices();
+    MiracastError discover_devices(bool isNotificationRequired = true);
     MiracastError connect_device(std::string device_mac , std::string device_name );
 
     std::string get_localIp();
@@ -76,7 +76,7 @@ public:
     void send_msgto_test_notifier_thread( MIRACAST_SERVICE_TEST_NOTIFIER_MSGQ_ST stMsgQ );
 #endif /* ENABLE_MIRACAST_SERVICE_TEST_NOTIFIER */
 
-    MiracastError stop_discover_devices();
+    MiracastError stop_discover_devices(bool isNotificationRequired = true);
     MiracastError set_WFDParameters(void);
     void restart_session_discovery(std::string& mac_address);
     void flush_current_session(void);
@@ -106,6 +106,9 @@ public:
 
     void setP2PBackendDiscovery(bool is_enabled);
     void switch_launch_request_context(std::string& source_dev_ip,std::string& source_dev_mac,std::string& source_dev_name,std::string& sink_dev_ip);
+    void start_discoveryAsync(void);
+    void stop_discoveryAsync(void);
+    void restart_discoveryAsync(void);
 
 private:
     static MiracastController *m_miracast_ctrl_obj;

--- a/Miracast/MiracastService/MiracastService.h
+++ b/Miracast/MiracastService/MiracastService.h
@@ -24,6 +24,18 @@
 
 #include "Module.h"
 #include <MiracastController.h>
+#include "libIARM.h"
+#include "pwrMgr.h"
+
+typedef enum DeviceWiFiStates{
+	DEVICE_WIFI_STATE_UNINSTALLED = 0,
+	DEVICE_WIFI_STATE_DISABLED = 1,
+	DEVICE_WIFI_STATE_DISCONNECTED = 2,
+	DEVICE_WIFI_STATE_PAIRING = 3,
+	DEVICE_WIFI_STATE_CONNECTING = 4,
+	DEVICE_WIFI_STATE_CONNECTED = 5,
+	DEVICE_WIFI_STATE_FAILED = 6
+}DEVICE_WIFI_STATES;
 
 using std::vector;
 namespace WPEFramework
@@ -58,6 +70,11 @@ namespace WPEFramework
             static const string METHOD_MIRACAST_STOP_CLIENT_CONNECT;
             static const string METHOD_MIRACAST_SET_UPDATE_PLAYER_STATE;
             static const string METHOD_MIRACAST_SET_LOG_LEVEL;
+        #ifdef UNIT_TESTING
+            static const string METHOD_MIRACAST_GET_STATUS;
+            static const string METHOD_MIRACAST_SET_POWERSTATE;
+            static const string METHOD_MIRACAST_SET_WIFISTATE;
+        #endif /*UNIT_TESTING*/
 
 #ifdef ENABLE_MIRACAST_SERVICE_TEST_NOTIFIER
             static const string METHOD_MIRACAST_TEST_NOTIFIER;
@@ -74,6 +91,7 @@ namespace WPEFramework
             virtual void onMiracastServiceClientConnectionRequest(string client_mac, string client_name) override;
             virtual void onMiracastServiceClientConnectionError(string client_mac, string client_name , eMIRACAST_SERVICE_ERR_CODE error_code ) override;
             virtual void onMiracastServiceLaunchRequest(string src_dev_ip, string src_dev_mac, string src_dev_name, string sink_dev_ip, bool is_connect_req_reported ) override;
+            virtual void onStateChange(eMIRA_SERVICE_STATES state ) override;
 
             BEGIN_INTERFACE_MAP(MiracastService)
             INTERFACE_ENTRY(PluginHost::IPlugin)
@@ -87,29 +105,53 @@ namespace WPEFramework
         private:
             bool m_isServiceInitialized;
             bool m_isServiceEnabled;
+            std::mutex m_DiscoveryStateMutex;
+            std::recursive_mutex m_EventMutex;
             guint m_FriendlyNameMonitorTimerID{0};
+            guint m_WiFiConnectedStateMonitorTimerID{0};
+            guint m_MiracastConnectionMonitorTimerID{0};
             eMIRA_SERVICE_STATES m_eService_state;
             std::string m_src_dev_ip;
             std::string m_src_dev_mac;
             std::string m_src_dev_name;
             std::string m_sink_dev_ip;
             WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement> *m_SystemPluginObj = NULL;
-            uint32_t setEnable(const JsonObject &parameters, JsonObject &response);
+            WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement> *m_WiFiPluginObj = NULL;
+            uint32_t setEnableWrapper(const JsonObject &parameters, JsonObject &response);
             uint32_t getEnable(const JsonObject &parameters, JsonObject &response);
             uint32_t setP2PBackendDiscovery(const JsonObject &parameters, JsonObject &response);
             uint32_t acceptClientConnection(const JsonObject &parameters, JsonObject &response);
             uint32_t stopClientConnection(const JsonObject &parameters, JsonObject &response);
             uint32_t updatePlayerState(const JsonObject &parameters, JsonObject &response);
             uint32_t setLogging(const JsonObject &parameters, JsonObject &response);
+        #ifdef UNIT_TESTING
+            uint32_t getStatus(const JsonObject &parameters, JsonObject &response);
+            uint32_t setPowerStateWrapper(const JsonObject &parameters, JsonObject &response);
+            uint32_t setWiFiStateWrapper(const JsonObject &parameters, JsonObject &response);
+        #endif /*UNIT_TESTING*/
 
             std::string reasonDescription(eMIRACAST_SERVICE_ERR_CODE e);
-            void getSystemPlugin();
+            void getThunderPlugins();
             bool updateSystemFriendlyName();
             void onFriendlyNameUpdateHandler(const JsonObject &parameters);
             static gboolean monitor_friendly_name_timercallback(gpointer userdata);
+            void setWiFiState(DEVICE_WIFI_STATES wifiState);
+            void onWIFIStateChangedHandler(const JsonObject &parameters);
+            static gboolean monitor_wifi_connection_state_timercallback(gpointer userdata);
+            void remove_wifi_connection_state_timer(void);
+            static gboolean monitor_miracast_connection_timercallback(gpointer userdata);
+            void remove_miracast_connection_timer(void);
             bool envGetValue(const char *key, std::string &value);
             eMIRA_SERVICE_STATES getCurrentServiceState(void);
             void changeServiceState(eMIRA_SERVICE_STATES eService_state);
+            IARM_Bus_PWRMgr_PowerState_t getCurrentPowerState(void);
+            void setPowerState(IARM_Bus_PWRMgr_PowerState_t pwrState);
+            std::string getPowerStateString(IARM_Bus_PWRMgr_PowerState_t pwrState);
+            void setEnable(bool isEnabled);
+
+            const void InitializeIARM();
+            void DeinitializeIARM();
+            static void pwrMgrModeChangeEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len);
 
             // We do not allow this plugin to be copied !!
             MiracastService(const MiracastService &) = delete;

--- a/Miracast/MiracastService/P2P/MiracastP2P.cpp
+++ b/Miracast/MiracastService/P2P/MiracastP2P.cpp
@@ -458,10 +458,21 @@ MiracastError MiracastP2P::discover_devices(void)
 {
     MiracastError ret = MIRACAST_FAIL;
     std::string command, retBuffer;
+    std::string opt_flag_buffer = MiracastCommon::parse_opt_flag("/opt/miracast_custom_p2p_scan");
     MIRACASTLOG_TRACE("Entering..");
 
     /*Start Passive Scanning*/
-    command = "P2P_EXT_LISTEN 200 1000";
+    command = "P2P_EXT_LISTEN 0 0";
+    ret = executeCommand(command, NON_GLOBAL_INTERFACE, retBuffer);
+
+    if (!opt_flag_buffer.empty())
+    {
+	    command = "P2P_EXT_LISTEN " + opt_flag_buffer;
+    }
+    else
+    {
+	    command = "P2P_EXT_LISTEN 200 1000";
+    }
 
     ret = executeCommand(command, NON_GLOBAL_INTERFACE, retBuffer);
     if (ret != MIRACAST_OK)

--- a/Miracast/common/MiracastCommon.h
+++ b/Miracast/common/MiracastCommon.h
@@ -126,7 +126,6 @@ typedef struct group_info
 typedef enum msg_type_e
 {
     P2P_MSG = 0x01,
-    RTSP_MSG,
     CONTRLR_FW_MSG
 } eMSG_TYPE;
 
@@ -142,11 +141,15 @@ typedef enum emira_service_states_e
 {
     MIRACAST_SERVICE_STATE_IDLE,
     MIRACAST_SERVICE_STATE_DISCOVERABLE,
+    MIRACAST_SERVICE_STATE_RESTARTING_SESSION,
+    MIRACAST_SERVICE_STATE_CONNECTING,
     MIRACAST_SERVICE_STATE_CONNECTION_ACCEPTED,
+    MIRACAST_SERVICE_STATE_CONNECTION_REJECTED,
     MIRACAST_SERVICE_STATE_CONNECTION_ERROR,
     MIRACAST_SERVICE_STATE_PLAYER_LAUNCHED,
     MIRACAST_SERVICE_STATE_APP_REQ_TO_ABORT_CONNECTION,
-    MIRACAST_SERVICE_STATE_DIRECT_LAUCH_REQUESTED
+    MIRACAST_SERVICE_STATE_DIRECT_LAUCH_REQUESTED,
+    MIRACAST_SERVICE_STATE_DIRECT_LAUCH_WITH_CONNECTING
 } eMIRA_SERVICE_STATES;
 
 typedef enum miracast_player_states_e
@@ -319,6 +322,7 @@ public:
     virtual void onMiracastServiceClientConnectionRequest(string client_mac, string client_name) = 0;
     virtual void onMiracastServiceClientConnectionError(string client_mac, string client_name , eMIRACAST_SERVICE_ERR_CODE error_code ) = 0;
     virtual void onMiracastServiceLaunchRequest(string src_dev_ip, string src_dev_mac, string src_dev_name, string sink_dev_ip, bool is_connect_req_reported ) = 0;
+    virtual void onStateChange(eMIRA_SERVICE_STATES state ) = 0;
 };
 
 /**


### PR DESCRIPTION
RDKTV-31210 RDKTV-30775 RDKTV-31401 - Miracast Fixes

Reason for change: Fixes to Disable and Enable Miracast discovery later while wakeup from Deepsleep and switching from one ssid to another ssid.
Test procedure: Miracast Functionality should work
Risks: High
Signed-off-by: yuvaramachandran_gurusamy [yuvaramachandran_gurusamy@comcast.com](mailto:yuvaramachandran_gurusamy@comcast.com)