### PR TITLE
RDKDEV-1025 : libWPEFrameworkScreenCapture.so: undefined symbol NxClient_GetDefaultJoinSettings and update capture video setting for screen shot

### DIFF
--- a/ScreenCapture/CMakeLists.txt
+++ b/ScreenCapture/CMakeLists.txt
@@ -54,7 +54,11 @@ endif()
 
 target_include_directories(${MODULE_NAME} PRIVATE ../helpers)
 
-target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins -lpng -lcurl)
+if (BUILD_BROADCOM)
+ target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins -lpng -lcurl -lnxclient)
+else ()
+ target_link_libraries(${MODULE_NAME} PRIVATE ${NAMESPACE}Plugins::${NAMESPACE}Plugins -lpng -lcurl)
+endif()
 
 install(TARGETS ${MODULE_NAME}
         DESTINATION lib/${STORAGE_DIRECTORY}/plugins)

--- a/ScreenCapture/ScreenCapture.cpp
+++ b/ScreenCapture/ScreenCapture.cpp
@@ -380,10 +380,10 @@ namespace WPEFramework
             memset(&screenshotSettings, 0, sizeof(screenshotSettings));
 
             #ifdef SCREENCAP_SVP_ENABLED
-            screenshotSettings.screenshotWindow = NxClient_ScreenshotWindow_eGraphics;
+	    screenshotSettings.captureVideo = false;
             LOGWARN("[SCREENCAP]: Using NxClient_ScreenshotWindow_eGraphics (graphics only, no video)");
             #else
-            screenshotSettings.screenshotWindow = NxClient_ScreenshotWindow_eAll;
+	    screenshotSettings.captureVideo = true;
             LOGWARN("[SCREENCAP]: Using NxClient_ScreenshotWindow_eAll (graphics including video)");
             #endif
 


### PR DESCRIPTION
RDKDEV-1025 : libWPEFrameworkScreenCapture.so: undefined symbol NxClient_GetDefaultJoinSettings and update capture video setting for screen shot

Reason for change: Fixing libWPEFrameworkScreenCapture linking issue and updating screen capture setting
Test Procedure: Verify build is successful and Screen capture should work 
Risks: None
Signed-off-by : juventus.wang@broadcom.com







