### PR TITLE
DELIA-65834 : Skipped new mode request

### DIFF
--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -1388,13 +1388,22 @@ namespace WPEFramework {
             JsonObject param;
             std::string oldMode = m_currentMode;
             bool result = true;
-
+            if(m_remainingDuration>0)
+            {
+                populateResponseWithError(SysSrv_ModeChangeInProgress, response);
+                LOGERR("Mode change is already in progress.current mode is %s and it will be in progress for next %d seconds. Please try again later.\n",m_currentMode.c_str(),m_remainingDuration);
+                returnResponse(false);
+            }
             if (parameters.HasLabel("modeInfo")) {
                 param.FromString(parameters["modeInfo"].String());
                 if (param.HasLabel("duration") && param.HasLabel("mode")) {
                     int duration = param["duration"].Number();
                     std::string newMode = param["mode"].String();
-
+                    if(duration>86400)
+                    {
+                        LOGWARN("Duration is more than 24 hours. Setting duration to 24 hours,which is maximum allowed duration to set\n");
+                        duration = 86400;
+                    }
                     LOGWARN("request to switch to mode '%s' from mode '%s' \
                             with duration %d\n", newMode.c_str(),
                             oldMode.c_str(), duration);

--- a/SystemServices/SystemServicesHelper.cpp
+++ b/SystemServices/SystemServicesHelper.cpp
@@ -46,7 +46,8 @@ static const std::map<int, std::string> ErrCodeMap = {
     {SysSrv_LibcurlError, "LIbCurl service error"},
     {SysSrv_DynamicMemoryAllocationFailed, "Dynamic Memory Allocation Failed"},
     {SysSrv_ManufacturerDataReadFailed, "Manufacturer Data Read Failed"},
-    {SysSrv_KeyNotFound, "Key not found"}
+    {SysSrv_KeyNotFound, "Key not found"},
+    {SysSrv_ModeChangeInProgress, "Mode change is in progress"}
 };
 
 std::string getErrorDescription(int errCode)

--- a/SystemServices/SystemServicesHelper.h
+++ b/SystemServices/SystemServicesHelper.h
@@ -104,7 +104,8 @@ enum SysSrv_ErrorCode {
     SysSrv_LibcurlError,
     SysSrv_DynamicMemoryAllocationFailed,
     SysSrv_ManufacturerDataReadFailed,
-    SysSrv_KeyNotFound
+    SysSrv_KeyNotFound,
+    SysSrv_ModeChangeInProgress
 };
 
 enum FirmwareUpdateState {


### PR DESCRIPTION
Reason for change: Throwing error in case of new mode request(when newmode requested is same as currentmode),
                   thereby avoiding crash.

Test Procedure: 1.Set device to any of the modes(WAREHOUSE/EAS/NORMAL) for 30s.
                2.During that 30s,again make a request to set another mode(WAREHOUSE/EAS/NORMAL).
                3.Check for crashes.

Risks: Low