### PR TITLE
RDKDEV-1071 REFPLTV-2288 RDKServices : Wpeframework crash & restarting observed on setMode as Warehouse

### DIFF
--- a/SystemServices/CHANGELOG.md
+++ b/SystemServices/CHANGELOG.md
@@ -19,11 +19,11 @@ All notable changes to this RDK Service will be documented in this file.
 
 ## [3.0.2] - 2024-08-12
 ### Update
-- RDKDEV-1071:  
+- RDKDEV-1071: brief comment updated 
 
 ## [3.0.1] - 2024-08-12
 ### Fixed
-- RDKDEV-1071: bried comment updated 
+- RDKDEV-1071: Wpeframework crash & restarting observed on setMode as Warehouse 
 
 ## [3.0.0] - 2024-07-29
 ### Removed

--- a/SystemServices/CHANGELOG.md
+++ b/SystemServices/CHANGELOG.md
@@ -17,9 +17,13 @@ All notable changes to this RDK Service will be documented in this file.
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
 
+## [3.0.2] - 2024-08-12
+### Update
+- RDKDEV-1071:  
+
 ## [3.0.1] - 2024-08-12
 ### Fixed
-- RDKDEV-1071: Wpeframework crash & restarting observed on setMode as Warehouse 
+- RDKDEV-1071: bried comment updated 
 
 ## [3.0.0] - 2024-07-29
 ### Removed

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -67,7 +67,7 @@ using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 3
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 1
+#define API_VERSION_NUMBER_PATCH 2
 
 #define MAX_REBOOT_DELAY 86400 /* 24Hr = 86400 sec */
 #define TR181_FW_DELAY_REBOOT "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.AutoReboot.fwDelayReboot"

--- a/SystemServices/cTimer.h
+++ b/SystemServices/cTimer.h
@@ -49,7 +49,9 @@ class cTimer{
         bool start();
 
         /***
-         * @brief   : stop timer thread.
+         * @brief   : stop timer thread.After calling stop() either join() or detach() need to be called.
+	 if child thread (timerThread) done it's work call cTimer::detach() after cTimer::stop(). 
+	 if SystemServices plugin going to Deinitialize call cTimer::join() after cTimer::stop().
          * @return   : nil
          */
         void stop();


### PR DESCRIPTION
Reason for change: Added logs in cTimer.h
Test Procedure: Build and verify.
Risks: Low
Signed-off-by: ramkumar_prabaharan@comcast.com