### PR TITLE
RDKDEV-1076,RTD131X-1256 - DAC Apps are not launching in Thunder 4.4

### DIFF
--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -713,6 +713,11 @@ namespace WPEFramework {
                     }
                 }
             }
+	    // This changes is added for response is getting empty on launching DAC application
+	    if (!FromMessage(response, message, isResponseString))
+	    {
+		return Core::ERROR_GENERAL;
+	    }
 #elif (THUNDER_VERSION == 2)
             auto resp =  dispatcher_->Invoke(sThunderSecurityToken, channelId, *message);
 #else


### PR DESCRIPTION
Reason for change: DAC apps is not launced after installing in Thunder 4.4 version Image

Test Procedure: Refer ticket

Risks: Medium