### PR TITLE
DELIA-65984 - onError event is posted for WiFi scan even when scan is successful

### DIFF
--- a/NetworkManager/INetworkManager.h
+++ b/NetworkManager/INetworkManager.h
@@ -196,7 +196,8 @@ namespace WPEFramework
                 WIFI_STATE_CONNECTION_INTERRUPTED,
                 WIFI_STATE_INVALID_CREDENTIALS,
                 WIFI_STATE_AUTHENTICATION_FAILED,
-                WIFI_STATE_ERROR
+                WIFI_STATE_ERROR,
+                WIFI_STATE_INVALID
             };
 
             using IInterfaceDetailsIterator = RPC::IIteratorType<InterfaceDetails,     ID_NETWORKMANAGER_INTERFACE_DETAILS_ITERATOR>;

--- a/NetworkManager/NetworkManagerRDKProxy.cpp
+++ b/NetworkManager/NetworkManagerRDKProxy.cpp
@@ -380,7 +380,7 @@ namespace WPEFramework
                 case WIFI_DISABLED:
                     return Exchange::INetworkManager::WIFI_STATE_DISABLED;
             }
-            return Exchange::INetworkManager::WIFI_STATE_CONNECTION_FAILED;
+            return Exchange::INetworkManager::WIFI_STATE_INVALID;
         }
 
         Exchange::INetworkManager::WiFiState errorcode_to_wifi_state(WiFiErrorCode_t code) {
@@ -390,6 +390,8 @@ namespace WPEFramework
                     return Exchange::INetworkManager::WIFI_STATE_SSID_CHANGED;
                 case WIFI_CONNECTION_LOST:
                     return Exchange::INetworkManager::WIFI_STATE_CONNECTION_LOST;
+                case WIFI_CONNECTION_FAILED:
+                    return Exchange::INetworkManager::WIFI_STATE_CONNECTION_FAILED;
                 case WIFI_CONNECTION_INTERRUPTED:
                     return Exchange::INetworkManager::WIFI_STATE_CONNECTION_INTERRUPTED;
                 case WIFI_INVALID_CREDENTIALS:
@@ -401,7 +403,7 @@ namespace WPEFramework
                 case WIFI_UNKNOWN:
                     return Exchange::INetworkManager::WIFI_STATE_ERROR;
             }
-            return Exchange::INetworkManager::WIFI_STATE_CONNECTION_FAILED;
+            return Exchange::INetworkManager::WIFI_STATE_INVALID;
         }
 
         void NetworkManagerInternalEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len)


### PR DESCRIPTION
Reason for change: WIFI_STATE_CONNECTION_FAILED was returned in the error code mapping, when none of the error code matches because of which this event is being posted to EPG and they are getting WIFI_STATE_CONNECTION_FAILED event. Removed this event from existing code and added new evnt for default case Test Procedure: Check whether any irrelevant state is posted during scanning in wpeframework log
Risks: Low
Priority: P1
Signed-off-by: Gururaaja ESR <Gururaja_ErodeSriranganRamlingham@comcast.com>