### PR TITLE
Fix DS Audio Failures

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -324,8 +324,6 @@ namespace WPEFramework {
 
             registerMethodLockedApi("getAudioDelay", &DisplaySettings::getAudioDelay, this);
             registerMethodLockedApi("setAudioDelay", &DisplaySettings::setAudioDelay, this);
-            registerMethodLockedApi("getAudioDelayOffset", &DisplaySettings::getAudioDelayOffset, this);
-            registerMethodLockedApi("setAudioDelayOffset", &DisplaySettings::setAudioDelayOffset, this);
             registerMethodLockedApi("getSinkAtmosCapability", &DisplaySettings::getSinkAtmosCapability, this);
             registerMethodLockedApi("setAudioAtmosOutputMode", &DisplaySettings::setAudioAtmosOutputMode, this);
             registerMethodLockedApi("setForceHDRMode", &DisplaySettings::setForceHDRMode, this);
@@ -3810,127 +3808,6 @@ namespace WPEFramework {
             catch (const device::Exception& err)
             {
                 LOG_DEVICE_EXCEPTION2(audioPort, sAudioDelayMs);
-                success = false;
-            }
-            returnResponse(success);
-        }
-
-        uint32_t DisplaySettings::getAudioDelayOffset (const JsonObject& parameters, JsonObject& response) 
-        {   //sample servicemanager response:
-            LOGINFOMETHOD();
-
-            bool success = true;
-            string audioPort = parameters["audioPort"].String();//empty value will browse all ports
-
-            if (!checkPortName(audioPort))
-                audioPort = "HDMI0";
-
-            uint32_t audioDelayOffsetMs = 0;
-            try
-            {
-                /* Return the sound mode of the audio ouput connected to the specified audioPort */
-                /* Check if HDMI is connected - Return (default) Stereo Mode if not connected */
-                if (audioPort.empty())
-                {
-                    std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
-                    if (isDisplayConnected(strVideoPort))
-                    {
-                        audioPort = "HDMI0";
-                    }
-                    else
-                    {
-                        /*  * If HDMI is not connected
-                            * Get the SPDIF if it is supported by platform
-                            * If Platform does not have connected ports. Default to HDMI.
-                        */
-                        audioPort = "HDMI0";
-                        device::List<device::VideoOutputPort> vPorts = device::Host::getInstance().getVideoOutputPorts();
-                        for (size_t i = 0; i < vPorts.size(); i++)
-                        {
-                            device::VideoOutputPort &vPort = vPorts.at(i);
-                            if (isDisplayConnected(vPort.getName()))
-                            {
-                                audioPort = "SPDIF0";
-                                break;
-                            }
-                        }
-                    }
-                }
-
-                device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
-                aPort.getAudioDelayOffset (audioDelayOffsetMs);
-				response["audioDelayOffset"] = std::to_string(audioDelayOffsetMs);
-            }
-            catch (const device::Exception& err)
-            {
-                LOG_DEVICE_EXCEPTION1(audioPort);
-                success = false;
-            }
-
-            returnResponse(success);
-        }
-
-        uint32_t DisplaySettings::setAudioDelayOffset (const JsonObject& parameters, JsonObject& response)
-        {   //sample servicemanager response:
-            LOGINFOMETHOD();
-
-            returnIfParamNotFound(parameters, "audioDelayOffset");
-
-            string sAudioDelayOffsetMs = parameters["audioDelayOffset"].String();
-            int audioDelayOffsetMs = 0;
-            try
-            {
-                audioDelayOffsetMs = stoi(sAudioDelayOffsetMs);
-            }
-            catch (const std::exception &err)
-            {
-                LOGERR("Failed to parse audioDelayOffset '%s'", sAudioDelayOffsetMs.c_str());
-                returnResponse(false);
-            }
-
-            bool success = true;
-            string audioPort = parameters["audioPort"].String();//empty value will browse all ports
-
-            if (!checkPortName(audioPort))
-                audioPort = "HDMI0";
-
-            try
-            {
-                /* Return the sound mode of the audio ouput connected to the specified audioPort */
-                /* Check if HDMI is connected - Return (default) Stereo Mode if not connected */
-                if (audioPort.empty())
-                {
-                    std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
-                    if (isDisplayConnected(strVideoPort))
-                    {
-                        audioPort = "HDMI0";
-                    }
-                    else
-                    {
-                        /*  * If HDMI is not connected
-                            * Get the SPDIF if it is supported by platform
-                            * If Platform does not have connected ports. Default to HDMI.
-                        */
-                        audioPort = "HDMI0";
-                        device::List<device::VideoOutputPort> vPorts = device::Host::getInstance().getVideoOutputPorts();
-                        for (size_t i = 0; i < vPorts.size(); i++)
-                        {
-                            device::VideoOutputPort &vPort = vPorts.at(i);
-                            if (isDisplayConnected(vPort.getName()))
-                            {
-                                audioPort = "SPDIF0";
-                                break;
-                            }
-                        }
-                    }
-                }
-
-                device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
-                aPort.setAudioDelayOffset (audioDelayOffsetMs);
-            }
-            catch (const device::Exception& err)
-            {
-                LOG_DEVICE_EXCEPTION2(audioPort, sAudioDelayOffsetMs);
                 success = false;
             }
             returnResponse(success);

--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -96,8 +96,6 @@ namespace WPEFramework {
 	    uint32_t getSupportedMS12AudioProfiles(const JsonObject& parameters, JsonObject& response);
             uint32_t getAudioDelay(const JsonObject& parameters, JsonObject& response);
             uint32_t setAudioDelay(const JsonObject& parameters, JsonObject& response);
-            uint32_t getAudioDelayOffset(const JsonObject& parameters, JsonObject& response);
-            uint32_t setAudioDelayOffset(const JsonObject& parameters, JsonObject& response);
             uint32_t getSinkAtmosCapability(const JsonObject& parameters, JsonObject& response);
             uint32_t setAudioAtmosOutputMode(const JsonObject& parameters, JsonObject& response);
             uint32_t getTVHDRCapabilities(const JsonObject& parameters, JsonObject& response);

--- a/DisplaySettings/DisplaySettings.json
+++ b/DisplaySettings/DisplaySettings.json
@@ -15,11 +15,6 @@
             "type": "string",
             "example": "0"
         },
-        "audioDelayOffset": {
-            "summary": "Delay offset (in ms) on the selected audio port",
-            "type": "string",
-            "example": "0"
-        },
         "supportedAudioFormat": {
             "summary": "A list of supported audio formats",
             "type": "array",
@@ -294,35 +289,6 @@
                 },
                 "required": [
                     "audioDelay",
-                    "success"
-                ]
-            }
-        },
-        "getAudioDelayOffset":{
-            "summary": "Returns the audio delay offset (in ms) on the selected audio port. If the `audioPort` argument is not specified, it will browse all ports (checking HDMI0 first). If there is no display connected, then it defaults to `HDMI0`.",
-            "params": {
-                "type":"object",
-                "properties": {
-                    "audioPort": {
-                        "$ref": "#/definitions/audioPort0"
-                    }
-                },
-                "required": [
-                    "audioPort"
-                ]
-            },
-            "result": {
-                "type":"object",
-                "properties": {
-                    "audioDelayOffset": {
-                        "$ref": "#/definitions/audioDelayOffset"
-                    },
-                    "success": {
-                        "$ref": "#/common/success"
-                    }
-                },
-                "required": [
-                    "audioDelayOffset",
                     "success"
                 ]
             }
@@ -1962,27 +1928,6 @@
                 "required": [
                     "audioPort",
                     "audioDelay"
-                ]
-            },
-            "result": {
-                "$ref": "#/common/result"
-            }
-        },
-        "setAudioDelayOffset":{
-            "summary": "Sets the audio delay offset (in ms) on the selected audio port. If the `audioPort` argument is not specified, it will browse all ports (checking HDMI0 first). If there is no display connected, then it defaults to `HDMI0`.",
-            "params": {
-                "type":"object",
-                "properties": {
-                    "audioPort": {
-                        "$ref": "#/definitions/audioPort0"
-                    },
-                    "audioDelayOffset": {
-                        "$ref": "#/definitions/audioDelayOffset"
-                    }
-                },
-                "required": [
-                    "audioPort",
-                    "audioDelayOffset"
                 ]
             },
             "result": {


### PR DESCRIPTION
RDK-49033: Fix DS Audio Failures

Reason for change: Remove the deprectaed APIs from DS Audio
Test Procedure: Build and Verify
Risks: Low