### PR TITLE
RDKDEV-1071 REFPLTV-2288 RDKServices : Wpeframework crash & restarting observed on setMode as Warehouse

### DIFF
--- a/SystemServices/CHANGELOG.md
+++ b/SystemServices/CHANGELOG.md
@@ -16,6 +16,11 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+
+## [3.0.1] - 2024-08-12
+### Fixed
+- RDKDEV-1071: Wpeframework crash & restarting observed on setMode as Warehouse 
+
 ## [3.0.0] - 2024-07-29
 ### Removed
 - Removed the deprecated cache APIs 

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -67,7 +67,7 @@ using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 3
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 0
+#define API_VERSION_NUMBER_PATCH 1
 
 #define MAX_REBOOT_DELAY 86400 /* 24Hr = 86400 sec */
 #define TR181_FW_DELAY_REBOOT "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.AutoReboot.fwDelayReboot"

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -554,6 +554,7 @@ namespace WPEFramework {
         void SystemServices::Deinitialize(PluginHost::IShell*)
         {
             m_operatingModeTimer.stop();
+           m_operatingModeTimer.join();
 #if defined(USE_IARMBUS) || defined(USE_IARM_BUS)
             DeinitializeIARM();
 #endif /* defined(USE_IARMBUS) || defined(USE_IARM_BUS) */
@@ -1489,6 +1490,7 @@ namespace WPEFramework {
                 m_remainingDuration--;
             } else {
                 m_operatingModeTimer.stop();
+               m_operatingModeTimer.detach();
                 JsonObject parameters, param, response;
                 param["mode"] = "NORMAL";
                 param["duration"] = 0;

--- a/SystemServices/cTimer.cpp
+++ b/SystemServices/cTimer.cpp
@@ -74,10 +74,19 @@ bool cTimer::start()
  */
 void cTimer::stop()
 {
-    this->clear = true;
-    if (timerThread.joinable()) {
-        timerThread.join();
-    }
+       this->clear = true;
+}
+
+void cTimer::detach()
+{
+        timerThread.detach();
+}
+
+void cTimer::join()
+{
+       if (timerThread.joinable()) {
+               timerThread.join();
+        }
 }
 
 /***

--- a/SystemServices/cTimer.h
+++ b/SystemServices/cTimer.h
@@ -53,6 +53,8 @@ class cTimer{
          * @return   : nil
          */
         void stop();
+       void detach();
+       void join();
 
         /***
          * @brief        : Set interval in which the given function should be invoked.


### PR DESCRIPTION
Reason for change: Added threadTimer.detach and removed join from stop timer to avoid first time setMode crash. While deactivating clear and join is called to avoid crash in deactivation.

Test Procedure: Build and verify.

Risks: Low

Signed-off-by: Selva Kumar MR [selvakumar_mr@comcast.com](mailto:selvakumar_mr@comcast.com)