### PR TITLE
RDKDEV-991 - Add additional methods in UsbAccess plugin

### DIFF
--- a/UsbAccess/UsbAccess.cpp
+++ b/UsbAccess/UsbAccess.cpp
@@ -8,8 +8,11 @@
 #include <mutex>
 #include <fstream>
 #include "secure_wrapper.h"
+#include <sys/vfs.h>
+#include <sys/statvfs.h>
 #include "libIBus.h"
 #include "sysMgr.h"
+#include <sstream>
 
 #include "UtilsJsonRpc.h"
 #include "UtilsIarm.h"
@@ -19,12 +22,20 @@
 #define API_VERSION_NUMBER_PATCH 5
 const string WPEFramework::Plugin::UsbAccess::SERVICE_NAME = "org.rdk.UsbAccess";
 const string WPEFramework::Plugin::UsbAccess::METHOD_GET_FILE_LIST = "getFileList";
+const string WPEFramework::Plugin::UsbAccess::METHOD_GET_FILE_INFO = "getFileInfo";
 const string WPEFramework::Plugin::UsbAccess::METHOD_CREATE_LINK = "createLink";
 const string WPEFramework::Plugin::UsbAccess::METHOD_CLEAR_LINK = "clearLink";
 const string WPEFramework::Plugin::UsbAccess::METHOD_GET_AVAILABLE_FIRMWARE_FILES = "getAvailableFirmwareFiles";
 const string WPEFramework::Plugin::UsbAccess::METHOD_GET_MOUNTED = "getMounted";
+const string WPEFramework::Plugin::UsbAccess::METHOD_GET_MOUNTED_INFO = "getMountedInfo";
+const string WPEFramework::Plugin::UsbAccess::METHOD_GET_PARTITION_INFO = "getPartitionInfo";
+const string WPEFramework::Plugin::UsbAccess::METHOD_GET_PARTITION_COUNT = "getPartitionCount";
+const string WPEFramework::Plugin::UsbAccess::METHOD_GET_DEVICE_COUNT = "getDeviceCount";
+
 const string WPEFramework::Plugin::UsbAccess::METHOD_UPDATE_FIRMWARE = "updateFirmware";
 const string WPEFramework::Plugin::UsbAccess::METHOD_ARCHIVE_LOGS = "ArchiveLogs";
+const string WPEFramework::Plugin::UsbAccess::METHOD_GET_USB_SIZE = "getUSBSize";
+const string WPEFramework::Plugin::UsbAccess::METHOD_UNMOUNT_USB = "unmountUSB";
 const string WPEFramework::Plugin::UsbAccess::LINK_URL_HTTP = "http://localhost:50050/usbdrive";
 const string WPEFramework::Plugin::UsbAccess::LINK_PATH = "/tmp/usbdrive";
 const string WPEFramework::Plugin::UsbAccess::EVT_ON_USB_MOUNT_CHANGED = "onUSBMountChanged";
@@ -219,6 +230,13 @@ namespace Plugin {
         registerMethod(_T("getMounted"), &UsbAccess::getMountedWrapper, this);
         registerMethod(_T("updateFirmware"), &UsbAccess::updateFirmware, this);
         registerMethod(_T("ArchiveLogs"), &UsbAccess::archiveLogs, this);
+        registerMethod(_T("getUSBSize"), &UsbAccess::getUSBSizeWrapper, this);
+        registerMethod(_T("unmountUSB"), &UsbAccess::unmountUSBWrapper, this);
+        registerMethod(_T("getFileInfo"), &UsbAccess::getFileInfoWrapper, this);
+        registerMethod(_T("getMountedInfo"), &UsbAccess::getMountedInfoWrapper, this);
+        registerMethod(_T("getPartitionInfo"), &UsbAccess::getPartitionInfoWrapper, this);
+        registerMethod(_T("getPartitionCount"), &UsbAccess::getPartitionCountWrapper, this);
+        registerMethod(_T("getDeviceCount"), &UsbAccess::getDeviceCountWrapper, this);
     }
 
     UsbAccess::~UsbAccess()
@@ -302,6 +320,43 @@ namespace Plugin {
 
         returnResponse(result);
     }
+
+
+    uint32_t UsbAccess::getFileInfoWrapper(const JsonObject& parameters, JsonObject& response)
+    {
+        LOGINFOMETHOD();
+        bool result = false;
+
+        string pathParam;
+        if (parameters.HasLabel("path"))
+            pathParam = parameters["path"].String();
+
+        struct FileInfo fileinfo;
+        result = getFileInfo(pathParam, fileinfo);
+
+        if (!result)
+            response["error"] = "not found";
+        else
+        {
+            JsonArray arr;
+            //for_each(files.begin(), files.end(), [&arr](const FileEnt& it)
+            //{
+                JsonObject ent;
+                ent["name"] = fileinfo.fileName;
+                ent["Type"] = string(1, fileinfo.fileType);
+                ent["accessTime"] = fileinfo.accessTime;
+                ent["creatTime"] = fileinfo.creatTime;
+                ent["fileSize"] = fileinfo.fileSize;
+                ent["fileCount"] = fileinfo.fileCount;
+                ent["dirCount"] = fileinfo.dirCount;
+                //ent["totalTime"] = fileinfo.totalTime;
+                arr.Add(ent);
+            //});
+            response["contents"] = arr;
+        }
+        returnResponse(result);
+    }
+
 
     uint32_t UsbAccess::createLinkWrapper(const JsonObject &parameters, JsonObject &response)
     {
@@ -507,6 +562,169 @@ namespace Plugin {
             
         returnResponse(result);
     }
+
+    uint32_t UsbAccess::getPartitionCountWrapper(const JsonObject &parameters, JsonObject &response)
+    {
+        LOGINFOMETHOD();
+        bool result = true;
+        std::list<string> paths;
+        result =  getMounted(paths);
+        int PartitionCount = paths.size();
+        response["PartitionCount"] = PartitionCount;
+        returnResponse(result);
+    }
+
+
+    uint32_t UsbAccess::getPartitionInfoWrapper(const JsonObject &parameters, JsonObject &response)
+    {
+        LOGINFOMETHOD();
+        bool result = true;
+        char buffer[32] = "";
+        unsigned long long int blocksize = 0;
+        JsonArray arr;
+        JsonObject ent;
+        string pathParam;
+        if (parameters.HasLabel("path"))
+            pathParam = parameters["path"].String();
+
+        std::list<std::string> mountedPaths;
+        if (!getMounted(mountedPaths) || std::find(mountedPaths.begin(), mountedPaths.end(), pathParam) == mountedPaths.end())
+        {
+            result = false;
+            ent["error"] = "Invalid path";
+            LOGINFO("Invalid path\n");
+        }
+        else
+        {
+            struct statvfs fs;
+            if (statvfs(pathParam.c_str(), &fs) == -1) {
+                result = false;
+            }
+
+            FILE* fp = v_secure_popen("r", "df -T %s | tail -n +2 | awk '{print $2}'" , pathParam.c_str());
+            if (fp == NULL)
+            {
+                LOGERR("Cannot run command");
+                result = false;
+                return result;
+            }
+
+            while (fgets(buffer, 32, fp) != NULL);
+
+            string File_system = buffer;
+
+            int ret = v_secure_pclose(fp);
+            if (ret == -1)
+            {
+                result = false;
+            }
+
+            if (!result)
+            {
+                ent["error"] = "Not found";
+                LOGINFO("Not found\n");
+            }
+            else
+            {
+                blocksize = fs.f_frsize /1024;
+                ent["path"] = pathParam;
+                ent["FileSystem"] = File_system;
+                ent["size(MB)"] = blocksize;
+                ent["TotalBlocks"] = fs.f_blocks;
+                ent["AvailableBlocks"] =  fs.f_bavail;
+                ent["TotalSpace(MB)"] = (fs.f_blocks * blocksize) / 1024;
+                ent["UsedSpace(MB)"] =  ((fs.f_blocks - fs.f_bavail) * blocksize) / 1024;
+                ent["AvailableSpace(MB)"] = (fs.f_bavail * blocksize) / 1024;
+            }     
+
+            arr.Add(ent);
+            response["contents"] = arr;	
+        }
+        returnResponse(result);    
+    }
+
+    uint32_t UsbAccess::getMountedInfoWrapper(const JsonObject &parameters, JsonObject &response)
+    {
+        LOGINFOMETHOD();
+        bool result = true;
+        char buffer[32] = "";
+        std::list<string> paths;
+        result = getMounted(paths);
+        JsonArray arr;
+        JsonObject ent;
+        LOGINFO("paths count = %d\n", paths.size());
+
+
+        if(paths.size() != 0)
+        {
+            for_each(paths.begin(), paths.end(), [&](const string& it)
+            {
+                string name = "";
+                string command = "findmnt -n -o source ";
+                command = command + it;
+                FILE* fp = popen(command.c_str(), "r");
+                if (fp == NULL) 
+                {
+                    LOGERR("Cannot run command");
+                    result = false;
+                    return;
+                }   
+                
+                while (fgets(buffer, 32, fp) != NULL);
+
+                name = buffer;
+
+                int ret = pclose(fp);
+                if (ret == -1) 
+                {
+                    result = false;
+                }
+                ent["name"] = name;
+                ent["path"] = it;
+                arr.Add(ent);
+            });
+        }
+        else
+        {
+            result = false;
+            ent["error"] = "Not found";
+            LOGINFO("Not found\n");
+            arr.Add(ent);
+        }
+        
+        response["contents"] = arr;
+
+        returnResponse(result);
+    }
+
+
+    uint32_t UsbAccess::getDeviceCountWrapper(const JsonObject& parameters, JsonObject& response)
+    {
+        LOGINFOMETHOD();
+        bool result = true;
+        char buffer[32] = "";
+        string command =  "lsblk -o NAME,TYPE | grep \"disk\" | grep \"sd[a-z]\" | wc -l";
+        FILE* fp = popen(command.c_str(), "r");
+        if (fp == NULL) 
+        {
+            LOGERR("Cannot run command");
+            result = false;
+            return result;
+        }   
+        
+        while (fgets(buffer, 32, fp) != NULL);
+
+        string DeviceCount = buffer;
+
+        int ret = pclose(fp);
+        if (ret == -1) 
+        {
+            result = false;
+        }
+        response["DeviceCount"] = DeviceCount;
+        returnResponse(result);
+    }
+
 
     uint32_t UsbAccess::getMountedWrapper(const JsonObject &parameters, JsonObject &response)
     {
@@ -716,6 +934,80 @@ namespace Plugin {
         return result;
     }
 
+    // internal methods
+    bool UsbAccess::getFileInfo(const string& path, struct FileInfo& fileinfo)
+    {
+        bool result = false;
+        if (!path.empty())
+        {
+            //memset(&fileinfo, 0, sizeof(struct FileInfo));
+	    fileinfo = FileInfo();
+            struct stat file_stat;
+            if (stat(path.c_str(), &file_stat) == -1)
+            {
+                return result;
+            }
+            else
+            {
+                if (S_ISDIR(file_stat.st_mode))
+                {
+                    fileinfo.fileType = 'd';
+                    DIR *dirp = opendir(path.c_str());
+                    long int file_count = 0;
+                    long int dir_count = 0;
+                    struct dirent *entry;
+                    while ((entry = readdir(dirp)) != NULL)
+                    {
+                        if (entry->d_type == DT_REG)
+                        {
+                            file_count++;
+                        }
+                        else if (entry->d_type == DT_DIR)
+                        {
+                            if (strcmp(entry->d_name, ".") != 0 && strcmp(entry->d_name, "..") != 0) {
+                                dir_count++;
+                            }
+                        }
+                    }
+                    closedir(dirp);
+                    fileinfo.fileCount = file_count;
+                    fileinfo.dirCount = dir_count;
+                }
+                else
+                {
+                    fileinfo.fileType = 'f';
+                    fileinfo.fileCount = 0;
+                    fileinfo.dirCount = 0;
+                }
+
+
+                //get file name
+                string filePath = path.c_str();
+                size_t pos = filePath.find_last_of("/\\");
+                if (pos != std::string::npos)
+                {
+                    LOGINFO("filePath.substr: %s\n", filePath.substr(pos + 1).c_str());
+                    fileinfo.fileName = filePath.substr(pos + 1).c_str();
+                } else
+                {
+                    LOGINFO("filePath.substr: %s\n", filePath.c_str());
+                    fileinfo.fileName = filePath.c_str();
+                }
+
+                char atime_str[20];
+                char mtime_str[20];
+                strftime(atime_str, sizeof(atime_str), "%Y-%m-%d %H:%M:%S", localtime(&file_stat.st_atime));
+                strftime(mtime_str, sizeof(mtime_str), "%Y-%m-%d %H:%M:%S", localtime(&file_stat.st_mtime));
+                fileinfo.accessTime = atime_str;
+                fileinfo.creatTime = mtime_str;
+                fileinfo.fileSize = file_stat.st_size;
+                result = true;
+            }
+        }
+        return result;
+    }
+
+
     bool UsbAccess::getMounted(std::list <std::string>& paths)
     {
         bool result = false;
@@ -769,5 +1061,67 @@ namespace Plugin {
 
         return result;
     }
+
+    uint32_t UsbAccess::getUSBSizeWrapper(const JsonObject &parameters, JsonObject &response)
+    {
+        LOGINFOMETHOD();
+
+        bool result = false;
+        char totalsize[20] = {'\0'};
+        char usedsize[20] = {'\0'};
+        char freesize[20] = {'\0'};
+
+        string pathParam;
+        if (parameters.HasLabel("path"))
+        {
+            pathParam = parameters["path"].String();
+        }
+        else
+        {
+            response["error"] = "Mount path empty";
+            returnResponse(result);
+        }
+        FILE* fp = v_secure_popen("r", "df -h | grep %s$ | awk \'{print $2 \" \" $3 \" \" $4}\'", pathParam.c_str());
+        if(fp)
+        {
+            if(fscanf(fp,"%s %s %s", totalsize, usedsize, freesize) == EOF)
+            {
+                returnResponse(result);
+            }
+            response["totalsize"] = string(totalsize);
+            response["usedsize"] = string(usedsize);
+            response["freesize"] = string(freesize);
+            v_secure_pclose(fp);            
+            result = true;
+        }
+        returnResponse(result);
+    }
+
+    uint32_t UsbAccess::unmountUSBWrapper(const JsonObject &parameters, JsonObject &response)
+    {
+        LOGINFOMETHOD();
+
+        bool result = false;
+
+        string pathParam;
+        if (parameters.HasLabel("path"))
+        {
+            pathParam = parameters["path"].String();
+        }
+        else
+        {
+            response["error"] = "Mount path empty";
+            returnResponse(result);
+        }
+        FILE* fp = v_secure_popen("r", "systemd-umount -u %s", pathParam.c_str());
+        if(fp)
+        {
+            v_secure_pclose(fp);           
+            result = true;
+        }
+        returnResponse(result);
+    }
+
+
 } // namespace Plugin
 } // namespace WPEFramework

--- a/UsbAccess/UsbAccess.h
+++ b/UsbAccess/UsbAccess.h
@@ -30,12 +30,19 @@ namespace Plugin {
         static const string SERVICE_NAME;
         //methods
         static const string METHOD_GET_FILE_LIST;
+        static const string METHOD_GET_FILE_INFO;
         static const string METHOD_CREATE_LINK;
         static const string METHOD_CLEAR_LINK;
         static const string METHOD_GET_AVAILABLE_FIRMWARE_FILES;
         static const string METHOD_GET_MOUNTED;
+        static const string METHOD_GET_MOUNTED_INFO;
+        static const string METHOD_GET_PARTITION_INFO;
+        static const string METHOD_GET_DEVICE_COUNT;
+        static const string METHOD_GET_PARTITION_COUNT;
         static const string METHOD_UPDATE_FIRMWARE;
         static const string METHOD_ARCHIVE_LOGS;
+        static const string METHOD_GET_USB_SIZE;
+        static const string METHOD_UNMOUNT_USB;
         //events
         static const string EVT_ON_USB_MOUNT_CHANGED;
         static const string EVT_ON_ARCHIVE_LOGS;
@@ -63,13 +70,20 @@ namespace Plugin {
 
         //methods ("parameters" here is "params" from the curl request)
         uint32_t getFileListWrapper(const JsonObject& parameters, JsonObject& response);
+        uint32_t getFileInfoWrapper(const JsonObject& parameters, JsonObject& response);
         uint32_t createLinkWrapper(const JsonObject& parameters, JsonObject& response);
         uint32_t clearLinkWrapper(const JsonObject& parameters, JsonObject& response);
         uint32_t getLinksWrapper(const JsonObject& parameters, JsonObject& response);
         uint32_t getAvailableFirmwareFilesWrapper(const JsonObject& parameters, JsonObject& response);
         uint32_t getMountedWrapper(const JsonObject& parameters, JsonObject& response);
+        uint32_t getMountedInfoWrapper(const JsonObject& parameters, JsonObject& response);
+        uint32_t getPartitionInfoWrapper(const JsonObject& parameters, JsonObject& response);
+        uint32_t getDeviceCountWrapper(const JsonObject& parameters, JsonObject& response);
+        uint32_t getPartitionCountWrapper(const JsonObject& parameters, JsonObject& response);
         uint32_t updateFirmware(const JsonObject& parameters, JsonObject& response);
         uint32_t archiveLogs(const JsonObject& parameters, JsonObject& response);
+        uint32_t getUSBSizeWrapper(const JsonObject& parameters, JsonObject& response);
+        uint32_t unmountUSBWrapper(const JsonObject& parameters, JsonObject& response);
 
     private/*iarm*/:
         void InitializeIARM();
@@ -89,8 +103,29 @@ namespace Plugin {
         };
         typedef std::list<FileEnt> FileList;
 
+        struct FileInfo
+        {
+            char fileType; // 'f' or 'd'
+            string fileName;
+            string accessTime;
+            string creatTime;
+            long int fileSize;
+            long int fileCount;
+            long int dirCount;
+            long int totalTime;
+            string picSize;
+        };   
+
+        struct MountedInfo
+        {
+            string deviceName;
+            string mountPath;
+        };
+
         static bool getFileList(const string& path, FileList& files, const string& fileRegex, bool includeFolders);
+        static bool getFileInfo(const string& path, struct FileInfo& fileinfo);
         static bool getMounted(std::list<string>& paths);
+        static bool getMountedInfo(const string& path, struct MountedInfo& mountedinfo);
 
         void archiveLogsInternal();
         void onArchiveLogs(ArchiveLogsError error, const string& filePath);


### PR DESCRIPTION
Reason for change: unmountUSB, getUSBSize, getFileInfo, getMountedInfo, getPartitionInfo, getPartitionCount, getDeviceCount methods added in UsbAccess plugin. Support for 2 USB also added.

Risks: Low

Test Procedure: Use curl commands and verify all the commands give proper responses

From: lanyujie [lanyujie@skyworth.com](mailto:lanyujie@skyworth.com), zhangguangchen [zhangguangchen@skyworth.com](mailto:zhangguangchen@skyworth.com), niuben [niuben@skyworth.com](mailto:niuben@skyworth.com)