### PR TITLE
RDKDEV-1071 REFPLTV-2288 RDKServices : Wpeframework crash & restarting observed on setMode as Warehouse

### DIFF
--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -557,6 +557,7 @@ namespace WPEFramework {
         void SystemServices::Deinitialize(PluginHost::IShell*)
         {
             m_operatingModeTimer.stop();
+           m_operatingModeTimer.join();
 #if defined(USE_IARMBUS) || defined(USE_IARM_BUS)
             DeinitializeIARM();
 #endif /* defined(USE_IARMBUS) || defined(USE_IARM_BUS) */
@@ -1432,6 +1433,7 @@ namespace WPEFramework {
                 m_remainingDuration--;
             } else {
                 m_operatingModeTimer.stop();
+               m_operatingModeTimer.detach();
                 JsonObject parameters, param, response;
                 param["mode"] = "NORMAL";
                 param["duration"] = 0;

--- a/SystemServices/cTimer.cpp
+++ b/SystemServices/cTimer.cpp
@@ -74,10 +74,19 @@ bool cTimer::start()
  */
 void cTimer::stop()
 {
-    this->clear = true;
-    if (timerThread.joinable()) {
-        timerThread.join();
-    }
+       this->clear = true;
+}
+
+void cTimer::detach()
+{
+        timerThread.detach();
+}
+
+void cTimer::join()
+{
+       if (timerThread.joinable()) {
+               timerThread.join();
+        }
 }
 
 /***

--- a/SystemServices/cTimer.h
+++ b/SystemServices/cTimer.h
@@ -53,6 +53,8 @@ class cTimer{
          * @return   : nil
          */
         void stop();
+       void detach();
+       void join();
 
         /***
          * @brief        : Set interval in which the given function should be invoked.


### PR DESCRIPTION
Reason for change: Added threadTimer.detach and removed join from stop timer to avoid first time setMode crash. While deactivating clear and join is called to avoid crash in deactivation.

Test Procedure: Build and verify.

Risks: Low

Signed-off-by: Selva Kumar MR selvakumar_mr@comcast.com