### PR TITLE
RDK-50751: Remove HDCPProfile and move the APIs DisplayInfo

### DIFF
--- a/DisplayInfo/CHANGELOG.md
+++ b/DisplayInfo/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+## [1.0.7] - 2024-06-25
+### Added
+- ishdcpcompliant, ishdcpenabled, ishdcpsupported, hdcpreason, supportedhdcpversion, displayhdcpversion, currenthdcpversion property integration 
+
 ## [1.0.6] - 2024-03-29
 ### Security
 - Resolved security vulnerabilities

--- a/DisplayInfo/DisplayInfo.cpp
+++ b/DisplayInfo/DisplayInfo.cpp
@@ -21,7 +21,7 @@
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 6
+#define API_VERSION_NUMBER_PATCH 7
 
 namespace WPEFramework {
 namespace {
@@ -239,6 +239,43 @@ namespace Plugin {
         if (_hdrProperties->HDRSetting(hdrType) == Core::ERROR_NONE) {
             displayInfo.Hdrtype = static_cast<JsonData::DisplayInfo::DisplayinfoData::HdrtypeType>(hdrType);
         }
+
+        status = false;
+        if (_connectionProperties->IsHDCPCompliant(status) == Core::ERROR_NONE) {
+            displayInfo.Ishdcpcompliant = status;
+        }
+
+        status = false;
+        if (_connectionProperties->IsHDCPEnabled(status) == Core::ERROR_NONE) {
+            displayInfo.Ishdcpenabled = status;
+        }
+
+        status = false;
+        if (_connectionProperties->IsHDCPSupported(status) == Core::ERROR_NONE) {
+            displayInfo.Ishdcpsupported = status;
+        }
+
+        value = 0;
+        if (_connectionProperties->HdcpReason(value) == Core::ERROR_NONE) {
+            displayInfo.Hdcpreason = value;
+        }
+
+        Exchange::IConnectionProperties::HDCPProtectionType supportedHDCPVersion(Exchange::IConnectionProperties::HDCPProtectionType::HDCP_Unencrypted);
+        if ((const_cast<const Exchange::IConnectionProperties*>(_connectionProperties))->SupportedHDCPVersion(hdcpProtection) == Core::ERROR_NONE) {
+            displayInfo.Supportedhdcpversion = static_cast<JsonData::DisplayInfo::DisplayinfoData::HdcpprotectionType>(supportedHDCPVersion);
+        }
+
+        Exchange::IConnectionProperties::HDCPProtectionType displayHDCPVersion(Exchange::IConnectionProperties::HDCPProtectionType::HDCP_Unencrypted);
+        if ((const_cast<const Exchange::IConnectionProperties*>(_connectionProperties))->DisplayHDCPVersion(hdcpProtection) == Core::ERROR_NONE) {
+            displayInfo.Displayhdcpversion = static_cast<JsonData::DisplayInfo::DisplayinfoData::HdcpprotectionType>(displayHDCPVersion);
+        }
+
+        Exchange::IConnectionProperties::HDCPProtectionType currentHDCPVersion(Exchange::IConnectionProperties::HDCPProtectionType::HDCP_Unencrypted);
+        if ((const_cast<const Exchange::IConnectionProperties*>(_connectionProperties))->CurrentHDCPVersion(hdcpProtection) == Core::ERROR_NONE) {
+            displayInfo.Currenthdcpversion = static_cast<JsonData::DisplayInfo::DisplayinfoData::HdcpprotectionType>(currentHDCPVersion);
+        }
+
+
     }
 
     void DisplayInfo::Deactivated(RPC::IRemoteConnection* connection)

--- a/DisplayInfo/DisplayInfo.json
+++ b/DisplayInfo/DisplayInfo.json
@@ -296,6 +296,89 @@
                  ],
                 "example": "EOTF_SMPTE_ST_2084"
             }            
+        }, 
+        "ishdcpcompliant": {
+            "summary": "The status 'HDCP compliant' will return true if the display device is connected and HDCP is in an authenticated state. The internal display is intended for sink devices (TVs), while the connected display device is for streaming source devices (STBs).",
+            "readonly": true,
+            "params": {
+                "type": "boolean",
+                "example": false
+            }
+        },
+        "ishdcpenabled": {
+            "summary": "This status indicates whether HDCP is enabled in the software stack. Typically, HDCP is enabled by default on all devices but can be disabled by setting a software flag.",
+            "readonly": true,
+            "params": {
+                "type": "boolean",
+                "example": false
+            }
+        },
+        "ishdcpsupported": {
+            "summary": "This field indicates the HDCP support status, serving as a static indicator for HDCP compatibility. HDCP support is enabled by default on all RDK devices, ensuring compatibility with protected content.",
+            "readonly": true,
+            "params": {
+                "type": "boolean",
+                "example": false
+            }
+        },
+        "hdcpreason": {
+            "summary": "Gets hdcp status reason as integer status code",
+            "readonly": true,
+            "params": {
+                "type": "integer",
+                "size": 32,
+                "example": 0,
+                "value description":{
+                    "0" : "Connected Sink Device does not support HDCP",
+                    "1" : "HDCP Authentication Process is not initiated",
+                    "2" : "HDCP Authentication Process is initiated and Passed",
+                    "3" : "HDCP Authentication Failure or Link Integroty Failure",
+                    "4" : "HDCP Authentication in Progress",
+                    "5" : "HDMI output port disabled"
+				}
+            }
+        },
+        "supportedhdcpversion": {
+            "summary": "The supported HDCP version refers to the HDCP version of the host device.",
+            "readonly": true,
+            "params": {
+                "type": "string",
+                "enum": [
+                    "HdcpUnencrypted",
+                    "Hdcp1x",
+                    "Hdcp2x",
+                    "HdcpAuto"
+                ],
+                "example": "Hdcp1x"
+            }
+        },
+        "displayhdcpversion": {
+            "summary": "The 'Display HDCP version' refers to different HDCP versions depending on the device context: for the source device (STB), it indicates the HDCP version of the connected display, whereas for the sink device (TV), it will be the same HDCP version of the host device",
+            "readonly": true,
+            "params": {
+                "type": "string",
+                "enum": [
+                    "HdcpUnencrypted",
+                    "Hdcp1x",
+                    "Hdcp2x",
+                    "HdcpAuto"
+                ],
+                "example": "Hdcp1x"
+            }
+        },
+        "currenthdcpversion": {
+            "summary": "The 'Current HDCP version' refers to the HDCP version determined based on the capabilities of both the host device and the connected display.",
+            "readonly": true,
+            "params": {
+                "type": "string",
+                "enum": [
+                    "HdcpUnencrypted",
+                    "Hdcp1x",
+                    "Hdcp2x",
+                    "HdcpAuto"
+                ],
+                "example": "Hdcp1x"
+            }
         }
     },
     "events": {

--- a/HdcpProfile/HdcpProfile.json
+++ b/HdcpProfile/HdcpProfile.json
@@ -66,7 +66,7 @@
     },
     "methods": {
         "getHDCPStatus": {
-            "summary": "Returns HDCP-related data.  \n**hdcpReason Argument Values**  \n* `0`: HDMI cable is not connected or rx sense status is `off`  \n* `1`: Rx device is connected with power ON state, and HDCP authentication is not initiated  \n* `2`: HDCP success  \n* `3`:  HDCP authentication failed after multiple retries  \n* `4`:  HDCP authentication in progress   \n* `5`: HDMI video port is disabled.",
+            "summary": "This method is depricated use DisplayInfo plugin properties instead .Returns HDCP-related data.  \n**hdcpReason Argument Values**  \n* `0`: HDMI cable is not connected or rx sense status is `off`  \n* `1`: Rx device is connected with power ON state, and HDCP authentication is not initiated  \n* `2`: HDCP success  \n* `3`:  HDCP authentication failed after multiple retries  \n* `4`:  HDCP authentication in progress   \n* `5`: HDMI video port is disabled.",
             "result": {
                 "type":"object",
                 "properties": {


### PR DESCRIPTION
Reason for change:
Remove HDCPProfile and move the APIs DisplayInfo

Test Procedure: None
Risks: Low

Change-Id: Ifc737ef1a4aab3aaf36a4c5115dff86069e5abea Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>