### PR TITLE
RDK-51378: UserSettings Plugin missing default values

### DIFF
--- a/Tests/L2Tests/L2TestsPlugin/tests/UserSettings_L2Test.cpp
+++ b/Tests/L2Tests/L2TestsPlugin/tests/UserSettings_L2Test.cpp
@@ -572,7 +572,6 @@ TEST_F(UserSettingTest, SetAndGetMethodsUsingJsonRpcConnectionSuccessCase)
     uint32_t status = Core::ERROR_GENERAL;
     uint32_t signalled = UserSettings_StateInvalid;
 
-    JsonObject params;
     bool enabled = true;
     string preferredLanguages = "en";
     string presentationLanguages = "fra";
@@ -584,7 +583,7 @@ TEST_F(UserSettingTest, SetAndGetMethodsUsingJsonRpcConnectionSuccessCase)
 
     TEST_LOG("Testing AudioDescriptionSuccess");
     status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
-                                       _T("onaudiodescriptionchanged"),
+                                       _T("OnAudioDescriptionChanged"),
                                        [this, &async_handler](const JsonObject& parameters) {
                                            bool enabled = parameters["enabled"].Boolean();
                                            async_handler.OnAudioDescriptionChanged(enabled);
@@ -594,26 +593,27 @@ TEST_F(UserSettingTest, SetAndGetMethodsUsingJsonRpcConnectionSuccessCase)
     EXPECT_CALL(async_handler, OnAudioDescriptionChanged(MatchRequestStatusBool(enabled)))
     .WillOnce(Invoke(this, &UserSettingTest::OnAudioDescriptionChanged));
 
-    params["value"] = true;
-    status = InvokeServiceMethod("org.rdk.UserSettings", "setaudiodescription", params, result_json);
+    JsonObject paramsAudioDes;
+    paramsAudioDes["enabled"] = true;
+    status = InvokeServiceMethod("org.rdk.UserSettings", "SetAudioDescription", paramsAudioDes, result_json);
     EXPECT_EQ(status,Core::ERROR_NONE);
 
     signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_OnAudioDescriptionChanged);
     EXPECT_TRUE(signalled & UserSettings_OnAudioDescriptionChanged);
 
     /* Unregister for events. */
-    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("onaudiodescriptionchanged"));
+    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("OnAudioDescriptionChanged"));
     EXPECT_EQ(status,Core::ERROR_NONE);
 
-    status = InvokeServiceMethod("org.rdk.UserSettings", "getaudiodescription", result_bool);
+    status = InvokeServiceMethod("org.rdk.UserSettings", "GetAudioDescription", result_bool);
     EXPECT_EQ(status, Core::ERROR_NONE);
     EXPECT_TRUE(result_bool.Value());
 
     TEST_LOG("Testing PreferredAudioLanguagesSuccess");
     status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
-                                           _T("onpreferredaudiolanguageschanged"),
+                                           _T("OnPreferredAudioLanguagesChanged"),
                                            [&async_handler](const JsonObject& parameters) {
-                                           string preferredLanguages = parameters["preferredlanguages"].String();
+                                           string preferredLanguages = parameters["preferredLanguages"].String();
                                            async_handler.OnPreferredAudioLanguagesChanged(preferredLanguages);
                                        });
     EXPECT_EQ(Core::ERROR_NONE, status);
@@ -621,23 +621,24 @@ TEST_F(UserSettingTest, SetAndGetMethodsUsingJsonRpcConnectionSuccessCase)
     EXPECT_CALL(async_handler, OnPreferredAudioLanguagesChanged(MatchRequestStatusString(preferredLanguages)))
     .WillOnce(Invoke(this, &UserSettingTest::OnPreferredAudioLanguagesChanged));
 
-    params["value"] = preferredLanguages;
-    status = InvokeServiceMethod("org.rdk.UserSettings", "setpreferredaudiolanguages", params, result_json);
+    JsonObject paramsAudioLanguage;
+    paramsAudioLanguage["preferredLanguages"] = preferredLanguages;
+    status = InvokeServiceMethod("org.rdk.UserSettings", "SetPreferredAudioLanguages", paramsAudioLanguage, result_json);
     EXPECT_EQ(status,Core::ERROR_NONE);
 
     signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_OnPreferredAudioLanguagesChanged);
     EXPECT_TRUE(signalled & UserSettings_OnPreferredAudioLanguagesChanged);
-    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("onpreferredaudiolanguageschanged"));
+    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("OnPreferredAudioLanguagesChanged"));
 
-    status = InvokeServiceMethod("org.rdk.UserSettings", "getpreferredaudiolanguages", result_string);
+    status = InvokeServiceMethod("org.rdk.UserSettings", "GetPreferredAudioLanguages", result_string);
     EXPECT_EQ(status,Core::ERROR_NONE);
     EXPECT_EQ(result_string.Value(), preferredLanguages);
 
     TEST_LOG("Testing PresentationLanguageSuccess");
     status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
-                                           _T("onpresentationlanguagechanged"),
+                                           _T("OnPresentationLanguageChanged"),
                                            [&async_handler](const JsonObject& parameters) {
-                                           string presentationLanguages = parameters["presentationlanguages"].String();
+                                           string presentationLanguages = parameters["presentationLanguages"].String();
                                            async_handler.OnPresentationLanguageChanged(presentationLanguages);
                                        });
     EXPECT_EQ(Core::ERROR_NONE, status);
@@ -645,21 +646,22 @@ TEST_F(UserSettingTest, SetAndGetMethodsUsingJsonRpcConnectionSuccessCase)
     EXPECT_CALL(async_handler, OnPresentationLanguageChanged(MatchRequestStatusString(presentationLanguages)))
     .WillOnce(Invoke(this, &UserSettingTest::OnPresentationLanguageChanged));
 
-    params["value"] = presentationLanguages;
-    status = InvokeServiceMethod("org.rdk.UserSettings", "setpresentationlanguage", params, result_json);
+    JsonObject paramsPresLanguage;
+    paramsPresLanguage["presentationLanguages"] = presentationLanguages;
+    status = InvokeServiceMethod("org.rdk.UserSettings", "SetPresentationLanguage", paramsPresLanguage, result_json);
     EXPECT_EQ(status,Core::ERROR_NONE);
 
     signalled = WaitForRequestStatus(JSON_TIMEOUT, UserSettings_OnPresentationLanguageChanged);
     EXPECT_TRUE(signalled & UserSettings_OnPresentationLanguageChanged);
-    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("onpresentationlanguagechanged"));
+    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("OnPresentationLanguageChanged"));
 
-    status = InvokeServiceMethod("org.rdk.UserSettings", "getpresentationlanguage", result_string);
+    status = InvokeServiceMethod("org.rdk.UserSettings", "GetPresentationLanguage", result_string);
     EXPECT_EQ(status,Core::ERROR_NONE);
     EXPECT_EQ(result_string.Value(), presentationLanguages);
 
     TEST_LOG("Testing SetCaptionsSuccess");
     status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
-                                       _T("oncaptionschanged"),
+                                       _T("OnCaptionsChanged"),
                                        [this, &async_handler](const JsonObject& parameters) {
                                            bool enabled = parameters["enabled"].Boolean();
                                            async_handler.OnCaptionsChanged(enabled);
@@ -669,23 +671,24 @@ TEST_F(UserSettingTest, SetAndGetMethodsUsingJsonRpcConnectionSuccessCase)
     EXPECT_CALL(async_handler, OnCaptionsChanged(MatchRequestStatusBool(enabled)))
     .WillOnce(Invoke(this, &UserSettingTest::OnCaptionsChanged));
 
-    params["value"] = true;
-    status = InvokeServiceMethod("org.rdk.UserSettings", "setcaptions", params, result_json);
+    JsonObject paramsCaptions;
+    paramsCaptions["enabled"] = true;
+    status = InvokeServiceMethod("org.rdk.UserSettings", "SetCaptions", paramsCaptions, result_json);
     EXPECT_EQ(status,Core::ERROR_NONE);
 
     signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_OnCaptionsChanged);
     EXPECT_TRUE(signalled & UserSettings_OnCaptionsChanged);
-    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("oncaptionschanged"));
+    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("OnCaptionsChanged"));
 
-    status = InvokeServiceMethod("org.rdk.UserSettings", "getcaptions", result_bool);
+    status = InvokeServiceMethod("org.rdk.UserSettings", "GetCaptions", result_bool);
     EXPECT_EQ(status,Core::ERROR_NONE);
     EXPECT_TRUE(result_bool.Value());
 
     TEST_LOG("Testing SetPreferredCaptionsLanguagesSuccess");
     status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
-                                           _T("onpreferredcaptionslanguageschanged"),
+                                           _T("OnPreferredCaptionsLanguagesChanged"),
                                            [&async_handler](const JsonObject& parameters) {
-                                           string preferredCaptionsLanguages = parameters["preferredlanguages"].String();
+                                           string preferredCaptionsLanguages = parameters["preferredLanguages"].String();
                                            async_handler.OnPreferredCaptionsLanguagesChanged(preferredCaptionsLanguages);
                                        });
     EXPECT_EQ(Core::ERROR_NONE, status);
@@ -693,21 +696,22 @@ TEST_F(UserSettingTest, SetAndGetMethodsUsingJsonRpcConnectionSuccessCase)
     EXPECT_CALL(async_handler, OnPreferredCaptionsLanguagesChanged(MatchRequestStatusString(preferredCaptionsLanguages)))
     .WillOnce(Invoke(this, &UserSettingTest::OnPreferredCaptionsLanguagesChanged));
 
-    params["value"] = preferredCaptionsLanguages;
-    status = InvokeServiceMethod("org.rdk.UserSettings", "setpreferredcaptionslanguages", params, result_json);
+    JsonObject paramsPrefLang;
+    paramsPrefLang["preferredLanguages"] = preferredCaptionsLanguages;
+    status = InvokeServiceMethod("org.rdk.UserSettings", "SetPreferredCaptionsLanguages", paramsPrefLang, result_json);
     EXPECT_EQ(status,Core::ERROR_NONE);
 
     signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_OnPreferredCaptionsLanguagesChanged);
     EXPECT_TRUE(signalled & UserSettings_OnPreferredCaptionsLanguagesChanged);
-    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("onpreferredcaptionslanguageschanged"));
+    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("OnPreferredCaptionsLanguagesChanged"));
 
-    status = InvokeServiceMethod("org.rdk.UserSettings", "getpreferredcaptionslanguages", result_string);
+    status = InvokeServiceMethod("org.rdk.UserSettings", "GetPreferredCaptionsLanguages", result_string);
     EXPECT_EQ(status,Core::ERROR_NONE);
     EXPECT_EQ(result_string.Value(), preferredCaptionsLanguages);
 
     TEST_LOG("Testing SetPreferredClosedCaptionServiceSuccess");
     status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
-                                           _T("onpreferredclosedcaptionservicechanged"),
+                                           _T("OnPreferredClosedCaptionServiceChanged"),
                                            [&async_handler](const JsonObject& parameters) {
                                            string preferredService = parameters["service"].String();
                                            async_handler.OnPreferredClosedCaptionServiceChanged(preferredService);
@@ -717,15 +721,16 @@ TEST_F(UserSettingTest, SetAndGetMethodsUsingJsonRpcConnectionSuccessCase)
     EXPECT_CALL(async_handler, OnPreferredClosedCaptionServiceChanged(MatchRequestStatusString(preferredService)))
     .WillOnce(Invoke(this, &UserSettingTest::OnPreferredClosedCaptionServiceChanged));
 
-    params["value"] = preferredService;
-    status = InvokeServiceMethod("org.rdk.UserSettings", "setpreferredclosedcaptionservice", params, result_json);
+    JsonObject paramspreferredService;
+    paramspreferredService["service"] = preferredService;
+    status = InvokeServiceMethod("org.rdk.UserSettings", "SetPreferredClosedCaptionService", paramspreferredService, result_json);
     EXPECT_EQ(status,Core::ERROR_NONE);
 
     signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_OnPreferredClosedCaptionServiceChanged);
     EXPECT_TRUE(signalled & UserSettings_OnPreferredClosedCaptionServiceChanged);
-    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("onpreferredclosedcaptionservicechanged"));
+    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("OnPreferredClosedCaptionServiceChanged"));
 
-    status = InvokeServiceMethod("org.rdk.UserSettings", "getpreferredclosedcaptionservice", result_string);
+    status = InvokeServiceMethod("org.rdk.UserSettings", "GetPreferredClosedCaptionService", result_string);
     EXPECT_EQ(status,Core::ERROR_NONE);
     EXPECT_EQ(result_string.Value(), preferredService);
 }

--- a/Tests/L2Tests/patches/RDKV-48604-User-Settings-Thunder-Plugin.patch
+++ b/Tests/L2Tests/patches/RDKV-48604-User-Settings-Thunder-Plugin.patch
@@ -1,15 +1,15 @@
-commit f5fcf7060609b702016a710dd0a53a37528fbe52
+commit fa2d0c0221c33e4437a158e58a7a75de3f5c5a05
 Author: Siva Thandayuthapani <sithanda@synamedia.com>
-Date:   Mon Jun 24 13:45:39 2024 +0530
+Date:   Wed Jul 31 17:36:53 2024 +0530
 
-    R4.4.1 L2 test RDKV-48604-User-Settings-Thunder-Plugin.patch
+    patches
 
 diff --git a/interfaces/IUserSettings.h b/interfaces/IUserSettings.h
 new file mode 100755
-index 0000000..d223462
+index 0000000..95f21c1
 --- /dev/null
 +++ b/interfaces/IUserSettings.h
-@@ -0,0 +1,160 @@
+@@ -0,0 +1,166 @@
 +/*
 + * If not stated otherwise in this file or this component's LICENSE file the
 + * following copyright and licenses apply:
@@ -43,73 +43,80 @@ index 0000000..d223462
 +  struct EXTERNAL INotification : virtual public Core::IUnknown {
 +    enum { ID = ID_USER_SETTINGS_NOTIFICATION };
 +
++    // @alt OnAudioDescriptionChanged
 +    // @brief The AudioDescription setting has changed.
 +    // @param enabled: Enabled/Disabled.
 +    virtual void OnAudioDescriptionChanged(const bool enabled) = 0;
 +
++    // @alt OnPreferredAudioLanguagesChanged
 +    // @brief The preferredLanguages setting has changed.
 +    // @param preferredLanguages: PreferredLanguages.
-+    virtual void OnPreferredAudioLanguagesChanged(const string& preferredLanguages) = 0;
++    virtual void OnPreferredAudioLanguagesChanged(const string& preferredLanguages /* @text preferredLanguages */) = 0;
 +
++    // @alt OnPresentationLanguageChanged
 +    // @brief The PresentationLanguages setting has changed.
 +    // @param presentationLanguages: PresentationLanguages.
-+    virtual void OnPresentationLanguageChanged(const string& presentationLanguages) = 0;
++    virtual void OnPresentationLanguageChanged(const string& presentationLanguages /* @text presentationLanguages */) = 0;
 +
++    // @alt OnCaptionsChanged
 +    // @brief The Captions setting has changed.
 +    // @param enabled: Enabled/Disabled.
 +    virtual void OnCaptionsChanged(const bool enabled) = 0;
 +
++    // @alt OnPreferredCaptionsLanguagesChanged
 +    // @brief The PreferredCaptionsLanguages setting has changed.
 +    // @param preferredLanguages: PreferredLanguages.
-+    virtual void OnPreferredCaptionsLanguagesChanged(const string& preferredLanguages) = 0;
++    virtual void OnPreferredCaptionsLanguagesChanged(const string& preferredLanguages /* @text preferredLanguages */) = 0;
 +
++    // @alt OnPreferredClosedCaptionServiceChanged
 +    // @brief The PreferredClosedCaptionService setting has changed.
 +    // @param service: "CC[1-4]", "TEXT[1-4]", "SERVICE[1-64]".
 +    virtual void OnPreferredClosedCaptionServiceChanged(const string& service) = 0;
 +
++    // @alt OnPrivacyModeChanged
 +    // @brief The PrivacyMode setting has changed.
 +    // @param privacyMode: "SHARE", "DO_NOT_SHARE".
-+    virtual void OnPrivacyModeChanged(const string& privacyMode) = 0;
++    virtual void OnPrivacyModeChanged(const string& privacyMode /* @text privacyMode */) = 0;
 +  };
 +
 +  virtual uint32_t Register(Exchange::IUserSettings::INotification* notification /* @in */) = 0;
 +  virtual uint32_t Unregister(Exchange::IUserSettings::INotification* notification /* @in */) = 0;
 +
-+  // @property
++  // @alt SetAudioDescription
 +  // @brief Sets AudioDescription ON/OFF. Players should preferred Audio Descriptive tracks over normal audio track when enabled
 +  // @param enabled: Enabled/Disabled
 +  virtual uint32_t SetAudioDescription(const bool enabled /* @in */) = 0;
 +
-+  // @property
++  // @alt GetAudioDescription
 +  // @brief Gets the current AudioDescription setting
 +  // @param enabled: Enabled/Disabled
 +  virtual uint32_t GetAudioDescription(bool &enabled /* @out */) const = 0;
 +
-+  // @property
++  // @alt SetPreferredAudioLanguages
 +  // @brief A prioritized list of ISO 639-2/B codes for the preferred audio languages,
 +  // expressed as a comma separated lists of languages of zero of more elements.
 +  // The players will pick the audio track that has the best match compared with
 +  // this list. In the absence of a matching track, the player should by best
 +  // effort select the preferred audio track.*/
 +  // @param preferredLanguages: PreferredLanguages
-+  virtual uint32_t SetPreferredAudioLanguages(const string& preferredLanguages  /* @in */) = 0;
++  virtual uint32_t SetPreferredAudioLanguages(const string& preferredLanguages  /* @in @text preferredLanguages */) = 0;
 +
-+  // @property  
++  // @alt GetPreferredAudioLanguages
 +  // @brief Gets the current PreferredAudioLanguages setting
 +  // @param preferredLanguages: PreferredLanguages
-+  virtual uint32_t GetPreferredAudioLanguages(string &preferredLanguages /* @out */) const = 0;
++  virtual uint32_t GetPreferredAudioLanguages(string &preferredLanguages /* @out @text preferredLanguages */) const = 0;
 +
-+  // @property  
++  // @alt SetPresentationLanguage
 +  // @brief Sets the presentationLanguages in a full BCP 47 value, including script, region, variant
 +  // @param presentationLanguages: "en-US", "es-US", "en-CA", "fr-CA"
-+  virtual uint32_t SetPresentationLanguage(const string& presentationLanguages /* @in */) = 0;
++  virtual uint32_t SetPresentationLanguage(const string& presentationLanguages /* @in @text presentationLanguages */) = 0;
 +
-+  // @property  
++  // @alt GetPresentationLanguage
 +  // @brief Gets the presentationLanguages
 +  // @param presentationLanguages: "en-US", "es-US", "en-CA", "fr-CA"
-+  virtual uint32_t GetPresentationLanguage(string &presentationLanguages /* @out */) const = 0;
++  virtual uint32_t GetPresentationLanguage(string &presentationLanguages /* @out @text presentationLanguages */) const = 0;
 +
-+  // @property  
++  // @alt SetCaptions
 +  // @brief brief Sets Captions ON/OFF.
 +  // @details A setting of ON indicates that Players should select a subtitle track for presentation
 +  // The Setting does not influence any running sessions. It is up to the player to enforce the setting.
@@ -123,12 +130,12 @@ index 0000000..d223462
 +  // @param enabled Sets the state
 +  virtual uint32_t SetCaptions(const bool enabled  /* @in */) = 0;
 +
-+  // @property  
++  // @alt GetCaptions
 +  // @brief Gets the Captions setting.
 +  // @param enabled Receives the state
 +  virtual uint32_t GetCaptions(bool &enabled /* @out */) const = 0;
 +
-+  // @property  
++  // @alt SetPreferredCaptionsLanguages
 +  // @brief Set preferred languages for captions.
 +  // @details A prioritized list of ISO 639-2/B codes for the preferred Captions languages,
 +  // expressed as a comma separated lists of languages of zero of more elements.
@@ -136,40 +143,40 @@ index 0000000..d223462
 +  // this list. In the absence of a matching track, the player should by best
 +  // effort select the preferred subtitle track. 
 +  // @param preferredLanguages Is the list to set (e.g. "eng,fra")
-+  virtual uint32_t SetPreferredCaptionsLanguages(const string& preferredLanguages  /* @in */) = 0;
++  virtual uint32_t SetPreferredCaptionsLanguages(const string& preferredLanguages  /* @in @text preferredLanguages */) = 0;
 +
-+  // @property  
++  // @alt GetPreferredCaptionsLanguages
 +  // @brief Gets the current PreferredCaptionsLanguages setting.
 +  // @param preferredLanguages (e.g. "eng,fra")
-+  virtual uint32_t GetPreferredCaptionsLanguages(string &preferredLanguages /* @out */) const = 0;
++  virtual uint32_t GetPreferredCaptionsLanguages(string &preferredLanguages /* @out @text preferredLanguages */) const = 0;
 +
-+  // @property  
++  // @alt SetPreferredClosedCaptionService
 +  // @brief Sets the PreferredClosedCaptionService.
 +  // @details The setting should be honored by the player. The behaviour of AUTO may be player specific.
 +  // Valid input for service is "CC[1-4]", "TEXT[1-4]", "SERVICE[1-64]" 
 +  // @param service Identifies the service to display e.g. "CC3".
-+
 +  virtual uint32_t SetPreferredClosedCaptionService(const string& service  /* @in */) = 0;
 +
-+  // @property  
++  // @alt GetPreferredClosedCaptionService
 +  // @brief Gets the current PreferredClosedCaptionService setting.
 +  // @param service Identifies the service to display e.g. "CC3".
 +  virtual uint32_t GetPreferredClosedCaptionService(string &service /* @out */) const = 0;
 +
-+  // @property  
++  // @alt SetPrivacyMode
 +  // @brief Sets the PrivacyMode.
 +  // @details The setting should be honored by the Telemetry.
 +  // If privacyMode is "DO_NOT_SHARE", logs and crash report should not be uploaded.
 +  // @param privacyMode: "SHARE", "DO_NOT_SHARE"
-+  virtual uint32_t SetPrivacyMode(const string& privacyMode /* @in */) = 0;
++  virtual uint32_t SetPrivacyMode(const string& privacyMode /* @in @text privacyMode*/) = 0;
 +
-+  // @property  
++  // @alt GetPrivacyMode
 +  // @brief Gets the current PrivacyMode setting.
 +  // @param privacyMode e.g "SHARE"
-+  virtual uint32_t GetPrivacyMode(string &privacyMode /* @out */) const = 0;
++  virtual uint32_t GetPrivacyMode(string &privacyMode /* @out @text privacyMode */) const = 0;
 +};
 +} // namespace Exchange
 +} // namespace WPEFramework
+\ No newline at end of file
 diff --git a/interfaces/Ids.h b/interfaces/Ids.h
 index 64151cf..7aac530 100644
 --- a/interfaces/Ids.h

--- a/UserSettings/UserSettingsImplementation.cpp
+++ b/UserSettings/UserSettingsImplementation.cpp
@@ -317,6 +317,55 @@ void UserSettingsImplementation::ValueChanged(const Exchange::IStore2::ScopeType
     }
 }
 
+uint32_t UserSettingsImplementation::SetUserSettingsValue(const string& key, const string& value)
+{
+    uint32_t status = Core::ERROR_GENERAL;
+
+    ASSERT (nullptr != _remotStoreObject);
+    if (nullptr != _remotStoreObject)
+    {
+        status = _remotStoreObject->SetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, key, value, 0);
+    }
+
+    return status;
+}
+
+uint32_t UserSettingsImplementation::GetUserSettingsValue(const string& key, string &value) const
+{
+
+    uint32_t status = Core::ERROR_GENERAL;
+    uint32_t ttl = 0;
+
+    // Create a map of default values
+    std::map<string, string> usersettings_default_map = {{USERSETTINGS_AUDIO_DESCRIPTION_KEY, "false"},
+                                                         {USERSETTINGS_PREFERRED_AUDIO_LANGUAGES_KEY, ""},
+                                                         {USERSETTINGS_PRESENTATION_LANGUAGE_KEY, ""},
+                                                         {USERSETTINGS_CAPTIONS_KEY, "false"},
+                                                         {USERSETTINGS_PREFERRED_CAPTIONS_LANGUAGES_KEY, ""},
+                                                         {USERSETTINGS_PREFERRED_CLOSED_CAPTIONS_SERVICE_KEY, "AUTO"}};
+
+    ASSERT (nullptr != _remotStoreObject);
+    if (nullptr != _remotStoreObject)
+    {
+        status = _remotStoreObject->GetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, key, value, ttl);
+
+        LOGINFO("Key[%s] value[%s] status[%d]", key.c_str(), value.c_str(), status);
+        if(Core::ERROR_UNKNOWN_KEY == status || Core::ERROR_NOT_EXIST == status)
+        {
+            if(usersettings_default_map.find(key)!=usersettings_default_map.end())
+            {
+                value = usersettings_default_map[key];
+                status = Core::ERROR_NONE;
+            }
+            else
+            {
+                LOGERR("Default value is not found in usersettings_default_map for '%s' Key", key.c_str());
+            }
+        }
+    }
+    return status;
+}
+
 uint32_t UserSettingsImplementation::SetAudioDescription(const bool enabled)
 {
     uint32_t status = Core::ERROR_GENERAL;
@@ -325,12 +374,7 @@ uint32_t UserSettingsImplementation::SetAudioDescription(const bool enabled)
 
     _adminLock.Lock();
 
-    ASSERT (nullptr != _remotStoreObject);
-
-    if (nullptr != _remotStoreObject)
-    {
-        status = _remotStoreObject->SetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_AUDIO_DESCRIPTION_KEY, (enabled)?"true":"false", 0);
-    }
+    status = SetUserSettingsValue(USERSETTINGS_AUDIO_DESCRIPTION_KEY, (enabled)?"true":"false");
 
     _adminLock.Unlock();
 
@@ -341,26 +385,20 @@ uint32_t UserSettingsImplementation::GetAudioDescription(bool &enabled) const
 {
     uint32_t status = Core::ERROR_GENERAL;
     std::string value = "";
-    uint32_t ttl = 0;
 
     _adminLock.Lock();
 
-    ASSERT (nullptr != _remotStoreObject);
+    status = GetUserSettingsValue(USERSETTINGS_AUDIO_DESCRIPTION_KEY, value);
 
-    if (nullptr != _remotStoreObject)
+    if(Core::ERROR_NONE == status)
     {
-        status = _remotStoreObject->GetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_AUDIO_DESCRIPTION_KEY, value, ttl);
-
-        if(Core::ERROR_NONE == status)
+        if (0 == value.compare("true"))
         {
-            if (0 == value.compare("true"))
-            {
-                enabled = true;
-            }
-            else
-            {
-                enabled = false;
-            }
+            enabled = true;
+        }
+        else
+        {
+            enabled = false;
         }
     }
 
@@ -377,12 +415,7 @@ uint32_t UserSettingsImplementation::SetPreferredAudioLanguages(const string& pr
 
     _adminLock.Lock();
 
-    ASSERT (nullptr != _remotStoreObject);
-
-    if (nullptr != _remotStoreObject)
-    {
-        status = _remotStoreObject->SetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_PREFERRED_AUDIO_LANGUAGES_KEY, preferredLanguages, 0);
-    }
+    status = SetUserSettingsValue(USERSETTINGS_PREFERRED_AUDIO_LANGUAGES_KEY, preferredLanguages);
 
     _adminLock.Unlock();
 
@@ -393,16 +426,10 @@ uint32_t UserSettingsImplementation::GetPreferredAudioLanguages(string &preferre
 {
     uint32_t status = Core::ERROR_GENERAL;
     std::string value = "";
-    uint32_t ttl = 0;
 
     _adminLock.Lock();
 
-    ASSERT (nullptr != _remotStoreObject);
-
-    if (nullptr != _remotStoreObject)
-    {
-        status = _remotStoreObject->GetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_PREFERRED_AUDIO_LANGUAGES_KEY, preferredLanguages, ttl);
-    }
+    status = GetUserSettingsValue(USERSETTINGS_PREFERRED_AUDIO_LANGUAGES_KEY, preferredLanguages);
 
     _adminLock.Unlock();
 
@@ -417,12 +444,7 @@ uint32_t UserSettingsImplementation::SetPresentationLanguage(const string& prese
 
     _adminLock.Lock();
 
-    ASSERT (nullptr != _remotStoreObject);
-
-    if (nullptr != _remotStoreObject)
-    {
-        status = _remotStoreObject->SetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_PRESENTATION_LANGUAGE_KEY, presentationLanguages, 0);
-    }
+    status = SetUserSettingsValue(USERSETTINGS_PRESENTATION_LANGUAGE_KEY, presentationLanguages);
 
     _adminLock.Unlock();
 
@@ -433,16 +455,10 @@ uint32_t UserSettingsImplementation::GetPresentationLanguage(string &presentatio
 {
     uint32_t status = Core::ERROR_GENERAL;
     std::string value = "";
-    uint32_t ttl = 0;
 
     _adminLock.Lock();
 
-    ASSERT (nullptr != _remotStoreObject);
-
-    if (nullptr != _remotStoreObject)
-    {
-        status = _remotStoreObject->GetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_PRESENTATION_LANGUAGE_KEY, presentationLanguages, ttl);
-    }
+    status = GetUserSettingsValue(USERSETTINGS_PRESENTATION_LANGUAGE_KEY, presentationLanguages);
 
     _adminLock.Unlock();
 
@@ -457,12 +473,7 @@ uint32_t UserSettingsImplementation::SetCaptions(const bool enabled)
 
     _adminLock.Lock();
 
-    ASSERT (nullptr != _remotStoreObject);
-
-    if (nullptr != _remotStoreObject)
-    {
-        status = _remotStoreObject->SetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_CAPTIONS_KEY, (enabled)?"true":"false", 0);
-    }
+    status = SetUserSettingsValue(USERSETTINGS_CAPTIONS_KEY, (enabled)?"true":"false");
 
     _adminLock.Unlock();
 
@@ -473,26 +484,20 @@ uint32_t UserSettingsImplementation::GetCaptions(bool &enabled) const
 {
     uint32_t status = Core::ERROR_GENERAL;
     std::string value = "";
-    uint32_t ttl = 0;
 
     _adminLock.Lock();
 
-    ASSERT (nullptr != _remotStoreObject);
+    status = GetUserSettingsValue(USERSETTINGS_CAPTIONS_KEY, value);
 
-    if (nullptr != _remotStoreObject)
+    if(Core::ERROR_NONE == status)
     {
-        status = _remotStoreObject->GetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_CAPTIONS_KEY, value, ttl);
-
-        if(Core::ERROR_NONE == status)
+        if (0 == value.compare("true"))
         {
-            if (0 == value.compare("true"))
-            {
-                enabled = true;
-            }
-            else
-            {
-                enabled = false;
-            }
+            enabled = true;
+        }
+        else
+        {
+            enabled = false;
         }
     }
 
@@ -509,12 +514,7 @@ uint32_t UserSettingsImplementation::SetPreferredCaptionsLanguages(const string&
 
     _adminLock.Lock();
 
-    ASSERT (nullptr != _remotStoreObject);
-
-    if (nullptr != _remotStoreObject)
-    {
-        status = _remotStoreObject->SetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_PREFERRED_CAPTIONS_LANGUAGES_KEY, preferredLanguages, 0);
-    }
+    status = SetUserSettingsValue(USERSETTINGS_PREFERRED_CAPTIONS_LANGUAGES_KEY, preferredLanguages);
 
     _adminLock.Unlock();
 
@@ -525,16 +525,10 @@ uint32_t UserSettingsImplementation::GetPreferredCaptionsLanguages(string &prefe
 {
     uint32_t status = Core::ERROR_GENERAL;
     std::string value = "";
-    uint32_t ttl = 0;
 
     _adminLock.Lock();
 
-    ASSERT (nullptr != _remotStoreObject);
-
-    if (nullptr != _remotStoreObject)
-    {
-        status = _remotStoreObject->GetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_PREFERRED_CAPTIONS_LANGUAGES_KEY, preferredLanguages, ttl);
-    }
+    status = GetUserSettingsValue(USERSETTINGS_PREFERRED_CAPTIONS_LANGUAGES_KEY, preferredLanguages);
 
     _adminLock.Unlock();
 
@@ -549,12 +543,7 @@ uint32_t UserSettingsImplementation::SetPreferredClosedCaptionService(const stri
 
     _adminLock.Lock();
 
-    ASSERT (nullptr != _remotStoreObject);
-
-    if (nullptr != _remotStoreObject)
-    {
-        status = _remotStoreObject->SetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_PREFERRED_CLOSED_CAPTIONS_SERVICE_KEY, service, 0);
-    }
+    status = SetUserSettingsValue(USERSETTINGS_PREFERRED_CLOSED_CAPTIONS_SERVICE_KEY, service);
 
     _adminLock.Unlock();
 
@@ -565,16 +554,10 @@ uint32_t UserSettingsImplementation::GetPreferredClosedCaptionService(string &se
 {
     uint32_t status = Core::ERROR_GENERAL;
     std::string value = "";
-    uint32_t ttl = 0;
 
     _adminLock.Lock();
 
-    ASSERT (nullptr != _remotStoreObject);
-
-    if (nullptr != _remotStoreObject)
-    {
-        status = _remotStoreObject->GetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_PREFERRED_CLOSED_CAPTIONS_SERVICE_KEY, service, ttl);
-    }
+    status = GetUserSettingsValue(USERSETTINGS_PREFERRED_CLOSED_CAPTIONS_SERVICE_KEY, service);
 
     _adminLock.Unlock();
 

--- a/UserSettings/UserSettingsImplementation.h
+++ b/UserSettings/UserSettingsImplementation.h
@@ -149,6 +149,8 @@ namespace Plugin {
 
         void registerEventHandlers();
         void ValueChanged(const Exchange::IStore2::ScopeType scope, const string& ns, const string& key, const string& value);
+        uint32_t SetUserSettingsValue(const string& key, const string& value);
+        uint32_t GetUserSettingsValue(const string& key, string &value) const;
 
     private:
         mutable Core::CriticalSection _adminLock;


### PR DESCRIPTION
Reason for change: User Settings Plugin missing default values
Changes Done:
1. If the data is not available for User Setting namespace or keys in persistent store, returning the default values.
2. Added the L2 test cases for ERROR_NOT_EXIST and ERROR_UNKNOWN_KEY.
3. Updated the **RDKV-48604-User-Settings-Thunder-Plugin.patch** file with latest IUSerSettings.h changes for L2 tests.

Test Procedure: Run User Settings curl commands and check whether we are getting default values or not.
Also run L2 tests with latest thunder (L2-tests-R4-4-1.yml) and verify.

Risks: Medium
Priority: P1