### PR TITLE
[BCM-1085]Unable to unmute the device after increasing the volume

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -3023,7 +3023,7 @@ namespace WPEFramework {
                         device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
 			current_volumelevel = (int)aPort.getLevel();
 			//unmute the device if it is currently muted and the volume is being changed
-                        if (aPort.isMuted() && level != current_volumelevel){
+                        if (aPort.isMuted()){
                                 aPort.setMuted(false);
                                 JsonObject params;
                                 params["muted"] = false;
@@ -3032,15 +3032,6 @@ namespace WPEFramework {
                         //Set the new volume level
                         aPort.setLevel(level); 
 
-                        // Check if the volume is set to 0 and mute the device
-                        if (level == 0.0) {
-                            aPort.setMuted(true);
-                            JsonObject params;
-                            params["muted"] = true;
-                            sendNotify("muteStatusChanged", params);
-                        }
-			
-                        //Notify if the levelhas change
                         if(current_volumelevel != (int)level)
                         {
                             JsonObject params;

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -3033,7 +3033,7 @@ namespace WPEFramework {
                         aPort.setLevel(level); 
 
                         // Check if the volume is set to 0 and mute the device
-                        if (level == 0) {
+                        if (level == 0.0) {
                             aPort.setMuted(true);
                             JsonObject params;
                             params["muted"] = true;

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -3030,7 +3030,16 @@ namespace WPEFramework {
                                 sendNotify("muteStatusChanged",params);
                         }
                         //Set the new volume level
-                        aPort.setLevel(level);
+                        aPort.setLevel(level); 
+
+                        // Check if the volume is set to 0 and mute the device
+                        if (level == 0) {
+                            aPort.setMuted(true);
+                            JsonObject params;
+                            params["muted"] = true;
+                            sendNotify("muteStatusChanged", params);
+                        }
+			
                         //Notify if the levelhas change
                         if(current_volumelevel != (int)level)
                         {

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -3022,7 +3022,16 @@ namespace WPEFramework {
                 {
                         device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
 			current_volumelevel = (int)aPort.getLevel();
+			//unmute the device if it is currently muted and the volume is being changed
++                       if (aPort.isMuted() && level != current_volumelevel){
++                               aPort.setMuted(false);
++                               JsonObject params;
++                               params["muted"] = false;
++                               sendNotify("muteStatusChanged",params);
++                       }
++                       //Set the new volume level
                         aPort.setLevel(level);
+                        //Notify if the levelhas change
                         if(current_volumelevel != (int)level)
                         {
                             JsonObject params;

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -3023,13 +3023,13 @@ namespace WPEFramework {
                         device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
 			current_volumelevel = (int)aPort.getLevel();
 			//unmute the device if it is currently muted and the volume is being changed
-+                       if (aPort.isMuted() && level != current_volumelevel){
-+                               aPort.setMuted(false);
-+                               JsonObject params;
-+                               params["muted"] = false;
-+                               sendNotify("muteStatusChanged",params);
-+                       }
-+                       //Set the new volume level
+                        if (aPort.isMuted() && level != current_volumelevel){
+                                aPort.setMuted(false);
+                                JsonObject params;
+                                params["muted"] = false;
+                                sendNotify("muteStatusChanged",params);
+                        }
+                        //Set the new volume level
                         aPort.setLevel(level);
                         //Notify if the levelhas change
                         if(current_volumelevel != (int)level)

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -3031,7 +3031,6 @@ namespace WPEFramework {
                         }
                         //Set the new volume level
                         aPort.setLevel(level); 
-
                         if(current_volumelevel != (int)level)
                         {
                             JsonObject params;


### PR DESCRIPTION
**Issue 1:**
Unable to unmute the device after increasing the volume level

**Scenario Flow**
Increase the volume after muting the device, then confirm that it is unmuted

**Script**
RDKV_CERT_AVS_Display_Settings_VA

**TestCase ID**
DS_54

**Steps to Reproduce**
1. Check the muted status using org.rdk.DisplaySettings.getMuted
```

root@brcm972126ott-refboard-PR0013507:~# curl --data-binary '{ "jsonrpc": "2.0", "id": 42, "method": "org.rdk.DisplaySettings.getMuted", "params": { "audioPort": "HDMI0" } }' http://127.0.0.1:9998/jsonrpc
{"jsonrpc":"2.0","id":42,"result":{"muted":false,"success":true}}root@brcm972126ott-refboard-PR0013507:~#
root@brcm972126ott-refboard-PR0013507:~#
```
2. If getmuted status is false then try to set muted status as true using org.rdk.DisplaySettings.setMuted else getmuted status is true skip step 2 and 3

```
root@brcm972126ott-refboard-PR0013507:~# curl --data-binary '{ "jsonrpc": "2.0", "id": 42, "method": "org.rdk.DisplaySettings.setMuted", "params": { "audioPort": "HDMI0", "muted": true } }' http://127.0.0.1:9998/jsonrpc
{"jsonrpc":"2.0","id":42,"result":{"success":true}}root@brcm972126ott-refboard-PR0013507:~#
root@brcm972126ott-refboard-PR0013507:~#
```
3. Check the muted status

```
root@brcm972126ott-refboard-PR0013507:~# curl --data-binary '{ "jsonrpc": "2.0", "id": 42, "method": "org.rdk.DisplaySettings.getMuted", "params": { "audioPort": "HDMI0" } }' http://127.0.0.1:9998/jsonrpc
{"jsonrpc":"2.0","id":42,"result":{"muted":true,"success":true}}root@brcm972126ott-refboard-PR0013507:~#
root@brcm972126ott-refboard-PR0013507:~#
```
4. Then Increase the volume level using org.rdk.DisplaySettings.1.setVolumeLevel

```
root@brcm972126ott-refboard-PR0013507:~# curl --header "Content-Type: application/json" --request POST --data '{"jsonrpc":"2.0", "id":3, "method":"org.rdk.DisplaySettings.1.setVolumeLevel", "params":{"audioPort":"HDMI0","volumeLevel":"70"}}' http://127.0.0.1:9998/jsonrpc
{"jsonrpc":"2.0","id":3,"result":{"success":true}}root@brcm972126ott-refboard-PR0013507:~#
```
root@brcm972126ott-refboard-PR0013507:~#
5. Check the volume level

```
root@brcm972126ott-refboard-PR0013507:~# curl --header "Content-Type: application/json" --request POST --data '{"jsonrpc":"2.0", "id":3, "method":"org.rdk.DisplaySettings.1.getVolumeLevel", "params":{"audioPort":"HDMI0"}' http://127.0.0.1:9998/jsonrpc
{"jsonrpc":"2.0","id":3,"result":{"volumeLevel":"70.000000","success":true}}root@brcm972126ott-refboard-PR0013507:~#
root@brcm972126ott-refboard-PR0013507:~#
```
6. Finally check the muted status
Observation still it is showing muted status as true only

```
root@brcm972126ott-refboard-PR0013507:~# curl --data-binary '{ "jsonrpc": "2.0", "id": 42, "method": "org.rdk.DisplaySettings.getMuted", "params": { "audioPort": "HDMI0" } }' http://127.0.0.1:9998/jsonrpc
{"jsonrpc":"2.0","id":42,"result":{"muted":true,"success":true}}root@brcm972126ott-refboard-PR0013507:~#
root@brcm972126ott-refboard-PR0013507:~#
```
Actual Result
Increase the volume after muting the device, then still it is showing muted status as true only

Expected Result
Increase the volume after muting the device, then it should show muted status as false

**Tested Build**

```
root@brcm972126ott-refboard-PR0013507:~# cat /version.txt
imagename:lib32-rdk-ipstb-tdk-image_BRCM972126OTT_FBT_TDK_rdk-next_20240604231907
BRANCH=rdk-next
YOCTO_VERSION=dunfell
VERSION=5.06.05.24
SPIN=0
BUILD_TIME="2024-06-04 23:19:07"
WPE_WEBKIT_VERSION=2.38.4+gitAUTOINC+fc1703ed69-r4
WPEFRAMEWORK-VERSION=R4.2
Generated on Tue Jun 04  23:19:07 UTC 2024
URSR_VERSION=24.0
root@brcm972126ott-refboard-PR0013507:~#
```
**Note**
Didn't tested these scenarios before. These are newly added testcase in AVS


**Issue 2:**
Unable to mute the device after setting the volume level to zero

**Scenario Flow**
Check the muted status after setting the volume level to zero then confirm that it is muted

**Script**
RDKV_CERT_AVS_Display_Settings_VA

**TestCase ID**
DS_55

**Steps to Reproduce**
1. Check the muted status using org.rdk.DisplaySettings.getMuted

```
root@brcm972126ott-refboard-PR0013912:~# curl --data-binary '{ "jsonrpc": "2.0", "id": 42, "method": "org.rdk.DisplaySettings.getMuted", "params": { "audioPort": "HDMI0" } }' http://127.0.0.1:9998/jsonrpc
{"jsonrpc":"2.0","id":42,"result":{"muted":false,"success":true}}root@brcm972126ott-refboard-PR0013912:~#
root@brcm972126ott-refboard-PR0013912:~# 
```

2. If getmuted status is true then try to set muted status as false using org.rdk.DisplaySettings.setMuted else getmuted status is true skip step 2 and 3

```
root@brcm972126ott-refboard-PR0013912:~# curl --data-binary '{ "jsonrpc": "2.0", "id": 42, "method": "org.rdk.DisplaySettings.setMuted", "params": { "audioPort": "HDMI0", "muted": false } }' http://127.0.0.1:9998/jsonrpc
{"jsonrpc":"2.0","id":42,"result":{"success":true}}root@brcm972126ott-refboard-PR0013912:~#
root@brcm972126ott-refboard-PR0013912:~# 
```

3. Check the muted status

```
root@brcm972126ott-refboard-PR0013912:~# curl --data-binary '{ "jsonrpc": "2.0", "id": 42, "method": "org.rdk.DisplaySettings.getMuted", "params": { "audioPort": "HDMI0" } }' http://127.0.0.1:9998/jsonrpc
{"jsonrpc":"2.0","id":42,"result":{"muted":false,"success":true}} 
root@brcm972126ott-refboard-PR0013912:~# 
```

4. Then set the volume level to zero using org.rdk.DisplaySettings.1.setVolumeLevel

```
root@brcm972126ott-refboard-PR0013912:~# curl --header "Content-Type: application/json" --request POST --data '{"jsonrpc":"2.0", "id":3, "method":"org.rdk.DisplaySettings.1.setVolumeLevel", "params":{"audioPort":"HDMI0","volumeLevel":"0"}}' http://127.0.0.1:9998/jsonrpc
{"jsonrpc":"2.0","id":3,"result":{"success":true}}root@brcm972126ott-refboard-PR0013912:~#
root@brcm972126ott-refboard-PR0013912:~# 
```

5. Check the volume level

```
root@brcm972126ott-refboard-PR0013912:~# curl --header "Content-Type: application/json" --request POST --data '{"jsonrpc":"2.0", "id":3, "method":"org.rdk.DisplaySettings.1.getVolumeLevel", "params":{"audioPort":"HDMI0"}' http://127.0.0.1:9998/jsonrpc
{"jsonrpc":"2.0","id":3,"result":{"volumeLevel":"0.000000","success":true}}root@brcm972126ott-refboard-PR0013912:~#
root@brcm972126ott-refboard-PR0013912:~# 
```

6. Finally check the muted status
Observation still it is showing muted status as false only

```
root@brcm972126ott-refboard-PR0013912:~#  curl --data-binary '{ "jsonrpc": "2.0", "id": 42, "method": "org.rdk.DisplaySettings.getMuted", "params": { "audioPort": "HDMI0" } }' http://127.0.0.1:9998/jsonrpc
{"jsonrpc":"2.0","id":42,"result":{"muted":false,"success":true}}root@brcm972126ott-refboard-PR0013912:~#
root@brcm972126ott-refboard-PR0013912:~# 
```

**Actual Result**
Set the volume level to zero, then still it is showing muted status as false only

**Expected Result**
Set the volume level to zero, then it should show muted status as true

**Tested Build**

```
root@brcm972126ott-refboard-PR0013912:~# cat /version.txt
imagename:lib32-rdk-ipstb-image_BRCM972126OTT_FBT_nightly-20240725-dunfell_20240725050552
BRANCH=nightly-20240725-dunfell
YOCTO_VERSION=dunfell
VERSION=nightly-20240725-dunfell.07.25.24
SPIN=0
BUILD_TIME="2024-07-25 05:05:52"
WPE_WEBKIT_VERSION=2.38.5+gitAUTOINC+44cb95d724-r10
WPEFRAMEWORK-VERSION=R4.4.1
Generated on Thu Jul 25  05:05:52 UTC 2024
URSR_VERSION=24.0
root@brcm972126ott-refboard-PR0013912:~# 
```
