### PR TITLE
RDK-52297: Core system supports dynamic partner configuration

### DIFF
--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -334,6 +334,9 @@ namespace WPEFramework {
         static IARM_Result_t _SysModeChange(void *arg);
         static void _systemStateChanged(const char *owner,
                 IARM_EventId_t eventId, void *data, size_t len);
+        static void _deviceMgtUpdateReceived(const char *owner, 
+                IARM_EventId_t eventId, void *data, size_t len);
+        static void  postdeviceMgtUpdatetoApp(std::string source,std::string type,bool success);
 #endif /* defined(USE_IARMBUS) || defined(USE_IARM_BUS) */
 
         SERVICE_REGISTRATION(SystemServices, API_VERSION_NUMBER_MAJOR, API_VERSION_NUMBER_MINOR, API_VERSION_NUMBER_PATCH);
@@ -571,6 +574,7 @@ namespace WPEFramework {
                 IARM_Result_t res;
                 IARM_CHECK( IARM_Bus_RegisterCall(IARM_BUS_COMMON_API_SysModeChange, _SysModeChange));
                 IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_SYSMGR_NAME, IARM_BUS_SYSMGR_EVENT_SYSTEMSTATE, _systemStateChanged));
+		IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_SYSMGR_NAME, IARM_BUS_SYSMGR_EVENT_DEVICE_UPDATE_RECEIVED, _deviceMgtUpdateReceived));
                 IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_PWRMGR_NAME, IARM_BUS_PWRMGR_EVENT_MODECHANGED, _powerEventHandler));
                 IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_PWRMGR_NAME, IARM_BUS_PWRMGR_EVENT_REBOOTING, _powerEventHandler));
                 IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_PWRMGR_NAME, IARM_BUS_PWRMGR_EVENT_NETWORK_STANDBYMODECHANGED, _powerEventHandler));
@@ -595,6 +599,7 @@ namespace WPEFramework {
             {
                 IARM_Result_t res;
                 IARM_CHECK( IARM_Bus_RemoveEventHandler(IARM_BUS_SYSMGR_NAME, IARM_BUS_SYSMGR_EVENT_SYSTEMSTATE, _systemStateChanged));
+		IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_SYSMGR_NAME, IARM_BUS_SYSMGR_EVENT_DEVICE_UPDATE_RECEIVED, _deviceMgtUpdateReceived));
                 IARM_CHECK( IARM_Bus_RemoveEventHandler(IARM_BUS_PWRMGR_NAME, IARM_BUS_PWRMGR_EVENT_MODECHANGED, _powerEventHandler));
                 IARM_CHECK( IARM_Bus_RemoveEventHandler(IARM_BUS_PWRMGR_NAME, IARM_BUS_PWRMGR_EVENT_REBOOTING, _powerEventHandler));
                 IARM_CHECK( IARM_Bus_RemoveEventHandler(IARM_BUS_PWRMGR_NAME, IARM_BUS_PWRMGR_EVENT_NETWORK_STANDBYMODECHANGED,_powerEventHandler ));
@@ -4231,6 +4236,28 @@ namespace WPEFramework {
         }
 
         /***
+	* @brief : To receive RFC device updates event from IARM.
+        * @param1[in]  : owner of the event
+	* @param2[in]  : eventID of the event
+        * @param3[in]  : data passed from the IARMBUS event
+	* @param4[in]  : len
+        */
+        void _deviceMgtUpdateReceived(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
+        {
+		bool issuccess = true;
+		std::string sourcename = "RFC";
+		std::string typevalue = "initial";
+
+		if (!strcmp(IARM_BUS_SYSMGR_NAME, owner)) {
+			if (IARM_BUS_SYSMGR_EVENT_DEVICE_UPDATE_RECEIVED  == eventId) {
+				LOGWARN("IARM_BUS_SYSMGR_EVENT_DEVICE_UPDATE_RECEIVED event received\n");
+				LOGWARN("_deviceMgtUpdateReceived: postdeviceMgtUpdatetoApp with sourcename:%s, typevalue:%s, issuccess:%d\n", sourcename.c_str(),typevalue.c_str(),issuccess);
+				postdeviceMgtUpdatetoApp(sourcename,typevalue,issuccess);
+			}
+		}
+	}
+				
+        /***
          * @brief : To receive Firmware Update State Change events from IARM.
          * @param1[in]  : owner of the event
          * @param2[in]  : eventID of the event
@@ -4424,6 +4451,24 @@ namespace WPEFramework {
             LOGINFO("Notifying onRebootRequest\n");
             sendNotify(EVT_ONREBOOTREQUEST, params);
         }
+
+	/***
+ 	* @brief : called when RFC settings update is received
+  	* @param1[in]  : string source
+   	* @param1[in]  : string type
+    	* @param1[in]  : bool success
+     	* @param2[out] : {param:{"source":<string>, "type":<string>, "success":<bool>}}
+      	*/
+	void SystemServices::postdeviceMgtUpdatetoApp(string source,
+		string type, bool success)
+	{
+		JsonObject params;
+		params["source"] = source;
+		params["type"] = type;
+		params["success"] = success;
+		LOGWARN("postdeviceMgtUpdatetoApp: source = %s type = %d success = %d\n", source.c_str(), type.c_str(), success);
+		sendNotify(EVT_ONDEVICEMGTUPDATERECEIVED, params);
+	}
 
         uint32_t SystemServices::getLastFirmwareFailureReason(const JsonObject& parameters, JsonObject& response)
         {

--- a/SystemServices/SystemServices.h
+++ b/SystemServices/SystemServices.h
@@ -69,6 +69,7 @@ using std::ofstream;
 #define EVT_ONTIMEZONEDSTCHANGED          "onTimeZoneDSTChanged"
 #define EVT_FRIENDLYNAMECHANGED           "onFriendlyNameChanged"
 #define EVT_ONLOGUPLOAD                   "onLogUpload"
+#define EVT_ONDEVICEMGTUPDATERECEIVED     "onDeviceMgtUpdateReceived"
 #define TERRITORYFILE                     "/opt/secure/persistent/System/Territory.txt"
 
 

--- a/Tests/mocks/Iarm.h
+++ b/Tests/mocks/Iarm.h
@@ -492,6 +492,7 @@ typedef enum _SYSMgr_EventId_t {
     IARM_BUS_SYSMGR_EVENT_KEYCODE_LOGGING_CHANGED, /*!< Key Code logging status update */
     IARM_BUS_SYSMGR_EVENT_USB_MOUNT_CHANGED, /*!< Fires when USB mounts change */
     IARM_BUS_SYSMGR_EVENT_APP_RELEASE_FOCUS, /*!< Application fires event to release focus*/
+    IARM_BUS_SYSMGR_EVENT_DEVICE_UPDATE_RECEIVED, /*!< Received RFC Device update*/
     IARM_BUS_SYSMGR_EVENT_MAX /*!< Max Event Id */
 } IARM_Bus_SYSMgr_EventId_t;
 


### PR DESCRIPTION
Reason for change: Invoke IARM event for RFC initialisation complete
Test Procedure: Build and Verify
Risks: low
Priority: P1
Signed-off-by: Naveenkumar Hanasi <naveenkumar_hanasi@comcast.com>
