### PR TITLE
XIONE-15405: HDMI CEC Logical address update

### DIFF
--- a/HdmiCecSource/HdmiCecSource.cpp
+++ b/HdmiCecSource/HdmiCecSource.cpp
@@ -785,7 +785,7 @@ namespace WPEFramework
                     if(param->data.state.newState == IARM_BUS_PWRMGR_POWERSTATE_ON)
                     {
                         powerState = 0; 
-		        getLogicalAddress(); //	get the updated LA after wakeup
+		        HdmiCecSource::_instance->getLogicalAddress(); //	get the updated LA after wakeup
                     }
                     else
                         powerState = 1;

--- a/HdmiCecSource/HdmiCecSource.cpp
+++ b/HdmiCecSource/HdmiCecSource.cpp
@@ -1381,7 +1381,6 @@ namespace WPEFramework
         void HdmiCecSource::getLogicalAddress()
         {
             LOGINFO("Entered getLogicalAddress ");
-	    int logical_addr;
 
             if (!IsCecMgrActivated) {
                 LOGWARN("CEC Mgr not activated CEC communication is not possible");
@@ -1389,7 +1388,6 @@ namespace WPEFramework
             }
             try{
                 LogicalAddress addr = LibCCEC::getInstance().getLogicalAddress(DEV_TYPE_TUNER);
-		logical_addr = addr.toInt();
 
                 std::string logicalAddrDeviceType = DeviceType(LogicalAddress(addr).getType()).toString().c_str();
 
@@ -1401,7 +1399,7 @@ namespace WPEFramework
                     logicalAddress = addr;
                     logicalAddressDeviceType = logicalAddrDeviceType;
 		    if(smConnection)
-			    smConnection->setSource(LogicalAddress(logical_addr));
+			    smConnection->setSource(LogicalAddress(logicalAddress));
                 }
             }
             catch (const std::exception& e)

--- a/HdmiCecSource/HdmiCecSource.cpp
+++ b/HdmiCecSource/HdmiCecSource.cpp
@@ -1399,7 +1399,7 @@ namespace WPEFramework
                     logicalAddress = addr;
                     logicalAddressDeviceType = logicalAddrDeviceType;
 		    if(smConnection)
-			    smConnection->setSource(LogicalAddress(logicalAddress));
+			    smConnection->setSource(&addr);
                 }
             }
             catch (const std::exception& e)

--- a/HdmiCecSource/HdmiCecSource.cpp
+++ b/HdmiCecSource/HdmiCecSource.cpp
@@ -785,6 +785,7 @@ namespace WPEFramework
                     if(param->data.state.newState == IARM_BUS_PWRMGR_POWERSTATE_ON)
                     {
                         powerState = 0; 
+		        getLogicalAddress(); //	get the updated LA after wakeup
                     }
                     else
                         powerState = 1;

--- a/HdmiCecSource/HdmiCecSource.cpp
+++ b/HdmiCecSource/HdmiCecSource.cpp
@@ -785,7 +785,7 @@ namespace WPEFramework
                     if(param->data.state.newState == IARM_BUS_PWRMGR_POWERSTATE_ON)
                     {
                         powerState = 0; 
-		        HdmiCecSource::_instance->getLogicalAddress(); //get the updated LA after wakeup
+		        HdmiCecSource::_instance->getLogicalAddress(); // get the updated LA after wakeup
                     }
                     else
                         powerState = 1;
@@ -1399,7 +1399,7 @@ namespace WPEFramework
                     logicalAddress = addr;
                     logicalAddressDeviceType = logicalAddrDeviceType;
 		    if(smConnection)
-		        smConnection->setSource(LogicalAddress(logicalAddress));
+		        smConnection->setSource(logicalAddress); //update initiator LA
                 }
             }
             catch (const std::exception& e)

--- a/HdmiCecSource/HdmiCecSource.cpp
+++ b/HdmiCecSource/HdmiCecSource.cpp
@@ -1398,6 +1398,8 @@ namespace WPEFramework
                 {
                     logicalAddress = addr;
                     logicalAddressDeviceType = logicalAddrDeviceType;
+		    if(smConnection)
+			    smConnection->setSource(LogicalAddress(logicalAddress));
                 }
             }
             catch (const std::exception& e)

--- a/HdmiCecSource/HdmiCecSource.cpp
+++ b/HdmiCecSource/HdmiCecSource.cpp
@@ -1381,6 +1381,7 @@ namespace WPEFramework
         void HdmiCecSource::getLogicalAddress()
         {
             LOGINFO("Entered getLogicalAddress ");
+	    int logical_addr;
 
             if (!IsCecMgrActivated) {
                 LOGWARN("CEC Mgr not activated CEC communication is not possible");
@@ -1388,6 +1389,7 @@ namespace WPEFramework
             }
             try{
                 LogicalAddress addr = LibCCEC::getInstance().getLogicalAddress(DEV_TYPE_TUNER);
+		logical_addr = addr.toInt();
 
                 std::string logicalAddrDeviceType = DeviceType(LogicalAddress(addr).getType()).toString().c_str();
 
@@ -1399,7 +1401,7 @@ namespace WPEFramework
                     logicalAddress = addr;
                     logicalAddressDeviceType = logicalAddrDeviceType;
 		    if(smConnection)
-			    smConnection->setSource(LogicalAddress(addr.toInt()));
+			    smConnection->setSource(LogicalAddress(logical_addr));
                 }
             }
             catch (const std::exception& e)

--- a/HdmiCecSource/HdmiCecSource.cpp
+++ b/HdmiCecSource/HdmiCecSource.cpp
@@ -785,7 +785,7 @@ namespace WPEFramework
                     if(param->data.state.newState == IARM_BUS_PWRMGR_POWERSTATE_ON)
                     {
                         powerState = 0; 
-		        HdmiCecSource::_instance->getLogicalAddress(); //	get the updated LA after wakeup
+		        HdmiCecSource::_instance->getLogicalAddress(); //get the updated LA after wakeup
                     }
                     else
                         powerState = 1;
@@ -1399,7 +1399,7 @@ namespace WPEFramework
                     logicalAddress = addr;
                     logicalAddressDeviceType = logicalAddrDeviceType;
 		    if(smConnection)
-			    smConnection->setSource(LogicalAddress(logicalAddress));
+		        smConnection->setSource(LogicalAddress(logicalAddress));
                 }
             }
             catch (const std::exception& e)

--- a/HdmiCecSource/HdmiCecSource.cpp
+++ b/HdmiCecSource/HdmiCecSource.cpp
@@ -1399,7 +1399,7 @@ namespace WPEFramework
                     logicalAddress = addr;
                     logicalAddressDeviceType = logicalAddrDeviceType;
 		    if(smConnection)
-			    smConnection->setSource(&addr);
+			    smConnection->setSource(LogicalAddress(addr.toInt()));
                 }
             }
             catch (const std::exception& e)


### PR DESCRIPTION
Reason for change: Get latest hdmi cec logical addr after device power mode
                   changed to ON or after wakeup.

Test Procedure: build and verify
Risks: Medium
Priority: P1
Signed-off-by: Srigayathry Pugazhenthi<srigayathry.pugazhenthi@sky.uk>