### PR TITLE
Close() MessageUnit on process exit

### DIFF
--- a/WebKitBrowser/Extension/main.cpp
+++ b/WebKitBrowser/Extension/main.cpp
@@ -148,6 +148,12 @@ public:
 #if defined(UPDATE_TZ_FROM_FILE)
         _tzSupport.Deinitialize();
 #endif
+
+#ifdef __CORE_MESSAGING__
+        // Messaging has to be destroyed before Singletons are disposed.
+        // We are not inside WPEProcess so need to do it manually.
+        Messaging::MessageUnit::Instance().Close();
+#endif
         if (_comClient.IsValid() == true) {
             _comClient.Release();
         }

--- a/WebKitBrowser/WebKitImplementation.cpp
+++ b/WebKitBrowser/WebKitImplementation.cpp
@@ -364,6 +364,13 @@ static GSourceFuncs _handlerIntervention =
         if (implementation != nullptr) {
             delete implementation;
             implementation = nullptr;
+#ifdef __CORE_MESSAGING__
+            // Messaging has to be destroyed before Singletons are disposed.
+            // WPEProcess will usually take care of this at the end of its main() func,
+            // but beeing here suggests that something went wrong and possibly
+            // we are closing with exit() func (from postExitJob())
+            Messaging::MessageUnit::Instance().Close();
+#endif
         }
     }
 


### PR DESCRIPTION
Messaging has to be destroyed before Singletons are disposed. WPEProcess will usually take care of this at the end of its main() func, but sometimes WebKit browser plugin uses exit() func to terminate the process. In such case we need to Close() MessageUnit manually to avoid hangs and asserts.

Without calling MessageUnit::Close() the process will hang for 120sec (3x40sec) in ~MessageUnit() destructor, waiting for SocketPort() closure (exact BT below). It looks like MessageUnit has to be closed before ResourceMonitor singleton destruction to avoid this hang.

Here are the logs printed when calling exit(1); Those are from MessageUnit singleton destruction:
```Sep 03 14:20:45 hisense-v2 WPEFramework[4426]: ===== $$ [5312]: ASSERT [/usr/src/debug/wpeframework/4.4-r0/git/Source/messaging/MessageUnit.h:845] (_dispatcher == nullptr)
Sep 03 14:20:45 hisense-v2 WPEFramework[4426]: [/usr/lib/libWPEFrameworkCore.so.4]:[DumpCallStack]:[19]
Sep 03 14:20:45 hisense-v2 WPEFramework[4426]: [/usr/lib/libWPEFrameworkMessaging.so.4]:[]:[-1]
Sep 03 14:20:45 hisense-v2 WPEFramework[4426]: [/usr/lib/libWPEFrameworkMessaging.so.4]:[]:[-1]

...

Sep 03 14:21:25 hisense-v2 WPEFramework[4426]: ===== $$ [5312]: ASSERT [/usr/src/debug/wpeframework/4.4-r0/git/Source/core/SocketPort.cpp:632] (closed == true)
Sep 03 14:21:25 hisense-v2 WPEFramework[4426]: [/usr/lib/libWPEFrameworkCore.so.4]:[DumpCallStack]:[19]
Sep 03 14:21:25 hisense-v2 WPEFramework[4426]: [/usr/lib/libWPEFrameworkCore.so.4]:[WPEFramework::Core::SocketPort::Close(unsigned int)]:[227]
Sep 03 14:21:25 hisense-v2 WPEFramework[4426]: [/usr/lib/libWPEFrameworkMessaging.so.4]:[]:[-1]

```
BT for hang:
```
(gdb) bt
#0  __libc_do_syscall () at ../sysdeps/unix/sysv/linux/arm/libc-do-syscall.S:47
#1  0xb3c3245c in __GI___clock_nanosleep_time64 (clock_id=clock_id@entry=0, flags=flags@entry=0, req=req@entry=0xbbb35a58, rem=0xbbb35a68) at ../sysdeps/unix/sysv/linux/clock_nanosleep.c:62
#2  0xb3c35c96 in __GI___nanosleep64 (rem=<optimized out>, req=0xbbb35a58) at ../sysdeps/unix/sysv/linux/nanosleep.c:25
#3  __GI___nanosleep (req=<optimized out>, rem=0xbbb35a80) at ../sysdeps/unix/sysv/linux/nanosleep.c:42
#4  0xb3e554ca in SleepMs (time=time@entry=100) at /usr/src/debug/wpeframework/4.4-r0/git/Source/core/Portability.cpp:272
#5  0xb3e590a4 in WPEFramework::Core::SocketPort::WaitForClosure (this=this@entry=0x1712b1c, time=time@entry=4294967295) at /usr/src/debug/wpeframework/4.4-r0/git/Source/core/SocketPort.cpp:970
#6  0xb3e59168 in WPEFramework::Core::SocketPort::Close (this=this@entry=0x1712b1c, waitTime=waitTime@entry=4294967295) at /usr/src/debug/wpeframework/4.4-r0/git/Source/core/SocketPort.cpp:620
#7  0xb3e95b0e in WPEFramework::Core::IPCChannelClientType<WPEFramework::Core::Void, true, true>::~IPCChannelClientType (this=this@entry=0x1712a50, __in_chrg=<optimized out>)
    at /usr/src/debug/wpeframework/4.4-r0/git/Source/messaging/../core/Link.h:214
#8  0xb3e95b92 in WPEFramework::Messaging::MessageUnit::MessageDispatcher::MetaDataBuffer::~MetaDataBuffer (this=0x1712a50, __in_chrg=<optimized out>) at /usr/src/debug/wpeframework/4.4-r0/git/Source/messaging/../core/IPCConnector.h:260
#9  0xb3e95bb8 in WPEFramework::Messaging::MessageUnit::MessageDispatcher::~MessageDispatcher (this=0x1712850, __in_chrg=<optimized out>) at /usr/src/debug/wpeframework/4.4-r0/git/Source/messaging/MessageUnit.h:817
#10 0xb3e95bd4 in WPEFramework::Messaging::MessageUnit::MessageDispatcher::~MessageDispatcher (this=0x1712850, __in_chrg=<optimized out>) at /usr/src/debug/wpeframework/4.4-r0/git/Source/messaging/MessageUnit.h:817
#11 0xb3e92e96 in std::default_delete<WPEFramework::Messaging::MessageUnit::MessageDispatcher>::operator() (this=<optimized out>, __ptr=<error reading variable: dwarf2_find_location_expression: Corrupted DWARF expression.>)
    at /usr/include/c++/11.3.0/bits/unique_ptr.h:79
#12 std::unique_ptr<WPEFramework::Messaging::MessageUnit::MessageDispatcher, std::default_delete<WPEFramework::Messaging::MessageUnit::MessageDispatcher> >::~unique_ptr (this=0x17120b4, __in_chrg=<optimized out>)
    at /usr/include/c++/11.3.0/bits/unique_ptr.h:361
#13 0xb3e9582e in WPEFramework::Messaging::MessageUnit::~MessageUnit (this=this@entry=0x1712098, __in_chrg=<optimized out>) at /usr/src/debug/wpeframework/4.4-r0/git/Source/messaging/MessageUnit.h:845
#14 0xb3e9590e in WPEFramework::Core::SingletonType<WPEFramework::Messaging::MessageUnit>::~SingletonType (this=0x1712090, __in_chrg=<optimized out>) at /usr/src/debug/wpeframework/4.4-r0/git/Source/messaging/../core/Singleton.h:105
#15 0xb3e9595c in WPEFramework::Core::SingletonType<WPEFramework::Messaging::MessageUnit>::~SingletonType (this=0x1712090, __in_chrg=<optimized out>) at /usr/src/debug/wpeframework/4.4-r0/git/Source/messaging/../core/Singleton.h:102
#16 0xb3e586b0 in WPEFramework::Core::Singleton::SingletonList::Dispose (this=this@entry=0xb3e7c3cc <WPEFramework::Core::Singleton::ListInstance()::g_Singletons>) at /usr/src/debug/wpeframework/4.4-r0/git/Source/core/Singleton.cpp:52
#17 0xb3e586d8 in WPEFramework::Core::Singleton::SingletonList::~SingletonList (this=0xb3e7c3cc <WPEFramework::Core::Singleton::ListInstance()::g_Singletons>, __in_chrg=<optimized out>)
    at /usr/src/debug/wpeframework/4.4-r0/git/Source/core/Singleton.cpp:43
#18 0xb3be1862 in __cxa_finalize (d=0xb3e7a8b4) at cxa_finalize.c:83
#19 0xb3e485f2 in __do_global_dtors_aux () at /usr/include/c++/11.3.0/bits/char_traits.h:357
#20 0xb3f9aa1a in _dl_fini () at dl-fini.c:142
#21 0xb3be13c2 in __run_exit_handlers (status=1, listp=0xb3cbf384 <__exit_funcs>, run_list_atexit=run_list_atexit@entry=true, run_dtors=run_dtors@entry=true) at exit.c:113
#22 0xb3be14ce in __GI_exit (status=<optimized out>) at exit.c:143
#23 0xb0e20416 in WPEFramework::Plugin::WebKitImplementation::postExitJob()::ExitJob::Dispatch() (this=<optimized out>) at /usr/src/debug/webkitbrowser-plugin/3.0+gitAUTOINC+1e6589af92-r1/git/WebKitBrowser/WebKitImplementation.cpp:2714
#24 0x00022ccc in ?? ()
Backtrace stopped: previous frame identical to this frame (corrupt stack?)
(gdb) 
```