### PR TITLE
RDKTV-31821 TV is not going to deep sleep

### DIFF
--- a/Network/CHANGELOG.md
+++ b/Network/CHANGELOG.md
@@ -16,6 +16,11 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.3.13] - 2024-07-19
+### Fixed
+- Fix for TV is not going to deep sleep
+- Remove initialConnectivityMonitor Start and stop added signaling
+  
 ## [1.3.12] - 2024-06-19
 ### Fixed
 - onInternetStatus event not posting error fix

--- a/Network/Network.cpp
+++ b/Network/Network.cpp
@@ -35,7 +35,7 @@ using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 3
-#define API_VERSION_NUMBER_PATCH 12
+#define API_VERSION_NUMBER_PATCH 13
 
 /* Netsrvmgr Based Macros & Structures */
 #define IARM_BUS_NM_SRV_MGR_NAME "NET_SRV_MGR"
@@ -1460,6 +1460,7 @@ typedef struct _IARM_BUS_NetSrvMgr_Iface_EventData_t {
             m_defIpversionCache = "";
             m_defInterfaceCache = "";
 
+            connectivityMonitor.signalConnectivityMonitor();
             sendNotify("onConnectionStatusChanged", params);
         }
 
@@ -1508,10 +1509,7 @@ typedef struct _IARM_BUS_NetSrvMgr_Iface_EventData_t {
             }
             params["status"] = string (acquired ? "ACQUIRED" : "LOST");
             sendNotify("onIPAddressStatusChanged", params);
-
-            connectivityMonitor.doInitialConnectivityMonitoring(30);
-            if(!acquired) // lost the ip
-                connectivityMonitor.stopInitialConnectivityMonitoring();
+            connectivityMonitor.signalConnectivityMonitor();
         }
 
         void Network::onDefaultInterfaceChanged(string oldInterface, string newInterface)

--- a/Network/NetworkConnectivity.cpp
+++ b/Network/NetworkConnectivity.cpp
@@ -554,12 +554,9 @@ namespace WPEFramework {
 
     void ConnectivityMonitor::signalConnectivityMonitor()
     {
-        if (isMonitorThreadRunning())
-        {
-            /* Reset the global value to UNKNOWN state so the cache is reset */
-            g_internetState = nsm_internetState::UNKNOWN;
-            cv_.notify_all();
-        }
+        /* Reset the global value to UNKNOWN state so the cache is reset */
+        g_internetState = nsm_internetState::UNKNOWN;
+        cv_.notify_all();
     }
 
     void ConnectivityMonitor::connectivityMonitorFunction()


### PR DESCRIPTION
The ‘startInitialConnectivityMonitor’ and ‘StopInitialConnectivityMonitor’ functions have been replaced with the ‘signalConnectivityMonitor’ function