### PR TITLE
Fix failing l1 testcases

### DIFF
--- a/Tests/L1Tests/tests/test_DeviceInfoJsonRpc.cpp
+++ b/Tests/L1Tests/tests/test_DeviceInfoJsonRpc.cpp
@@ -193,6 +193,18 @@ TEST_F(DeviceInfoJsonRpcTest, registeredMethods)
 
 TEST_F(DeviceInfoJsonRpcInitializedTest, systeminfo)
 {
+    ON_CALL(*p_iarmBusImplMock, IARM_Bus_Call)
+        .WillByDefault(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_MFRLIB_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_MFRLIB_API_GetSerializedData)));
+                auto* param = static_cast<IARM_Bus_MFRLib_GetSerializedData_Param_t*>(arg);
+                const char* str = "5678";
+                param->bufLen = strlen(str);
+                strncpy(param->buffer, str, sizeof(param->buffer));
+                param->type =  mfrSERIALIZED_TYPE_SERIALNUMBER;
+                return IARM_RESULT_SUCCESS;
+            });
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("systeminfo"), _T(""), response));
     EXPECT_THAT(response, ::testing::MatchesRegex("\\{"
                                                   "\"version\":\"#\","

--- a/Tests/L1Tests/tests/test_DeviceInfoWeb.cpp
+++ b/Tests/L1Tests/tests/test_DeviceInfoWeb.cpp
@@ -100,6 +100,19 @@ TEST_F(DeviceInfoWebInitializedTest, httpGet)
     request.Verb = Web::Request::HTTP_GET;
     request.Path = webPrefix;
 
+    ON_CALL(*p_iarmBusImplMock, IARM_Bus_Call)
+        .WillByDefault(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_MFRLIB_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_MFRLIB_API_GetSerializedData)));
+                auto* param = static_cast<IARM_Bus_MFRLib_GetSerializedData_Param_t*>(arg);
+                const char* str = "5678";
+                param->bufLen = strlen(str);
+                strncpy(param->buffer, str, sizeof(param->buffer));
+                param->type =  mfrSERIALIZED_TYPE_SERIALNUMBER;
+                return IARM_RESULT_SUCCESS;
+            });
+
     auto response = interface->Process(request);
     ASSERT_TRUE(response.IsValid());
 
@@ -180,6 +193,19 @@ TEST_F(DeviceInfoWebInitializedTest, httpGetSystem)
     Web::Request request;
     request.Verb = Web::Request::HTTP_GET;
     request.Path = webPrefix + _T("/System");
+
+    ON_CALL(*p_iarmBusImplMock, IARM_Bus_Call)
+        .WillByDefault(
+            [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_MFRLIB_NAME)));
+                EXPECT_EQ(string(methodName), string(_T(IARM_BUS_MFRLIB_API_GetSerializedData)));
+                auto* param = static_cast<IARM_Bus_MFRLib_GetSerializedData_Param_t*>(arg);
+                const char* str = "5678";
+                param->bufLen = strlen(str);
+                strncpy(param->buffer, str, sizeof(param->buffer));
+                param->type =  mfrSERIALIZED_TYPE_SERIALNUMBER;
+                return IARM_RESULT_SUCCESS;
+            });
 
     auto response = interface->Process(request);
     ASSERT_TRUE(response.IsValid());

--- a/Tests/L1Tests/tests/test_SystemServices.cpp
+++ b/Tests/L1Tests/tests/test_SystemServices.cpp
@@ -6237,7 +6237,7 @@ TEST_F(SystemServicesTest, setFSRSuccess){
         .Times(::testing::AnyNumber())
         .WillRepeatedly(
             [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
-                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_PWRMGR_NAME)));
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_MFRLIB_NAME)));
                 EXPECT_EQ(string(methodName), string(_T(IARM_BUS_MFRLIB_API_SetFsrFlag)));
                 auto param = static_cast<IARM_Bus_MFRLib_FsrFlag_Param_t>(arg);
                 EXPECT_EQ(param, (1));
@@ -6253,15 +6253,14 @@ TEST_F(SystemServicesTest, setFSRFailure){
         .Times(::testing::AnyNumber())
         .WillRepeatedly(
             [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
-                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_PWRMGR_NAME)));
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_MFRLIB_NAME)));
                 EXPECT_EQ(string(methodName), string(_T(IARM_BUS_MFRLIB_API_SetFsrFlag)));
                 auto param = static_cast<IARM_Bus_MFRLib_FsrFlag_Param_t>(arg);
                 EXPECT_EQ(param, (1));
                 return IARM_RESULT_INVALID_STATE;
             });
 
-    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("setFSRFlag"), _T("{\"fsrFlag\":1}"), response));
-    EXPECT_EQ(response, string("{\"success\":false}"));
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("setFSRFlag"), _T("{\"fsrFlag\":1}"), response));
 }
 
 TEST_F(SystemServicesTest, getFSRSuccess){
@@ -6269,7 +6268,7 @@ TEST_F(SystemServicesTest, getFSRSuccess){
         .Times(::testing::AnyNumber())
         .WillRepeatedly(
             [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
-                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_PWRMGR_NAME)));
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_MFRLIB_NAME)));
                 EXPECT_EQ(string(methodName), string(_T(IARM_BUS_MFRLIB_API_GetFsrFlag)));
                 auto param = static_cast<IARM_Bus_MFRLib_FsrFlag_Param_t>(arg);
                 EXPECT_EQ(param, (1));
@@ -6277,7 +6276,7 @@ TEST_F(SystemServicesTest, getFSRSuccess){
             });
 
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getFSRFlag"), _T("{}"), response));
-    EXPECT_EQ(response, string("{\"success\":true}"));
+    EXPECT_EQ(response, string("{\"fsrFlag\":true,\"success\":true}"));
 }
 
 TEST_F(SystemServicesTest, getFSRFailure){
@@ -6285,13 +6284,12 @@ TEST_F(SystemServicesTest, getFSRFailure){
         .Times(::testing::AnyNumber())
         .WillRepeatedly(
             [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
-                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_PWRMGR_NAME)));
+                EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_MFRLIB_NAME)));
                 EXPECT_EQ(string(methodName), string(_T(IARM_BUS_MFRLIB_API_GetFsrFlag)));
                 auto param = static_cast<IARM_Bus_MFRLib_FsrFlag_Param_t>(arg);
                 EXPECT_EQ(param, (1));
                 return IARM_RESULT_INVALID_STATE;
             });
 
-    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getFSRFlag"), _T("{}"), response));
-    EXPECT_EQ(response, string("{\"success\":false}"));
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("getFSRFlag"), _T("{}"), response));
 }

--- a/Tests/L1Tests/tests/test_UsbAccess.cpp
+++ b/Tests/L1Tests/tests/test_UsbAccess.cpp
@@ -419,8 +419,9 @@ TEST_F(UsbAccessTest, getFileListSuccess_whenAbsPathFound)
 
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getFileList"), _T("{\"path\":\"/run/media/sda1/logs/PreviousLogs\"}"), response));
     bool res1 = (response.compare(string("{\"path\":\"\\/run\\/media\\/sda1\\/logs\\/PreviousLogs\",\"contents\":[{\"name\":\"logFile.txt\",\"t\":\"f\"},{\"name\":\"..\",\"t\":\"d\"},{\"name\":\".\",\"t\":\"d\"}],\"success\":true}")) == 0);
-    bool res2 = (response.compare(string("{\"path\":\"\\/run\\/media\\/sda1\\/logs\\/PreviousLogs\",\"contents\":[{\"name\":\".\",\"t\":\"d\"},{\"name\":\"..\",\"t\":\"d\"},{\"name\":\"logFile.txt\",\"t\":\"f\"}],\"success\":true}")) == 0);
-    EXPECT_EQ(res1 || res2, true);
+    bool res2 = (response.compare(string("{\"path\":\"\\/run\\/media\\/sda1\\/logs\\/PreviousLogs\",\"contents\":[{\"name\":\"logFile.txt\",\"t\":\"f\"},{\"name\":\".\",\"t\":\"d\"},{\"name\":\"..\",\"t\":\"d\"}],\"success\":true}")) == 0);
+    bool res3 = (response.compare(string("{\"path\":\"\\/run\\/media\\/sda1\\/logs\\/PreviousLogs\",\"contents\":[{\"name\":\".\",\"t\":\"d\"},{\"name\":\"..\",\"t\":\"d\"},{\"name\":\"logFile.txt\",\"t\":\"f\"}],\"success\":true}")) == 0);
+    EXPECT_EQ( (res1 || res2 || res3), true);
 }
 
 /**
@@ -537,8 +538,9 @@ TEST_F(UsbAccessTest, getFileListSuccess_withRelativePathParam)
 
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getFileList"), _T("{\"path\":\"sda1/logs/PreviousLogs\"}"), response));
     bool res1 = (response.compare(string("{\"path\":\"\\/run\\/media\\/sda1\\/logs\\/PreviousLogs\",\"contents\":[{\"name\":\"logFile.txt\",\"t\":\"f\"},{\"name\":\"..\",\"t\":\"d\"},{\"name\":\".\",\"t\":\"d\"}],\"success\":true}")) == 0);
-    bool res2 = (response.compare(string("{\"path\":\"\\/run\\/media\\/sda1\\/logs\\/PreviousLogs\",\"contents\":[{\"name\":\".\",\"t\":\"d\"},{\"name\":\"..\",\"t\":\"d\"},{\"name\":\"logFile.txt\",\"t\":\"f\"}],\"success\":true}")) == 0);
-    EXPECT_EQ(res1 || res2, true);
+    bool res2 = (response.compare(string("{\"path\":\"\\/run\\/media\\/sda1\\/logs\\/PreviousLogs\",\"contents\":[{\"name\":\"logFile.txt\",\"t\":\"f\"},{\"name\":\".\",\"t\":\"d\"},{\"name\":\"..\",\"t\":\"d\"}],\"success\":true}")) == 0);
+    bool res3 = (response.compare(string("{\"path\":\"\\/run\\/media\\/sda1\\/logs\\/PreviousLogs\",\"contents\":[{\"name\":\".\",\"t\":\"d\"},{\"name\":\"..\",\"t\":\"d\"},{\"name\":\"logFile.txt\",\"t\":\"f\"}],\"success\":true}")) == 0);
+    EXPECT_EQ( (res1 || res2 || res3), true);
 }
 /**
  * @brief : getFileList when absolute path is found


### PR DESCRIPTION
Reason for change: Fix failing l1 testcases
Test Procedure: Run L1 workflow
Risks: Low
Priority: P1