### PR TITLE
DELIA-65621 Wpeframework crash observed on setMode

### DIFF
--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -554,6 +554,7 @@ namespace WPEFramework {
         void SystemServices::Deinitialize(PluginHost::IShell*)
         {
             m_operatingModeTimer.stop();
+	    m_operatingModeTimer.join();
 #if defined(USE_IARMBUS) || defined(USE_IARM_BUS)
             DeinitializeIARM();
 #endif /* defined(USE_IARMBUS) || defined(USE_IARM_BUS) */

--- a/SystemServices/cTimer.cpp
+++ b/SystemServices/cTimer.cpp
@@ -75,11 +75,14 @@ bool cTimer::start()
 void cTimer::stop()
 {
     this->clear = true;
-    if (timerThread.joinable()) {
-        timerThread.join();
-    }
 }
 
+void cTimer::join()
+{
+	if (timerThread.joinable()) {
+		timerThread.join();
+	}
+}
 /***
  * @brief     : Set interval in which the given function should be invoked.
  * @param1[in]   : function which has to be invoked on timed intervals

--- a/SystemServices/cTimer.h
+++ b/SystemServices/cTimer.h
@@ -54,6 +54,13 @@ class cTimer{
          */
         void stop();
 
+	/***
+         * @brief   : join timer thread.
+         * @return   : nil
+         */
+        void join();
+
+
         /***
          * @brief        : Set interval in which the given function should be invoked.
          * @param1[in]   : function which has to be invoked on timed intervals


### PR DESCRIPTION
Reason for change: Childthread calling join itself which cause crash. Removing that
Test Procedure: Build and verify.
Risks: Low
Signed-off-by: ramkumar_prabaharan@comcast.com