### PR TITLE
RDKTV-31814 - getSupportedAudioModes returns empty array

### DIFF
--- a/DisplaySettings/CHANGELOG.md
+++ b/DisplaySettings/CHANGELOG.md
@@ -15,6 +15,11 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+
+## [1.4.6] - 2024-07-31
+### Added
+- Update getSupportedAudioModes to return based on audioports not video ports
+
 ## [1.4.5] - 2024-06-03
 ### Added
 - update common resolution list for getSupportedResolutions.

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -85,7 +85,7 @@ using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 4
-#define API_VERSION_NUMBER_PATCH 5
+#define API_VERSION_NUMBER_PATCH 6
 
 static bool isCecEnabled = false;
 static bool isResCacheUpdated = false;
@@ -1252,21 +1252,19 @@ namespace WPEFramework {
             {
                 bool HAL_hasSurround = false;
 
-                device::List<device::VideoOutputPort> vPorts = device::Host::getInstance().getVideoOutputPorts();
-                for (size_t i = 0; i < vPorts.size(); i++) {
-                    device::AudioOutputPort &aPort = vPorts.at(i).getAudioOutputPort();
-                    for (size_t j = 0; j < aPort.getSupportedStereoModes().size(); j++) {
-                        if (audioPort.empty() || Utils::String::stringContains(aPort.getName(), audioPort))
+                device::List<device::AudioOutputPort> aPorts = device::Host::getInstance().getAudioOutputPorts();
+                for (size_t i = 0; i < aPorts.size(); i++) {
+                    if (audioPort.empty() || Utils::String::stringContains(aPorts.at(i).getName(), audioPort))
+                    {
+                        for (size_t j = 0; j < aPorts.at(i).getSupportedStereoModes().size(); j++)
                         {
-                            string audioMode = aPort.getSupportedStereoModes().at(j).getName();
-
+                            string audioMode = aPorts.at(i).getSupportedStereoModes().at(j).getName();
                             // Starging Version 5, "Surround" mode is replaced by "Auto Mode"
                             if (strcasecmp(audioMode.c_str(),"SURROUND") == 0)
                             {
                                 HAL_hasSurround = true;
                                 continue;
                             }
-
                             vectorSet(supportedAudioModes,audioMode);
                         }
                     }
@@ -1303,7 +1301,7 @@ namespace WPEFramework {
                         supportedAudioModes.emplace_back("AUTO (Stereo)");
                     }
                 }
-		else if (audioPort.empty() || Utils::String::stringContains(audioPort, "SPDIF0") || Utils::String::stringContains(audioPort, "HDMI_ARC0"))
+		else if (audioPort.empty() || Utils::String::stringContains(audioPort, "SPDIF0") || Utils::String::stringContains(audioPort, "HDMI_ARC0") || Utils::String::stringContains(audioPort, "HEADPHONE0"))
                 {
                     if (HAL_hasSurround) {
                         supportedAudioModes.emplace_back("SURROUND");


### PR DESCRIPTION
Reason for change:
Update Displaysettings to not be based on videoport Other audio ports
Test Procedure: None
Risks: Low
Priority: P1

Signed-off-by:Hayden Gfeller <Hayden_Gfeller@comcast.com>