### PR TITLE
RDKTV-29365: Deep Sleep to wake up needs 2 key presses

### DIFF
--- a/RDKShell/CHANGELOG.md
+++ b/RDKShell/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.6.1] - 2024-07-17
+### Fixed
+- Fix for Retry to get wake up keycode when Unknown
+
 ## [1.6.0] - 2024-06-12
 ### Added
 - Added Upstream onApplicationFocusChanged event change handling

--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -55,7 +55,7 @@
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 6
-#define API_VERSION_NUMBER_PATCH 0
+#define API_VERSION_NUMBER_PATCH 1
 
 const string WPEFramework::Plugin::RDKShell::SERVICE_NAME = "org.rdk.RDKShell";
 //methods
@@ -240,6 +240,7 @@ static uint32_t gWillDestroyEventWaitTime = RDKSHELL_WILLDESTROY_EVENT_WAITTIME;
 
 #define REMOTECONTROL_CALLSIGN "org.rdk.RemoteControl.1"
 #define KEYCODE_INVALID -1
+#define KEYCODE_UNKNOWN 255
 #define RETRY_INTERVAL_250MS 250000
 
 #define RDKSHELL_SURFACECLIENT_DISPLAYNAME "rdkshell_display"
@@ -6178,7 +6179,7 @@ namespace WPEFramework {
 	                auto remoteControlConnection = RDKShell::getThunderControllerClient(remoteControlCallsign);
 			int16_t keyCode = KEYCODE_INVALID, retry = 12;
 
-			while( keyCode == KEYCODE_INVALID )
+			while( keyCode == KEYCODE_INVALID || keyCode == KEYCODE_UNKNOWN)
 			{
 				JsonObject req, res, stat;
 				req.Set("netType",1);
@@ -6210,7 +6211,7 @@ namespace WPEFramework {
 					std::cout << "getNetStatus failed\n" << std::endl;
 
 				retry--;
-				if ( (retry == 0) || (keyCode != KEYCODE_INVALID) )
+				if ( (retry == 0) || (keyCode != KEYCODE_INVALID && keyCode != KEYCODE_UNKNOWN) )
 				break;
 				usleep(RETRY_INTERVAL_250MS);
 			   }


### PR DESCRIPTION
Reason for change: Change to retry to get last Wake up key when the key is unknown.
Test Procedure: Test Deep sleep too wake up.
Risks: Low