### PR TITLE
RDK-52297: Core system supports dynamic partner configuration

### DIFF
--- a/SystemServices/System.json
+++ b/SystemServices/System.json
@@ -2258,6 +2258,34 @@
                 ]
             }
         },
+                "onDeviceMgtUpdateReceived":{
+            "summary": "Triggered when the device management update complete",
+            "params": {
+                "type" :"object",
+                "properties": {
+                "source": {
+                        "summary": "Source information",
+                        "type": "string",
+                        "example":"rfc"
+                },
+                "type":{
+                    "summary": " Type of Update",
+                    "type": "string",
+                    "example": "initial"
+                },
+                "success":{
+                    "summary": "RFC updated succeeded",
+                    "type":"bool",
+                    "example": "true"
+                }
+                                },
+                "required":[
+                    "source",
+                    "type",
+                    "success"
+                ]
+            }
+         },
 		"onTimeZoneDSTChanged":{
             "summary": "Triggered when device time zone changed",
             "params": {

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -334,6 +334,8 @@ namespace WPEFramework {
         static IARM_Result_t _SysModeChange(void *arg);
         static void _systemStateChanged(const char *owner,
                 IARM_EventId_t eventId, void *data, size_t len);
+        static void _deviceMgtUpdateReceived(const char *owner,
+                IARM_EventId_t eventId, void *data, size_t len);
 #endif /* defined(USE_IARMBUS) || defined(USE_IARM_BUS) */
 
         SERVICE_REGISTRATION(SystemServices, API_VERSION_NUMBER_MAJOR, API_VERSION_NUMBER_MINOR, API_VERSION_NUMBER_PATCH);
@@ -571,6 +573,7 @@ namespace WPEFramework {
                 IARM_Result_t res;
                 IARM_CHECK( IARM_Bus_RegisterCall(IARM_BUS_COMMON_API_SysModeChange, _SysModeChange));
                 IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_SYSMGR_NAME, IARM_BUS_SYSMGR_EVENT_SYSTEMSTATE, _systemStateChanged));
+                IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_SYSMGR_NAME, IARM_BUS_SYSMGR_EVENT_DEVICE_UPDATE_RECEIVED, _deviceMgtUpdateReceived));
                 IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_PWRMGR_NAME, IARM_BUS_PWRMGR_EVENT_MODECHANGED, _powerEventHandler));
                 IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_PWRMGR_NAME, IARM_BUS_PWRMGR_EVENT_REBOOTING, _powerEventHandler));
                 IARM_CHECK( IARM_Bus_RegisterEventHandler(IARM_BUS_PWRMGR_NAME, IARM_BUS_PWRMGR_EVENT_NETWORK_STANDBYMODECHANGED, _powerEventHandler));
@@ -595,6 +598,7 @@ namespace WPEFramework {
             {
                 IARM_Result_t res;
                 IARM_CHECK( IARM_Bus_RemoveEventHandler(IARM_BUS_SYSMGR_NAME, IARM_BUS_SYSMGR_EVENT_SYSTEMSTATE, _systemStateChanged));
+                IARM_CHECK( IARM_Bus_RemoveEventHandler(IARM_BUS_SYSMGR_NAME, IARM_BUS_SYSMGR_EVENT_DEVICE_UPDATE_RECEIVED, _deviceMgtUpdateReceived));
                 IARM_CHECK( IARM_Bus_RemoveEventHandler(IARM_BUS_PWRMGR_NAME, IARM_BUS_PWRMGR_EVENT_MODECHANGED, _powerEventHandler));
                 IARM_CHECK( IARM_Bus_RemoveEventHandler(IARM_BUS_PWRMGR_NAME, IARM_BUS_PWRMGR_EVENT_REBOOTING, _powerEventHandler));
                 IARM_CHECK( IARM_Bus_RemoveEventHandler(IARM_BUS_PWRMGR_NAME, IARM_BUS_PWRMGR_EVENT_NETWORK_STANDBYMODECHANGED,_powerEventHandler ));
@@ -4231,6 +4235,28 @@ namespace WPEFramework {
         }
 
         /***
+       * @brief : To receive RFC device updates event from IARM.
+       * @param1[in]  : owner of the event
+       * @param2[in]  : eventID of the event
+       * @param3[in]  : data passed from the IARMBUS event
+       * @param4[in]  : len
+       */
+       void _deviceMgtUpdateReceived(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
+       {
+           if (!strcmp(IARM_BUS_SYSMGR_NAME, owner)) {
+               if (IARM_BUS_SYSMGR_EVENT_DEVICE_UPDATE_RECEIVED  == eventId) {
+                   LOGWARN("%s:%d IARM_BUS_SYSMGR_EVENT_DEVICE_UPDATE_RECEIVED event received\n",__FUNCTION__, __LINE__);
+                   if (SystemServices::_instance) {
+                       LOGWARN("%s:%d Invoke onDeviceMgtUpdateReceived to notify\n", __FUNCTION__, __LINE__);
+                       SystemServices::_instance->onDeviceMgtUpdateReceived((IARM_BUS_SYSMGR_DeviceMgtUpdateInfo_Param_t *)data);
+                   } else {
+                       LOGERR("%s:%d SystemServices::_instance is NULL.\n", __FUNCTION__, __LINE__);
+                   }
+               }
+           }
+       }
+
+        /***
          * @brief : To receive Firmware Update State Change events from IARM.
          * @param1[in]  : owner of the event
          * @param2[in]  : eventID of the event
@@ -4329,7 +4355,6 @@ namespace WPEFramework {
                 }
             }
         }
-
         /***
          * @brief : To validate the parameters in event data send from the IARMBUS, so as
          *		   to initiate  onTemperatureThresholdChanged event.
@@ -4424,6 +4449,21 @@ namespace WPEFramework {
             LOGINFO("Notifying onRebootRequest\n");
             sendNotify(EVT_ONREBOOTREQUEST, params);
         }
+
+       /***
+       * @brief : called when RFC settings update is received
+       * @param1[in]  : data passed from the IARMBUS event
+       * @param2[out] : {param:{"source":<string>, "type":<string>, "success":<bool>}}
+       */
+       void SystemServices::onDeviceMgtUpdateReceived(IARM_BUS_SYSMGR_DeviceMgtUpdateInfo_Param_t *config)
+       {
+               JsonObject params;
+               params["source"] = std::string(config->source);
+               params["type"] = std::string(config->type);
+               params["success"] = config->rfcComplete;
+               LOGWARN("onDeviceMgtUpdateReceived: source = %s type = %s success = %d\n", config->source, config->type, config->rfcComplete);
+               sendNotify(EVT_ONDEVICEMGTUPDATERECEIVED, params);
+       }
 
         uint32_t SystemServices::getLastFirmwareFailureReason(const JsonObject& parameters, JsonObject& response)
         {

--- a/SystemServices/SystemServices.h
+++ b/SystemServices/SystemServices.h
@@ -69,6 +69,7 @@ using std::ofstream;
 #define EVT_ONTIMEZONEDSTCHANGED          "onTimeZoneDSTChanged"
 #define EVT_FRIENDLYNAMECHANGED           "onFriendlyNameChanged"
 #define EVT_ONLOGUPLOAD                   "onLogUpload"
+#define EVT_ONDEVICEMGTUPDATERECEIVED     "onDeviceMgtUpdateReceived"
 #define TERRITORYFILE                     "/opt/secure/persistent/System/Territory.txt"
 
 
@@ -203,6 +204,7 @@ namespace WPEFramework {
                 void onFirmwarePendingReboot(int seconds); /* Event handler for Pending Reboot */
 		void onTerritoryChanged(string oldTerritory, string newTerritory, string oldRegion="", string newRegion="");
 		void onTimeZoneDSTChanged(string oldTimeZone, string newTimeZone, string oldAccuracy, string newAccuracy);
+		void onDeviceMgtUpdateReceived(IARM_BUS_SYSMGR_DeviceMgtUpdateInfo_Param_t *config);
                 /* Events : End */
 
                 /* Methods : Begin */

--- a/Tests/mocks/Iarm.h
+++ b/Tests/mocks/Iarm.h
@@ -479,6 +479,16 @@ typedef struct _IARM_BUS_PWRMgr_WareHouseOpn_EventData_t {
 #define IARM_BUS_SYSMGR_NAME "SYSMgr"
 #define IARM_BUS_SYSMGR_API_GetSystemStates "GetSystemStates"
 
+/**
+ *  @brief Structure which holds RFC device management update information.
+ */
+typedef struct _IARM_BUS_SYSMGR_DeviceMgtUpdateInfo_Param_t
+{
+      char source[10]; /* Device update src */
+      char type[10]; /* Device update type */
+      bool rfcComplete; /* RFC update status */
+} IARM_BUS_SYSMGR_DeviceMgtUpdateInfo_Param_t;
+
 typedef enum _SYSMgr_EventId_t {
     IARM_BUS_SYSMGR_EVENT_SYSTEMSTATE,
     IARM_BUS_SYSMGR_EVENT_XUPNP_DATA_REQUEST, /*!< Xupnp data  request frm Receiver to UPNP*/
@@ -492,6 +502,7 @@ typedef enum _SYSMgr_EventId_t {
     IARM_BUS_SYSMGR_EVENT_KEYCODE_LOGGING_CHANGED, /*!< Key Code logging status update */
     IARM_BUS_SYSMGR_EVENT_USB_MOUNT_CHANGED, /*!< Fires when USB mounts change */
     IARM_BUS_SYSMGR_EVENT_APP_RELEASE_FOCUS, /*!< Application fires event to release focus*/
+    IARM_BUS_SYSMGR_EVENT_DEVICE_UPDATE_RECEIVED, /*!< Received RFC Device update*/
     IARM_BUS_SYSMGR_EVENT_MAX /*!< Max Event Id */
 } IARM_Bus_SYSMgr_EventId_t;
 


### PR DESCRIPTION
Reason for change: Add new IARM event for RFC initialisation complete
Test Procedure: Build and Verify
Risks: low
Priority: P1
Signed-off-by: nhanasi<navihansi@gmail.com>