### PR TITLE
DELIA-65827: Serial Number not showing in DeviceInfo.1.systeminfo

### DIFF
--- a/DeviceInfo/CHANGELOG.md
+++ b/DeviceInfo/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+## [1.0.15] - 2024-08-21
+### Changed
+- DELIA-65827:  Return Empty SerialNumber in curl for "method": "DeviceInfo.1.systeminfo"
 
 ## [1.0.14] - 2024-08-02
 ### Changed

--- a/DeviceInfo/DeviceInfo.cpp
+++ b/DeviceInfo/DeviceInfo.cpp
@@ -53,11 +53,6 @@ namespace Plugin {
         _skipURL = static_cast<uint8_t>(service->WebPrefix().length());
         _subSystem = service->SubSystems();
         _service = service;
-#ifndef USE_THUNDER_R4
-        _systemId = Core::SystemInfo::Instance().Id(Core::SystemInfo::Instance().RawDeviceId(), ~0);
-#else
-        _systemId = string();
-#endif /* USE_THUNDER_R4 */
 
         ASSERT(_subSystem != nullptr);
 
@@ -158,6 +153,8 @@ namespace Plugin {
 
     void DeviceInfo::SysInfo(JsonData::DeviceInfo::SysteminfoData& systemInfo) const
     {
+        string serialNumber;
+
         Core::SystemInfo& singleton(Core::SystemInfo::Instance());
 
         systemInfo.Time = Core::Time::Now().ToRFC1123(true);
@@ -173,7 +170,11 @@ namespace Plugin {
         systemInfo.Freeswap = singleton.GetFreeSwap();
         systemInfo.Devicename = singleton.GetHostName();
         systemInfo.Cpuload = Core::NumberType<uint32_t>(static_cast<uint32_t>(singleton.GetCpuLoad())).Text();
-        systemInfo.Serialnumber = _systemId;
+
+        auto result = _deviceInfo->SerialNumber(serialNumber);
+        if (result == Core::ERROR_NONE) {
+            systemInfo.Serialnumber = serialNumber;
+        }
 
         auto cpuloadavg = singleton.GetCpuLoadAvg();
         if (cpuloadavg != nullptr) {

--- a/DeviceInfo/DeviceInfo.h
+++ b/DeviceInfo/DeviceInfo.h
@@ -68,7 +68,6 @@ namespace Plugin {
             : _skipURL(0)
             , _service(nullptr)
             , _subSystem(nullptr)
-            , _systemId()
             , _connectionId(0)
             , _deviceInfo(nullptr)
             , _deviceAudioCapabilities(nullptr)
@@ -138,7 +137,6 @@ namespace Plugin {
         uint8_t _skipURL;
         PluginHost::IShell* _service;
         PluginHost::ISubSystem* _subSystem;
-        string _systemId;
         uint32_t _connectionId;
         Exchange::IDeviceInfo* _deviceInfo;
         Exchange::IDeviceAudioCapabilities* _deviceAudioCapabilities;


### PR DESCRIPTION
Reason for change: Retrived the serial Number using SerialNumber api instead of  RawDeviceId(Thunder)
Test Procedure: Verify in Jenkin Build
Risks: High
Signed-off-by: Thamim  Razith <tabbas651@cable.comcast.com>