### PR TITLE
RDKDEV-1071 REFPLTV-2288 RDKServices : Wpeframework crash & restartin…

### DIFF
--- a/SystemServices/cTimer.h
+++ b/SystemServices/cTimer.h
@@ -49,7 +49,9 @@ class cTimer{
         bool start();
 
         /***
-         * @brief   : stop timer thread.
+         * @brief   : stop timer thread.After calling stop() either join() or detach() need to be called.
+	 if child thread (timerThread) done it's work call cTimer::detach() after cTimer::stop(). 
+	 if SystemServices plugin going to Deinitialize call cTimer::join() after cTimer::stop().
          * @return   : nil
          */
         void stop();


### PR DESCRIPTION
…g observed on setMode as Warehouse

Reason for change: Added logs in cTimer.h
Test Procedure: Build and verify.
Risks: Low
Signed-off-by: ramkumar_prabaharan@comcast.com