### PR TITLE
LLAMA-14185: AVR shows incorrect audio format.

### DIFF
--- a/DisplaySettings/CHANGELOG.md
+++ b/DisplaySettings/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.4.7] - 2024-08-30
+### Added
+- Clear the SAD upon receiving the hotplug-out event.
+
 ## [1.4.6] - 2024-07-31
 ### Added
 - Update getSupportedAudioModes to return based on audioports not video ports

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -876,6 +876,14 @@ namespace WPEFramework {
 				   DisplaySettings::_instance->m_requestSadRetrigger = false;
                                 }
 
+				if (DisplaySettings::_instance->m_AudioDeviceSADState != AUDIO_DEVICE_SAD_CLEARED) {
+					DisplaySettings::_instance->m_AudioDeviceSADState = AUDIO_DEVICE_SAD_CLEARED;
+					LOGINFO("%s: Clearing Audio device SAD\n", __FUNCTION__);
+					sad_list.clear();
+				} else {
+				LOGINFO("SAD already cleared\n");
+				}
+
                             }// Release Mutex m_AudioDeviceStatesUpdateMutex
 			}
                         catch (const device::Exception& err)

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -85,7 +85,7 @@ using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 4
-#define API_VERSION_NUMBER_PATCH 6
+#define API_VERSION_NUMBER_PATCH 7
 
 static bool isCecEnabled = false;
 static bool isResCacheUpdated = false;


### PR DESCRIPTION
Reason for change: Clear the SAD upon receiving the hotplug-out event.
Test Procedure: refer the ticket
Risks: None
Signed-off-by: Neethu A S neethu.arambilsunny@sky.uk