### PR TITLE
RDK-52297: Core system supports dynamic partner configuration

### DIFF
--- a/SystemServices/CHANGELOG.md
+++ b/SystemServices/CHANGELOG.md
@@ -16,6 +16,9 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [3.1.0] - 2024-09-03
+### Update
+- RDK-52297: Core system supports dynamic partner configuration
 
 ## [3.0.2] - 2024-08-12
 ### Update

--- a/SystemServices/System.json
+++ b/SystemServices/System.json
@@ -2233,6 +2233,34 @@
                 ]
             }
         },
+                "onDeviceMgtUpdateReceived":{
+            "summary": "Triggered when the device management update completes",
+            "params": {
+                "type" :"object",
+                "properties": {
+                "source": {
+                        "summary": "Source information from where the event on update is posted",
+                        "type": "string",
+                        "example":"rfc"
+                },
+                "type":{
+                    "summary": " Type of Update received currently it will be used as initial",
+                    "type": "string",
+                    "example": "initial"
+                },
+                "success":{
+                    "summary": "Status information of update whether success or failure",
+                    "type":"bool",
+                    "example": "true"
+                }
+                                },
+                "required":[
+                    "source",
+                    "type",
+                    "success"
+                ]
+            }
+         },
 		"onTimeZoneDSTChanged":{
             "summary": "Triggered when device time zone changed",
             "params": {

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -66,8 +66,8 @@
 using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 3
-#define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 2
+#define API_VERSION_NUMBER_MINOR 1
+#define API_VERSION_NUMBER_PATCH 0
 
 #define MAX_REBOOT_DELAY 86400 /* 24Hr = 86400 sec */
 #define TR181_FW_DELAY_REBOOT "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.AutoReboot.fwDelayReboot"

--- a/SystemServices/SystemServices.h
+++ b/SystemServices/SystemServices.h
@@ -68,6 +68,7 @@ using std::ofstream;
 #define EVT_ONTIMEZONEDSTCHANGED          "onTimeZoneDSTChanged"
 #define EVT_FRIENDLYNAMECHANGED           "onFriendlyNameChanged"
 #define EVT_ONLOGUPLOAD                   "onLogUpload"
+#define EVT_ONDEVICEMGTUPDATERECEIVED     "onDeviceMgtUpdateReceived"
 #define TERRITORYFILE                     "/opt/secure/persistent/System/Territory.txt"
 
 
@@ -201,6 +202,7 @@ namespace WPEFramework {
                 void onFirmwarePendingReboot(int seconds); /* Event handler for Pending Reboot */
 		void onTerritoryChanged(string oldTerritory, string newTerritory, string oldRegion="", string newRegion="");
 		void onTimeZoneDSTChanged(string oldTimeZone, string newTimeZone, string oldAccuracy, string newAccuracy);
+		void onDeviceMgtUpdateReceived(IARM_BUS_SYSMGR_DeviceMgtUpdateInfo_Param_t *config);
                 /* Events : End */
 
                 /* Methods : Begin */

--- a/Tests/mocks/Iarm.h
+++ b/Tests/mocks/Iarm.h
@@ -479,6 +479,16 @@ typedef struct _IARM_BUS_PWRMgr_WareHouseOpn_EventData_t {
 #define IARM_BUS_SYSMGR_NAME "SYSMgr"
 #define IARM_BUS_SYSMGR_API_GetSystemStates "GetSystemStates"
 
+/**
+ *  @brief Structure which holds RFC device management update information.
+ */
+typedef struct _IARM_BUS_SYSMGR_DeviceMgtUpdateInfo_Param_t
+{
+      char source[10];                                    /*!< Device Management Update source. Ex: rfc */
+      char type[10];                                      /*!< Device Management Update type. Ex: initial */
+      bool status;                                        /*!< Device Management Update status. true/false */
+} IARM_BUS_SYSMGR_DeviceMgtUpdateInfo_Param_t;
+
 typedef enum _SYSMgr_EventId_t {
     IARM_BUS_SYSMGR_EVENT_SYSTEMSTATE,
     IARM_BUS_SYSMGR_EVENT_XUPNP_DATA_REQUEST, /*!< Xupnp data  request frm Receiver to UPNP*/
@@ -492,6 +502,7 @@ typedef enum _SYSMgr_EventId_t {
     IARM_BUS_SYSMGR_EVENT_KEYCODE_LOGGING_CHANGED, /*!< Key Code logging status update */
     IARM_BUS_SYSMGR_EVENT_USB_MOUNT_CHANGED, /*!< Fires when USB mounts change */
     IARM_BUS_SYSMGR_EVENT_APP_RELEASE_FOCUS, /*!< Application fires event to release focus*/
+    IARM_BUS_SYSMGR_EVENT_DEVICE_UPDATE_RECEIVED, /*!< Received Device Management update information */
     IARM_BUS_SYSMGR_EVENT_MAX /*!< Max Event Id */
 } IARM_Bus_SYSMgr_EventId_t;
 


### PR DESCRIPTION
Reason for change: Add new IARM event for RFC initialisation complete
Test Procedure: Build and Verify
Risks: low
Priority: P1
Signed-off-by: nhanasi<navihansi@gmail.com>