### PR TITLE
RDK-52231 Add SharedStorage plugin - bug fix

### DIFF
--- a/SharedStorage/SharedStorage.cpp
+++ b/SharedStorage/SharedStorage.cpp
@@ -127,7 +127,7 @@ namespace Plugin {
             _csObject = m_CloudStoreRef->QueryInterface<Exchange::IStore2>();
             if (nullptr == _csObject)
             {
-                message = _T("SharedStorage plugin could not be initialized.");
+                //message = _T("SharedStorage plugin could not be initialized.");
                 TRACE(Trace::Error, (_T("%s: Can't get CloudStore interface"), __FUNCTION__));
                 m_CloudStoreRef->Release();
                 m_CloudStoreRef = nullptr;
@@ -139,7 +139,7 @@ namespace Plugin {
         }
         else
         {
-            message = _T("SharedStorage plugin could not be initialized.");
+            //message = _T("SharedStorage plugin could not be initialized.");
             TRACE(Trace::Error, (_T("%s: Can't get CloudStore interface"), __FUNCTION__));
         }
 

--- a/SharedStorage/SharedStorage.cpp
+++ b/SharedStorage/SharedStorage.cpp
@@ -143,9 +143,6 @@ namespace Plugin {
             TRACE(Trace::Error, (_T("%s: Can't get CloudStore interface"), __FUNCTION__));
         }
 
-        if (message.length() != 0) {
-            Deinitialize(service);
-        }
         SYSLOG(Logging::Startup, (string(_T("SharedStorage Initialize complete"))));
         return message;
     }


### PR DESCRIPTION
Reason for change: Remove Deinitialize from Initialize, in case of failure
Test Procedure: SharedStorage APIs
Risks: Low
Priority: P1