### PR TITLE
RDK-52297: Core system supports dynamic partner configuration

### DIFF
--- a/SystemServices/System.json
+++ b/SystemServices/System.json
@@ -2259,22 +2259,22 @@
             }
         },
                 "onDeviceMgtUpdateReceived":{
-            "summary": "Triggered when the device management update complete",
+            "summary": "Triggered when the device management update completes",
             "params": {
                 "type" :"object",
                 "properties": {
                 "source": {
-                        "summary": "Source information",
+                        "summary": "Source information from where the event on update is posted",
                         "type": "string",
                         "example":"rfc"
                 },
                 "type":{
-                    "summary": " Type of Update",
+                    "summary": " Type of Update received currently it will be used as initial",
                     "type": "string",
                     "example": "initial"
                 },
                 "success":{
-                    "summary": "RFC updated succeeded",
+                    "summary": "Status information of update whether success or failure",
                     "type":"bool",
                     "example": "true"
                 }

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -4235,7 +4235,7 @@ namespace WPEFramework {
         }
 
         /***
-       * @brief : To receive RFC device updates event from IARM.
+       * @brief : To receive device updates event from IARM.
        * @param1[in]  : owner of the event
        * @param2[in]  : eventID of the event
        * @param3[in]  : data passed from the IARMBUS event
@@ -4451,7 +4451,7 @@ namespace WPEFramework {
         }
 
        /***
-       * @brief : called when RFC settings update is received
+       * @brief : called when Device Mgt settings update is received
        * @param1[in]  : data passed from the IARMBUS event
        * @param2[out] : {param:{"source":<string>, "type":<string>, "success":<bool>}}
        */
@@ -4460,8 +4460,8 @@ namespace WPEFramework {
                JsonObject params;
                params["source"] = std::string(config->source);
                params["type"] = std::string(config->type);
-               params["success"] = config->rfcComplete;
-               LOGWARN("onDeviceMgtUpdateReceived: source = %s type = %s success = %d\n", config->source, config->type, config->rfcComplete);
+               params["success"] = config->status;
+               LOGWARN("onDeviceMgtUpdateReceived: source = %s type = %s success = %d\n", config->source, config->type, config->status);
                sendNotify(EVT_ONDEVICEMGTUPDATERECEIVED, params);
        }
 

--- a/Tests/mocks/Iarm.h
+++ b/Tests/mocks/Iarm.h
@@ -484,9 +484,9 @@ typedef struct _IARM_BUS_PWRMgr_WareHouseOpn_EventData_t {
  */
 typedef struct _IARM_BUS_SYSMGR_DeviceMgtUpdateInfo_Param_t
 {
-      char source[10]; /* Device update src */
-      char type[10]; /* Device update type */
-      bool rfcComplete; /* RFC update status */
+      char source[10];                                    /*!< Device Management Update source. Ex: rfc */
+      char type[10];                                      /*!< Device Management Update type. Ex: initial */
+      bool status;                                        /*!< Device Management Update status. true/false */
 } IARM_BUS_SYSMGR_DeviceMgtUpdateInfo_Param_t;
 
 typedef enum _SYSMgr_EventId_t {
@@ -502,7 +502,7 @@ typedef enum _SYSMgr_EventId_t {
     IARM_BUS_SYSMGR_EVENT_KEYCODE_LOGGING_CHANGED, /*!< Key Code logging status update */
     IARM_BUS_SYSMGR_EVENT_USB_MOUNT_CHANGED, /*!< Fires when USB mounts change */
     IARM_BUS_SYSMGR_EVENT_APP_RELEASE_FOCUS, /*!< Application fires event to release focus*/
-    IARM_BUS_SYSMGR_EVENT_DEVICE_UPDATE_RECEIVED, /*!< Received RFC Device update*/
+    IARM_BUS_SYSMGR_EVENT_DEVICE_UPDATE_RECEIVED,  /*!< Received Device Management update information */
     IARM_BUS_SYSMGR_EVENT_MAX /*!< Max Event Id */
 } IARM_Bus_SYSMgr_EventId_t;
 


### PR DESCRIPTION
Reason for change: Update the bool variable to generic name
Test Procedure: Build and Verify
Risks: low
Priority: P1
Signed-off-by: nhanasi<navihansi@gmail.com>