### PR TITLE
XIONE-15405: HDMI CEC Logical address update

### DIFF
--- a/HdmiCecSource/CHANGELOG.md
+++ b/HdmiCecSource/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.1.1] - 2024-09-04
+### Changed
+- Changed power mode handler function to update LA after wakeup
+
 ## [1.1.0] - 2024-07-15
 ### Added
 - Added event for sendKey Presss and release messages 

--- a/HdmiCecSource/HdmiCecSource.cpp
+++ b/HdmiCecSource/HdmiCecSource.cpp
@@ -818,6 +818,7 @@ namespace WPEFramework
                     if(param->data.state.newState == IARM_BUS_PWRMGR_POWERSTATE_ON)
                     {
                         powerState = 0; 
+			HdmiCecSource::_instance->getLogicalAddress(); // get the updated LA after wakeup
                     }
                     else
                         powerState = 1;
@@ -1430,6 +1431,8 @@ namespace WPEFramework
                 {
                     logicalAddress = addr;
                     logicalAddressDeviceType = logicalAddrDeviceType;
+		    if(smConnection)
+                        smConnection->setSource(logicalAddress); //update initiator LA
                 }
             }
             catch (const std::exception& e)


### PR DESCRIPTION
Reason for change: Get latest hdmi cec logical addr after device power mode
                   changed to ON or after wakeup.

Test Procedure: build and verify
Risks: Medium
Priority: P1
Signed-off-by: Srigayathry Pugazhenthi<srigayathry.pugazhenthi@sky.uk>