### PR TITLE
RDK-50967 : Add RED state notification

### DIFF
--- a/SystemServices/System.json
+++ b/SystemServices/System.json
@@ -216,6 +216,17 @@
             "type": "integer",
             "example": 5
         },
+	"redRecoveryState": {
+            "summary": "The state",
+            "enum": [
+                "Recovery Completed",
+                "Recovery Started",
+                "Recovery Downloaded",
+                "Recovery Programmed"
+            ],
+            "type": "integer",
+            "example": 3
+        },
         "source": {
             "summary": "The source of the reboot",
             "type": "string",
@@ -2020,6 +2031,20 @@
                 },
                 "required": [
                     "firmwareUpdateStateChange"
+                ]
+            }
+        },
+	"onRedRecoveryStateChange":{
+            "summary": "Triggered when the red recovery transistion  \nState details are:  \n* `0`: Recovery completed  \n* `1`: Fatal error detected  \n* `2`: Firmware Info requested  \n* `3`: Recovery firmware programmed",
+            "params": {
+                "type" :"object",
+                "properties": {
+                    "redRecoveryStateChange": {
+                        "$ref": "#/definitions/redRecoveryState"
+                    }
+                },
+                "required": [
+                    "redrecoveryStateChange"
                 ]
             }
         },

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -2274,6 +2274,23 @@ namespace WPEFramework {
             }
         }
 
+	/***
+         * @brief : sends notification when red recovery state has changed.
+         *
+         * @param1[in]  : newstate
+         * @param2[out] : {"jsonrpc": "2.0","method":
+         *                     "org.rdk.SystemServices.events.1.onRedRecoveryStateChange",
+         *                     "param":{"redRecoveryState":<enum:0-3>}}
+         */
+        void SystemServices::onRedRecoveryStateChange(int newState)
+        {
+                JsonObject params;
+                const RedRecoveryState redRecoveryState = (RedRecoveryState)newState;
+                params["redRecoveryStateChange"] = (int)redRecoveryState;
+                LOGINFO("redRecoveryState = %d\n", (int)redRecoveryState);
+                sendNotify(EVT_ONREDRECOVERYSTATECHANGED, params);
+        }
+
         /***
          * @brief : sends notification when time source state has changed.
          *
@@ -4247,7 +4264,16 @@ namespace WPEFramework {
                             LOGERR("SystemServices::_instance is NULL.\n");
                         }
                     } break;
-
+		case IARM_BUS_SYSMGR_SYSSTATE_RED_RECOV_UPDATE_STATE:
+                    {
+                        LOGWARN("IARMEvt: IARM_BUS_SYSMGR_SYSSTATE_RED_RECOV_UPDATE_STATE = '%d'\n", state);
+                        if (SystemServices::_instance)
+                        {
+                            SystemServices::_instance->onRedRecoveryStateChange(state);
+                        } else {
+                           LOGERR("SystemServices::_instance is NULL.\n");
+                        }
+                    } break;
                 case IARM_BUS_SYSMGR_SYSSTATE_TIME_SOURCE:
                     {
                         if (sysEventData->data.systemStates.state)

--- a/SystemServices/SystemServices.h
+++ b/SystemServices/SystemServices.h
@@ -58,6 +58,7 @@ using std::ofstream;
 #define EVT_ONNETWORKSTANDBYMODECHANGED   "onNetworkStandbyModeChanged"
 #define EVT_ONFIRMWAREUPDATEINFORECEIVED  "onFirmwareUpdateInfoReceived"
 #define EVT_ONFIRMWAREUPDATESTATECHANGED  "onFirmwareUpdateStateChange"
+#define EVT_ONREDRECOVERYSTATECHANGED     "onRedRecoveryStateChange"
 #define EVT_ONTEMPERATURETHRESHOLDCHANGED "onTemperatureThresholdChanged"
 #define EVT_ONMACADDRESSRETRIEVED         "onMacAddressesRetreived"
 #define EVT_ONREBOOTREQUEST               "onRebootRequest"
@@ -193,6 +194,7 @@ namespace WPEFramework {
                 void onNetorkModeChanged(bool betworkStandbyMode);
                 void onSystemModeChanged(string mode);
                 void onFirmwareUpdateStateChange(int state);
+		void onRedRecoveryStateChange(int state);
                 void onClockSet();
                 void onLogUpload(int newState);
                 void onTemperatureThresholdChanged(string thresholdType,

--- a/SystemServices/SystemServicesHelper.h
+++ b/SystemServices/SystemServicesHelper.h
@@ -118,6 +118,13 @@ enum FirmwareUpdateState {
     FirmwareUpdateStateNoUpgradeNeeded
 };
 
+enum RedRecoveryState {
+    RedRecoveryStateCompleted = 0,
+    RedRecoveryStateStarted,
+    RedRecoveryStateDownloaded,
+    RedRecoveryStateProgrammed
+};
+
 const string GZ_STATUS = "/opt/gzenabled";
 
 /* Used as CURL Data buffer */


### PR DESCRIPTION
Reason for change: Adding RED state notification in the system plugin
Test Procedure: check the RED state feature
Risks: Low
Priority: P1