### PR TITLE
DELIA-65865 Intialise buff varialbe in archiveLogsInternal method

### DIFF
--- a/Tests/L2Tests/L2TestsPlugin/tests/UsbAccess_L2Test.cpp
+++ b/Tests/L2Tests/L2TestsPlugin/tests/UsbAccess_L2Test.cpp
@@ -23,10 +23,7 @@ typedef enum : uint32_t {
 
 }UsbAccessL2test_async_events_t;
 
-/* Needs usbaccess middleware fix (DELIA-65868) to run this test. for now commented the test UsbAccessArchiveLogs for Thunder R4*/
-#ifndef USE_THUNDER_R4
 char buffer[1024];
-#endif /* !USE_THUNDER_R4 */
 
 /**
  * @brief Compare two request status objects
@@ -539,8 +536,6 @@ TEST_F(UsbAccess_L2test, SymLinkoperations)
 
 }
 
-/* Needs usbaccess middleware fix (DELIA-65868) to run this test. for now commented the test UsbAccessArchiveLogs for Thunder R4*/
-#ifndef USE_THUNDER_R4
 /********************************************************
 ************Test case Details **************************
 ** 1. Subscribe for onArchiveLogs Events
@@ -653,5 +648,4 @@ TEST_F(UsbAccess_L2test,UsbAccessArchiveLogs)
     /* Unregister for events. */
     jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("onArchiveLogs"));
 }
-#endif /* !USE_THUNDER_R4 */
 

--- a/UsbAccess/UsbAccess.cpp
+++ b/UsbAccess/UsbAccess.cpp
@@ -586,7 +586,7 @@ namespace Plugin {
                 string script = (ARCHIVE_LOGS_SCRIPT + " " + usbPath);
                 FILE* fp = v_secure_popen("r","%s %s",ARCHIVE_LOGS_SCRIPT.c_str(),usbPath.c_str());
                 if (NULL != fp) {
-                    char buf[256];
+                    char buf[256] = {0};
                     while(fgets(buf, sizeof(buf), fp) != NULL)
                     {
                         usbFilePath = buf; //Capture file path returned by the script


### PR DESCRIPTION
DELIA-65865 Intialise buff varialbe in archiveLogsInternal method

Reason for change: Enabling usbaccess for latest thunder version
Test Procedure : NA
Risks: Medium
Priority: P0