### PR TITLE
RDKVREFPLT-2768- Adding Youtube and Amazon callsign changes in hibernateExternal()

### DIFF
--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -1645,7 +1645,7 @@ namespace WPEFramework {
                 return;
             }
 
-            if (callsign.find("Netflix") != string::npos || callsign.find("Cobalt") != string::npos)
+            if (callsign.find("Netflix") != string::npos || callsign.find("Cobalt") != string::npos || callsign.find("Amazon") != string::npos || callsign.find("YouTube") != string::npos)
             {
                 // Check if native app is suspended
                 bool suspendedOrHibernated = false;


### PR DESCRIPTION
RDKVREFPLT-2768- Adding Youtube and Amazon callsign changes in hibernateExternal()

Reason for change: Changes added previously for Cobalt and Netflix , now adding Amazon and YouTube

Test Procedure: Build and verified

Risks: Low