### PR TITLE
RDKTV-31765: Set US endpoint - SecureStore

### DIFF
--- a/PersistentStore/CMakeLists.txt
+++ b/PersistentStore/CMakeLists.txt
@@ -24,7 +24,7 @@ set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
 set(CMAKE_CXX_STANDARD 11)
 
 set(PLUGIN_PERSISTENTSTORE_MODE "Local" CACHE STRING "Controls if the plugin should run in its own process, in process or remote")
-set(PLUGIN_PERSISTENTSTORE_URI "ss.eu.prod.developer.comcast.com:443" CACHE STRING "Account scope endpoint")
+set(PLUGIN_PERSISTENTSTORE_URI "ss.prod.developer.comcast.com:443" CACHE STRING "Account scope endpoint")
 set(PLUGIN_PERSISTENTSTORE_PATH "/opt/secure/persistent/rdkservicestore" CACHE STRING "Path")
 set(PLUGIN_PERSISTENTSTORE_LEGACYPATH "/opt/persistent/rdkservicestore" CACHE STRING "Previously used path")
 set(PLUGIN_PERSISTENTSTORE_KEY "" CACHE STRING "Encryption key")


### PR DESCRIPTION
Reason for change: Set US endpoint for xumo tv devices
Test Procedure: None
Risks: Low
Priority: P0

Change-Id: Ic0fd9039e624b527996000b70f503067e74ab984