### PR TITLE
RDK-51378: UserSettings Plugin missing default values

### DIFF
--- a/Tests/L2Tests/L2TestsPlugin/tests/UserSettings_L2Test.cpp
+++ b/Tests/L2Tests/L2TestsPlugin/tests/UserSettings_L2Test.cpp
@@ -233,6 +233,20 @@ UserSettingTest::~UserSettingTest()
 
     status = DeactivateService("org.rdk.UserSettings");
     EXPECT_EQ(Core::ERROR_NONE, status);
+
+    status = DeactivateService("org.rdk.PersistentStore");
+    EXPECT_EQ(Core::ERROR_NONE, status);
+
+    int file_status = remove("/tmp/secure/persistent/rdkservicestore");
+    // Check if the file has been successfully removed
+    if (file_status != 0)
+    {
+        TEST_LOG("Error deleting file[/tmp/secure/persistent/rdkservicestore]");
+    }
+    else
+    {
+        TEST_LOG("File[/tmp/secure/persistent/rdkservicestore] successfully deleted");
+    }
 }
 
 uint32_t UserSettingTest::WaitForRequestStatus(uint32_t timeout_ms, UserSettingsL2test_async_events_t expected_status)
@@ -377,282 +391,16 @@ MATCHER_P(MatchRequestStatusBool, expected, "")
     return expected == actual;
 }
 
-TEST_F(UserSettingTest,AudioDescriptionSuccess)
+/* Activating UserSettings and Persistent store plugins and UserSettings namespace has no entries in db.
+   So that we can verify whether UserSettings plugin is receiving default values from PersistentStore or not*/
+TEST_F(UserSettingTest, VerifyDefaultValues)
 {
-    JSONRPC::LinkType<Core::JSON::IElement> jsonrpc(USERSETTING_CALLSIGN, USERSETTINGL2TEST_CALLSIGN);
-    StrictMock<AsyncHandlerMock_UserSetting> async_handler;
     uint32_t status = Core::ERROR_GENERAL;
-    JsonObject params;
-    JsonObject result_json;
-    Core::JSON::Boolean result_bool;
-    bool expected_enabled = true;
     uint32_t signalled = UserSettings_StateInvalid;
-
-    TEST_LOG("Testing AudioDescriptionSuccess");
-
-    status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
-                                       _T("onaudiodescriptionchanged"),
-                                       [this, &async_handler](const JsonObject& parameters) {
-                                           bool enabled = parameters["enabled"].Boolean();
-                                           async_handler.OnAudioDescriptionChanged(enabled);
-                                       });
-
-    EXPECT_EQ(Core::ERROR_NONE, status);
-
-    EXPECT_CALL(async_handler, OnAudioDescriptionChanged(MatchRequestStatusBool(expected_enabled)))
-        .WillOnce(Invoke(this, &UserSettingTest::OnAudioDescriptionChanged));
-
-    params["value"] = true;
-    status = InvokeServiceMethod("org.rdk.UserSettings", "setaudiodescription", params, result_json);
-    EXPECT_EQ(status,Core::ERROR_NONE);
-
-    signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_OnAudioDescriptionChanged);
-    EXPECT_TRUE(signalled & UserSettings_OnAudioDescriptionChanged);
-
-    /* Unregister for events. */
-    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("onaudiodescriptionchanged"));
-
-    EXPECT_EQ(status,Core::ERROR_NONE);
-    if (status != Core::ERROR_NONE) {
-        TEST_LOG("Expected Core::ERROR_NONE (0) but got: %u", status);
-    }
-
-    status = InvokeServiceMethod("org.rdk.UserSettings", "getaudiodescription", result_bool);
-    EXPECT_EQ(status, Core::ERROR_NONE);
-
-    TEST_LOG("result_bool: %d", result_bool.Value());
-    EXPECT_TRUE(result_bool.Value());
-}
-
-TEST_F(UserSettingTest,PreferredAudioLanguagesSuccess)
-{
-    JSONRPC::LinkType<Core::JSON::IElement> jsonrpc(USERSETTING_CALLSIGN, USERSETTINGL2TEST_CALLSIGN);
-    StrictMock<AsyncHandlerMock_UserSetting> async_handler;
-    uint32_t status = Core::ERROR_GENERAL;
-    JsonObject params;
-    JsonObject result_json;
-    Core::JSON::String result_string;
-    std::string preferredLanguages = "en,fr,es";
-    uint32_t signalled = UserSettings_StateInvalid;
-
-    TEST_LOG("Testing PreferredAudioLanguagesSuccess");
-
-    status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
-                                           _T("onpreferredaudiolanguageschanged"),
-                                           [&async_handler](const JsonObject& parameters) {
-                                           std::string preferredLanguages = parameters["preferredLanguages"].String();
-                                           async_handler.OnPreferredAudioLanguagesChanged(preferredLanguages);
-                                       });
-
-    EXPECT_EQ(Core::ERROR_NONE, status);
-
-    EXPECT_CALL(async_handler, OnPreferredAudioLanguagesChanged(MatchRequestStatusString(preferredLanguages)))
-        .WillOnce(Invoke(this, &UserSettingTest::OnPreferredAudioLanguagesChanged));
-
-    params["value"] = preferredLanguages;
-    status = InvokeServiceMethod("org.rdk.UserSettings", "setpreferredaudiolanguages", params, result_json);
-    EXPECT_EQ(status,Core::ERROR_NONE);
-
-    signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_OnPreferredAudioLanguagesChanged);
-    EXPECT_TRUE(signalled & UserSettings_OnPreferredAudioLanguagesChanged);
-
-    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("onpreferredaudiolanguageschanged"));
-
-    EXPECT_EQ(status,Core::ERROR_NONE);
-    if (status != Core::ERROR_NONE) {
-        TEST_LOG("Expected Core::ERROR_NONE (0) but got: %u", status);
-    }
-
-    status = InvokeServiceMethod("org.rdk.UserSettings", "getpreferredaudiolanguages", result_string);
-    EXPECT_EQ(status,Core::ERROR_NONE);
-
-    EXPECT_EQ(result_string.Value(), preferredLanguages);
-}
-
-TEST_F(UserSettingTest,PresentationLanguageSuccess)
-{
-    JSONRPC::LinkType<Core::JSON::IElement> jsonrpc(USERSETTING_CALLSIGN, USERSETTINGL2TEST_CALLSIGN);
-    StrictMock<AsyncHandlerMock_UserSetting> async_handler;
-    uint32_t status = Core::ERROR_GENERAL;
-    JsonObject params;
-    JsonObject result_json;
-    Core::JSON::String result_string;
-    std::string presentationLanguage = "en";
-    uint32_t signalled = UserSettings_StateInvalid;
-
-    TEST_LOG("Testing PresentationLanguageSuccess");
-
-    status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
-                                           _T("onpresentationlanguagechanged"),
-                                           [&async_handler](const JsonObject& parameters) {
-                                           std::string presentationLanguage = parameters["presentationLanguages"].String();
-                                           async_handler.OnPresentationLanguageChanged(presentationLanguage);
-                                       });
-
-    EXPECT_EQ(Core::ERROR_NONE, status);
-
-    EXPECT_CALL(async_handler, OnPresentationLanguageChanged(MatchRequestStatusString(presentationLanguage)))
-        .WillOnce(Invoke(this, &UserSettingTest::OnPresentationLanguageChanged));
-
-    params["value"] = "en";
-    status = InvokeServiceMethod("org.rdk.UserSettings", "setpresentationlanguage", params, result_json);
-    EXPECT_EQ(status,Core::ERROR_NONE);
-
-    signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_OnPresentationLanguageChanged);
-    EXPECT_TRUE(signalled & UserSettings_OnPresentationLanguageChanged);
-
-    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("onpresentationlanguagechanged"));
-
-    EXPECT_EQ(status,Core::ERROR_NONE);
-    if (status != Core::ERROR_NONE) {
-        TEST_LOG("Expected Core::ERROR_NONE (0) but got: %u", status);
-    }
-
-    status = InvokeServiceMethod("org.rdk.UserSettings", "getpresentationlanguage", result_string);
-    EXPECT_EQ(status,Core::ERROR_NONE);
-
-    EXPECT_EQ(result_string.Value(), presentationLanguage);
-}
-
-TEST_F(UserSettingTest,SetCaptionsSuccess)
-{
-    JSONRPC::LinkType<Core::JSON::IElement> jsonrpc(USERSETTING_CALLSIGN, USERSETTINGL2TEST_CALLSIGN);
-    StrictMock<AsyncHandlerMock_UserSetting> async_handler;
-    uint32_t status = Core::ERROR_GENERAL;
-    JsonObject params;
-    JsonObject result_json;
-    Core::JSON::Boolean result_bool;
-    bool expected_enabled = true;
-    uint32_t signalled = UserSettings_StateInvalid;
-
-    TEST_LOG("Testing SetCaptionsSuccess");
-
-    status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
-                                       _T("oncaptionschanged"),
-                                       [this, &async_handler](const JsonObject& parameters) {
-                                           bool enabled = parameters["enabled"].Boolean();
-                                           async_handler.OnCaptionsChanged(enabled);
-                                       });
-
-    EXPECT_EQ(Core::ERROR_NONE, status);
-
-    EXPECT_CALL(async_handler, OnCaptionsChanged(MatchRequestStatusBool(expected_enabled)))
-        .WillOnce(Invoke(this, &UserSettingTest::OnCaptionsChanged));
-
-    params["value"] = true;
-    status = InvokeServiceMethod("org.rdk.UserSettings", "setcaptions", params, result_json);
-    EXPECT_EQ(status,Core::ERROR_NONE);
-
-    signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_OnCaptionsChanged);
-    EXPECT_TRUE(signalled & UserSettings_OnCaptionsChanged);
-
-    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("oncaptionschanged"));
-
-    EXPECT_EQ(status,Core::ERROR_NONE);
-    if (status != Core::ERROR_NONE) {
-        TEST_LOG("Expected Core::ERROR_NONE (0) but got: %u", status);
-    }
-
-    status = InvokeServiceMethod("org.rdk.UserSettings", "getcaptions", result_bool);
-    EXPECT_EQ(status,Core::ERROR_NONE);
-
-    TEST_LOG("result_bool: %d", result_bool.Value());
-    EXPECT_TRUE(result_bool.Value());
-}
-
-TEST_F(UserSettingTest,SetPreferredCaptionsLanguagesSuccess)
-{
-    JSONRPC::LinkType<Core::JSON::IElement> jsonrpc(USERSETTING_CALLSIGN, USERSETTINGL2TEST_CALLSIGN);
-    StrictMock<AsyncHandlerMock_UserSetting> async_handler;
-    uint32_t status = Core::ERROR_GENERAL;
-    JsonObject params;
-    JsonObject result_json;
-    Core::JSON::String result_string;
-    string preferredLanguages = "en,es";
-    uint32_t signalled = UserSettings_StateInvalid;
-
-    TEST_LOG("Testing SetPreferredCaptionsLanguagesSuccess");
-
-    status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
-                                           _T("onpreferredcaptionslanguageschanged"),
-                                           [&async_handler](const JsonObject& parameters) {
-                                           std::string preferredLanguages = parameters["preferredLanguages"].String();
-                                           async_handler.OnPreferredCaptionsLanguagesChanged(preferredLanguages);
-                                       });
-
-    EXPECT_EQ(Core::ERROR_NONE, status);
-
-    EXPECT_CALL(async_handler, OnPreferredCaptionsLanguagesChanged(MatchRequestStatusString(preferredLanguages)))
-        .WillOnce(Invoke(this, &UserSettingTest::OnPreferredCaptionsLanguagesChanged));
-
-    params["value"] = "en,es";
-    status = InvokeServiceMethod("org.rdk.UserSettings", "setpreferredcaptionslanguages", params, result_json);
-    EXPECT_EQ(status,Core::ERROR_NONE);
-
-    signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_OnPreferredCaptionsLanguagesChanged);
-    EXPECT_TRUE(signalled & UserSettings_OnPreferredCaptionsLanguagesChanged);
-
-    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("onpreferredcaptionslanguageschanged"));
-
-    EXPECT_EQ(status,Core::ERROR_NONE);
-    if (status != Core::ERROR_NONE) {
-        TEST_LOG("Expected Core::ERROR_NONE (0) but got: %u", status);
-    }
-
-    status = InvokeServiceMethod("org.rdk.UserSettings", "getpreferredcaptionslanguages", result_string);
-    EXPECT_EQ(status,Core::ERROR_NONE);
-
-    EXPECT_EQ(result_string.Value(), preferredLanguages);
-}
-
-TEST_F(UserSettingTest,SetPreferredClosedCaptionServiceSuccess)
-{
-    JSONRPC::LinkType<Core::JSON::IElement> jsonrpc(USERSETTING_CALLSIGN, USERSETTINGL2TEST_CALLSIGN);
-    StrictMock<AsyncHandlerMock_UserSetting> async_handler;
-    uint32_t status = Core::ERROR_GENERAL;
-    JsonObject params;
-    JsonObject result_json;
-    Core::JSON::String result_string;
-    string expected_service = "CC3";
-    uint32_t signalled = UserSettings_StateInvalid;
-
-    TEST_LOG("Testing SetPreferredClosedCaptionServiceSuccess");
-
-    status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
-                                           _T("onpreferredclosedcaptionservicechanged"),
-                                           [&async_handler](const JsonObject& parameters) {
-                                               std::string preferredService = parameters["service"].String();
-                                           async_handler.OnPreferredClosedCaptionServiceChanged(preferredService);
-                                       });
-    EXPECT_EQ(Core::ERROR_NONE, status);
-
-    EXPECT_CALL(async_handler, OnPreferredClosedCaptionServiceChanged(MatchRequestStatusString(expected_service)))
-        .WillOnce(Invoke(this, &UserSettingTest::OnPreferredClosedCaptionServiceChanged));
-
-    params["value"] = "CC3";
-    status = InvokeServiceMethod("org.rdk.UserSettings", "setpreferredclosedcaptionservice", params, result_json);
-    EXPECT_EQ(status,Core::ERROR_NONE);
-
-    signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_OnPreferredClosedCaptionServiceChanged);
-    EXPECT_TRUE(signalled & UserSettings_OnPreferredClosedCaptionServiceChanged);
-
-    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("onpreferredclosedcaptionservicechanged"));
-
-    EXPECT_EQ(status,Core::ERROR_NONE);
-    if (status != Core::ERROR_NONE) {
-        TEST_LOG("Expected Core::ERROR_NONE (0) but got: %u", status);
-    }
-
-    status = InvokeServiceMethod("org.rdk.UserSettings", "getpreferredclosedcaptionservice", result_string);
-    EXPECT_EQ(status,Core::ERROR_NONE);
-
-    EXPECT_EQ(result_string.Value(), expected_service);
-}
-
-TEST_F(UserSettingTest,AudioDescriptionSuccessUsingComRpcConnection)
-{
-    uint32_t status = Core::ERROR_GENERAL;
     Core::Sink<NotificationHandler> notification;
+    bool defaultBooleanValue = true;
+    string defaultStrValue = "eng";
+
     if (CreateUserSettingInterfaceObjectUsingComRPCConnection() != Core::ERROR_NONE)
     {
         TEST_LOG("Invalid Client_UserSettings");
@@ -662,12 +410,357 @@ TEST_F(UserSettingTest,AudioDescriptionSuccessUsingComRpcConnection)
         ASSERT_TRUE(m_controller_usersettings!= nullptr);
         if (m_controller_usersettings)
         {
-            uint32_t signalled = UserSettings_StateInvalid;
             ASSERT_TRUE(m_usersettingsplugin!= nullptr);
             if (m_usersettingsplugin)
             {
                 m_usersettingsplugin->AddRef();
                 m_usersettingsplugin->Register(&notification);
+
+                /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
+                status = m_usersettingsplugin->GetAudioDescription(defaultBooleanValue);
+                EXPECT_EQ(defaultBooleanValue, false);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* defaultStrValue should get empty string and the return status is Core::ERROR_NONE */
+                status = m_usersettingsplugin->GetPreferredAudioLanguages(defaultStrValue);
+                EXPECT_EQ(defaultStrValue, "");
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* defaultStrValue should get empty string and the return status is Core::ERROR_NONE */
+                status = m_usersettingsplugin->GetPresentationLanguage(defaultStrValue);
+                EXPECT_EQ(defaultStrValue, "");
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
+                status = m_usersettingsplugin->GetCaptions(defaultBooleanValue);
+                EXPECT_EQ(defaultBooleanValue, false);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* defaultStrValue should get empty string and the return status is Core::ERROR_NONE */
+                status = m_usersettingsplugin->GetPreferredCaptionsLanguages(defaultStrValue);
+                EXPECT_EQ(defaultStrValue, "");
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* defaultStrValue should get "AUTO" and the return status is Core::ERROR_NONE */
+                status = m_usersettingsplugin->GetPreferredClosedCaptionService(defaultStrValue);
+                EXPECT_EQ(defaultStrValue, "AUTO");
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                 /* Setting Audio Description value as true.So UserSettings namespace has one entry in db.
+                 But we are trying to get PreferredAudioLanguages, which has no entry in db.
+                 So GetPreferredAudioLanguages should return the empty string and the return status
+                 from Persistant store is  Core::ERROR_UNKNOWN_KEY and return status from usersettings is Core::ERROR_NONE */
+                 status = m_usersettingsplugin->SetAudioDescription(defaultBooleanValue);
+                 EXPECT_EQ(status,Core::ERROR_NONE);
+                 if (status != Core::ERROR_NONE)
+                 {
+                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                     TEST_LOG("Err: %s", errorMsg.c_str());
+                 }
+
+                 signalled = notification.WaitForRequestStatus(JSON_TIMEOUT,UserSettings_OnAudioDescriptionChanged);
+                 EXPECT_TRUE(signalled & UserSettings_OnAudioDescriptionChanged);
+
+                 /* We are trying to get PreferredAudioLanguages, which has no entry in db.
+                 Persistant store returns status as Core::ERROR_UNKNOWN_KEY to UserSettings 
+                 GetPreferredAudioLanguages should get the empty string.*/
+                status = m_usersettingsplugin->GetPreferredAudioLanguages(defaultStrValue);
+                EXPECT_EQ(defaultStrValue, "");
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* We are trying to get PresentationLanguage, which has no entry in db.
+                Persistant store returns status as Core::ERROR_UNKNOWN_KEY to UserSettings 
+                GetPreferredAudioLanguages should get the empty string.*/
+                status = m_usersettingsplugin->GetPresentationLanguage(defaultStrValue);
+                EXPECT_EQ(defaultStrValue, "");
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* We are trying to get Captions, which has no entry in db.
+                Persistant store returns status as Core::ERROR_UNKNOWN_KEY to UserSettings 
+                GetPreferredAudioLanguages should get the empty string.*/
+                status = m_usersettingsplugin->GetCaptions(defaultBooleanValue);
+                EXPECT_EQ(defaultBooleanValue, false);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* We are trying to get PreferredCaptionsLanguages, which has no entry in db.
+                Persistant store returns status as Core::ERROR_UNKNOWN_KEY to UserSettings 
+                GetPreferredAudioLanguages should get the empty string.*/
+                status = m_usersettingsplugin->GetPreferredCaptionsLanguages(defaultStrValue);
+                EXPECT_EQ(defaultStrValue, "");
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* We are trying to get PreferredClosedCaptionService, which has no entry in db.
+                Persistant store returns status as Core::ERROR_UNKNOWN_KEY to UserSettings 
+                GetPreferredAudioLanguages should get the empty string.*/
+                status = m_usersettingsplugin->GetPreferredClosedCaptionService(defaultStrValue);
+                EXPECT_EQ(defaultStrValue, "AUTO");
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                m_usersettingsplugin->Unregister(&notification);
+                m_usersettingsplugin->Release();
+            }
+            else
+            {
+                TEST_LOG("m_usersettingsplugin is NULL");
+            }
+            m_controller_usersettings->Release();
+        }
+        else
+        {
+            TEST_LOG("m_controller_usersettings is NULL");
+        }
+    }
+}
+
+TEST_F(UserSettingTest, SetAndGetMethodsUsingJsonRpcConnectionSuccessCase)
+{
+    JSONRPC::LinkType<Core::JSON::IElement> jsonrpc(USERSETTING_CALLSIGN, USERSETTINGL2TEST_CALLSIGN);
+    StrictMock<AsyncHandlerMock_UserSetting> async_handler;
+    uint32_t status = Core::ERROR_GENERAL;
+    uint32_t signalled = UserSettings_StateInvalid;
+
+    bool enabled = true;
+    string preferredLanguages = "en";
+    string presentationLanguages = "fra";
+    string preferredCaptionsLanguages = "en,es";
+    string preferredService = "CC3";
+    Core::JSON::String result_string;
+    Core::JSON::Boolean result_bool;
+    JsonObject result_json;
+
+    TEST_LOG("Testing AudioDescriptionSuccess");
+    status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
+                                       _T("OnAudioDescriptionChanged"),
+                                       [this, &async_handler](const JsonObject& parameters) {
+                                           bool enabled = parameters["enabled"].Boolean();
+                                           async_handler.OnAudioDescriptionChanged(enabled);
+                                       });
+    EXPECT_EQ(Core::ERROR_NONE, status);
+
+    EXPECT_CALL(async_handler, OnAudioDescriptionChanged(MatchRequestStatusBool(enabled)))
+    .WillOnce(Invoke(this, &UserSettingTest::OnAudioDescriptionChanged));
+
+    JsonObject paramsAudioDes;
+    paramsAudioDes["enabled"] = true;
+    status = InvokeServiceMethod("org.rdk.UserSettings", "SetAudioDescription", paramsAudioDes, result_json);
+    EXPECT_EQ(status,Core::ERROR_NONE);
+
+    signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_OnAudioDescriptionChanged);
+    EXPECT_TRUE(signalled & UserSettings_OnAudioDescriptionChanged);
+
+    /* Unregister for events. */
+    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("OnAudioDescriptionChanged"));
+    EXPECT_EQ(status,Core::ERROR_NONE);
+
+    status = InvokeServiceMethod("org.rdk.UserSettings", "GetAudioDescription", result_bool);
+    EXPECT_EQ(status, Core::ERROR_NONE);
+    EXPECT_TRUE(result_bool.Value());
+
+    TEST_LOG("Testing PreferredAudioLanguagesSuccess");
+    status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
+                                           _T("OnPreferredAudioLanguagesChanged"),
+                                           [&async_handler](const JsonObject& parameters) {
+                                           string preferredLanguages = parameters["preferredLanguages"].String();
+                                           async_handler.OnPreferredAudioLanguagesChanged(preferredLanguages);
+                                       });
+    EXPECT_EQ(Core::ERROR_NONE, status);
+
+    EXPECT_CALL(async_handler, OnPreferredAudioLanguagesChanged(MatchRequestStatusString(preferredLanguages)))
+    .WillOnce(Invoke(this, &UserSettingTest::OnPreferredAudioLanguagesChanged));
+
+    JsonObject paramsAudioLanguage;
+    paramsAudioLanguage["preferredLanguages"] = preferredLanguages;
+    status = InvokeServiceMethod("org.rdk.UserSettings", "SetPreferredAudioLanguages", paramsAudioLanguage, result_json);
+    EXPECT_EQ(status,Core::ERROR_NONE);
+
+    signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_OnPreferredAudioLanguagesChanged);
+    EXPECT_TRUE(signalled & UserSettings_OnPreferredAudioLanguagesChanged);
+    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("OnPreferredAudioLanguagesChanged"));
+
+    status = InvokeServiceMethod("org.rdk.UserSettings", "GetPreferredAudioLanguages", result_string);
+    EXPECT_EQ(status,Core::ERROR_NONE);
+    EXPECT_EQ(result_string.Value(), preferredLanguages);
+
+    TEST_LOG("Testing PresentationLanguageSuccess");
+    status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
+                                           _T("OnPresentationLanguageChanged"),
+                                           [&async_handler](const JsonObject& parameters) {
+                                           string presentationLanguages = parameters["presentationLanguages"].String();
+                                           async_handler.OnPresentationLanguageChanged(presentationLanguages);
+                                       });
+    EXPECT_EQ(Core::ERROR_NONE, status);
+
+    EXPECT_CALL(async_handler, OnPresentationLanguageChanged(MatchRequestStatusString(presentationLanguages)))
+    .WillOnce(Invoke(this, &UserSettingTest::OnPresentationLanguageChanged));
+
+    JsonObject paramsPresLanguage;
+    paramsPresLanguage["presentationLanguages"] = presentationLanguages;
+    status = InvokeServiceMethod("org.rdk.UserSettings", "SetPresentationLanguage", paramsPresLanguage, result_json);
+    EXPECT_EQ(status,Core::ERROR_NONE);
+
+    signalled = WaitForRequestStatus(JSON_TIMEOUT, UserSettings_OnPresentationLanguageChanged);
+    EXPECT_TRUE(signalled & UserSettings_OnPresentationLanguageChanged);
+    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("OnPresentationLanguageChanged"));
+
+    status = InvokeServiceMethod("org.rdk.UserSettings", "GetPresentationLanguage", result_string);
+    EXPECT_EQ(status,Core::ERROR_NONE);
+    EXPECT_EQ(result_string.Value(), presentationLanguages);
+
+    TEST_LOG("Testing SetCaptionsSuccess");
+    status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
+                                       _T("OnCaptionsChanged"),
+                                       [this, &async_handler](const JsonObject& parameters) {
+                                           bool enabled = parameters["enabled"].Boolean();
+                                           async_handler.OnCaptionsChanged(enabled);
+                                       });
+    EXPECT_EQ(Core::ERROR_NONE, status);
+
+    EXPECT_CALL(async_handler, OnCaptionsChanged(MatchRequestStatusBool(enabled)))
+    .WillOnce(Invoke(this, &UserSettingTest::OnCaptionsChanged));
+
+    JsonObject paramsCaptions;
+    paramsCaptions["enabled"] = true;
+    status = InvokeServiceMethod("org.rdk.UserSettings", "SetCaptions", paramsCaptions, result_json);
+    EXPECT_EQ(status,Core::ERROR_NONE);
+
+    signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_OnCaptionsChanged);
+    EXPECT_TRUE(signalled & UserSettings_OnCaptionsChanged);
+    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("OnCaptionsChanged"));
+
+    status = InvokeServiceMethod("org.rdk.UserSettings", "GetCaptions", result_bool);
+    EXPECT_EQ(status,Core::ERROR_NONE);
+    EXPECT_TRUE(result_bool.Value());
+
+    TEST_LOG("Testing SetPreferredCaptionsLanguagesSuccess");
+    status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
+                                           _T("OnPreferredCaptionsLanguagesChanged"),
+                                           [&async_handler](const JsonObject& parameters) {
+                                           string preferredCaptionsLanguages = parameters["preferredLanguages"].String();
+                                           async_handler.OnPreferredCaptionsLanguagesChanged(preferredCaptionsLanguages);
+                                       });
+    EXPECT_EQ(Core::ERROR_NONE, status);
+
+    EXPECT_CALL(async_handler, OnPreferredCaptionsLanguagesChanged(MatchRequestStatusString(preferredCaptionsLanguages)))
+    .WillOnce(Invoke(this, &UserSettingTest::OnPreferredCaptionsLanguagesChanged));
+
+    JsonObject paramsPrefLang;
+    paramsPrefLang["preferredLanguages"] = preferredCaptionsLanguages;
+    status = InvokeServiceMethod("org.rdk.UserSettings", "SetPreferredCaptionsLanguages", paramsPrefLang, result_json);
+    EXPECT_EQ(status,Core::ERROR_NONE);
+
+    signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_OnPreferredCaptionsLanguagesChanged);
+    EXPECT_TRUE(signalled & UserSettings_OnPreferredCaptionsLanguagesChanged);
+    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("OnPreferredCaptionsLanguagesChanged"));
+
+    status = InvokeServiceMethod("org.rdk.UserSettings", "GetPreferredCaptionsLanguages", result_string);
+    EXPECT_EQ(status,Core::ERROR_NONE);
+    EXPECT_EQ(result_string.Value(), preferredCaptionsLanguages);
+
+    TEST_LOG("Testing SetPreferredClosedCaptionServiceSuccess");
+    status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
+                                           _T("OnPreferredClosedCaptionServiceChanged"),
+                                           [&async_handler](const JsonObject& parameters) {
+                                           string preferredService = parameters["service"].String();
+                                           async_handler.OnPreferredClosedCaptionServiceChanged(preferredService);
+                                       });
+    EXPECT_EQ(Core::ERROR_NONE, status);
+
+    EXPECT_CALL(async_handler, OnPreferredClosedCaptionServiceChanged(MatchRequestStatusString(preferredService)))
+    .WillOnce(Invoke(this, &UserSettingTest::OnPreferredClosedCaptionServiceChanged));
+
+    JsonObject paramspreferredService;
+    paramspreferredService["service"] = preferredService;
+    status = InvokeServiceMethod("org.rdk.UserSettings", "SetPreferredClosedCaptionService", paramspreferredService, result_json);
+    EXPECT_EQ(status,Core::ERROR_NONE);
+
+    signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_OnPreferredClosedCaptionServiceChanged);
+    EXPECT_TRUE(signalled & UserSettings_OnPreferredClosedCaptionServiceChanged);
+    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("OnPreferredClosedCaptionServiceChanged"));
+
+    status = InvokeServiceMethod("org.rdk.UserSettings", "GetPreferredClosedCaptionService", result_string);
+    EXPECT_EQ(status,Core::ERROR_NONE);
+    EXPECT_EQ(result_string.Value(), preferredService);
+}
+
+TEST_F(UserSettingTest,SetAndGetMethodsUsingComRpcConnectionSuccessCase)
+{
+    uint32_t status = Core::ERROR_GENERAL;
+    bool getBoolValue = false;
+    string getStringValue = "";
+    Core::Sink<NotificationHandler> notification;
+    uint32_t signalled = UserSettings_StateInvalid;
+
+    if (CreateUserSettingInterfaceObjectUsingComRPCConnection() != Core::ERROR_NONE)
+    {
+        TEST_LOG("Invalid Client_UserSettings");
+    }
+    else
+    {
+        ASSERT_TRUE(m_controller_usersettings!= nullptr);
+        if (m_controller_usersettings)
+        {
+            ASSERT_TRUE(m_usersettingsplugin!= nullptr);
+            if (m_usersettingsplugin)
+            {
+                m_usersettingsplugin->AddRef();
+                m_usersettingsplugin->Register(&notification);
+
+                TEST_LOG("Setting and Getting AudioDescription Values");
                 status = m_usersettingsplugin->SetAudioDescription(true);
                 EXPECT_EQ(status,Core::ERROR_NONE);
                 if (status != Core::ERROR_NONE)
@@ -675,56 +768,11 @@ TEST_F(UserSettingTest,AudioDescriptionSuccessUsingComRpcConnection)
                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
                     TEST_LOG("Err: %s", errorMsg.c_str());
                 }
-
-                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT,UserSettings_OnAudioDescriptionChanged);
+                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT, UserSettings_OnAudioDescriptionChanged);
                 EXPECT_TRUE(signalled & UserSettings_OnAudioDescriptionChanged);
 
-                bool Enable = false;
-                status = m_usersettingsplugin->GetAudioDescription(Enable);
-                EXPECT_EQ(Enable, true);
-                EXPECT_EQ(status,Core::ERROR_NONE);
-                if (status != Core::ERROR_NONE)
-                {
-                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
-                    TEST_LOG("Err: %s", errorMsg.c_str());
-                }
-                m_usersettingsplugin->Unregister(&notification);
-                m_usersettingsplugin->Release();
-            }
-            else
-            {
-                TEST_LOG("m_usersettingsplugin is NULL");
-            }
-            m_controller_usersettings->Release();
-        }
-        else
-        {
-            TEST_LOG("m_controller_usersettings is NULL");
-        }
-    }
-}
-
-TEST_F(UserSettingTest,PreferredAudioLanguagesSuccessUsingComRpcConnection)
-{
-    uint32_t status = Core::ERROR_GENERAL;
-    Core::Sink<NotificationHandler> notification;
-    if (CreateUserSettingInterfaceObjectUsingComRPCConnection() != Core::ERROR_NONE)
-    {
-        TEST_LOG("Invalid Client_UserSettings");
-    }
-    else
-    {
-        ASSERT_TRUE(m_controller_usersettings!= nullptr);
-        if (m_controller_usersettings)
-        {
-            uint32_t signalled = UserSettings_StateInvalid;
-            ASSERT_TRUE(m_usersettingsplugin!= nullptr);
-            if (m_usersettingsplugin)
-            {
-                m_usersettingsplugin->AddRef();
-                m_usersettingsplugin->Register(&notification);
-                const string preferredLanguages = "eng";
-                status = m_usersettingsplugin->SetPreferredAudioLanguages(preferredLanguages);
+                status = m_usersettingsplugin->GetAudioDescription(getBoolValue);
+                EXPECT_EQ(getBoolValue, true);
                 EXPECT_EQ(status,Core::ERROR_NONE);
                 if (status != Core::ERROR_NONE)
                 {
@@ -732,56 +780,19 @@ TEST_F(UserSettingTest,PreferredAudioLanguagesSuccessUsingComRpcConnection)
                     TEST_LOG("Err: %s", errorMsg.c_str());
                 }
 
+                TEST_LOG("Setting and Getting PreferredAudioLanguages Values");
+                status = m_usersettingsplugin->SetPreferredAudioLanguages("eng");
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
                 signalled = notification.WaitForRequestStatus(JSON_TIMEOUT,UserSettings_OnPreferredAudioLanguagesChanged);
                 EXPECT_TRUE(signalled & UserSettings_OnPreferredAudioLanguagesChanged);
 
-                string preferredLanguages1 = "";
-                status = m_usersettingsplugin->GetPreferredAudioLanguages(preferredLanguages1);
-                EXPECT_EQ(preferredLanguages1, preferredLanguages);
-                EXPECT_EQ(status,Core::ERROR_NONE);
-                if (status != Core::ERROR_NONE)
-                {
-                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
-                    TEST_LOG("Err: %s", errorMsg.c_str());
-                }
-                m_usersettingsplugin->Unregister(&notification);
-                m_usersettingsplugin->Release();
-            }
-            else
-            {
-                TEST_LOG("m_usersettingsplugin is NULL");
-            }
-            m_controller_usersettings->Release();
-        }
-        else
-        {
-            TEST_LOG("m_controller_usersettings is NULL");
-        }
-    }
-}
-
-TEST_F(UserSettingTest,PresentationLanguageSuccessUsingComRpcConnection)
-{
-    uint32_t status = Core::ERROR_GENERAL;
-    Core::Sink<NotificationHandler> notification;
-
-    if (CreateUserSettingInterfaceObjectUsingComRPCConnection() != Core::ERROR_NONE)
-    {
-        TEST_LOG("Invalid mClient_UserSettings");
-    }
-    else
-    {
-        ASSERT_TRUE(m_controller_usersettings!= nullptr);
-        if (m_controller_usersettings)
-        {
-            uint32_t signalled = UserSettings_StateInvalid;
-            ASSERT_TRUE(m_usersettingsplugin!= nullptr);
-            if (m_usersettingsplugin)
-            {
-                m_usersettingsplugin->AddRef();
-                m_usersettingsplugin->Register(&notification);
-                const string presentationLanguage = "fra";
-                status = m_usersettingsplugin->SetPresentationLanguage(presentationLanguage);
+                status = m_usersettingsplugin->GetPreferredAudioLanguages(getStringValue);
+                EXPECT_EQ(getStringValue, "eng");
                 EXPECT_EQ(status,Core::ERROR_NONE);
                 if (status != Core::ERROR_NONE)
                 {
@@ -789,54 +800,28 @@ TEST_F(UserSettingTest,PresentationLanguageSuccessUsingComRpcConnection)
                     TEST_LOG("Err: %s", errorMsg.c_str());
                 }
 
+                TEST_LOG("Setting and Getting PresentationLanguage Values");
+                status = m_usersettingsplugin->SetPresentationLanguage("fra");
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
                 signalled = notification.WaitForRequestStatus(JSON_TIMEOUT,UserSettings_OnPresentationLanguageChanged);
                 EXPECT_TRUE(signalled & UserSettings_OnPresentationLanguageChanged);
 
-                string presentationLanguage1 = "";
-                status = m_usersettingsplugin->GetPresentationLanguage(presentationLanguage1);
-                EXPECT_EQ(presentationLanguage1, presentationLanguage);
+                status = m_usersettingsplugin->GetPresentationLanguage(getStringValue);
+                EXPECT_EQ(getStringValue, "fra");
                 EXPECT_EQ(status,Core::ERROR_NONE);
                 if (status != Core::ERROR_NONE)
                 {
                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
                     TEST_LOG("Err: %s", errorMsg.c_str());
                 }
-                m_usersettingsplugin->Unregister(&notification);
-                m_usersettingsplugin->Release();
-            }
-            else
-            {
-                TEST_LOG("m_usersettingsplugin is NULL");
-            }
-            m_controller_usersettings->Release();
-        }
-        else
-        {
-            TEST_LOG("m_controller_usersettings is NULL");
-        }
-    }
-}
 
-TEST_F(UserSettingTest,CaptionsSuccessUsingComRpcConnection)
-{
-    uint32_t status = Core::ERROR_GENERAL;
-    Core::Sink<NotificationHandler> notification;
-
-    if (CreateUserSettingInterfaceObjectUsingComRPCConnection() != Core::ERROR_NONE)
-    {
-        TEST_LOG("Invalid Client_UserSettings");
-    }
-    else
-    {
-        ASSERT_TRUE(m_controller_usersettings!= nullptr);
-        if (m_controller_usersettings)
-        {
-            uint32_t signalled = UserSettings_StateInvalid;
-            ASSERT_TRUE(m_usersettingsplugin!= nullptr);
-            if (m_usersettingsplugin)
-            {
-                m_usersettingsplugin->AddRef();
-                m_usersettingsplugin->Register(&notification);
+                TEST_LOG("Setting and Getting Captions Values");
+                getBoolValue = false;
                 status = m_usersettingsplugin->SetCaptions(true);
                 EXPECT_EQ(status,Core::ERROR_NONE);
                 if (status != Core::ERROR_NONE)
@@ -844,57 +829,11 @@ TEST_F(UserSettingTest,CaptionsSuccessUsingComRpcConnection)
                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
                     TEST_LOG("Err: %s", errorMsg.c_str());
                 }
-
                 signalled = notification.WaitForRequestStatus(JSON_TIMEOUT,UserSettings_OnCaptionsChanged);
                 EXPECT_TRUE(signalled & UserSettings_OnCaptionsChanged);
 
-                bool Enable = false;
-                status = m_usersettingsplugin->GetCaptions(Enable);
-                EXPECT_EQ(Enable, true);
-                EXPECT_EQ(status,Core::ERROR_NONE);
-                if (status != Core::ERROR_NONE)
-                {
-                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
-                    TEST_LOG("Err: %s", errorMsg.c_str());
-                }
-                m_usersettingsplugin->Unregister(&notification);
-                m_usersettingsplugin->Release();
-            }
-            else
-            {
-                TEST_LOG("m_usersettingsplugin is NULL");
-            }
-            m_controller_usersettings->Release();
-        }
-        else
-        {
-            TEST_LOG("m_controller_usersettings is NULL");
-        }
-    }
-}
-
-TEST_F(UserSettingTest,PreferredCaptionsLanguagesSuccessUsingComRpcConnection)
-{
-    uint32_t status = Core::ERROR_GENERAL;
-    Core::Sink<NotificationHandler> notification;
-
-    if (CreateUserSettingInterfaceObjectUsingComRPCConnection() != Core::ERROR_NONE)
-    {
-        TEST_LOG("Invalid mClient_UserSettings");
-    }
-    else
-    {
-        ASSERT_TRUE(m_controller_usersettings!= nullptr);
-        if (m_controller_usersettings)
-        {
-            const string preferredCaptionsLanguages = "eng";
-            uint32_t signalled = UserSettings_StateInvalid;
-            ASSERT_TRUE(m_usersettingsplugin!= nullptr);
-            if (m_usersettingsplugin)
-            {
-                m_usersettingsplugin->AddRef();
-                m_usersettingsplugin->Register(&notification);
-                status = m_usersettingsplugin->SetPreferredCaptionsLanguages(preferredCaptionsLanguages);
+                status = m_usersettingsplugin->GetCaptions(getBoolValue);
+                EXPECT_EQ(getBoolValue, true);
                 EXPECT_EQ(status,Core::ERROR_NONE);
                 if (status != Core::ERROR_NONE)
                 {
@@ -902,18 +841,46 @@ TEST_F(UserSettingTest,PreferredCaptionsLanguagesSuccessUsingComRpcConnection)
                     TEST_LOG("Err: %s", errorMsg.c_str());
                 }
 
+                TEST_LOG("Setting and Getting Captions Values");
+                status = m_usersettingsplugin->SetPreferredCaptionsLanguages("en,es");
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
                 signalled = notification.WaitForRequestStatus(JSON_TIMEOUT,UserSettings_OnPreferredCaptionsLanguagesChanged);
                 EXPECT_TRUE(signalled & UserSettings_OnPreferredCaptionsLanguagesChanged);
 
-                string preferredCaptionsLanguages1 = "";
-                status = m_usersettingsplugin->GetPreferredCaptionsLanguages(preferredCaptionsLanguages1);
-                EXPECT_EQ(preferredCaptionsLanguages1, preferredCaptionsLanguages);
+                status = m_usersettingsplugin->GetPreferredCaptionsLanguages(getStringValue);
+                EXPECT_EQ(getStringValue, "en,es");
                 EXPECT_EQ(status,Core::ERROR_NONE);
                 if (status != Core::ERROR_NONE)
                 {
                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
                     TEST_LOG("Err: %s", errorMsg.c_str());
                 }
+
+                TEST_LOG("Setting and Getting PreferredClosedCaptionService Values");
+                status = m_usersettingsplugin->SetPreferredClosedCaptionService("CC3");
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT,UserSettings_OnPreferredClosedCaptionServiceChanged);
+                EXPECT_TRUE(signalled & UserSettings_OnPreferredClosedCaptionServiceChanged);
+
+                status = m_usersettingsplugin->GetPreferredClosedCaptionService(getStringValue);
+                EXPECT_EQ(getStringValue, "CC3");
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
                 m_usersettingsplugin->Unregister(&notification);
                 m_usersettingsplugin->Release();
             }
@@ -930,59 +897,3 @@ TEST_F(UserSettingTest,PreferredCaptionsLanguagesSuccessUsingComRpcConnection)
     }
 }
 
-TEST_F(UserSettingTest,PreferredClosedCaptionServiceSuccessUsingComRpcConnection)
-{
-    uint32_t status = Core::ERROR_GENERAL;
-    Core::Sink<NotificationHandler> notification;
-
-    if (CreateUserSettingInterfaceObjectUsingComRPCConnection() != Core::ERROR_NONE)
-    {
-        TEST_LOG("Invalid Client_UserSettings");
-    }
-    else
-    {
-        ASSERT_TRUE(m_controller_usersettings!= nullptr);
-        if (m_controller_usersettings)
-        {
-            uint32_t signalled = UserSettings_StateInvalid;
-            ASSERT_TRUE(m_usersettingsplugin!= nullptr);
-            if (m_usersettingsplugin)
-            {
-                m_usersettingsplugin->AddRef();
-                m_usersettingsplugin->Register(&notification);
-                const string preferredClosedCaptionService = "CC3";
-                status = m_usersettingsplugin->SetPreferredClosedCaptionService(preferredClosedCaptionService);
-                EXPECT_EQ(status,Core::ERROR_NONE);
-                if (status != Core::ERROR_NONE)
-                {
-                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
-                    TEST_LOG("Err: %s", errorMsg.c_str());
-                }
-
-                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT,UserSettings_OnPreferredClosedCaptionServiceChanged);
-                EXPECT_TRUE(signalled & UserSettings_OnPreferredClosedCaptionServiceChanged);
-
-                string preferredClosedCaptionService1 = "";
-                status = m_usersettingsplugin->GetPreferredClosedCaptionService(preferredClosedCaptionService1);
-                EXPECT_EQ(preferredClosedCaptionService1, preferredClosedCaptionService);
-                EXPECT_EQ(status,Core::ERROR_NONE);
-                if (status != Core::ERROR_NONE)
-                {
-                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
-                    TEST_LOG("Err: %s", errorMsg.c_str());
-                }
-                m_usersettingsplugin->Unregister(&notification);
-                m_usersettingsplugin->Release();
-            }
-            else
-            {
-                TEST_LOG("UserSettingsPlugin is NULL");
-            }
-            m_controller_usersettings->Release();
-        }
-        else
-        {
-            TEST_LOG("m_controller_usersettings is NULL");
-        }
-    }
-}

--- a/Tests/L2Tests/patches/RDKV-48604-User-Settings-Thunder-Plugin.patch
+++ b/Tests/L2Tests/patches/RDKV-48604-User-Settings-Thunder-Plugin.patch
@@ -1,18 +1,15 @@
-From 6382e8759eb966a7b4d2a1f1d0988edb35194aa3 Mon Sep 17 00:00:00 2001
-From: kprathyusha <kprathyusha@synamedia.com>
-Date: Wed, 26 Jun 2024 15:42:01 +0530
-Subject: [PATCH] Add ITextToSpeech.h
+commit fa2d0c0221c33e4437a158e58a7a75de3f5c5a05
+Author: Siva Thandayuthapani <sithanda@synamedia.com>
+Date:   Wed Jul 31 17:36:53 2024 +0530
 
----
- interfaces/IUserSettings.h | 146 +++++++++++++++++++++++++++++++++++++++++++++
- interfaces/Ids.h           |   5 +-
- 2 files changed, 150 insertions(+), 1 deletion(-)
- create mode 100755 interfaces/IUserSettings.h
+    patches
 
-diff -uprN a/interfaces/IUserSettings.h b/interfaces/IUserSettings.h
---- a/interfaces/IUserSettings.h	1970-01-01 03:00:00.000000000 +0300
-+++ b/interfaces/IUserSettings.h	2024-06-27 18:41:13.733055666 +0300
-@@ -0,0 +1,178 @@
+diff --git a/interfaces/IUserSettings.h b/interfaces/IUserSettings.h
+new file mode 100755
+index 0000000..95f21c1
+--- /dev/null
++++ b/interfaces/IUserSettings.h
+@@ -0,0 +1,166 @@
 +/*
 + * If not stated otherwise in this file or this component's LICENSE file the
 + * following copyright and licenses apply:
@@ -85,19 +82,16 @@ diff -uprN a/interfaces/IUserSettings.h b/interfaces/IUserSettings.h
 +  virtual uint32_t Register(Exchange::IUserSettings::INotification* notification /* @in */) = 0;
 +  virtual uint32_t Unregister(Exchange::IUserSettings::INotification* notification /* @in */) = 0;
 +
-+  // @property
 +  // @alt SetAudioDescription
 +  // @brief Sets AudioDescription ON/OFF. Players should preferred Audio Descriptive tracks over normal audio track when enabled
 +  // @param enabled: Enabled/Disabled
 +  virtual uint32_t SetAudioDescription(const bool enabled /* @in */) = 0;
 +
-+  // @property
 +  // @alt GetAudioDescription
 +  // @brief Gets the current AudioDescription setting
 +  // @param enabled: Enabled/Disabled
 +  virtual uint32_t GetAudioDescription(bool &enabled /* @out */) const = 0;
 +
-+  // @property
 +  // @alt SetPreferredAudioLanguages
 +  // @brief A prioritized list of ISO 639-2/B codes for the preferred audio languages,
 +  // expressed as a comma separated lists of languages of zero of more elements.
@@ -107,25 +101,21 @@ diff -uprN a/interfaces/IUserSettings.h b/interfaces/IUserSettings.h
 +  // @param preferredLanguages: PreferredLanguages
 +  virtual uint32_t SetPreferredAudioLanguages(const string& preferredLanguages  /* @in @text preferredLanguages */) = 0;
 +
-+  // @property
 +  // @alt GetPreferredAudioLanguages
 +  // @brief Gets the current PreferredAudioLanguages setting
 +  // @param preferredLanguages: PreferredLanguages
 +  virtual uint32_t GetPreferredAudioLanguages(string &preferredLanguages /* @out @text preferredLanguages */) const = 0;
 +
-+  // @property
 +  // @alt SetPresentationLanguage
 +  // @brief Sets the presentationLanguages in a full BCP 47 value, including script, region, variant
 +  // @param presentationLanguages: "en-US", "es-US", "en-CA", "fr-CA"
 +  virtual uint32_t SetPresentationLanguage(const string& presentationLanguages /* @in @text presentationLanguages */) = 0;
 +
-+  // @property
 +  // @alt GetPresentationLanguage
 +  // @brief Gets the presentationLanguages
 +  // @param presentationLanguages: "en-US", "es-US", "en-CA", "fr-CA"
 +  virtual uint32_t GetPresentationLanguage(string &presentationLanguages /* @out @text presentationLanguages */) const = 0;
 +
-+  // @property
 +  // @alt SetCaptions
 +  // @brief brief Sets Captions ON/OFF.
 +  // @details A setting of ON indicates that Players should select a subtitle track for presentation
@@ -140,13 +130,11 @@ diff -uprN a/interfaces/IUserSettings.h b/interfaces/IUserSettings.h
 +  // @param enabled Sets the state
 +  virtual uint32_t SetCaptions(const bool enabled  /* @in */) = 0;
 +
-+  // @property
 +  // @alt GetCaptions
 +  // @brief Gets the Captions setting.
 +  // @param enabled Receives the state
 +  virtual uint32_t GetCaptions(bool &enabled /* @out */) const = 0;
 +
-+  // @property
 +  // @alt SetPreferredCaptionsLanguages
 +  // @brief Set preferred languages for captions.
 +  // @details A prioritized list of ISO 639-2/B codes for the preferred Captions languages,
@@ -157,13 +145,11 @@ diff -uprN a/interfaces/IUserSettings.h b/interfaces/IUserSettings.h
 +  // @param preferredLanguages Is the list to set (e.g. "eng,fra")
 +  virtual uint32_t SetPreferredCaptionsLanguages(const string& preferredLanguages  /* @in @text preferredLanguages */) = 0;
 +
-+  // @property
 +  // @alt GetPreferredCaptionsLanguages
 +  // @brief Gets the current PreferredCaptionsLanguages setting.
 +  // @param preferredLanguages (e.g. "eng,fra")
 +  virtual uint32_t GetPreferredCaptionsLanguages(string &preferredLanguages /* @out @text preferredLanguages */) const = 0;
 +
-+  // @property
 +  // @alt SetPreferredClosedCaptionService
 +  // @brief Sets the PreferredClosedCaptionService.
 +  // @details The setting should be honored by the player. The behaviour of AUTO may be player specific.
@@ -171,7 +157,6 @@ diff -uprN a/interfaces/IUserSettings.h b/interfaces/IUserSettings.h
 +  // @param service Identifies the service to display e.g. "CC3".
 +  virtual uint32_t SetPreferredClosedCaptionService(const string& service  /* @in */) = 0;
 +
-+  // @property
 +  // @alt GetPreferredClosedCaptionService
 +  // @brief Gets the current PreferredClosedCaptionService setting.
 +  // @param service Identifies the service to display e.g. "CC3".
@@ -191,11 +176,12 @@ diff -uprN a/interfaces/IUserSettings.h b/interfaces/IUserSettings.h
 +};
 +} // namespace Exchange
 +} // namespace WPEFramework
+\ No newline at end of file
 diff --git a/interfaces/Ids.h b/interfaces/Ids.h
-index a37db24..a9f4556 100644
+index 64151cf..7aac530 100644
 --- a/interfaces/Ids.h
 +++ b/interfaces/Ids.h
-@@ -354,7 +354,10 @@ namespace Exchange {
+@@ -360,7 +360,10 @@ namespace Exchange {
          ID_SCRIPT_ENGINE_NOTIFICATION                = ID_SCRIPT_ENGINE + 1,
  
          ID_TEXT_TO_SPEECH                            = RPC::IDS::ID_EXTERNAL_INTERFACE_OFFSET + 0x4C0,
@@ -207,6 +193,3 @@ index a37db24..a9f4556 100644
      };
  }
  }
--- 
-2.11.0
-

--- a/UserSettings/CHANGELOG.md
+++ b/UserSettings/CHANGELOG.md
@@ -16,7 +16,12 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
-## [1.1.0] - 2024-06-02
+
+## [1.0.2] - 2024-07-08
+### Fixed
+- UserSettings Plugin missing default values updated.
+
+## [1.0.1] - 2024-06-02
 ### Added
 - Added GetPrivacyMode/GetPrivacyMode calls.
 

--- a/UserSettings/UserSettingsImplementation.cpp
+++ b/UserSettings/UserSettingsImplementation.cpp
@@ -317,6 +317,55 @@ void UserSettingsImplementation::ValueChanged(const Exchange::IStore2::ScopeType
     }
 }
 
+uint32_t UserSettingsImplementation::SetUserSettingsValue(const string& key, const string& value)
+{
+    uint32_t status = Core::ERROR_GENERAL;
+
+    ASSERT (nullptr != _remotStoreObject);
+    if (nullptr != _remotStoreObject)
+    {
+        status = _remotStoreObject->SetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, key, value, 0);
+    }
+
+    return status;
+}
+
+uint32_t UserSettingsImplementation::GetUserSettingsValue(const string& key, string &value) const
+{
+
+    uint32_t status = Core::ERROR_GENERAL;
+    uint32_t ttl = 0;
+
+    // Create a map of default values
+    std::map<string, string> usersettings_default_map = {{USERSETTINGS_AUDIO_DESCRIPTION_KEY, "false"},
+                                                         {USERSETTINGS_PREFERRED_AUDIO_LANGUAGES_KEY, ""},
+                                                         {USERSETTINGS_PRESENTATION_LANGUAGE_KEY, ""},
+                                                         {USERSETTINGS_CAPTIONS_KEY, "false"},
+                                                         {USERSETTINGS_PREFERRED_CAPTIONS_LANGUAGES_KEY, ""},
+                                                         {USERSETTINGS_PREFERRED_CLOSED_CAPTIONS_SERVICE_KEY, "AUTO"}};
+
+    ASSERT (nullptr != _remotStoreObject);
+    if (nullptr != _remotStoreObject)
+    {
+        status = _remotStoreObject->GetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, key, value, ttl);
+
+        LOGINFO("Key[%s] value[%s] status[%d]", key.c_str(), value.c_str(), status);
+        if(Core::ERROR_UNKNOWN_KEY == status || Core::ERROR_NOT_EXIST == status)
+        {
+            if(usersettings_default_map.find(key)!=usersettings_default_map.end())
+            {
+                value = usersettings_default_map[key];
+                status = Core::ERROR_NONE;
+            }
+            else
+            {
+                LOGERR("Default value is not found in usersettings_default_map for '%s' Key", key.c_str());
+            }
+        }
+    }
+    return status;
+}
+
 uint32_t UserSettingsImplementation::SetAudioDescription(const bool enabled)
 {
     uint32_t status = Core::ERROR_GENERAL;
@@ -325,12 +374,7 @@ uint32_t UserSettingsImplementation::SetAudioDescription(const bool enabled)
 
     _adminLock.Lock();
 
-    ASSERT (nullptr != _remotStoreObject);
-
-    if (nullptr != _remotStoreObject)
-    {
-        status = _remotStoreObject->SetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_AUDIO_DESCRIPTION_KEY, (enabled)?"true":"false", 0);
-    }
+    status = SetUserSettingsValue(USERSETTINGS_AUDIO_DESCRIPTION_KEY, (enabled)?"true":"false");
 
     _adminLock.Unlock();
 
@@ -341,26 +385,20 @@ uint32_t UserSettingsImplementation::GetAudioDescription(bool &enabled) const
 {
     uint32_t status = Core::ERROR_GENERAL;
     std::string value = "";
-    uint32_t ttl = 0;
 
     _adminLock.Lock();
 
-    ASSERT (nullptr != _remotStoreObject);
+    status = GetUserSettingsValue(USERSETTINGS_AUDIO_DESCRIPTION_KEY, value);
 
-    if (nullptr != _remotStoreObject)
+    if(Core::ERROR_NONE == status)
     {
-        status = _remotStoreObject->GetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_AUDIO_DESCRIPTION_KEY, value, ttl);
-
-        if(Core::ERROR_NONE == status)
+        if (0 == value.compare("true"))
         {
-            if (0 == value.compare("true"))
-            {
-                enabled = true;
-            }
-            else
-            {
-                enabled = false;
-            }
+            enabled = true;
+        }
+        else
+        {
+            enabled = false;
         }
     }
 
@@ -377,12 +415,7 @@ uint32_t UserSettingsImplementation::SetPreferredAudioLanguages(const string& pr
 
     _adminLock.Lock();
 
-    ASSERT (nullptr != _remotStoreObject);
-
-    if (nullptr != _remotStoreObject)
-    {
-        status = _remotStoreObject->SetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_PREFERRED_AUDIO_LANGUAGES_KEY, preferredLanguages, 0);
-    }
+    status = SetUserSettingsValue(USERSETTINGS_PREFERRED_AUDIO_LANGUAGES_KEY, preferredLanguages);
 
     _adminLock.Unlock();
 
@@ -393,16 +426,10 @@ uint32_t UserSettingsImplementation::GetPreferredAudioLanguages(string &preferre
 {
     uint32_t status = Core::ERROR_GENERAL;
     std::string value = "";
-    uint32_t ttl = 0;
 
     _adminLock.Lock();
 
-    ASSERT (nullptr != _remotStoreObject);
-
-    if (nullptr != _remotStoreObject)
-    {
-        status = _remotStoreObject->GetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_PREFERRED_AUDIO_LANGUAGES_KEY, preferredLanguages, ttl);
-    }
+    status = GetUserSettingsValue(USERSETTINGS_PREFERRED_AUDIO_LANGUAGES_KEY, preferredLanguages);
 
     _adminLock.Unlock();
 
@@ -417,12 +444,7 @@ uint32_t UserSettingsImplementation::SetPresentationLanguage(const string& prese
 
     _adminLock.Lock();
 
-    ASSERT (nullptr != _remotStoreObject);
-
-    if (nullptr != _remotStoreObject)
-    {
-        status = _remotStoreObject->SetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_PRESENTATION_LANGUAGE_KEY, presentationLanguages, 0);
-    }
+    status = SetUserSettingsValue(USERSETTINGS_PRESENTATION_LANGUAGE_KEY, presentationLanguages);
 
     _adminLock.Unlock();
 
@@ -433,16 +455,10 @@ uint32_t UserSettingsImplementation::GetPresentationLanguage(string &presentatio
 {
     uint32_t status = Core::ERROR_GENERAL;
     std::string value = "";
-    uint32_t ttl = 0;
 
     _adminLock.Lock();
 
-    ASSERT (nullptr != _remotStoreObject);
-
-    if (nullptr != _remotStoreObject)
-    {
-        status = _remotStoreObject->GetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_PRESENTATION_LANGUAGE_KEY, presentationLanguages, ttl);
-    }
+    status = GetUserSettingsValue(USERSETTINGS_PRESENTATION_LANGUAGE_KEY, presentationLanguages);
 
     _adminLock.Unlock();
 
@@ -457,12 +473,7 @@ uint32_t UserSettingsImplementation::SetCaptions(const bool enabled)
 
     _adminLock.Lock();
 
-    ASSERT (nullptr != _remotStoreObject);
-
-    if (nullptr != _remotStoreObject)
-    {
-        status = _remotStoreObject->SetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_CAPTIONS_KEY, (enabled)?"true":"false", 0);
-    }
+    status = SetUserSettingsValue(USERSETTINGS_CAPTIONS_KEY, (enabled)?"true":"false");
 
     _adminLock.Unlock();
 
@@ -473,26 +484,20 @@ uint32_t UserSettingsImplementation::GetCaptions(bool &enabled) const
 {
     uint32_t status = Core::ERROR_GENERAL;
     std::string value = "";
-    uint32_t ttl = 0;
 
     _adminLock.Lock();
 
-    ASSERT (nullptr != _remotStoreObject);
+    status = GetUserSettingsValue(USERSETTINGS_CAPTIONS_KEY, value);
 
-    if (nullptr != _remotStoreObject)
+    if(Core::ERROR_NONE == status)
     {
-        status = _remotStoreObject->GetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_CAPTIONS_KEY, value, ttl);
-
-        if(Core::ERROR_NONE == status)
+        if (0 == value.compare("true"))
         {
-            if (0 == value.compare("true"))
-            {
-                enabled = true;
-            }
-            else
-            {
-                enabled = false;
-            }
+            enabled = true;
+        }
+        else
+        {
+            enabled = false;
         }
     }
 
@@ -509,12 +514,7 @@ uint32_t UserSettingsImplementation::SetPreferredCaptionsLanguages(const string&
 
     _adminLock.Lock();
 
-    ASSERT (nullptr != _remotStoreObject);
-
-    if (nullptr != _remotStoreObject)
-    {
-        status = _remotStoreObject->SetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_PREFERRED_CAPTIONS_LANGUAGES_KEY, preferredLanguages, 0);
-    }
+    status = SetUserSettingsValue(USERSETTINGS_PREFERRED_CAPTIONS_LANGUAGES_KEY, preferredLanguages);
 
     _adminLock.Unlock();
 
@@ -525,16 +525,10 @@ uint32_t UserSettingsImplementation::GetPreferredCaptionsLanguages(string &prefe
 {
     uint32_t status = Core::ERROR_GENERAL;
     std::string value = "";
-    uint32_t ttl = 0;
 
     _adminLock.Lock();
 
-    ASSERT (nullptr != _remotStoreObject);
-
-    if (nullptr != _remotStoreObject)
-    {
-        status = _remotStoreObject->GetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_PREFERRED_CAPTIONS_LANGUAGES_KEY, preferredLanguages, ttl);
-    }
+    status = GetUserSettingsValue(USERSETTINGS_PREFERRED_CAPTIONS_LANGUAGES_KEY, preferredLanguages);
 
     _adminLock.Unlock();
 
@@ -549,12 +543,7 @@ uint32_t UserSettingsImplementation::SetPreferredClosedCaptionService(const stri
 
     _adminLock.Lock();
 
-    ASSERT (nullptr != _remotStoreObject);
-
-    if (nullptr != _remotStoreObject)
-    {
-        status = _remotStoreObject->SetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_PREFERRED_CLOSED_CAPTIONS_SERVICE_KEY, service, 0);
-    }
+    status = SetUserSettingsValue(USERSETTINGS_PREFERRED_CLOSED_CAPTIONS_SERVICE_KEY, service);
 
     _adminLock.Unlock();
 
@@ -565,16 +554,10 @@ uint32_t UserSettingsImplementation::GetPreferredClosedCaptionService(string &se
 {
     uint32_t status = Core::ERROR_GENERAL;
     std::string value = "";
-    uint32_t ttl = 0;
 
     _adminLock.Lock();
 
-    ASSERT (nullptr != _remotStoreObject);
-
-    if (nullptr != _remotStoreObject)
-    {
-        status = _remotStoreObject->GetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_PREFERRED_CLOSED_CAPTIONS_SERVICE_KEY, service, ttl);
-    }
+    status = GetUserSettingsValue(USERSETTINGS_PREFERRED_CLOSED_CAPTIONS_SERVICE_KEY, service);
 
     _adminLock.Unlock();
 

--- a/UserSettings/UserSettingsImplementation.h
+++ b/UserSettings/UserSettingsImplementation.h
@@ -149,6 +149,8 @@ namespace Plugin {
 
         void registerEventHandlers();
         void ValueChanged(const Exchange::IStore2::ScopeType scope, const string& ns, const string& key, const string& value);
+        uint32_t SetUserSettingsValue(const string& key, const string& value);
+        uint32_t GetUserSettingsValue(const string& key, string &value) const;
 
     private:
         mutable Core::CriticalSection _adminLock;


### PR DESCRIPTION
Reason for change: User Settings Plugin missing default values Changes Done:

1. If the data is not available for User Setting namespace or keys in persistent store, returning the default values.
2. Added the L2 test cases for ERROR_NOT_EXIST and ERROR_UNKNOWN_KEY.
3. Updated the RDKV-48604-User-Settings-Thunder-Plugin.patch file with latest IUSerSettings.h changes for L2 tests.

Test Procedure: Run User Settings curl commands and check whether we are getting default values or not. Also run L2 tests with latest thunder (L2-tests-R4-4-1.yml) and verify.

Risks: Medium
Priority: P1