### PR TITLE
RDKDEV-1076,RTD131X-1256 - DAC Apps are not launching in Thunder 4.4

### DIFF
--- a/RDKShell/CHANGELOG.md
+++ b/RDKShell/CHANGELOG.md
@@ -16,6 +16,11 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+
+## [1.6.5] - 2024-09-09
+### Added
+- Added for response is getting empty on launching DAC application
+
 ## [1.6.4] - 2024-09-05
 ### Added
 - Fix to activate RA after the Graphics subsystem, handle mutex

--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -53,7 +53,7 @@
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 6
-#define API_VERSION_NUMBER_PATCH 4
+#define API_VERSION_NUMBER_PATCH 5
 
 const string WPEFramework::Plugin::RDKShell::SERVICE_NAME = "org.rdk.RDKShell";
 //methods

--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -713,6 +713,11 @@ namespace WPEFramework {
                     }
                 }
             }
+	    // This changes is added for response is getting empty on launching DAC application
+	    if (!FromMessage(response, message, isResponseString))
+	    {
+		return Core::ERROR_GENERAL;
+	    }
 #elif (THUNDER_VERSION == 2)
             auto resp =  dispatcher_->Invoke(sThunderSecurityToken, channelId, *message);
 #else


### PR DESCRIPTION
Reason for change: DAC apps is not launced after installing in Thunder 4.4 version Image

Test Procedure: Refer ticket

Risks: Medium