### PR TITLE
RDK-45352 RDK-45346: Upgrade SkyXione-LLAMA & Xumo devices to use Thunder R4.4.1

### DIFF
--- a/DeviceInfo/CHANGELOG.md
+++ b/DeviceInfo/CHANGELOG.md
@@ -15,6 +15,11 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+
+## [1.0.13] - 2024-05-31
+### Changed
+- RDK-45345: Upgrade Sky Glass devices to use Thunder R4.4.1
+
 ## [1.0.12] - 2023-01-26
 ### Changed
 - RDK-44991: Upgrade Flex-2.0 devices to use Thunder R4.4.1

--- a/DeviceInfo/DeviceInfo.cpp
+++ b/DeviceInfo/DeviceInfo.cpp
@@ -161,7 +161,7 @@ namespace Plugin {
         Core::SystemInfo& singleton(Core::SystemInfo::Instance());
 
         systemInfo.Time = Core::Time::Now().ToRFC1123(true);
-#if ((THUNDER_VERSION_MAJOR >= 4) && (THUNDER_VERSION_MINOR >= 4))
+#if ((THUNDER_VERSION >= 4) && (THUNDER_VERSION_MINOR >= 4))
 	systemInfo.Version = _subSystem->Version() + _T("#") + _subSystem->BuildTreeHash();
 #else
 	systemInfo.Version = _service->Version() + _T("#") + _subSystem->BuildTreeHash();

--- a/DeviceInfo/Module.h
+++ b/DeviceInfo/Module.h
@@ -25,7 +25,7 @@
 #endif
 
 #include <plugins/plugins.h>
-#if ((THUNDER_VERSION_MAJOR >= 4) && (THUNDER_VERSION_MINOR == 4))
+#if ((THUNDER_VERSION >= 4) && (THUNDER_VERSION_MINOR == 4))
 #include <definitions/definitions.h>
 #else
 #include <interfaces/definitions.h>

--- a/Messenger/CHANGELOG.md
+++ b/Messenger/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.1.4] - 2024-05-31
+### Changed
+- RDK-45345: Upgrade Sky Glass devices to use Thunder R4.4.1
+
 ## [1.1.3] - 2023-01-26
 ### Changed
 - RDK-44991: Upgrade Flex-2.0 devices to use Thunder R4.4.1

--- a/Messenger/Module.h
+++ b/Messenger/Module.h
@@ -24,7 +24,7 @@
 #endif
 
 #include <plugins/plugins.h>
-#if ((THUNDER_VERSION_MAJOR >= 4) && (THUNDER_VERSION_MINOR == 4))
+#if ((THUNDER_VERSION >= 4) && (THUNDER_VERSION_MINOR == 4))
 #include <definitions/definitions.h>
 #else
 #include <interfaces/definitions.h>

--- a/Monitor/CHANGELOG.md
+++ b/Monitor/CHANGELOG.md
@@ -15,6 +15,11 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+
+## [1.0.7] - 2024-07-24
+### Changed
+- RDK-45345: Upgrade Sky Glass devices to use Thunder R4.4.1
+
 ## [1.0.7] - 2024-07-19
 ### Changed
 - Added Delay in Thread Restart Logic

--- a/Monitor/Monitor.h
+++ b/Monitor/Monitor.h
@@ -753,7 +753,7 @@ namespace Plugin {
                 _service = nullptr;
             }
 
-#if (THUNDER_VERSION_MAJOR >= 4)
+#if (THUNDER_VERSION >= 4)
 #if (THUNDER_VERSION_MINOR == 2)
             void Activation(const string& name, PluginHost::IShell* service) override
             {

--- a/OpenCDMi/CHANGELOG.md
+++ b/OpenCDMi/CHANGELOG.md
@@ -15,6 +15,11 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+
+## [1.0.6] - 2024-05-31
+### Changed
+- RDK-45345: Upgrade Sky Glass devices to use Thunder R4.4.1
+
 ## [1.0.5] - 2024-03-29
 ### Security
 - Resolved security vulnerabilities

--- a/OpenCDMi/FrameworkRPC.cpp
+++ b/OpenCDMi/FrameworkRPC.cpp
@@ -114,7 +114,7 @@ namespace Plugin {
                 : RPC::Communicator(source, _T(""), Core::ProxyType<Core::IIPCServer>(engine))
                 , _parentInterface(parentInterface)
             {
-#if ((THUNDER_VERSION_MAJOR == 2) || ((THUNDER_VERSION_MAJOR == 4) && (THUNDER_VERSION_MINOR == 2)))
+#if ((THUNDER_VERSION == 2) || ((THUNDER_VERSION == 4) && (THUNDER_VERSION_MINOR == 2)))
                 engine->Announcements(Announcement());
 #endif
                 Open(Core::infinite);

--- a/RDKShell/CHANGELOG.md
+++ b/RDKShell/CHANGELOG.md
@@ -15,6 +15,11 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+
+## [1.4.188888888] - 2024-05-31
+### Changed
+- RDK-45345: Upgrade Sky Glass devices to use Thunder R4.4.1
+
 ## [1.4.17] - 2024-04-10
 ### Added
 - Fix for rdkshell missing events

--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -571,7 +571,11 @@ namespace WPEFramework {
         private:
           uint32_t mId { 0 };
           std::string mCallSign { };
+#if ((THUNDER_VERSION >= 4) && (THUNDER_VERSION_MINOR == 4))
+          PluginHost::ILocalDispatcher * dispatcher_ {nullptr};
+#else
           PluginHost::IDispatcher * dispatcher_ {nullptr};
+#endif
 
           Core::ProxyType<Core::JSONRPC::Message> Message() const
           {
@@ -620,7 +624,11 @@ namespace WPEFramework {
             : mCallSign(callsign)
           {
             if (service)
+#if ((THUNDER_VERSION >= 4) && (THUNDER_VERSION_MINOR == 4))
+              dispatcher_ = service->QueryInterfaceByCallsign<PluginHost::ILocalDispatcher>(mCallSign);
+#else
               dispatcher_ = service->QueryInterfaceByCallsign<PluginHost::IDispatcher>(mCallSign);
+#endif
           }
       
           JSONRPCDirectLink(PluginHost::IShell* service)
@@ -664,12 +672,47 @@ namespace WPEFramework {
             ToMessage(parameters, message);
 
             const uint32_t channelId = ~0;
-#ifndef USE_THUNDER_R4
+#if ((THUNDER_VERSION >= 4) && (THUNDER_VERSION_MINOR == 4))
+            string output = "";
+            uint32_t result = Core::ERROR_BAD_REQUEST;
+
+            if (dispatcher_  != nullptr) {
+                PluginHost::ILocalDispatcher* localDispatcher = dispatcher_->Local();
+
+                ASSERT(localDispatcher != nullptr);
+
+                if (localDispatcher != nullptr)
+                    result =  dispatcher_->Invoke(channelId, message->Id.Value(), sThunderSecurityToken, message->Designator.Value(), message->Parameters.Value(),output);
+            }
+
+            if (message.IsValid() == true) {
+                if (result == static_cast<uint32_t>(~0)) {
+                    message.Release();
+                }
+                else if (result == Core::ERROR_NONE)
+                {
+                    if (output.empty() == true)
+                        message->Result.Null(true);
+                    else
+                        message->Result = output;
+                }
+                else
+                {
+                    message->Error.SetError(result);
+                    if (output.empty() == false) {
+                        message->Error.Text = output;
+                    }
+                }
+            }
+#elif (THUNDER_VERSION == 2)
             auto resp =  dispatcher_->Invoke(sThunderSecurityToken, channelId, *message);
 #else
             Core::JSONRPC::Context context(channelId, message->Id.Value(), sThunderSecurityToken) ;
             auto resp = dispatcher_->Invoke(context, *message);
-#endif /* USE_THUNDER_R4 */
+#endif
+
+#if ((THUNDER_VERSION == 2) || (THUNDER_VERSION >= 4) && (THUNDER_VERSION_MINOR == 2))
+
             if (resp->Error.IsSet()) {
               std::cout << "Call failed: " << message->Designator.Value() << " error: " <<  resp->Error.Text.Value() << "\n";
               return resp->Error.Code;
@@ -677,7 +720,7 @@ namespace WPEFramework {
 
             if (!FromMessage(response, resp, isResponseString))
               return Core::ERROR_GENERAL;
-
+#endif
             return Core::ERROR_NONE;
           }
         };

--- a/ResourceManager/CHANGELOG.md
+++ b/ResourceManager/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.0.2] - 2024-05-31
+### Changed
+- RDK-45345: Upgrade Sky Glass devices to use Thunder R4.4.1
+
 ## [1.0.1] - 2023-11-08
 ### Changed
 -  Added an RFC to control reserveTTS API

--- a/RustAdapter/CHANGELOG.md
+++ b/RustAdapter/CHANGELOG.md
@@ -15,6 +15,11 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+
+## [1.0.4] - 2024-05-31
+### Changed
+- RDK-45345: Upgrade Sky Glass devices to use Thunder R4.4.1
+
 ## [1.0.3] - 2023-01-26
 ### Changed
 - RDK-44991: Upgrade Flex-2.0 devices to use Thunder R4.4.1

--- a/RustAdapter/LocalPlugin.cpp
+++ b/RustAdapter/LocalPlugin.cpp
@@ -194,7 +194,7 @@ WPEFramework::Plugin::Rust::LocalPlugin::SendTo(uint32_t channel_id, const char 
 
 #if JSON_RPC_CONTEXT
 
-#if ((THUNDER_VERSION_MAJOR >= 4) && (THUNDER_VERSION_MINOR == 4))
+#if ((THUNDER_VERSION >= 4) && (THUNDER_VERSION_MINOR == 4))
 WPEFramework::Core::hresult
   WPEFramework::Plugin::Rust::LocalPlugin::Invoke(ICallback* callback, const uint32_t channelId, const uint32_t id, const string& token, const string& method, const string& parameters, string& response)
 {
@@ -240,7 +240,7 @@ WPEFramework::Core::ProxyType<WPEFramework::Core::JSONRPC::Message>
 }
 #endif
 
-#if ((THUNDER_VERSION_MAJOR == 4) && (THUNDER_VERSION_MINOR == 4))
+#if ((THUNDER_VERSION == 4) && (THUNDER_VERSION_MINOR == 4))
 WPEFramework::Core::hresult WPEFramework::Plugin::Rust::LocalPlugin::Revoke(ICallback* callback)
 {
     return {};
@@ -253,7 +253,7 @@ WPEFramework::Core::hresult WPEFramework::Plugin::Rust::LocalPlugin::Validate(co
 #endif
 
 
-#if ((THUNDER_VERSION_MAJOR == 2) || ((THUNDER_VERSION_MAJOR == 4) && (THUNDER_VERSION_MINOR == 2)))
+#if ((THUNDER_VERSION == 2) || ((THUNDER_VERSION == 4) && (THUNDER_VERSION_MINOR == 2)))
 void
 WPEFramework::Plugin::Rust::LocalPlugin::Activate(
   WPEFramework::PluginHost::IShell *shell)
@@ -321,7 +321,7 @@ WPEFramework::Plugin::Rust::LocalPlugin::Information() const
   return { };
 }
 
-#if ((THUNDER_VERSION_MAJOR >= 4) && (THUNDER_VERSION_MINOR == 2))
+#if ((THUNDER_VERSION >= 4) && (THUNDER_VERSION_MINOR == 2))
 void WPEFramework::Plugin::Rust::LocalPlugin::Close(const uint32_t channelId) /* override */
 {
   return;

--- a/RustAdapter/LocalPlugin.h
+++ b/RustAdapter/LocalPlugin.h
@@ -72,7 +72,7 @@ public:
   /**
    * IDispatcher::Activate
    */
-#if ((THUNDER_VERSION_MAJOR == 2) || ((THUNDER_VERSION_MAJOR == 4) && (THUNDER_VERSION_MINOR == 2)))
+#if ((THUNDER_VERSION == 2) || ((THUNDER_VERSION == 4) && (THUNDER_VERSION_MINOR == 2)))
   void Activate(PluginHost::IShell *shell) override;
   /**
    *
@@ -89,7 +89,7 @@ public:
   /**
    * IDispatcher::Close
    */
-#if ((THUNDER_VERSION_MAJOR >= 4) && (THUNDER_VERSION_MINOR == 2))
+#if ((THUNDER_VERSION >= 4) && (THUNDER_VERSION_MINOR == 2))
   void Close(const uint32_t channelId) override;
 #endif /* THUNDER_VERSION */
   /**
@@ -97,7 +97,7 @@ public:
    */
 #if JSON_RPC_CONTEXT
 
-#if ((THUNDER_VERSION_MAJOR >= 4) && (THUNDER_VERSION_MINOR == 4))
+#if ((THUNDER_VERSION >= 4) && (THUNDER_VERSION_MINOR == 4))
   Core::hresult Invoke(ICallback* callback, const uint32_t channelId, const uint32_t id, const string& token, const string& method, const string& parameters, string& response ) override;
 #else
   Core::ProxyType<Core::JSONRPC::Message> Invoke(
@@ -110,7 +110,7 @@ public:
     const string& token, const uint32_t channelId, const Core::JSONRPC::Message& req) override;
 #endif
 
-#if ((THUNDER_VERSION_MAJOR >= 4) && (THUNDER_VERSION_MINOR == 4))
+#if ((THUNDER_VERSION >= 4) && (THUNDER_VERSION_MINOR == 4))
   Core::hresult Revoke(ICallback* callback) override;
   Core::hresult Validate(const string& token, const string& method, const string& paramaters /* @restrict:(4M-1) */) const override;
 #endif
@@ -121,7 +121,7 @@ public:
   Core::ProxyType<Core::JSON::IElement> Inbound(const uint32_t id,
     const Core::ProxyType<Core::JSON::IElement> &element) override;
 
-#if ((THUNDER_VERSION_MAJOR >= 4) && (THUNDER_VERSION_MINOR == 4))
+#if ((THUNDER_VERSION >= 4) && (THUNDER_VERSION_MINOR == 4))
 public:
    WPEFramework::PluginHost::ILocalDispatcher* Local() override {
         return nullptr; // Replace nullptr with your actual implementation.

--- a/RustAdapter/RemotePlugin.cpp
+++ b/RustAdapter/RemotePlugin.cpp
@@ -95,7 +95,7 @@ RemotePlugin::SendTo(uint32_t channel_id, const char *json)
 }
 #if JSON_RPC_CONTEXT
 
-#if ((THUNDER_VERSION_MAJOR >= 4) && (THUNDER_VERSION_MINOR == 4))
+#if ((THUNDER_VERSION >= 4) && (THUNDER_VERSION_MINOR == 4))
 WPEFramework::Core::hresult RemotePlugin::Invoke(ICallback* callback, const uint32_t channelId, const uint32_t id, const string& token, const string& method, const string& parameters, string& response)
 {
   m_stream.SendInvoke(channelId, token, response);
@@ -127,7 +127,7 @@ RemotePlugin::Invoke(
 }
 #endif
 
-#if ((THUNDER_VERSION_MAJOR == 2) || ((THUNDER_VERSION_MAJOR == 4) && (THUNDER_VERSION_MINOR == 2)))
+#if ((THUNDER_VERSION == 2) || ((THUNDER_VERSION == 4) && (THUNDER_VERSION_MINOR == 2)))
 void
 RemotePlugin::Activate(
   WPEFramework::PluginHost::IShell *shell)
@@ -189,7 +189,7 @@ RemotePlugin::Information() const
   return { };
 }
 
-#if (THUNDER_VERSION_MAJOR >= 4)
+#if (THUNDER_VERSION >= 4)
 #if (THUNDER_VERSION_MINOR == 2)
 void RemotePlugin::Close(const uint32_t channelId) /* override */
 {

--- a/RustAdapter/RemotePlugin.h
+++ b/RustAdapter/RemotePlugin.h
@@ -74,7 +74,7 @@ public:
   /**
    * IDispatcher::Activate
    */
-#if ((THUNDER_VERSION_MAJOR == 2) || ((THUNDER_VERSION_MAJOR == 4) && (THUNDER_VERSION_MINOR == 2)))
+#if ((THUNDER_VERSION == 2) || ((THUNDER_VERSION == 4) && (THUNDER_VERSION_MINOR == 2)))
   void Activate(PluginHost::IShell *shell) override;
   /**
    *
@@ -90,14 +90,14 @@ public:
   /**
    * IDispatcher::Close
    */
-#if ((THUNDER_VERSION_MAJOR >= 4) && (THUNDER_VERSION_MINOR == 2))
+#if ((THUNDER_VERSION >= 4) && (THUNDER_VERSION_MINOR == 2))
   void Close(const uint32_t channelId) override;
 #endif
 
   /**
    * IDispatcher::Close
    */
-#if ((THUNDER_VERSION_MAJOR >= 4 && THUNDER_VERSION_MINOR == 4))
+#if ((THUNDER_VERSION >= 4 && THUNDER_VERSION_MINOR == 4))
   Core::hresult Revoke(ICallback* callback) override;
   Core::hresult Validate(const string& token, const string& method, const string& paramaters /* @restrict:(4M-1) */) const override;
 #endif /* THUNDER_VERSION */
@@ -107,7 +107,7 @@ public:
    */
 #if JSON_RPC_CONTEXT   
 
-#if ((THUNDER_VERSION_MAJOR >= 4) && (THUNDER_VERSION_MINOR == 4))
+#if ((THUNDER_VERSION >= 4) && (THUNDER_VERSION_MINOR == 4))
   Core::hresult Invoke(ICallback* callback, const uint32_t channelId, const uint32_t id, const string& token, const string& method, const string& parameters, string& response ) override;
 #else
   Core::ProxyType<Core::JSONRPC::Message> Invoke(
@@ -126,7 +126,7 @@ public:
     const Core::ProxyType<Core::JSON::IElement> &element) override;
 
   void onRead(const Response& rsp);
-#if ((THUNDER_VERSION_MAJOR == 4) && (THUNDER_VERSION_MINOR == 4))
+#if ((THUNDER_VERSION == 4) && (THUNDER_VERSION_MINOR == 4))
 public:
    WPEFramework::PluginHost::ILocalDispatcher* Local() override {
         return nullptr; // Replace nullptr with your actual implementation.

--- a/RustAdapter/RustAdapter.cpp
+++ b/RustAdapter/RustAdapter.cpp
@@ -101,7 +101,7 @@ WPEFramework::Plugin::RustAdapter::Release() const
 
 #if JSON_RPC_CONTEXT
 
-#if ((THUNDER_VERSION_MAJOR == 4) && (THUNDER_VERSION_MINOR == 4))
+#if ((THUNDER_VERSION == 4) && (THUNDER_VERSION_MINOR == 4))
 WPEFramework::Core::hresult
 WPEFramework::Plugin::RustAdapter::Invoke(ICallback* callback, const uint32_t channelId, const uint32_t id, const string& token, const string& method, const string& parameters, string& response )
 {
@@ -126,7 +126,7 @@ WPEFramework::Core::ProxyType<WPEFramework::Core::JSONRPC::Message>
 }
 #endif
 
-#if ((THUNDER_VERSION_MAJOR == 2) || ((THUNDER_VERSION_MAJOR == 4)  && (THUNDER_VERSION_MINOR == 2)))
+#if ((THUNDER_VERSION == 2) || ((THUNDER_VERSION == 4)  && (THUNDER_VERSION_MINOR == 2)))
 void
 WPEFramework::Plugin::RustAdapter::Activate(
   WPEFramework::PluginHost::IShell *shell)
@@ -153,7 +153,7 @@ WPEFramework::Plugin::RustAdapter::Detach(PluginHost::Channel &channel)
   m_impl->Detach(channel);
 }
 
-#if ((THUNDER_VERSION_MAJOR == 4) && (THUNDER_VERSION_MINOR == 2))
+#if ((THUNDER_VERSION == 4) && (THUNDER_VERSION_MINOR == 2))
 void
 WPEFramework::Plugin::RustAdapter::Close(const uint32_t channelId)
 {
@@ -161,7 +161,7 @@ WPEFramework::Plugin::RustAdapter::Close(const uint32_t channelId)
 }
 #endif /* THUNDER_VERSION */
 
-#if ((THUNDER_VERSION_MAJOR == 4) && (THUNDER_VERSION_MINOR == 4))
+#if ((THUNDER_VERSION == 4) && (THUNDER_VERSION_MINOR == 4))
 WPEFramework::Core::hresult WPEFramework::Plugin::RustAdapter::Revoke(ICallback* callback)
 {
      return {};

--- a/RustAdapter/RustAdapter.h
+++ b/RustAdapter/RustAdapter.h
@@ -112,7 +112,7 @@ public:
   /**
    * IDispatcher::Activate
    */
-#if ((THUNDER_VERSION_MAJOR == 2) || ((THUNDER_VERSION_MAJOR == 4) && (THUNDER_VERSION_MINOR == 2)))
+#if ((THUNDER_VERSION == 2) || ((THUNDER_VERSION == 4) && (THUNDER_VERSION_MINOR == 2)))
   void Activate(PluginHost::IShell *shell) override;
   /**
    *
@@ -128,7 +128,7 @@ public:
   /**
    * IDispatcher::Close
    */
-#if (THUNDER_VERSION_MAJOR >= 4)
+#if (THUNDER_VERSION >= 4)
 #if (THUNDER_VERSION_MINOR == 2)
   void Close(const uint32_t channelId) override;
 #endif
@@ -143,7 +143,7 @@ public:
    */
 #if JSON_RPC_CONTEXT
 
-#if ((THUNDER_VERSION_MAJOR >= 4) && (THUNDER_VERSION_MINOR == 4))
+#if ((THUNDER_VERSION >= 4) && (THUNDER_VERSION_MINOR == 4))
   Core::hresult Invoke(ICallback* callback, const uint32_t channelId, const uint32_t id, const string& token, const string& method, const string& parameters, string& response ) override;
 #else
   Core::ProxyType<Core::JSONRPC::Message> Invoke(
@@ -176,7 +176,7 @@ public:
 
   static std::string GetAuthToken(WPEFramework::PluginHost::IShell* service, const std::string &callsign);
 
-#if ((THUNDER_VERSION_MAJOR >= 4) && (THUNDER_VERSION_MINOR == 4))
+#if ((THUNDER_VERSION >= 4) && (THUNDER_VERSION_MINOR == 4))
 public:
    WPEFramework::PluginHost::ILocalDispatcher* Local() override {
         return nullptr; // Replace nullptr with your actual implementation.

--- a/SecurityAgent/CHANGELOG.md
+++ b/SecurityAgent/CHANGELOG.md
@@ -15,6 +15,11 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+
+## [1.1.5] - 2024-05-31
+### Changed
+- RDK-45345: Upgrade Sky Glass devices to use Thunder R4.4.1
+
 ## [1.1.4] - 2024-03-29
 ### Fixed
 - Fixed coverity reported issues

--- a/SecurityAgent/SecurityAgent.cpp
+++ b/SecurityAgent/SecurityAgent.cpp
@@ -99,7 +99,6 @@ namespace Plugin {
     {
         Config config;
         config.FromString(service->ConfigLine());
-        string version = service->Version();
         string webPrefix = service->WebPrefix();
         string callsign = service->Callsign();
 

--- a/SecurityAgent/SecurityAgent.h
+++ b/SecurityAgent/SecurityAgent.h
@@ -52,7 +52,9 @@ namespace Plugin {
                 if(_parentInterface != nullptr){
                     _parentInterface->AddRef();
                 }
-                engine->Announcements(Announcement());
+#if ((THUNDER_VERSION == 2) || ((THUNDER_VERSION == 4) && (THUNDER_VERSION_MINOR == 2)))
+		engine->Announcements(Announcement());
+#endif
                 Open(Core::infinite);
             }
             ~TokenDispatcher() override

--- a/SystemServices/CHANGELOG.md
+++ b/SystemServices/CHANGELOG.md
@@ -15,6 +15,11 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+
+## [2.2.2] - 2024-05-31
+### Changed
+- RDK-45345: Upgrade Sky Glass devices to use Thunder R4.4.1
+
 ## [2.1.3] - 2024-03-29
 ### Security
 - Resolved security vulnerabilities

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -2241,7 +2241,7 @@ namespace WPEFramework {
                     newState == IARM_BUS_SYSMGR_LOG_UPLOAD_ABORTED ? LOG_UPLOAD_STATUS_ABORTED : LOG_UPLOAD_STATUS_FAILURE;
 
                 sendNotify(EVT_ONLOGUPLOAD, params);
-#if ((THUNDER_VERSION_MAJOR == 2) || ((THUNDER_VERSION_MAJOR == 4) && (THUNDER_VERSION_MINOR == 2)))
+#if ((THUNDER_VERSION == 2) || ((THUNDER_VERSION == 4) && (THUNDER_VERSION_MINOR == 2)))
                 GetHandler(2)->Notify(EVT_ONLOGUPLOAD, params);
 #endif
                 pid_t wp;

--- a/helpers/UtilsJsonRpc.h
+++ b/helpers/UtilsJsonRpc.h
@@ -49,7 +49,7 @@
  *
  * You should be capable of just using "Notify".
  */
-#if ((THUNDER_VERSION_MAJOR >= 4) && (THUNDER_VERSION_MINOR == 4))
+#if ((THUNDER_VERSION >= 4) && (THUNDER_VERSION_MINOR == 4))
 
 #define sendNotify(event,params) { \
     std::string json; \


### PR DESCRIPTION

RDK-45352 RDK-45346: Upgrade SkyXione-LLAMA & Xumo devices to use Thunder R4.4.1 (RDK-45352 RDK-45346: Add Support to RDKServices to be compatible with Thunder R4.4.1 #5116)

RDK-45352 RDK-45346: Upgrade SkyXione-LLAMA & Xumo devices to use Thunder R4.4.1

Reason for change: Compilation Error Fixed of rdkservices plugins against Thunder R4.4.1
Test Procedure: Verify in Jenkin Build
Risks: High
Signed-off-by: Thamim Razith tabbas651@cable.comcast.com

Updated: DeviceInfo/DeviceInfo.cpp
Updated: DeviceInfo/Module.h
Updated: Messenger/Module.h
Updated: Monitor/Monitor.h
Updated: OpenCDMi/FrameworkRPC.cpp
Updated: PersistentStore/Module.h
Updated: RDKShell/RDKShell.cpp
Updated: ResourceManager/ResourceManager.cpp
Updated: RustAdapter/LocalPlugin.cpp
Updated: RustAdapter/LocalPlugin.h
Updated: RustAdapter/RemotePlugin.cpp
Updated: RustAdapter/RemotePlugin.h
Updated: RustAdapter/RustAdapter.cpp
Updated: RustAdapter/RustAdapter.h
Updated: SecurityAgent/SecurityAgent.cpp
Updated: SecurityAgent/SecurityAgent.h
Updated: SystemServices/SystemServices.cpp
Updated: SystemServices/platformcaps/platformcapsdata.h
Updated: helpers/UtilsJsonRpc.h

(cherry picked from commit e3bf082)

RDK-45352 RDK-45346: Update rdkservices plugins to be compatible for Thunder R4.4.1 (#5118)

Reason for change: Updated LocalDispatcher correctly for Invoke method
Test Procedure: Verify in Jenkin Build
Risks: High
Signed-off-by: Thamim Razith tabbas651@cable.comcast.com

Updated: SystemServices/platformcaps/platformcapsdata.h

Update platformcapsdata.h
Co-authored-by: Karunakaran A 48997923+karuna2git@users.noreply.github.com

(cherry picked from commit 87c498d)

DELIA-64992: [R4.4.1] [Auto][24Q2]Device struck at Hubbl/Sky/Xumo Logo post CDL (#5142)

Reason for change: Modify the Invoke method error check with respect to Thunder R4.4.1 code
Test Procedure: Verify in Jenkin Build
Risks: High
Signed-off-by: Thamim Razith tabbas651@cable.comcast.com

XIONE-14377: [ALPACA_DE][UK][Alpaca IT][Foxtel] Ip linear (#5190)

Reason for change: removed the unnecessary dispatcher release from invoke method which landed for R4.4.1
Test Procedure: Verified in Jenkins Build
Signed-off-by: Thamim Razith tabbas651@cable.comcast.com

Co-authored-by: Karunakaran A 48997923+karuna2git@users.noreply.github.com (cherry picked from commit 2d3a914)

Update the Changelogs for Thunder R4.4.1 Sky-LLAMA changes