### PR TITLE
XIONE-13188: Fix deviceid query for Realtek platform

### DIFF
--- a/DeviceIdentification/Implementation/Realtek/Realtek.cpp
+++ b/DeviceIdentification/Implementation/Realtek/Realtek.cpp
@@ -17,44 +17,171 @@
  * limitations under the License.
  */
 #include "../../Module.h"
+#include <interfaces/IConfiguration.h>
 
 #include <fstream>
+#include <sys/utsname.h>
 
 namespace WPEFramework {
 namespace Plugin {
 
-    class DeviceImplementation : public PluginHost::ISubSystem::IIdentifier {
-        static constexpr const TCHAR* CPUInfoFile = _T("/proc/cpuinfo");
+    class DeviceImplementation : public PluginHost::ISubSystem::IIdentifier, public Exchange::IConfiguration {
         static constexpr const TCHAR* VERSIONFile = _T("/version.txt");
+    private:
+        static uint8_t constexpr MacSize = 6;
+
+    private:
+        class Config : public Core::JSON::Container {
+        public:
+            Config(const Config&);
+            Config& operator=(const Config&);
+
+            Config()
+                : Core::JSON::Container()
+                , Interface()
+            {
+                Add(_T("interface"), &Interface);
+            }
+
+            ~Config() override
+            {
+            }
+
+        public:
+            Core::JSON::String Interface;
+        };
+
+    private:
+       class AdapterObserver : public WPEFramework::Core::AdapterObserver::INotification {
+        public:
+            static int32_t constexpr WaitTime = 5000; //Just wait for 5 seconds
+
+        public:
+            AdapterObserver() = delete;
+            AdapterObserver(const AdapterObserver&) = delete;
+            AdapterObserver& operator=(const AdapterObserver&) = delete;
+
+            AdapterObserver(const string& interface)
+                : _signal(false, true)
+                , _interface(interface)
+                , _observer(this)
+            {
+                _observer.Open();
+                if (_interface.empty() != true) {
+                    // Check given interface has valid MAC
+                    if (IsInterfaceHasValidMAC(interface) == true) {
+                        _signal.SetEvent();
+                    }
+                } else {
+                    // If interface is not given then,
+                    // check any of the activated interface has valid MAC
+                    if (IsAnyInterfaceHasValidMAC() == true) {
+                       _signal.SetEvent();
+                    }
+                }
+            }
+            ~AdapterObserver() override
+            {
+                _observer.Close();
+            }
+
+        public:
+            virtual void Event(const string& interface) override
+            {
+                if (_interface.empty() != true) {
+                    // Check configured interface has valid MAC
+                    if (interface == _interface) {
+                         if (IsInterfaceHasValidMAC(interface) == true) {
+                           _signal.SetEvent();
+                         }
+                    }
+                } else {
+                    // If interface is not configured then,
+                    // check activated interface has valid MAC
+                    if (IsInterfaceHasValidMAC(interface) == true) {
+                       _signal.SetEvent();
+                    }
+                }
+            }
+            inline uint32_t WaitForCompletion(int32_t waitTime)
+            {
+                return _signal.Lock(waitTime);
+            }
+            const uint8_t* MACAddress()
+            {
+                return _MACAddressBuffer;
+            }
+
+       private:
+            inline bool IsAnyInterfaceHasValidMAC()
+            {
+                bool valid = false;
+                Core::AdapterIterator adapters;
+
+                while ((adapters.Next() == true)) {
+                    if ((valid = IsValidMAC(adapters)) == true) {
+                        break;
+                    }
+                }
+                return valid;
+            }
+            inline bool IsInterfaceHasValidMAC(const string& interface)
+            {
+                Core::AdapterIterator adapter(interface);
+                return IsValidMAC(adapter);
+            }
+            inline bool IsValidMAC(Core::AdapterIterator adapter)
+            {
+                bool valid = false;
+                if ((adapter.IsValid() == true) && ((valid = adapter.HasMAC()) == true)) {
+                    memset(_MACAddressBuffer, 0, Core::AdapterIterator::MacSize);
+                    adapter.MACAddress(_MACAddressBuffer, Core::AdapterIterator::MacSize);
+                }
+                return valid;
+            }
+
+        private:
+            Core::Event _signal;
+            string _interface;
+            Core::AdapterObserver _observer;
+            uint8_t _MACAddressBuffer[Core::AdapterIterator::MacSize];
+        };
 
     public:
         DeviceImplementation()
         {
             UpdateFirmwareVersion(_firmwareVersion);
-            UpdateIdentifier();
         }
+		virtual ~DeviceImplementation() = default;
 
         DeviceImplementation(const DeviceImplementation&) = delete;
         DeviceImplementation& operator=(const DeviceImplementation&) = delete;
-        virtual ~DeviceImplementation()
-        {
-            /* Nothing to do here. */
-        }
 
     public:
+        uint32_t Configure(PluginHost::IShell* service) override
+        {
+            if (service) {
+                Config config;
+                config.FromString(service->ConfigLine());
+
+                _interface = config.Interface.Value();
+                UpdateDeviceId();
+            }
+
+            return Core::ERROR_NONE;
+        }
+
         // Device Propertirs interface
 
         // Identifier interface
-        uint8_t Identifier(const uint8_t length, uint8_t buffer[]) const override
+        uint8_t Identifier(const uint8_t length, uint8_t* buffer) const override
         {
-            uint8_t result = 0;
-            if ((_identity.length())) {
-                result = (_identity.length() > length ? length : _identity.length());
-                ::memcpy(buffer, _identity.c_str(), result);
-            } else {
-                SYSLOG(Logging::Notification, (_T("Cannot determine system identity")));
+            uint8_t ret = 0;
+            if (_identifier.length()) {
+                ret = (_identifier.length() > length ? length : _identifier.length());
+                ::memcpy(buffer, _identifier.c_str(), ret);
             }
-            return result;
+            return ret;
         }
         string Architecture() const override
         {
@@ -69,11 +196,18 @@ namespace Plugin {
             return _firmwareVersion;
         }
 
-        BEGIN_INTERFACE_MAP(DeviceImplementation)
-        INTERFACE_ENTRY(PluginHost::ISubSystem::IIdentifier)
-        END_INTERFACE_MAP
 
     private:
+        void UpdateDeviceId()
+        {
+            AdapterObserver observer(_interface);
+
+            if (observer.WaitForCompletion(AdapterObserver::WaitTime) == Core::ERROR_NONE) {
+                _identifier.assign(reinterpret_cast<const char*>(observer.MACAddress()), Core::AdapterIterator::MacSize);
+            } else {
+                TRACE(Trace::Error, (_T("There is no any valid physical interface available")));
+            }
+        }
         inline void UpdateFirmwareVersion(string& firmwareVersion) const
         {
             string line;
@@ -92,26 +226,16 @@ namespace Plugin {
             }
         }
 
-        inline void UpdateIdentifier()
-        {
-            string line;
-            std::ifstream file(CPUInfoFile);
-            if (file.is_open()) {
-                while (getline(file, line)) {
-                    if (line.find("Serial") != std::string::npos) {
-                        std::size_t position = line.find(": ");
-                        if (position != std::string::npos) {
-                            _identity.assign(line.substr(position + 2, string::npos));
-                        }
-                    }
-                }
-                file.close();
-            }
-        }
+    public:
+        BEGIN_INTERFACE_MAP(DeviceImplementation)
+        INTERFACE_ENTRY(PluginHost::ISubSystem::IIdentifier)
+        INTERFACE_ENTRY(Exchange::IConfiguration)
+        END_INTERFACE_MAP
 
     private:
         string _firmwareVersion;
-        string _identity;
+        string _interface;
+        string _identifier;
     };
 
     SERVICE_REGISTRATION(DeviceImplementation, 1, 0);


### PR DESCRIPTION
Reason for change: Use MAC as deviceid for Realtek soc (Same with generic linux implementation) Test Procedure: After device booting into UI, run the following console commands:
  curl -s -d '{"method":"DeviceIdentification.deviceidentification","id":"42","jsonrpc":"2.0"}' http://127.0.0.1:9998/jsonrpc
Priority: P1
Risks: low

Cherry-pick to personal github for testing: https://github.com/maruku/rdkservices/commit/8ee348425e8e7d548489fb862d4ce181ec6e503e
Change for testing changes: https://gerrit.teamccp.com/857241
Jenkins custom image for testing: https://jenkins.ccp.xcal.tv/jenkins/job/SKYXIONE-SKY-Yocto-Pipeline/496/
Cherry-Pick: 746925ec4e90e0bdc346cd6bbfe9ad5981192a20
Change-Id: I799b094431f4662f693ec692d968c123d0ee279d