### PR TITLE
RDK-52180: Add ParentalControl new properties in Usersetttings

### DIFF
--- a/.github/workflows/L2-tests-R4-4-1.yml
+++ b/.github/workflows/L2-tests-R4-4-1.yml
@@ -60,6 +60,11 @@ jobs:
             ninja -C build
             sudo ninja -C build install
 
+      - name: Checkout rdkservices
+        uses: actions/checkout@v3
+        with:
+          path: rdkservices
+
       - name: Checkout Thunder
         uses: actions/checkout@v3
         with:
@@ -67,13 +72,19 @@ jobs:
           path: Thunder
           ref: ${{env.THUNDER_REF}}
 
+      - name: Apply patches Thunder
+        run: |
+          cd ${{github.workspace}}/Thunder
+          patch -p1 < ${{github.workspace}}/rdkservices/Tests/L2Tests/patches/Use_Legact_Alt_Based_On_ThunderTools_R4.4.3.patch
+          cd -
+
       - name: Checkout ThunderTools
         if: steps.cache.outputs.cache-hit != 'true'
         uses: actions/checkout@v3
         with:
           repository: rdkcentral/ThunderTools
           path: ThunderTools
-          ref: ${{env.THUNDER_REF}}
+          ref: R4.4.3
 
       - name: Build ThunderTools
         if: steps.cache.outputs.cache-hit != 'true'
@@ -89,11 +100,6 @@ jobs:
           cmake --build build/ThunderTools -j8
           &&
           cmake --install build/ThunderTools
-
-      - name: Checkout rdkservices
-        uses: actions/checkout@v3
-        with:
-          path: rdkservices
 
       - name: Checkout rdkservices
         run: |
@@ -138,6 +144,7 @@ jobs:
               patch -p1 < ${{github.workspace}}/rdkservices/Tests/L2Tests/patches/0007-RDK-IDeviceInfo-Changes.patch
               patch -p1 < ${{github.workspace}}/rdkservices/Tests/L2Tests/patches/0001-RDK-45037-Secure-Storage-Thunder-Plugin.patch
               patch -p1 < ${{github.workspace}}/rdkservices/Tests/L2Tests/patches/RDKV-48604-User-Settings-Thunder-Plugin.patch
+              patch -p1 < ${{github.workspace}}/rdkservices/Tests/L2Tests/patches/Use_Legact_Alt_In_ThunderInterfaces_Based_On_ThunderTools_R4.4.3.patch
               cd ..
 
       - name: Build ThunderInterfaces

--- a/Tests/L2Tests/L2TestsPlugin/tests/UserSettings_L2Test.cpp
+++ b/Tests/L2Tests/L2TestsPlugin/tests/UserSettings_L2Test.cpp
@@ -21,13 +21,19 @@ using ::WPEFramework::Exchange::IStore2;
 using ::WPEFramework::Exchange::IUserSettings;
 
 typedef enum : uint32_t {
-    UserSettings_OnAudioDescriptionChanged = 0x00000001,
-    UserSettings_OnPreferredAudioLanguagesChanged = 0x00000002,
-    UserSettings_OnPresentationLanguageChanged = 0x00000003,
-    UserSettings_OnCaptionsChanged = 0x00000004,
-    UserSettings_OnPreferredCaptionsLanguagesChanged = 0x00000005,
-    UserSettings_OnPreferredClosedCaptionServiceChanged = 0x00000006,
-    UserSettings_OnPrivacyModeChanged = 0x00000007,
+    UserSettings_onAudioDescriptionChanged = 0x00000001,
+    UserSettings_onPreferredAudioLanguagesChanged = 0x00000002,
+    UserSettings_onPresentationLanguageChanged = 0x00000003,
+    UserSettings_onCaptionsChanged = 0x00000004,
+    UserSettings_onPreferredCaptionsLanguagesChanged = 0x00000005,
+    UserSettings_onPreferredClosedCaptionServiceChanged = 0x00000006,
+    UserSettings_onPinControlChanged = 0x00000007,
+    UserSettings_onViewingRestrictionsChanged = 0x00000008,
+    UserSettings_onViewingRestrictionsWindowChanged = 0x00000009,
+    UserSettings_onLiveWatershedChanged = 0x0000000a,
+    UserSettings_onPlaybackWatershedChanged = 0x0000000b,
+    UserSettings_onBlockNotRatedContentChanged = 0x0000000c,
+    UserSettings_onPinOnPurchaseChanged = 0x0000000d,
     UserSettings_StateInvalid = 0x00000000
 }UserSettingsL2test_async_events_t;
 
@@ -37,13 +43,19 @@ class AsyncHandlerMock_UserSetting
         AsyncHandlerMock_UserSetting()
         {
         }
-        MOCK_METHOD(void, OnAudioDescriptionChanged, (const bool enabled));
-        MOCK_METHOD(void, OnPreferredAudioLanguagesChanged, (const string preferredLanguages));
-        MOCK_METHOD(void, OnPresentationLanguageChanged, (const string presentationLanguages));
-        MOCK_METHOD(void, OnCaptionsChanged, (bool enabled));
-        MOCK_METHOD(void, OnPreferredCaptionsLanguagesChanged, (const string preferredLanguages));
-        MOCK_METHOD(void, OnPreferredClosedCaptionServiceChanged, (const string service));
-        MOCK_METHOD(void, OnPrivacyModeChanged, (const string privacyMode));
+        MOCK_METHOD(void, onAudioDescriptionChanged, (const bool enabled));
+        MOCK_METHOD(void, onPreferredAudioLanguagesChanged, (const string preferredLanguages));
+        MOCK_METHOD(void, onPresentationLanguageChanged, (const string presentationLanguage));
+        MOCK_METHOD(void, onCaptionsChanged, (const bool enabled));
+        MOCK_METHOD(void, onPreferredCaptionsLanguagesChanged, (const string preferredLanguages));
+        MOCK_METHOD(void, onPreferredClosedCaptionServiceChanged, (const string service));
+        MOCK_METHOD(void, onPinControlChanged, (const bool enabled));
+        MOCK_METHOD(void, onViewingRestrictionsChanged, (const string viewingRestrictions));
+        MOCK_METHOD(void, onViewingRestrictionsWindowChanged, (const string viewingRestrictionsWindow));
+        MOCK_METHOD(void, onLiveWatershedChanged, (const bool enabled));
+        MOCK_METHOD(void, onPlaybackWatershedChanged, (const bool enabled));
+        MOCK_METHOD(void, onBlockNotRatedContentChanged, (const bool enabled));
+        MOCK_METHOD(void, onPinOnPurchaseChanged, (const bool enabled));
 
 };
 
@@ -74,7 +86,7 @@ class NotificationHandler : public Exchange::IUserSettings::INotification {
 
             TEST_LOG("OnAudioDescriptionChanged received: %s\n", str.c_str());
             /* Notify the requester thread. */
-            m_event_signalled |= UserSettings_OnAudioDescriptionChanged;
+            m_event_signalled |= UserSettings_onAudioDescriptionChanged;
             m_condition_variable.notify_one();
         }
 
@@ -85,19 +97,19 @@ class NotificationHandler : public Exchange::IUserSettings::INotification {
 
             TEST_LOG("OnPreferredAudioLanguagesChanged received: %s\n", preferredLanguages.c_str());
             /* Notify the requester thread. */
-            m_event_signalled |= UserSettings_OnPreferredAudioLanguagesChanged;
+            m_event_signalled |= UserSettings_onPreferredAudioLanguagesChanged;
             m_condition_variable.notify_one();
 
         }
 
-        void OnPresentationLanguageChanged(const string& presentationLanguages) override
+        void OnPresentationLanguageChanged(const string& presentationLanguage) override
         {
             TEST_LOG("OnPresentationLanguageChanged event triggered ***\n");
             std::unique_lock<std::mutex> lock(m_mutex);
 
-            TEST_LOG("OnPresentationLanguageChanged received: %s\n", presentationLanguages.c_str());
+            TEST_LOG("OnPresentationLanguageChanged received: %s\n", presentationLanguage.c_str());
             /* Notify the requester thread. */
-            m_event_signalled |= UserSettings_OnPresentationLanguageChanged;
+            m_event_signalled |= UserSettings_onPresentationLanguageChanged;
             m_condition_variable.notify_one();
 
         }
@@ -110,7 +122,7 @@ class NotificationHandler : public Exchange::IUserSettings::INotification {
 
             TEST_LOG("OnCaptionsChanged received: %s\n", str.c_str());
             /* Notify the requester thread. */
-            m_event_signalled |= UserSettings_OnCaptionsChanged;
+            m_event_signalled |= UserSettings_onCaptionsChanged;
             m_condition_variable.notify_one();
 
         }
@@ -122,7 +134,7 @@ class NotificationHandler : public Exchange::IUserSettings::INotification {
 
             TEST_LOG("OnPreferredAudioLanguagesChanged received: %s\n", preferredLanguages.c_str());
             /* Notify the requester thread. */
-            m_event_signalled |= UserSettings_OnPreferredCaptionsLanguagesChanged;
+            m_event_signalled |= UserSettings_onPreferredCaptionsLanguagesChanged;
             m_condition_variable.notify_one();
 
         }
@@ -134,21 +146,92 @@ class NotificationHandler : public Exchange::IUserSettings::INotification {
 
             TEST_LOG("OnPreferredClosedCaptionServiceChanged received: %s\n", service.c_str());
             /* Notify the requester thread. */
-            m_event_signalled |= UserSettings_OnPreferredClosedCaptionServiceChanged;
+            m_event_signalled |= UserSettings_onPreferredClosedCaptionServiceChanged;
+            m_condition_variable.notify_one();
+        }
+
+        void OnPinControlChanged(const bool enabled) override
+        {
+            TEST_LOG("OnPinControlChanged event triggered ***\n");
+            std::unique_lock<std::mutex> lock(m_mutex);
+            std::string str = enabled ? "true" : "false";
+
+            TEST_LOG("OnPinControlChanged received: %s\n", str.c_str());
+            /* Notify the requester thread. */
+            m_event_signalled |= UserSettings_onPinControlChanged;
+            m_condition_variable.notify_one();
+        }
+
+        void OnViewingRestrictionsChanged(const string& viewingRestrictions) override
+        {
+            TEST_LOG("OnViewingRestrictionsChanged event triggered ***\n");
+            std::unique_lock<std::mutex> lock(m_mutex);
+
+            TEST_LOG("OnViewingRestrictionsChanged received: %s\n", viewingRestrictions.c_str());
+            /* Notify the requester thread. */
+            m_event_signalled |= UserSettings_onViewingRestrictionsChanged;
             m_condition_variable.notify_one();
 
         }
 
-        void OnPrivacyModeChanged(const string& privacyMode) override
+        void OnViewingRestrictionsWindowChanged(const string& viewingRestrictionsWindow) override
         {
-            TEST_LOG("OnPrivacyModeChanged event triggered ***\n");
+            TEST_LOG("OnViewingRestrictionsWindowChanged event triggered ***\n");
             std::unique_lock<std::mutex> lock(m_mutex);
 
-            TEST_LOG("OnPrivacyModeChanged received: %s\n", privacyMode.c_str());
+            TEST_LOG("OnViewingRestrictionsWindowChanged received: %s\n", viewingRestrictionsWindow.c_str());
             /* Notify the requester thread. */
-            m_event_signalled |= UserSettings_OnPrivacyModeChanged;
+            m_event_signalled |= UserSettings_onViewingRestrictionsWindowChanged;
             m_condition_variable.notify_one();
 
+        }
+
+        void OnLiveWatershedChanged(const bool enabled) override
+        {
+            TEST_LOG("OnLiveWatershedChanged event triggered ***\n");
+            std::unique_lock<std::mutex> lock(m_mutex);
+            std::string str = enabled ? "true" : "false";
+
+            TEST_LOG("OnLiveWatershedChanged received: %s\n", str.c_str());
+            /* Notify the requester thread. */
+            m_event_signalled |= UserSettings_onLiveWatershedChanged;
+            m_condition_variable.notify_one();
+        }
+
+        void OnPlaybackWatershedChanged(const bool enabled) override
+        {
+            TEST_LOG("OnPlaybackWatershedChanged event triggered ***\n");
+            std::unique_lock<std::mutex> lock(m_mutex);
+            std::string str = enabled ? "true" : "false";
+
+            TEST_LOG("OnPlaybackWatershedChanged received: %s\n", str.c_str());
+            /* Notify the requester thread. */
+            m_event_signalled |= UserSettings_onPlaybackWatershedChanged;
+            m_condition_variable.notify_one();
+        }
+
+        void OnBlockNotRatedContentChanged(const bool enabled) override
+        {
+            TEST_LOG("OnBlockNotRatedContentChanged event triggered ***\n");
+            std::unique_lock<std::mutex> lock(m_mutex);
+            std::string str = enabled ? "true" : "false";
+
+            TEST_LOG("OnBlockNotRatedContentChanged received: %s\n", str.c_str());
+            /* Notify the requester thread. */
+            m_event_signalled |= UserSettings_onBlockNotRatedContentChanged;
+            m_condition_variable.notify_one();
+        }
+
+        void OnPinOnPurchaseChanged(const bool enabled) override
+        {
+            TEST_LOG("OnPinOnPurchaseChanged event triggered ***\n");
+            std::unique_lock<std::mutex> lock(m_mutex);
+            std::string str = enabled ? "true" : "false";
+
+            TEST_LOG("OnPinOnPurchaseChanged received: %s\n", str.c_str());
+            /* Notify the requester thread. */
+            m_event_signalled |= UserSettings_onPinOnPurchaseChanged;
+            m_condition_variable.notify_one();
         }
 
         uint32_t WaitForRequestStatus(uint32_t timeout_ms, UserSettingsL2test_async_events_t expected_status)
@@ -179,12 +262,19 @@ protected:
     public:
     UserSettingTest();
 
-      void OnAudioDescriptionChanged(const bool enabled);
-      void OnPreferredAudioLanguagesChanged(const string preferredLanguages);
-      void OnPresentationLanguageChanged(const string presentationLanguages);
-      void OnCaptionsChanged(bool enabled);
-      void OnPreferredCaptionsLanguagesChanged(const string preferredLanguages);
-      void OnPreferredClosedCaptionServiceChanged(const string service);
+      void onAudioDescriptionChanged(const bool enabled);
+      void onPreferredAudioLanguagesChanged(const string preferredLanguages);
+      void onPresentationLanguageChanged(const string presentationLanguage);
+      void onCaptionsChanged(bool enabled);
+      void onPreferredCaptionsLanguagesChanged(const string preferredLanguages);
+      void onPreferredClosedCaptionServiceChanged(const string service);
+      void onPinControlChanged(const bool enabled);
+      void onViewingRestrictionsChanged(const string viewingRestrictions);
+      void onViewingRestrictionsWindowChanged(const string viewingRestrictionsWindow);
+      void onLiveWatershedChanged(const bool enabled);
+      void onPlaybackWatershedChanged(const bool enabled);
+      void onBlockNotRatedContentChanged(const bool enabled);
+      void onPinOnPurchaseChanged(const bool enabled);
 
       uint32_t WaitForRequestStatus(uint32_t timeout_ms,UserSettingsL2test_async_events_t expected_status);
       uint32_t CreateUserSettingInterfaceObjectUsingComRPCConnection();
@@ -228,8 +318,8 @@ UserSettingTest::~UserSettingTest()
     uint32_t status = Core::ERROR_GENERAL;
 
     ON_CALL(*p_rBusApiImplMock, rbus_close(::testing::_ ))
-        .WillByDefault(
-           ::testing::Return(RBUS_ERROR_SUCCESS));
+    .WillByDefault(
+    ::testing::Return(RBUS_ERROR_SUCCESS));
 
     status = DeactivateService("org.rdk.UserSettings");
     EXPECT_EQ(Core::ERROR_NONE, status);
@@ -237,6 +327,7 @@ UserSettingTest::~UserSettingTest()
     status = DeactivateService("org.rdk.PersistentStore");
     EXPECT_EQ(Core::ERROR_NONE, status);
 
+    sleep(5);
     int file_status = remove("/tmp/secure/persistent/rdkservicestore");
     // Check if the file has been successfully removed
     if (file_status != 0)
@@ -268,6 +359,7 @@ uint32_t UserSettingTest::WaitForRequestStatus(uint32_t timeout_ms, UserSettings
     signalled = m_event_signalled;
     return signalled;
 }
+
 uint32_t UserSettingTest::CreateUserSettingInterfaceObjectUsingComRPCConnection()
 {
     uint32_t return_value =  Core::ERROR_GENERAL;
@@ -298,7 +390,7 @@ uint32_t UserSettingTest::CreateUserSettingInterfaceObjectUsingComRPCConnection(
     return return_value;
 }
 
-void UserSettingTest::OnAudioDescriptionChanged(const bool enabled)
+void UserSettingTest::onAudioDescriptionChanged(const bool enabled)
 {
     TEST_LOG("OnAudioDescriptionChanged event triggered ***\n");
     std::unique_lock<std::mutex> lock(m_mutex);
@@ -307,11 +399,11 @@ void UserSettingTest::OnAudioDescriptionChanged(const bool enabled)
     TEST_LOG("OnAudioDescriptionChanged received: %s\n", str.c_str());
 
     /* Notify the requester thread. */
-    m_event_signalled |= UserSettings_OnAudioDescriptionChanged;
+    m_event_signalled |= UserSettings_onAudioDescriptionChanged;
     m_condition_variable.notify_one();
 }
 
-void UserSettingTest::OnPreferredAudioLanguagesChanged(const string preferredLanguages)
+void UserSettingTest::onPreferredAudioLanguagesChanged(const string preferredLanguages)
 {
     TEST_LOG("OnPreferredAudioLanguagesChanged event triggered ***\n");
     std::unique_lock<std::mutex> lock(m_mutex);
@@ -319,23 +411,23 @@ void UserSettingTest::OnPreferredAudioLanguagesChanged(const string preferredLan
     TEST_LOG("OnPreferredAudioLanguagesChanged received: %s\n", preferredLanguages.c_str());
 
     /* Notify the requester thread. */
-    m_event_signalled |= UserSettings_OnPreferredAudioLanguagesChanged;
+    m_event_signalled |= UserSettings_onPreferredAudioLanguagesChanged;
     m_condition_variable.notify_one();
 }
 
-void UserSettingTest::OnPresentationLanguageChanged(const string presentationLanguages)
+void UserSettingTest::onPresentationLanguageChanged(const string presentationLanguage)
 {
     TEST_LOG("OnPresentationLanguageChanged event triggered ***\n");
     std::unique_lock<std::mutex> lock(m_mutex);
 
-    TEST_LOG("OnPresentationLanguageChanged received: %s\n", presentationLanguages.c_str());
+    TEST_LOG("OnPresentationLanguageChanged received: %s\n", presentationLanguage.c_str());
 
     /* Notify the requester thread. */
-    m_event_signalled |= UserSettings_OnPresentationLanguageChanged;
+    m_event_signalled |= UserSettings_onPresentationLanguageChanged;
     m_condition_variable.notify_one();
 }
 
-void UserSettingTest::OnCaptionsChanged(bool enabled)
+void UserSettingTest::onCaptionsChanged(bool enabled)
 {
     TEST_LOG("OnCaptionsChanged event triggered ***\n");
     std::unique_lock<std::mutex> lock(m_mutex);
@@ -344,11 +436,11 @@ void UserSettingTest::OnCaptionsChanged(bool enabled)
     TEST_LOG("OnCaptionsChanged received: %s\n", str.c_str());
 
     /* Notify the requester thread. */
-    m_event_signalled |= UserSettings_OnCaptionsChanged;
+    m_event_signalled |= UserSettings_onCaptionsChanged;
     m_condition_variable.notify_one();
 }
 
-void UserSettingTest::OnPreferredCaptionsLanguagesChanged(const string preferredLanguages)
+void UserSettingTest::onPreferredCaptionsLanguagesChanged(const string preferredLanguages)
 {
     TEST_LOG("OnPreferredCaptionsLanguagesChanged event triggered ***\n");
     std::unique_lock<std::mutex> lock(m_mutex);
@@ -356,11 +448,11 @@ void UserSettingTest::OnPreferredCaptionsLanguagesChanged(const string preferred
     TEST_LOG("OnPreferredAudioLanguagesChanged received: %s\n", preferredLanguages.c_str());
 
     /* Notify the requester thread. */
-    m_event_signalled |= UserSettings_OnPreferredCaptionsLanguagesChanged;
+    m_event_signalled |= UserSettings_onPreferredCaptionsLanguagesChanged;
     m_condition_variable.notify_one();
 }
 
-void UserSettingTest::OnPreferredClosedCaptionServiceChanged(const string service)
+void UserSettingTest::onPreferredClosedCaptionServiceChanged(const string service)
 {
     TEST_LOG("OnPreferredClosedCaptionServiceChanged event triggered ***\n");
     std::unique_lock<std::mutex> lock(m_mutex);
@@ -368,7 +460,91 @@ void UserSettingTest::OnPreferredClosedCaptionServiceChanged(const string servic
     TEST_LOG("OnPreferredClosedCaptionServiceChanged received: %s\n", service.c_str());
 
     /* Notify the requester thread. */
-    m_event_signalled |= UserSettings_OnPreferredClosedCaptionServiceChanged;
+    m_event_signalled |= UserSettings_onPreferredClosedCaptionServiceChanged;
+    m_condition_variable.notify_one();
+}
+
+void UserSettingTest::onPinControlChanged(bool enabled)
+{
+    TEST_LOG("OnPinControlChanged event triggered ***\n");
+    std::unique_lock<std::mutex> lock(m_mutex);
+    std::string str = enabled ? "true" : "false";
+
+    TEST_LOG("OnPinControlChanged received: %s\n", str.c_str());
+    /* Notify the requester thread. */
+    m_event_signalled |= UserSettings_onPinControlChanged;
+    m_condition_variable.notify_one();
+}
+
+void UserSettingTest::onViewingRestrictionsChanged(const string viewingRestrictions)
+{
+    TEST_LOG("OnViewingRestrictionsChanged event triggered ***\n");
+    std::unique_lock<std::mutex> lock(m_mutex);
+
+    TEST_LOG("OnViewingRestrictionsChanged received: %s\n", viewingRestrictions.c_str());
+    /* Notify the requester thread. */
+    m_event_signalled |= UserSettings_onViewingRestrictionsChanged;
+    m_condition_variable.notify_one();
+
+}
+
+void UserSettingTest::onViewingRestrictionsWindowChanged(const string viewingRestrictionsWindow)
+{
+    TEST_LOG("OnViewingRestrictionsWindowChanged event triggered ***\n");
+    std::unique_lock<std::mutex> lock(m_mutex);
+
+    TEST_LOG("OnViewingRestrictionsWindowChanged received: %s\n", viewingRestrictionsWindow.c_str());
+    /* Notify the requester thread. */
+    m_event_signalled |= UserSettings_onViewingRestrictionsWindowChanged;
+    m_condition_variable.notify_one();
+
+}
+
+void UserSettingTest::onLiveWatershedChanged(const bool enabled)
+{
+    TEST_LOG("OnLiveWatershedChanged event triggered ***\n");
+    std::unique_lock<std::mutex> lock(m_mutex);
+    std::string str = enabled ? "true" : "false";
+
+    TEST_LOG("OnLiveWatershedChanged received: %s\n", str.c_str());
+    /* Notify the requester thread. */
+    m_event_signalled |= UserSettings_onLiveWatershedChanged;
+    m_condition_variable.notify_one();
+}
+
+void UserSettingTest::onPlaybackWatershedChanged(const bool enabled)
+{
+    TEST_LOG("OnPlaybackWatershedChanged event triggered ***\n");
+    std::unique_lock<std::mutex> lock(m_mutex);
+    std::string str = enabled ? "true" : "false";
+
+    TEST_LOG("OnPlaybackWatershedChanged received: %s\n", str.c_str());
+    /* Notify the requester thread. */
+    m_event_signalled |= UserSettings_onPlaybackWatershedChanged;
+    m_condition_variable.notify_one();
+}
+
+void UserSettingTest::onBlockNotRatedContentChanged(const bool enabled)
+{
+    TEST_LOG("OnBlockNotRatedContentChanged event triggered ***\n");
+    std::unique_lock<std::mutex> lock(m_mutex);
+    std::string str = enabled ? "true" : "false";
+
+    TEST_LOG("OnBlockNotRatedContentChanged received: %s\n", str.c_str());
+    /* Notify the requester thread. */
+    m_event_signalled |= UserSettings_onBlockNotRatedContentChanged;
+    m_condition_variable.notify_one();
+}
+
+void UserSettingTest::onPinOnPurchaseChanged(const bool enabled)
+{
+    TEST_LOG("OnPinOnPurchaseChanged event triggered ***\n");
+    std::unique_lock<std::mutex> lock(m_mutex);
+    std::string str = enabled ? "true" : "false";
+
+    TEST_LOG("OnPinOnPurchaseChanged received: %s\n", str.c_str());
+    /* Notify the requester thread. */
+    m_event_signalled |= UserSettings_onPinOnPurchaseChanged;
     m_condition_variable.notify_one();
 }
 
@@ -476,6 +652,79 @@ TEST_F(UserSettingTest, VerifyDefaultValues)
                     TEST_LOG("Err: %s", errorMsg.c_str());
                 }
 
+                 /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
+                 status = m_usersettingsplugin->GetPinControl(defaultBooleanValue);
+                 EXPECT_EQ(defaultBooleanValue, false);
+                 EXPECT_EQ(status,Core::ERROR_NONE);
+                 if (status != Core::ERROR_NONE)
+                 {
+                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                     TEST_LOG("Err: %s", errorMsg.c_str());
+                 }
+
+
+                 /* defaultStrValue should get "" and the return status is Core::ERROR_NONE */
+                 status = m_usersettingsplugin->GetViewingRestrictions(defaultStrValue);
+                 EXPECT_EQ(defaultStrValue, "");
+                 EXPECT_EQ(status,Core::ERROR_NONE);
+                 if (status != Core::ERROR_NONE)
+                 {
+                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                     TEST_LOG("Err: %s", errorMsg.c_str());
+                 }
+
+                 /* defaultStrValue should get "" and the return status is Core::ERROR_NONE */
+                 status = m_usersettingsplugin->GetViewingRestrictionsWindow(defaultStrValue);
+                 EXPECT_EQ(defaultStrValue, "");
+                 EXPECT_EQ(status,Core::ERROR_NONE);
+                 if (status != Core::ERROR_NONE)
+                 {
+                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                     TEST_LOG("Err: %s", errorMsg.c_str());
+                 }
+
+                 /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
+                 status = m_usersettingsplugin->GetLiveWatershed(defaultBooleanValue);
+                 EXPECT_EQ(defaultBooleanValue, false);
+                 EXPECT_EQ(status,Core::ERROR_NONE);
+                 if (status != Core::ERROR_NONE)
+                 {
+                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                     TEST_LOG("Err: %s", errorMsg.c_str());
+                 }
+
+                 /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
+                 status = m_usersettingsplugin->GetPlaybackWatershed(defaultBooleanValue);
+                 EXPECT_EQ(defaultBooleanValue, false);
+                 EXPECT_EQ(status,Core::ERROR_NONE);
+                 if (status != Core::ERROR_NONE)
+                 {
+                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                     TEST_LOG("Err: %s", errorMsg.c_str());
+                 }
+
+
+                 /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
+                 status = m_usersettingsplugin->GetBlockNotRatedContent(defaultBooleanValue);
+                 EXPECT_EQ(defaultBooleanValue, false);
+                 EXPECT_EQ(status,Core::ERROR_NONE);
+                 if (status != Core::ERROR_NONE)
+                 {
+                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                     TEST_LOG("Err: %s", errorMsg.c_str());
+                 }
+
+
+                 /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
+                 status = m_usersettingsplugin->GetPinOnPurchase(defaultBooleanValue);
+                 EXPECT_EQ(defaultBooleanValue, false);
+                 EXPECT_EQ(status,Core::ERROR_NONE);
+                 if (status != Core::ERROR_NONE)
+                 {
+                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                     TEST_LOG("Err: %s", errorMsg.c_str());
+                 }
+
                  /* Setting Audio Description value as true.So UserSettings namespace has one entry in db.
                  But we are trying to get PreferredAudioLanguages, which has no entry in db.
                  So GetPreferredAudioLanguages should return the empty string and the return status
@@ -488,8 +737,8 @@ TEST_F(UserSettingTest, VerifyDefaultValues)
                      TEST_LOG("Err: %s", errorMsg.c_str());
                  }
 
-                 signalled = notification.WaitForRequestStatus(JSON_TIMEOUT,UserSettings_OnAudioDescriptionChanged);
-                 EXPECT_TRUE(signalled & UserSettings_OnAudioDescriptionChanged);
+                 signalled = notification.WaitForRequestStatus(JSON_TIMEOUT,UserSettings_onAudioDescriptionChanged);
+                 EXPECT_TRUE(signalled & UserSettings_onAudioDescriptionChanged);
 
                  /* We are trying to get PreferredAudioLanguages, which has no entry in db.
                  Persistant store returns status as Core::ERROR_UNKNOWN_KEY to UserSettings 
@@ -551,6 +800,76 @@ TEST_F(UserSettingTest, VerifyDefaultValues)
                     TEST_LOG("Err: %s", errorMsg.c_str());
                 }
 
+                /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
+                status = m_usersettingsplugin->GetPinControl(defaultBooleanValue);
+                EXPECT_EQ(defaultBooleanValue, false);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* defaultStrValue should get "" and the return status is Core::ERROR_NONE */
+                status = m_usersettingsplugin->GetViewingRestrictions(defaultStrValue);
+                EXPECT_EQ(defaultStrValue, "");
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* defaultStrValue should get "" and the return status is Core::ERROR_NONE */
+                status = m_usersettingsplugin->GetViewingRestrictionsWindow(defaultStrValue);
+                EXPECT_EQ(defaultStrValue, "");
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
+                status = m_usersettingsplugin->GetLiveWatershed(defaultBooleanValue);
+                EXPECT_EQ(defaultBooleanValue, false);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
+                status = m_usersettingsplugin->GetPlaybackWatershed(defaultBooleanValue);
+                EXPECT_EQ(defaultBooleanValue, false);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
+                status = m_usersettingsplugin->GetBlockNotRatedContent(defaultBooleanValue);
+                EXPECT_EQ(defaultBooleanValue, false);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
+                status = m_usersettingsplugin->GetPinOnPurchase(defaultBooleanValue);
+                EXPECT_EQ(defaultBooleanValue, false);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
                 m_usersettingsplugin->Unregister(&notification);
                 m_usersettingsplugin->Release();
             }
@@ -576,165 +895,359 @@ TEST_F(UserSettingTest, SetAndGetMethodsUsingJsonRpcConnectionSuccessCase)
 
     bool enabled = true;
     string preferredLanguages = "en";
-    string presentationLanguages = "fra";
+    string presentationLanguage = "fra";
     string preferredCaptionsLanguages = "en,es";
     string preferredService = "CC3";
+    string viewingRestrictions = "ALWAYS";
     Core::JSON::String result_string;
     Core::JSON::Boolean result_bool;
     JsonObject result_json;
 
     TEST_LOG("Testing AudioDescriptionSuccess");
     status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
-                                       _T("OnAudioDescriptionChanged"),
+                                       _T("onAudioDescriptionChanged"),
                                        [this, &async_handler](const JsonObject& parameters) {
                                            bool enabled = parameters["enabled"].Boolean();
-                                           async_handler.OnAudioDescriptionChanged(enabled);
+                                           async_handler.onAudioDescriptionChanged(enabled);
                                        });
     EXPECT_EQ(Core::ERROR_NONE, status);
 
-    EXPECT_CALL(async_handler, OnAudioDescriptionChanged(MatchRequestStatusBool(enabled)))
-    .WillOnce(Invoke(this, &UserSettingTest::OnAudioDescriptionChanged));
+    EXPECT_CALL(async_handler, onAudioDescriptionChanged(MatchRequestStatusBool(enabled)))
+    .WillOnce(Invoke(this, &UserSettingTest::onAudioDescriptionChanged));
 
     JsonObject paramsAudioDes;
     paramsAudioDes["enabled"] = true;
-    status = InvokeServiceMethod("org.rdk.UserSettings", "SetAudioDescription", paramsAudioDes, result_json);
+    status = InvokeServiceMethod("org.rdk.UserSettings", "setAudioDescription", paramsAudioDes, result_json);
     EXPECT_EQ(status,Core::ERROR_NONE);
 
-    signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_OnAudioDescriptionChanged);
-    EXPECT_TRUE(signalled & UserSettings_OnAudioDescriptionChanged);
+    signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_onAudioDescriptionChanged);
+    EXPECT_TRUE(signalled & UserSettings_onAudioDescriptionChanged);
 
     /* Unregister for events. */
-    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("OnAudioDescriptionChanged"));
+    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("onAudioDescriptionChanged"));
     EXPECT_EQ(status,Core::ERROR_NONE);
 
-    status = InvokeServiceMethod("org.rdk.UserSettings", "GetAudioDescription", result_bool);
+    status = InvokeServiceMethod("org.rdk.UserSettings", "getAudioDescription", result_bool);
     EXPECT_EQ(status, Core::ERROR_NONE);
     EXPECT_TRUE(result_bool.Value());
 
     TEST_LOG("Testing PreferredAudioLanguagesSuccess");
     status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
-                                           _T("OnPreferredAudioLanguagesChanged"),
+                                           _T("onPreferredAudioLanguagesChanged"),
                                            [&async_handler](const JsonObject& parameters) {
                                            string preferredLanguages = parameters["preferredLanguages"].String();
-                                           async_handler.OnPreferredAudioLanguagesChanged(preferredLanguages);
+                                           async_handler.onPreferredAudioLanguagesChanged(preferredLanguages);
                                        });
     EXPECT_EQ(Core::ERROR_NONE, status);
 
-    EXPECT_CALL(async_handler, OnPreferredAudioLanguagesChanged(MatchRequestStatusString(preferredLanguages)))
-    .WillOnce(Invoke(this, &UserSettingTest::OnPreferredAudioLanguagesChanged));
+    EXPECT_CALL(async_handler, onPreferredAudioLanguagesChanged(MatchRequestStatusString(preferredLanguages)))
+    .WillOnce(Invoke(this, &UserSettingTest::onPreferredAudioLanguagesChanged));
 
     JsonObject paramsAudioLanguage;
     paramsAudioLanguage["preferredLanguages"] = preferredLanguages;
-    status = InvokeServiceMethod("org.rdk.UserSettings", "SetPreferredAudioLanguages", paramsAudioLanguage, result_json);
+    status = InvokeServiceMethod("org.rdk.UserSettings", "setPreferredAudioLanguages", paramsAudioLanguage, result_json);
     EXPECT_EQ(status,Core::ERROR_NONE);
 
-    signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_OnPreferredAudioLanguagesChanged);
-    EXPECT_TRUE(signalled & UserSettings_OnPreferredAudioLanguagesChanged);
-    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("OnPreferredAudioLanguagesChanged"));
+    signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_onPreferredAudioLanguagesChanged);
+    EXPECT_TRUE(signalled & UserSettings_onPreferredAudioLanguagesChanged);
+    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("onPreferredAudioLanguagesChanged"));
 
-    status = InvokeServiceMethod("org.rdk.UserSettings", "GetPreferredAudioLanguages", result_string);
+    status = InvokeServiceMethod("org.rdk.UserSettings", "getPreferredAudioLanguages", result_string);
     EXPECT_EQ(status,Core::ERROR_NONE);
     EXPECT_EQ(result_string.Value(), preferredLanguages);
 
     TEST_LOG("Testing PresentationLanguageSuccess");
     status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
-                                           _T("OnPresentationLanguageChanged"),
+                                           _T("onPresentationLanguageChanged"),
                                            [&async_handler](const JsonObject& parameters) {
-                                           string presentationLanguages = parameters["presentationLanguages"].String();
-                                           async_handler.OnPresentationLanguageChanged(presentationLanguages);
+                                           string presentationLanguage = parameters["presentationLanguage"].String();
+                                           async_handler.onPresentationLanguageChanged(presentationLanguage);
                                        });
     EXPECT_EQ(Core::ERROR_NONE, status);
 
-    EXPECT_CALL(async_handler, OnPresentationLanguageChanged(MatchRequestStatusString(presentationLanguages)))
-    .WillOnce(Invoke(this, &UserSettingTest::OnPresentationLanguageChanged));
+    EXPECT_CALL(async_handler, onPresentationLanguageChanged(MatchRequestStatusString(presentationLanguage)))
+    .WillOnce(Invoke(this, &UserSettingTest::onPresentationLanguageChanged));
 
     JsonObject paramsPresLanguage;
-    paramsPresLanguage["presentationLanguages"] = presentationLanguages;
-    status = InvokeServiceMethod("org.rdk.UserSettings", "SetPresentationLanguage", paramsPresLanguage, result_json);
+    paramsPresLanguage["presentationLanguage"] = presentationLanguage;
+    status = InvokeServiceMethod("org.rdk.UserSettings", "setPresentationLanguage", paramsPresLanguage, result_json);
     EXPECT_EQ(status,Core::ERROR_NONE);
 
-    signalled = WaitForRequestStatus(JSON_TIMEOUT, UserSettings_OnPresentationLanguageChanged);
-    EXPECT_TRUE(signalled & UserSettings_OnPresentationLanguageChanged);
-    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("OnPresentationLanguageChanged"));
+    signalled = WaitForRequestStatus(JSON_TIMEOUT, UserSettings_onPresentationLanguageChanged);
+    EXPECT_TRUE(signalled & UserSettings_onPresentationLanguageChanged);
+    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("onPresentationLanguageChanged"));
 
-    status = InvokeServiceMethod("org.rdk.UserSettings", "GetPresentationLanguage", result_string);
+    status = InvokeServiceMethod("org.rdk.UserSettings", "getPresentationLanguage", result_string);
     EXPECT_EQ(status,Core::ERROR_NONE);
-    EXPECT_EQ(result_string.Value(), presentationLanguages);
+    EXPECT_EQ(result_string.Value(), presentationLanguage);
 
     TEST_LOG("Testing SetCaptionsSuccess");
     status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
-                                       _T("OnCaptionsChanged"),
+                                       _T("onCaptionsChanged"),
                                        [this, &async_handler](const JsonObject& parameters) {
                                            bool enabled = parameters["enabled"].Boolean();
-                                           async_handler.OnCaptionsChanged(enabled);
+                                           async_handler.onCaptionsChanged(enabled);
                                        });
     EXPECT_EQ(Core::ERROR_NONE, status);
 
-    EXPECT_CALL(async_handler, OnCaptionsChanged(MatchRequestStatusBool(enabled)))
-    .WillOnce(Invoke(this, &UserSettingTest::OnCaptionsChanged));
+    EXPECT_CALL(async_handler, onCaptionsChanged(MatchRequestStatusBool(enabled)))
+    .WillOnce(Invoke(this, &UserSettingTest::onCaptionsChanged));
 
     JsonObject paramsCaptions;
     paramsCaptions["enabled"] = true;
-    status = InvokeServiceMethod("org.rdk.UserSettings", "SetCaptions", paramsCaptions, result_json);
+    status = InvokeServiceMethod("org.rdk.UserSettings", "setCaptions", paramsCaptions, result_json);
     EXPECT_EQ(status,Core::ERROR_NONE);
 
-    signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_OnCaptionsChanged);
-    EXPECT_TRUE(signalled & UserSettings_OnCaptionsChanged);
-    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("OnCaptionsChanged"));
+    signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_onCaptionsChanged);
+    EXPECT_TRUE(signalled & UserSettings_onCaptionsChanged);
+    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("onCaptionsChanged"));
 
-    status = InvokeServiceMethod("org.rdk.UserSettings", "GetCaptions", result_bool);
+    status = InvokeServiceMethod("org.rdk.UserSettings", "getCaptions", result_bool);
     EXPECT_EQ(status,Core::ERROR_NONE);
     EXPECT_TRUE(result_bool.Value());
 
     TEST_LOG("Testing SetPreferredCaptionsLanguagesSuccess");
     status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
-                                           _T("OnPreferredCaptionsLanguagesChanged"),
+                                           _T("onPreferredCaptionsLanguagesChanged"),
                                            [&async_handler](const JsonObject& parameters) {
                                            string preferredCaptionsLanguages = parameters["preferredLanguages"].String();
-                                           async_handler.OnPreferredCaptionsLanguagesChanged(preferredCaptionsLanguages);
+                                           async_handler.onPreferredCaptionsLanguagesChanged(preferredCaptionsLanguages);
                                        });
     EXPECT_EQ(Core::ERROR_NONE, status);
 
-    EXPECT_CALL(async_handler, OnPreferredCaptionsLanguagesChanged(MatchRequestStatusString(preferredCaptionsLanguages)))
-    .WillOnce(Invoke(this, &UserSettingTest::OnPreferredCaptionsLanguagesChanged));
+    EXPECT_CALL(async_handler, onPreferredCaptionsLanguagesChanged(MatchRequestStatusString(preferredCaptionsLanguages)))
+    .WillOnce(Invoke(this, &UserSettingTest::onPreferredCaptionsLanguagesChanged));
 
     JsonObject paramsPrefLang;
     paramsPrefLang["preferredLanguages"] = preferredCaptionsLanguages;
-    status = InvokeServiceMethod("org.rdk.UserSettings", "SetPreferredCaptionsLanguages", paramsPrefLang, result_json);
+    status = InvokeServiceMethod("org.rdk.UserSettings", "setPreferredCaptionsLanguages", paramsPrefLang, result_json);
     EXPECT_EQ(status,Core::ERROR_NONE);
 
-    signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_OnPreferredCaptionsLanguagesChanged);
-    EXPECT_TRUE(signalled & UserSettings_OnPreferredCaptionsLanguagesChanged);
+    signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_onPreferredCaptionsLanguagesChanged);
+    EXPECT_TRUE(signalled & UserSettings_onPreferredCaptionsLanguagesChanged);
     jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("OnPreferredCaptionsLanguagesChanged"));
 
-    status = InvokeServiceMethod("org.rdk.UserSettings", "GetPreferredCaptionsLanguages", result_string);
+    status = InvokeServiceMethod("org.rdk.UserSettings", "getPreferredCaptionsLanguages", result_string);
     EXPECT_EQ(status,Core::ERROR_NONE);
     EXPECT_EQ(result_string.Value(), preferredCaptionsLanguages);
 
     TEST_LOG("Testing SetPreferredClosedCaptionServiceSuccess");
     status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
-                                           _T("OnPreferredClosedCaptionServiceChanged"),
+                                           _T("onPreferredClosedCaptionServiceChanged"),
                                            [&async_handler](const JsonObject& parameters) {
                                            string preferredService = parameters["service"].String();
-                                           async_handler.OnPreferredClosedCaptionServiceChanged(preferredService);
+                                           async_handler.onPreferredClosedCaptionServiceChanged(preferredService);
                                        });
     EXPECT_EQ(Core::ERROR_NONE, status);
 
-    EXPECT_CALL(async_handler, OnPreferredClosedCaptionServiceChanged(MatchRequestStatusString(preferredService)))
-    .WillOnce(Invoke(this, &UserSettingTest::OnPreferredClosedCaptionServiceChanged));
+    EXPECT_CALL(async_handler, onPreferredClosedCaptionServiceChanged(MatchRequestStatusString(preferredService)))
+    .WillOnce(Invoke(this, &UserSettingTest::onPreferredClosedCaptionServiceChanged));
 
     JsonObject paramspreferredService;
     paramspreferredService["service"] = preferredService;
-    status = InvokeServiceMethod("org.rdk.UserSettings", "SetPreferredClosedCaptionService", paramspreferredService, result_json);
+    status = InvokeServiceMethod("org.rdk.UserSettings", "setPreferredClosedCaptionService", paramspreferredService, result_json);
     EXPECT_EQ(status,Core::ERROR_NONE);
 
-    signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_OnPreferredClosedCaptionServiceChanged);
-    EXPECT_TRUE(signalled & UserSettings_OnPreferredClosedCaptionServiceChanged);
-    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("OnPreferredClosedCaptionServiceChanged"));
+    signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_onPreferredClosedCaptionServiceChanged);
+    EXPECT_TRUE(signalled & UserSettings_onPreferredClosedCaptionServiceChanged);
+    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("onPreferredClosedCaptionServiceChanged"));
 
-    status = InvokeServiceMethod("org.rdk.UserSettings", "GetPreferredClosedCaptionService", result_string);
+    status = InvokeServiceMethod("org.rdk.UserSettings", "getPreferredClosedCaptionService", result_string);
     EXPECT_EQ(status,Core::ERROR_NONE);
     EXPECT_EQ(result_string.Value(), preferredService);
+
+    TEST_LOG("Testing PinControl Success");
+    status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
+                                       _T("onPinControlChanged"),
+                                       [this, &async_handler](const JsonObject& parameters) {
+                                           bool enabled = parameters["enabled"].Boolean();
+                                           async_handler.onPinControlChanged(enabled);
+                                       });
+    EXPECT_EQ(Core::ERROR_NONE, status);
+
+    EXPECT_CALL(async_handler, onPinControlChanged(MatchRequestStatusBool(enabled)))
+    .WillOnce(Invoke(this, &UserSettingTest::onPinControlChanged));
+
+    JsonObject paramsPinControl;
+    paramsPinControl["enabled"] = true;
+    status = InvokeServiceMethod("org.rdk.UserSettings", "setPinControl", paramsPinControl, result_json);
+    EXPECT_EQ(status,Core::ERROR_NONE);
+
+    signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_onPinControlChanged);
+    EXPECT_TRUE(signalled & UserSettings_onPinControlChanged);
+
+    /* Unregister for events. */
+    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("onPinControlChanged"));
+    EXPECT_EQ(status,Core::ERROR_NONE);
+
+    status = InvokeServiceMethod("org.rdk.UserSettings", "getPinControl", result_bool);
+    EXPECT_EQ(status, Core::ERROR_NONE);
+    EXPECT_TRUE(result_bool.Value());
+
+    string viewRes = "{\"restrictions\": [{\"scheme\": \"US_TV\", \"restrict\": [\"TV-Y7/FV\"]}, {\"scheme\": \"MPAA\", \"restrict\": []}]}";
+    TEST_LOG("Testing SetViewingRestrictions Success");
+    status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
+                                           _T("onViewingRestrictionsChanged"),
+                                           [&async_handler](const JsonObject& parameters) {
+                                           string viewRes = parameters["viewingRestrictions"].String();
+                                           async_handler.onViewingRestrictionsChanged(viewRes);
+                                       });
+    EXPECT_EQ(Core::ERROR_NONE, status);
+
+    EXPECT_CALL(async_handler, onViewingRestrictionsChanged(MatchRequestStatusString(viewRes)))
+    .WillOnce(Invoke(this, &UserSettingTest::onViewingRestrictionsChanged));
+
+    JsonObject paramsViewRestrictions;
+    paramsViewRestrictions["viewingRestrictions"] = viewRes;
+    status = InvokeServiceMethod("org.rdk.UserSettings", "setViewingRestrictions", paramsViewRestrictions, result_json);
+    EXPECT_EQ(status,Core::ERROR_NONE);
+
+    signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_onViewingRestrictionsChanged);
+    EXPECT_TRUE(signalled & UserSettings_onViewingRestrictionsChanged);
+    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("onViewingRestrictionsChanged"));
+
+    status = InvokeServiceMethod("org.rdk.UserSettings", "getViewingRestrictions", result_string);
+    EXPECT_EQ(status,Core::ERROR_NONE);
+    EXPECT_EQ(result_string.Value(), viewRes);
+
+    string viewResWindow = "ALWAYS";
+    TEST_LOG("Testing SetViewingRestrictionsWindow Success");
+    status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
+                                           _T("onViewingRestrictionsWindowChanged"),
+                                           [&async_handler](const JsonObject& parameters) {
+                                           string viewResWindow = parameters["viewingRestrictionsWindow"].String();
+                                           async_handler.onViewingRestrictionsWindowChanged(viewResWindow);
+                                       });
+    EXPECT_EQ(Core::ERROR_NONE, status);
+
+    EXPECT_CALL(async_handler, onViewingRestrictionsWindowChanged(MatchRequestStatusString(viewResWindow)))
+    .WillOnce(Invoke(this, &UserSettingTest::onViewingRestrictionsWindowChanged));
+
+    JsonObject paramsViewResWindow;
+    paramsViewResWindow["viewingRestrictionsWindow"] = viewResWindow;
+    status = InvokeServiceMethod("org.rdk.UserSettings", "setViewingRestrictionsWindow", paramsViewResWindow, result_json);
+    EXPECT_EQ(status,Core::ERROR_NONE);
+
+    signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_onViewingRestrictionsWindowChanged);
+    EXPECT_TRUE(signalled & UserSettings_onViewingRestrictionsWindowChanged);
+    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("onViewingRestrictionsWindowChanged"));
+
+    status = InvokeServiceMethod("org.rdk.UserSettings", "getViewingRestrictionsWindow", result_string);
+    EXPECT_EQ(status,Core::ERROR_NONE);
+    EXPECT_EQ(result_string.Value(), viewResWindow);
+
+    TEST_LOG("Testing LiveWatershed Success");
+    status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
+                                       _T("onLiveWatershedChanged"),
+                                       [this, &async_handler](const JsonObject& parameters) {
+                                           bool enabled = parameters["enabled"].Boolean();
+                                           async_handler.onLiveWatershedChanged(enabled);
+                                       });
+    EXPECT_EQ(Core::ERROR_NONE, status);
+
+    EXPECT_CALL(async_handler, onLiveWatershedChanged(MatchRequestStatusBool(enabled)))
+    .WillOnce(Invoke(this, &UserSettingTest::onLiveWatershedChanged));
+
+    JsonObject paramsLiveWatershed;
+    paramsLiveWatershed["enabled"] = true;
+    status = InvokeServiceMethod("org.rdk.UserSettings", "setLiveWatershed", paramsLiveWatershed, result_json);
+    EXPECT_EQ(status,Core::ERROR_NONE);
+
+    signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_onLiveWatershedChanged);
+    EXPECT_TRUE(signalled & UserSettings_onLiveWatershedChanged);
+
+    /* Unregister for events. */
+    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("onLiveWatershedChanged"));
+    EXPECT_EQ(status,Core::ERROR_NONE);
+
+    status = InvokeServiceMethod("org.rdk.UserSettings", "getLiveWatershed", result_bool);
+    EXPECT_EQ(status, Core::ERROR_NONE);
+    EXPECT_TRUE(result_bool.Value());
+
+    TEST_LOG("Testing PlaybackWatershed Success");
+    status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
+                                       _T("onPlaybackWatershedChanged"),
+                                       [this, &async_handler](const JsonObject& parameters) {
+                                           bool enabled = parameters["enabled"].Boolean();
+                                           async_handler.onPlaybackWatershedChanged(enabled);
+                                       });
+    EXPECT_EQ(Core::ERROR_NONE, status);
+
+    EXPECT_CALL(async_handler, onPlaybackWatershedChanged(MatchRequestStatusBool(enabled)))
+    .WillOnce(Invoke(this, &UserSettingTest::onPlaybackWatershedChanged));
+
+    JsonObject paramsPlaybackWatershed;
+    paramsPlaybackWatershed["enabled"] = true;
+    status = InvokeServiceMethod("org.rdk.UserSettings", "setPlaybackWatershed", paramsPlaybackWatershed, result_json);
+    EXPECT_EQ(status,Core::ERROR_NONE);
+
+    signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_onPlaybackWatershedChanged);
+    EXPECT_TRUE(signalled & UserSettings_onPlaybackWatershedChanged);
+
+    /* Unregister for events. */
+    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("onPlaybackWatershedChanged"));
+    EXPECT_EQ(status,Core::ERROR_NONE);
+
+    status = InvokeServiceMethod("org.rdk.UserSettings", "getPlaybackWatershed", result_bool);
+    EXPECT_EQ(status, Core::ERROR_NONE);
+    EXPECT_TRUE(result_bool.Value());
+
+    TEST_LOG("Testing BlockNotRatedContent Success");
+    status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
+                                       _T("onBlockNotRatedContentChanged"),
+                                       [this, &async_handler](const JsonObject& parameters) {
+                                           bool enabled = parameters["enabled"].Boolean();
+                                           async_handler.onBlockNotRatedContentChanged(enabled);
+                                       });
+    EXPECT_EQ(Core::ERROR_NONE, status);
+
+    EXPECT_CALL(async_handler, onBlockNotRatedContentChanged(MatchRequestStatusBool(enabled)))
+    .WillOnce(Invoke(this, &UserSettingTest::onBlockNotRatedContentChanged));
+
+    JsonObject paramsBlockNotRatedContent;
+    paramsBlockNotRatedContent["enabled"] = true;
+    status = InvokeServiceMethod("org.rdk.UserSettings", "setBlockNotRatedContent", paramsBlockNotRatedContent, result_json);
+    EXPECT_EQ(status,Core::ERROR_NONE);
+
+    signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_onBlockNotRatedContentChanged);
+    EXPECT_TRUE(signalled & UserSettings_onBlockNotRatedContentChanged);
+
+    /* Unregister for events. */
+    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("onBlockNotRatedContentChanged"));
+    EXPECT_EQ(status,Core::ERROR_NONE);
+
+    status = InvokeServiceMethod("org.rdk.UserSettings", "getBlockNotRatedContent", result_bool);
+    EXPECT_EQ(status, Core::ERROR_NONE);
+    EXPECT_TRUE(result_bool.Value());
+
+    TEST_LOG("Testing PinOnPurchase Success");
+    status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
+                                       _T("onPinOnPurchaseChanged"),
+                                       [this, &async_handler](const JsonObject& parameters) {
+                                           bool enabled = parameters["enabled"].Boolean();
+                                           async_handler.onPinOnPurchaseChanged(enabled);
+                                       });
+    EXPECT_EQ(Core::ERROR_NONE, status);
+
+    EXPECT_CALL(async_handler, onPinOnPurchaseChanged(MatchRequestStatusBool(enabled)))
+    .WillOnce(Invoke(this, &UserSettingTest::onPinOnPurchaseChanged));
+
+    JsonObject paramsPinOnPurchase;
+    paramsPinOnPurchase["enabled"] = true;
+    status = InvokeServiceMethod("org.rdk.UserSettings", "setPinOnPurchase", paramsPinOnPurchase, result_json);
+    EXPECT_EQ(status,Core::ERROR_NONE);
+
+    signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_onPinOnPurchaseChanged);
+    EXPECT_TRUE(signalled & UserSettings_onPinOnPurchaseChanged);
+
+    /* Unregister for events. */
+    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("onPinOnPurchaseChanged"));
+    EXPECT_EQ(status,Core::ERROR_NONE);
+
+    status = InvokeServiceMethod("org.rdk.UserSettings", "getPinOnPurchase", result_bool);
+    EXPECT_EQ(status, Core::ERROR_NONE);
+    EXPECT_TRUE(result_bool.Value());
+
 }
 
 TEST_F(UserSettingTest,SetAndGetMethodsUsingComRpcConnectionSuccessCase)
@@ -768,8 +1281,8 @@ TEST_F(UserSettingTest,SetAndGetMethodsUsingComRpcConnectionSuccessCase)
                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
                     TEST_LOG("Err: %s", errorMsg.c_str());
                 }
-                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT, UserSettings_OnAudioDescriptionChanged);
-                EXPECT_TRUE(signalled & UserSettings_OnAudioDescriptionChanged);
+                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT, UserSettings_onAudioDescriptionChanged);
+                EXPECT_TRUE(signalled & UserSettings_onAudioDescriptionChanged);
 
                 status = m_usersettingsplugin->GetAudioDescription(getBoolValue);
                 EXPECT_EQ(getBoolValue, true);
@@ -788,8 +1301,8 @@ TEST_F(UserSettingTest,SetAndGetMethodsUsingComRpcConnectionSuccessCase)
                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
                     TEST_LOG("Err: %s", errorMsg.c_str());
                 }
-                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT,UserSettings_OnPreferredAudioLanguagesChanged);
-                EXPECT_TRUE(signalled & UserSettings_OnPreferredAudioLanguagesChanged);
+                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT,UserSettings_onPreferredAudioLanguagesChanged);
+                EXPECT_TRUE(signalled & UserSettings_onPreferredAudioLanguagesChanged);
 
                 status = m_usersettingsplugin->GetPreferredAudioLanguages(getStringValue);
                 EXPECT_EQ(getStringValue, "eng");
@@ -808,8 +1321,8 @@ TEST_F(UserSettingTest,SetAndGetMethodsUsingComRpcConnectionSuccessCase)
                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
                     TEST_LOG("Err: %s", errorMsg.c_str());
                 }
-                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT,UserSettings_OnPresentationLanguageChanged);
-                EXPECT_TRUE(signalled & UserSettings_OnPresentationLanguageChanged);
+                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT,UserSettings_onPresentationLanguageChanged);
+                EXPECT_TRUE(signalled & UserSettings_onPresentationLanguageChanged);
 
                 status = m_usersettingsplugin->GetPresentationLanguage(getStringValue);
                 EXPECT_EQ(getStringValue, "fra");
@@ -829,8 +1342,8 @@ TEST_F(UserSettingTest,SetAndGetMethodsUsingComRpcConnectionSuccessCase)
                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
                     TEST_LOG("Err: %s", errorMsg.c_str());
                 }
-                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT,UserSettings_OnCaptionsChanged);
-                EXPECT_TRUE(signalled & UserSettings_OnCaptionsChanged);
+                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT,UserSettings_onCaptionsChanged);
+                EXPECT_TRUE(signalled & UserSettings_onCaptionsChanged);
 
                 status = m_usersettingsplugin->GetCaptions(getBoolValue);
                 EXPECT_EQ(getBoolValue, true);
@@ -849,8 +1362,8 @@ TEST_F(UserSettingTest,SetAndGetMethodsUsingComRpcConnectionSuccessCase)
                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
                     TEST_LOG("Err: %s", errorMsg.c_str());
                 }
-                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT,UserSettings_OnPreferredCaptionsLanguagesChanged);
-                EXPECT_TRUE(signalled & UserSettings_OnPreferredCaptionsLanguagesChanged);
+                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT,UserSettings_onPreferredCaptionsLanguagesChanged);
+                EXPECT_TRUE(signalled & UserSettings_onPreferredCaptionsLanguagesChanged);
 
                 status = m_usersettingsplugin->GetPreferredCaptionsLanguages(getStringValue);
                 EXPECT_EQ(getStringValue, "en,es");
@@ -869,11 +1382,151 @@ TEST_F(UserSettingTest,SetAndGetMethodsUsingComRpcConnectionSuccessCase)
                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
                     TEST_LOG("Err: %s", errorMsg.c_str());
                 }
-                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT,UserSettings_OnPreferredClosedCaptionServiceChanged);
-                EXPECT_TRUE(signalled & UserSettings_OnPreferredClosedCaptionServiceChanged);
+                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT,UserSettings_onPreferredClosedCaptionServiceChanged);
+                EXPECT_TRUE(signalled & UserSettings_onPreferredClosedCaptionServiceChanged);
 
                 status = m_usersettingsplugin->GetPreferredClosedCaptionService(getStringValue);
                 EXPECT_EQ(getStringValue, "CC3");
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                TEST_LOG("Setting and Getting PinControl Values");
+                status = m_usersettingsplugin->SetPinControl(true);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT, UserSettings_onPinControlChanged);
+                EXPECT_TRUE(signalled & UserSettings_onPinControlChanged);
+
+                status = m_usersettingsplugin->GetPinControl(getBoolValue);
+                EXPECT_EQ(getBoolValue, true);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+                string viewRes = "{\"restrictions\": [{\"scheme\": \"US_TV\", \"restrict\": [\"TV-Y7/FV\"]}, {\"scheme\": \"MPAA\", \"restrict\": []}]}";
+                TEST_LOG("Setting and Getting ViewingRestrictions Values");
+                status = m_usersettingsplugin->SetViewingRestrictions(viewRes);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT,UserSettings_onViewingRestrictionsChanged);
+                EXPECT_TRUE(signalled & UserSettings_onViewingRestrictionsChanged);
+
+                status = m_usersettingsplugin->GetViewingRestrictions(getStringValue);
+                EXPECT_EQ(getStringValue, viewRes);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                TEST_LOG("Setting and Getting ViewingRestrictionsWindow Values");
+                status = m_usersettingsplugin->SetViewingRestrictionsWindow("ALWAYS");
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT,UserSettings_onViewingRestrictionsWindowChanged);
+                EXPECT_TRUE(signalled & UserSettings_onViewingRestrictionsWindowChanged);
+
+                status = m_usersettingsplugin->GetViewingRestrictionsWindow(getStringValue);
+                EXPECT_EQ(getStringValue, "ALWAYS");
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                TEST_LOG("Setting and Getting LiveWatershed Values");
+                status = m_usersettingsplugin->SetLiveWatershed(true);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT, UserSettings_onLiveWatershedChanged);
+                EXPECT_TRUE(signalled & UserSettings_onLiveWatershedChanged);
+
+                status = m_usersettingsplugin->GetLiveWatershed(getBoolValue);
+                EXPECT_EQ(getBoolValue, true);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                TEST_LOG("Setting and Getting PlaybackWatershed Values");
+                status = m_usersettingsplugin->SetPlaybackWatershed(true);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT, UserSettings_onPlaybackWatershedChanged);
+                EXPECT_TRUE(signalled & UserSettings_onPlaybackWatershedChanged);
+
+                status = m_usersettingsplugin->GetPlaybackWatershed(getBoolValue);
+                EXPECT_EQ(getBoolValue, true);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                TEST_LOG("Setting and Getting BlockNotRatedContent Values");
+                status = m_usersettingsplugin->SetBlockNotRatedContent(true);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT, UserSettings_onBlockNotRatedContentChanged);
+                EXPECT_TRUE(signalled & UserSettings_onBlockNotRatedContentChanged);
+
+                status = m_usersettingsplugin->GetBlockNotRatedContent(getBoolValue);
+                EXPECT_EQ(getBoolValue, true);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                TEST_LOG("Setting and Getting PinOnPurchase Values");
+                status = m_usersettingsplugin->SetPinOnPurchase(true);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT, UserSettings_onPinOnPurchaseChanged);
+                EXPECT_TRUE(signalled & UserSettings_onPinOnPurchaseChanged);
+
+                status = m_usersettingsplugin->GetPinOnPurchase(getBoolValue);
+                EXPECT_EQ(getBoolValue, true);
                 EXPECT_EQ(status,Core::ERROR_NONE);
                 if (status != Core::ERROR_NONE)
                 {
@@ -896,4 +1549,277 @@ TEST_F(UserSettingTest,SetAndGetMethodsUsingComRpcConnectionSuccessCase)
         }
     }
 }
+
+TEST_F(UserSettingTest, NoDBFileInPersistentstoreErrorCase)
+{
+    uint32_t status = Core::ERROR_GENERAL;
+    bool getBoolValue = false;
+    string getStringValue = "";
+    Core::Sink<NotificationHandler> notification;
+    uint32_t signalled = UserSettings_StateInvalid;
+
+    if (CreateUserSettingInterfaceObjectUsingComRPCConnection() != Core::ERROR_NONE)
+    {
+        TEST_LOG("Invalid Client_UserSettings");
+    }
+    else
+    {
+        ASSERT_TRUE(m_controller_usersettings!= nullptr);
+        if (m_controller_usersettings)
+        {
+            ASSERT_TRUE(m_usersettingsplugin!= nullptr);
+            if (m_usersettingsplugin)
+            {
+                m_usersettingsplugin->AddRef();
+                m_usersettingsplugin->Register(&notification);
+
+                TEST_LOG("Setting and Getting AudioDescription Values");
+                status = m_usersettingsplugin->SetAudioDescription(true);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT, UserSettings_onAudioDescriptionChanged);
+                EXPECT_TRUE(signalled & UserSettings_onAudioDescriptionChanged);
+
+                status = m_usersettingsplugin->GetAudioDescription(getBoolValue);
+                EXPECT_EQ(getBoolValue, true);
+                EXPECT_EQ(status, Core::ERROR_NONE);
+
+                TEST_LOG("Setting and Getting PinControl Values");
+                status = m_usersettingsplugin->SetPinControl(true);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT, UserSettings_onPinControlChanged);
+                EXPECT_TRUE(signalled & UserSettings_onPinControlChanged);
+
+                status = m_usersettingsplugin->GetPinControl(getBoolValue);
+                EXPECT_EQ(getBoolValue, true);
+                EXPECT_EQ(status, Core::ERROR_NONE);
+
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+                int file_status = remove("/tmp/secure/persistent/rdkservicestore");
+                // Check if the file has been successfully removed
+                if (file_status != 0)
+                {
+                    TEST_LOG("Error deleting file[/tmp/secure/persistent/rdkservicestore]");
+                }
+                else
+                {
+                    TEST_LOG("File[/tmp/secure/persistent/rdkservicestore] successfully deleted");
+                }
+
+                TEST_LOG("Setting and Getting AudioDescription Values after DB file deletion");
+                status = m_usersettingsplugin->SetAudioDescription(false);
+                EXPECT_EQ(status, Core::ERROR_GENERAL);
+
+                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT, UserSettings_onAudioDescriptionChanged);
+                EXPECT_TRUE(signalled & UserSettings_onAudioDescriptionChanged);
+
+                status = m_usersettingsplugin->GetAudioDescription(getBoolValue);
+                EXPECT_EQ(getBoolValue, true);
+                EXPECT_EQ(status, Core::ERROR_NONE);
+
+                TEST_LOG("Setting and Getting setPinControl Values after DB file deletion");
+                status = m_usersettingsplugin->SetPinControl(false);
+                EXPECT_EQ(status, Core::ERROR_GENERAL);
+
+                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT, UserSettings_onPinControlChanged);
+                EXPECT_TRUE(signalled & UserSettings_onPinControlChanged);
+
+                status = m_usersettingsplugin->GetPinControl(getBoolValue);
+                EXPECT_EQ(getBoolValue, true);
+                EXPECT_EQ(status, Core::ERROR_NONE);
+
+                m_usersettingsplugin->Unregister(&notification);
+                m_usersettingsplugin->Release();
+            }
+            else
+            {
+                TEST_LOG("m_usersettingsplugin is NULL");
+            }
+            m_controller_usersettings->Release();
+        }
+        else
+        {
+            TEST_LOG("m_controller_usersettings is NULL");
+        }
+    }
+}
+#if 0
+TEST_F(UserSettingTest, PersistentstoreIsDeactivatedErrorCase)
+{
+    uint32_t status = Core::ERROR_GENERAL;
+    bool getBoolValue = false;
+    string getStringValue = "";
+    Core::Sink<NotificationHandler> notification;
+    uint32_t signalled = UserSettings_StateInvalid;
+
+    status = DeactivateService("org.rdk.PersistentStore");
+    EXPECT_EQ(Core::ERROR_NONE, status);
+    sleep(5);
+
+    int file_status = remove("/tmp/secure/persistent/rdkservicestore");
+    // Check if the file has been successfully removed
+    if (file_status != 0)
+    {
+        TEST_LOG("Error deleting file[/tmp/secure/persistent/rdkservicestore]");
+    }
+    else
+    {
+        TEST_LOG("File[/tmp/secure/persistent/rdkservicestore] successfully deleted");
+    }
+
+    if (CreateUserSettingInterfaceObjectUsingComRPCConnection() != Core::ERROR_NONE)
+    {
+        TEST_LOG("Invalid Client_UserSettings");
+    }
+    else
+    {
+        ASSERT_TRUE(m_controller_usersettings!= nullptr);
+        if (m_controller_usersettings)
+        {
+            ASSERT_TRUE(m_usersettingsplugin!= nullptr);
+            if (m_usersettingsplugin)
+            {
+                m_usersettingsplugin->AddRef();
+                m_usersettingsplugin->Register(&notification);
+
+                TEST_LOG("Setting and Getting AudioDescription Values");
+                status = m_usersettingsplugin->setAudioDescription(true);
+                EXPECT_EQ(status,Core::ERROR_GENERAL);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT, UserSettings_onAudioDescriptionChanged);
+                EXPECT_FALSE(signalled & UserSettings_onAudioDescriptionChanged);
+
+                status = m_usersettingsplugin->getAudioDescription(getBoolValue);
+                EXPECT_EQ(getBoolValue, false);
+                EXPECT_EQ(status, Core::ERROR_NONE);
+
+                TEST_LOG("Setting and Getting PinControl Values");
+                status = m_usersettingsplugin->setPinControl(true);
+                EXPECT_EQ(status,Core::ERROR_GENERAL);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT, UserSettings_onPinControlChanged);
+                EXPECT_FALSE(signalled & UserSettings_onPinControlChanged);
+
+                status = m_usersettingsplugin->getPinControl(getBoolValue);
+                EXPECT_EQ(getBoolValue, false);
+                EXPECT_EQ(status, Core::ERROR_NONE);
+
+                m_usersettingsplugin->Unregister(&notification);
+                m_usersettingsplugin->Release();
+            }
+            else
+            {
+                TEST_LOG("m_usersettingsplugin is NULL");
+            }
+            m_controller_usersettings->Release();
+        }
+        else
+        {
+            TEST_LOG("m_controller_usersettings is NULL");
+        }
+    }
+}
+#endif
+TEST_F(UserSettingTest, PersistentstoreIsNotActivatedWhileUserSettingsActivatingErrorCase)
+{
+    uint32_t status = Core::ERROR_GENERAL;
+    bool getBoolValue = false;
+    string getStringValue = "";
+    Core::Sink<NotificationHandler> notification;
+    uint32_t signalled = UserSettings_StateInvalid;
+
+    status = DeactivateService("org.rdk.UserSettings");
+    EXPECT_EQ(Core::ERROR_NONE, status);
+    status = DeactivateService("org.rdk.PersistentStore");
+    EXPECT_EQ(Core::ERROR_NONE, status);
+
+    int file_status = remove("/tmp/secure/persistent/rdkservicestore");
+    // Check if the file has been successfully removed
+    if (file_status != 0)
+    {
+        TEST_LOG("Error deleting file[/tmp/secure/persistent/rdkservicestore]");
+    }
+    else
+    {
+        TEST_LOG("File[/tmp/secure/persistent/rdkservicestore] successfully deleted");
+    }
+
+    sleep(5);
+    status = ActivateService("org.rdk.UserSettings");
+    EXPECT_EQ(Core::ERROR_NONE, status);
+
+    if (CreateUserSettingInterfaceObjectUsingComRPCConnection() != Core::ERROR_NONE)
+    {
+        TEST_LOG("Invalid Client_UserSettings");
+    }
+    else
+    {
+        ASSERT_TRUE(m_controller_usersettings!= nullptr);
+        if (m_controller_usersettings)
+        {
+            ASSERT_TRUE(m_usersettingsplugin!= nullptr);
+            if (m_usersettingsplugin)
+            {
+                m_usersettingsplugin->AddRef();
+                m_usersettingsplugin->Register(&notification);
+
+                TEST_LOG("Setting and Getting AudioDescription Values");
+                status = m_usersettingsplugin->SetAudioDescription(true);
+                EXPECT_EQ(status,Core::ERROR_GENERAL);
+
+                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT, UserSettings_onAudioDescriptionChanged);
+                EXPECT_FALSE(signalled & UserSettings_onAudioDescriptionChanged);
+
+                status = m_usersettingsplugin->GetAudioDescription(getBoolValue);
+                EXPECT_EQ(getBoolValue, false);
+                EXPECT_EQ(status, Core::ERROR_GENERAL);
+
+                TEST_LOG("Setting and Getting PinControl Values");
+                status = m_usersettingsplugin->SetPinControl(true);
+                EXPECT_EQ(status,Core::ERROR_GENERAL);
+
+                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT, UserSettings_onPinControlChanged);
+                EXPECT_FALSE(signalled & UserSettings_onPinControlChanged);
+
+                status = m_usersettingsplugin->GetPinControl(getBoolValue);
+                EXPECT_EQ(getBoolValue, false);
+                EXPECT_EQ(status, Core::ERROR_GENERAL);
+
+                m_usersettingsplugin->Unregister(&notification);
+                m_usersettingsplugin->Release();
+            }
+            else
+            {
+                TEST_LOG("m_usersettingsplugin is NULL");
+            }
+            m_controller_usersettings->Release();
+        }
+        else
+        {
+            TEST_LOG("m_controller_usersettings is NULL");
+        }
+    }
+}
+
 

--- a/Tests/L2Tests/L2TestsPlugin/tests/UserSettings_L2Test.cpp
+++ b/Tests/L2Tests/L2TestsPlugin/tests/UserSettings_L2Test.cpp
@@ -27,13 +27,14 @@ typedef enum : uint32_t {
     UserSettings_onCaptionsChanged = 0x00000004,
     UserSettings_onPreferredCaptionsLanguagesChanged = 0x00000005,
     UserSettings_onPreferredClosedCaptionServiceChanged = 0x00000006,
-    UserSettings_onPinControlChanged = 0x00000007,
-    UserSettings_onViewingRestrictionsChanged = 0x00000008,
-    UserSettings_onViewingRestrictionsWindowChanged = 0x00000009,
-    UserSettings_onLiveWatershedChanged = 0x0000000a,
-    UserSettings_onPlaybackWatershedChanged = 0x0000000b,
-    UserSettings_onBlockNotRatedContentChanged = 0x0000000c,
-    UserSettings_onPinOnPurchaseChanged = 0x0000000d,
+    UserSettings_onPrivacyModeChanged = 0x00000007,
+    UserSettings_onPinControlChanged = 0x00000008,
+    UserSettings_onViewingRestrictionsChanged = 0x00000009,
+    UserSettings_onViewingRestrictionsWindowChanged = 0x0000000a,
+    UserSettings_onLiveWatershedChanged = 0x0000000b,
+    UserSettings_onPlaybackWatershedChanged = 0x0000000c,
+    UserSettings_onBlockNotRatedContentChanged = 0x0000000d,
+    UserSettings_onPinOnPurchaseChanged = 0x0000000e,
     UserSettings_StateInvalid = 0x00000000
 }UserSettingsL2test_async_events_t;
 
@@ -49,6 +50,7 @@ class AsyncHandlerMock_UserSetting
         MOCK_METHOD(void, onCaptionsChanged, (const bool enabled));
         MOCK_METHOD(void, onPreferredCaptionsLanguagesChanged, (const string preferredLanguages));
         MOCK_METHOD(void, onPreferredClosedCaptionServiceChanged, (const string service));
+        MOCK_METHOD(void, onPrivacyModeChanged, (const string privacyMode));
         MOCK_METHOD(void, onPinControlChanged, (const bool enabled));
         MOCK_METHOD(void, onViewingRestrictionsChanged, (const string viewingRestrictions));
         MOCK_METHOD(void, onViewingRestrictionsWindowChanged, (const string viewingRestrictionsWindow));
@@ -147,6 +149,17 @@ class NotificationHandler : public Exchange::IUserSettings::INotification {
             TEST_LOG("OnPreferredClosedCaptionServiceChanged received: %s\n", service.c_str());
             /* Notify the requester thread. */
             m_event_signalled |= UserSettings_onPreferredClosedCaptionServiceChanged;
+            m_condition_variable.notify_one();
+        }
+
+        void OnPrivacyModeChanged(const string& privacyMode) override
+        {
+            TEST_LOG("OnPrivacyModeChanged event triggered ***\n");
+            std::unique_lock<std::mutex> lock(m_mutex);
+
+            TEST_LOG("OnPrivacyModeChanged received: %s\n", privacyMode.c_str());
+            /* Notify the requester thread. */
+            m_event_signalled |= UserSettings_onPrivacyModeChanged;
             m_condition_variable.notify_one();
         }
 

--- a/Tests/L2Tests/L2TestsPlugin/tests/UserSettings_L2Test.cpp
+++ b/Tests/L2Tests/L2TestsPlugin/tests/UserSettings_L2Test.cpp
@@ -58,7 +58,6 @@ class AsyncHandlerMock_UserSetting
         MOCK_METHOD(void, onPlaybackWatershedChanged, (const bool enabled));
         MOCK_METHOD(void, onBlockNotRatedContentChanged, (const bool enabled));
         MOCK_METHOD(void, onPinOnPurchaseChanged, (const bool enabled));
-
 };
 
 class NotificationHandler : public Exchange::IUserSettings::INotification {

--- a/Tests/L2Tests/patches/RDKV-48604-User-Settings-Thunder-Plugin.patch
+++ b/Tests/L2Tests/patches/RDKV-48604-User-Settings-Thunder-Plugin.patch
@@ -4,10 +4,12 @@ Date:   Fri Sep 6 12:49:05 2024 +0530
 
     RDK-48604: New UserSettings Thunder Plugin
 
-diff -uprN a/interfaces/IUserSettings.h b/interfaces/IUserSettings.h
---- a/interfaces/IUserSettings.h	1970-01-01 03:00:00.000000000 +0300
-+++ b/interfaces/IUserSettings.h	2024-09-10 00:56:19.923464729 +0300
-@@ -0,0 +1,264 @@
+diff --git a/interfaces/IUserSettings.h b/interfaces/IUserSettings.h
+new file mode 100755
+index 0000000..9353f6d
+--- /dev/null
++++ b/interfaces/IUserSettings.h
+@@ -0,0 +1,281 @@
 +/*
 + * If not stated otherwise in this file or this component's LICENSE file the
 + * following copyright and licenses apply:
@@ -70,6 +72,11 @@ diff -uprN a/interfaces/IUserSettings.h b/interfaces/IUserSettings.h
 +    // @brief The PreferredClosedCaptionService setting has changed.
 +    // @param service: "CC[1-4]", "TEXT[1-4]", "SERVICE[1-64]".
 +    virtual void OnPreferredClosedCaptionServiceChanged(const string& service) = 0;
++
++    // @text onPrivacyModeChanged
++    // @brief The PrivacyMode setting has changed.
++    // @param privacyMode: "SHARE", "DO_NOT_SHARE".
++    virtual void OnPrivacyModeChanged(const string& privacyMode /* @text privacyMode */) = 0;
 +
 +    // @text onPinControlChanged
 +    // @brief The PinControl setting has changed.
@@ -190,6 +197,18 @@ diff -uprN a/interfaces/IUserSettings.h b/interfaces/IUserSettings.h
 +  // @brief Gets the current PreferredClosedCaptionService setting.
 +  // @param service: Identifies the service to display e.g. "CC3".
 +  virtual uint32_t GetPreferredClosedCaptionService(string &service /* @out */) const = 0;
++
++  // @text setPrivacyMode
++  // @brief Sets the PrivacyMode.
++  // @details The setting should be honored by the Telemetry.
++  // If privacyMode is "DO_NOT_SHARE", logs and crash report should not be uploaded.
++  // @param privacyMode: "SHARE", "DO_NOT_SHARE"
++  virtual uint32_t SetPrivacyMode(const string& privacyMode /* @in @text privacyMode*/) = 0;
++
++  // @text getPrivacyMode
++  // @brief Gets the current PrivacyMode setting.
++  // @param privacyMode: "SHARE"
++  virtual uint32_t GetPrivacyMode(string &privacyMode /* @out @text privacyMode */) const = 0;
 +
 +  // @text setPinControl
 +  // @brief Sets PinControl ON/OFF. Parental Control as a whole is enabled or disabled.

--- a/Tests/L2Tests/patches/RDKV-48604-User-Settings-Thunder-Plugin.patch
+++ b/Tests/L2Tests/patches/RDKV-48604-User-Settings-Thunder-Plugin.patch
@@ -1,15 +1,13 @@
-commit fa2d0c0221c33e4437a158e58a7a75de3f5c5a05
-Author: Siva Thandayuthapani <sithanda@synamedia.com>
-Date:   Wed Jul 31 17:36:53 2024 +0530
+commit 8afc4a92b878252780fae90496b9782600a41bd0
+Author: Nagalakshmi Dosakayala <nadosakayala@synamedia.com>
+Date:   Fri Sep 6 12:49:05 2024 +0530
 
-    patches
+    RDK-48604: New UserSettings Thunder Plugin
 
-diff --git a/interfaces/IUserSettings.h b/interfaces/IUserSettings.h
-new file mode 100755
-index 0000000..95f21c1
---- /dev/null
-+++ b/interfaces/IUserSettings.h
-@@ -0,0 +1,166 @@
+diff -uprN a/interfaces/IUserSettings.h b/interfaces/IUserSettings.h
+--- a/interfaces/IUserSettings.h	1970-01-01 03:00:00.000000000 +0300
++++ b/interfaces/IUserSettings.h	2024-09-10 00:56:19.923464729 +0300
+@@ -0,0 +1,264 @@
 +/*
 + * If not stated otherwise in this file or this component's LICENSE file the
 + * following copyright and licenses apply:
@@ -35,64 +33,95 @@ index 0000000..95f21c1
 +
 +namespace WPEFramework {
 +namespace Exchange {
-+ // @json
-+struct EXTERNAL IUserSettings : virtual public Core::IUnknown {
++  // @json @text:keep
++  struct EXTERNAL IUserSettings : virtual public Core::IUnknown {
 +  enum { ID = ID_USER_SETTINGS };
 +
 +  // @event
 +  struct EXTERNAL INotification : virtual public Core::IUnknown {
 +    enum { ID = ID_USER_SETTINGS_NOTIFICATION };
 +
-+    // @alt OnAudioDescriptionChanged
++    // @text onAudioDescriptionChanged
 +    // @brief The AudioDescription setting has changed.
 +    // @param enabled: Enabled/Disabled.
 +    virtual void OnAudioDescriptionChanged(const bool enabled) = 0;
 +
-+    // @alt OnPreferredAudioLanguagesChanged
++    // @text onPreferredAudioLanguagesChanged
 +    // @brief The preferredLanguages setting has changed.
 +    // @param preferredLanguages: PreferredLanguages.
 +    virtual void OnPreferredAudioLanguagesChanged(const string& preferredLanguages /* @text preferredLanguages */) = 0;
 +
-+    // @alt OnPresentationLanguageChanged
++    // @text onPresentationLanguageChanged
 +    // @brief The PresentationLanguages setting has changed.
-+    // @param presentationLanguages: PresentationLanguages.
-+    virtual void OnPresentationLanguageChanged(const string& presentationLanguages /* @text presentationLanguages */) = 0;
++    // @param presentationLanguage: PresentationLanguage.
++    virtual void OnPresentationLanguageChanged(const string& presentationLanguage /* @text presentationLanguage */) = 0;
 +
-+    // @alt OnCaptionsChanged
++    // @text onCaptionsChanged
 +    // @brief The Captions setting has changed.
 +    // @param enabled: Enabled/Disabled.
 +    virtual void OnCaptionsChanged(const bool enabled) = 0;
 +
-+    // @alt OnPreferredCaptionsLanguagesChanged
++    // @text onPreferredCaptionsLanguagesChanged
 +    // @brief The PreferredCaptionsLanguages setting has changed.
 +    // @param preferredLanguages: PreferredLanguages.
 +    virtual void OnPreferredCaptionsLanguagesChanged(const string& preferredLanguages /* @text preferredLanguages */) = 0;
 +
-+    // @alt OnPreferredClosedCaptionServiceChanged
++    // @text onPreferredClosedCaptionServiceChanged
 +    // @brief The PreferredClosedCaptionService setting has changed.
 +    // @param service: "CC[1-4]", "TEXT[1-4]", "SERVICE[1-64]".
 +    virtual void OnPreferredClosedCaptionServiceChanged(const string& service) = 0;
 +
-+    // @alt OnPrivacyModeChanged
-+    // @brief The PrivacyMode setting has changed.
-+    // @param privacyMode: "SHARE", "DO_NOT_SHARE".
-+    virtual void OnPrivacyModeChanged(const string& privacyMode /* @text privacyMode */) = 0;
++    // @text onPinControlChanged
++    // @brief The PinControl setting has changed.
++    // @param enabled: Enabled/Disabled.
++    virtual void OnPinControlChanged(const bool enabled) = 0;
++
++    // @text onViewingRestrictionsChanged
++    // @brief The ViewingRestrictions setting has changed.
++    // @param viewingRestrictions:  Empty string
++    virtual void OnViewingRestrictionsChanged(const string& viewingRestrictions /* @text viewingRestrictions */) = 0;
++
++    // @text onViewingRestrictionsWindowChanged
++    // @brief The ViewingRestrictionsWindow setting has changed.
++    // @param viewingRestrictionsWindow: "ALWAYS"
++    virtual void OnViewingRestrictionsWindowChanged(const string& viewingRestrictionsWindow /* @text viewingRestrictionsWindow */) = 0;
++
++    // @text onLiveWatershedChanged
++    // @brief The LiveWatershed setting has changed.
++    // @param enabled: Enabled/Disabled.
++    virtual void OnLiveWatershedChanged(const bool enabled) = 0;
++
++    // @text onPlaybackWatershedChanged
++    // @brief The PlaybackWatershed setting has changed.
++    // @param enabled: Enabled/Disabled.
++    virtual void OnPlaybackWatershedChanged(const bool enabled) = 0;
++
++    // @text onBlockNotRatedContentChanged
++    // @brief The BlockNotRatedContent setting has changed.
++    // @param enabled: Enabled/Disabled.
++    virtual void OnBlockNotRatedContentChanged(const bool enabled) = 0;
++
++    // @text onPinOnPurchaseChanged
++    // @brief The PinOnPurchase setting has changed.
++    // @param enabled: Enabled/Disabled.
++    virtual void OnPinOnPurchaseChanged(const bool enabled) = 0;
++
 +  };
 +
 +  virtual uint32_t Register(Exchange::IUserSettings::INotification* notification /* @in */) = 0;
 +  virtual uint32_t Unregister(Exchange::IUserSettings::INotification* notification /* @in */) = 0;
 +
-+  // @alt SetAudioDescription
++  // @text setAudioDescription
 +  // @brief Sets AudioDescription ON/OFF. Players should preferred Audio Descriptive tracks over normal audio track when enabled
 +  // @param enabled: Enabled/Disabled
 +  virtual uint32_t SetAudioDescription(const bool enabled /* @in */) = 0;
 +
-+  // @alt GetAudioDescription
++  // @text getAudioDescription
 +  // @brief Gets the current AudioDescription setting
 +  // @param enabled: Enabled/Disabled
 +  virtual uint32_t GetAudioDescription(bool &enabled /* @out */) const = 0;
 +
-+  // @alt SetPreferredAudioLanguages
++  // @text setPreferredAudioLanguages
 +  // @brief A prioritized list of ISO 639-2/B codes for the preferred audio languages,
 +  // expressed as a comma separated lists of languages of zero of more elements.
 +  // The players will pick the audio track that has the best match compared with
@@ -101,22 +130,22 @@ index 0000000..95f21c1
 +  // @param preferredLanguages: PreferredLanguages
 +  virtual uint32_t SetPreferredAudioLanguages(const string& preferredLanguages  /* @in @text preferredLanguages */) = 0;
 +
-+  // @alt GetPreferredAudioLanguages
++  // @text getPreferredAudioLanguages
 +  // @brief Gets the current PreferredAudioLanguages setting
 +  // @param preferredLanguages: PreferredLanguages
 +  virtual uint32_t GetPreferredAudioLanguages(string &preferredLanguages /* @out @text preferredLanguages */) const = 0;
 +
-+  // @alt SetPresentationLanguage
-+  // @brief Sets the presentationLanguages in a full BCP 47 value, including script, region, variant
-+  // @param presentationLanguages: "en-US", "es-US", "en-CA", "fr-CA"
-+  virtual uint32_t SetPresentationLanguage(const string& presentationLanguages /* @in @text presentationLanguages */) = 0;
++  // @text setPresentationLanguage
++  // @brief Sets the presentationLanguage in a full BCP 47 value, including script, region, variant
++  // @param presentationLanguage: "en-US", "es-US", "en-CA", "fr-CA"
++  virtual uint32_t SetPresentationLanguage(const string& presentationLanguage /* @in @text presentationLanguage */) = 0;
 +
-+  // @alt GetPresentationLanguage
-+  // @brief Gets the presentationLanguages
-+  // @param presentationLanguages: "en-US", "es-US", "en-CA", "fr-CA"
-+  virtual uint32_t GetPresentationLanguage(string &presentationLanguages /* @out @text presentationLanguages */) const = 0;
++  // @text getPresentationLanguage
++  // @brief Gets the presentationLanguage
++  // @param presentationLanguage: "en-US", "es-US", "en-CA", "fr-CA"
++  virtual uint32_t GetPresentationLanguage(string &presentationLanguage /* @out @text presentationLanguage */) const = 0;
 +
-+  // @alt SetCaptions
++  // @text setCaptions
 +  // @brief brief Sets Captions ON/OFF.
 +  // @details A setting of ON indicates that Players should select a subtitle track for presentation
 +  // The Setting does not influence any running sessions. It is up to the player to enforce the setting.
@@ -127,68 +156,134 @@ index 0000000..95f21c1
 +  // When media players start playback, they should also call the GetCaptions method to retrieve the current enabled state.
 +  // This holds true for media players that utilize TextTrack render sessions for text track decode-display and also for media
 +  // players or apps that decode-display internally 
-+  // @param enabled Sets the state
++  // @param enabled: Sets the state
 +  virtual uint32_t SetCaptions(const bool enabled  /* @in */) = 0;
 +
-+  // @alt GetCaptions
++  // @text getCaptions
 +  // @brief Gets the Captions setting.
-+  // @param enabled Receives the state
++  // @param enabled: Receives the state
 +  virtual uint32_t GetCaptions(bool &enabled /* @out */) const = 0;
 +
-+  // @alt SetPreferredCaptionsLanguages
++  // @text setPreferredCaptionsLanguages
 +  // @brief Set preferred languages for captions.
 +  // @details A prioritized list of ISO 639-2/B codes for the preferred Captions languages,
 +  // expressed as a comma separated lists of languages of zero of more elements.
 +  // The players will pick the subtitle track that has the best match compared with
 +  // this list. In the absence of a matching track, the player should by best
 +  // effort select the preferred subtitle track. 
-+  // @param preferredLanguages Is the list to set (e.g. "eng,fra")
++  // @param preferredLanguages: Is the list to set (e.g. "eng,fra")
 +  virtual uint32_t SetPreferredCaptionsLanguages(const string& preferredLanguages  /* @in @text preferredLanguages */) = 0;
 +
-+  // @alt GetPreferredCaptionsLanguages
++  // @text getPreferredCaptionsLanguages
 +  // @brief Gets the current PreferredCaptionsLanguages setting.
-+  // @param preferredLanguages (e.g. "eng,fra")
++  // @param preferredLanguages: "eng,fra"
 +  virtual uint32_t GetPreferredCaptionsLanguages(string &preferredLanguages /* @out @text preferredLanguages */) const = 0;
 +
-+  // @alt SetPreferredClosedCaptionService
++  // @text setPreferredClosedCaptionService
 +  // @brief Sets the PreferredClosedCaptionService.
 +  // @details The setting should be honored by the player. The behaviour of AUTO may be player specific.
 +  // Valid input for service is "CC[1-4]", "TEXT[1-4]", "SERVICE[1-64]" 
-+  // @param service Identifies the service to display e.g. "CC3".
++  // @param service: Identifies the service to display e.g. "CC3".
 +  virtual uint32_t SetPreferredClosedCaptionService(const string& service  /* @in */) = 0;
 +
-+  // @alt GetPreferredClosedCaptionService
++  // @text getPreferredClosedCaptionService
 +  // @brief Gets the current PreferredClosedCaptionService setting.
-+  // @param service Identifies the service to display e.g. "CC3".
++  // @param service: Identifies the service to display e.g. "CC3".
 +  virtual uint32_t GetPreferredClosedCaptionService(string &service /* @out */) const = 0;
 +
-+  // @alt SetPrivacyMode
-+  // @brief Sets the PrivacyMode.
-+  // @details The setting should be honored by the Telemetry.
-+  // If privacyMode is "DO_NOT_SHARE", logs and crash report should not be uploaded.
-+  // @param privacyMode: "SHARE", "DO_NOT_SHARE"
-+  virtual uint32_t SetPrivacyMode(const string& privacyMode /* @in @text privacyMode*/) = 0;
++  // @text setPinControl
++  // @brief Sets PinControl ON/OFF. Parental Control as a whole is enabled or disabled.
++  // @param enabled: Enabled/Disabled
++  virtual uint32_t SetPinControl(const bool enabled /* @in */) = 0;
 +
-+  // @alt GetPrivacyMode
-+  // @brief Gets the current PrivacyMode setting.
-+  // @param privacyMode e.g "SHARE"
-+  virtual uint32_t GetPrivacyMode(string &privacyMode /* @out @text privacyMode */) const = 0;
++  // @text getPinControl
++  // @brief Gets the PinControl setting
++  // @param enabled: Enabled/Disabled
++  virtual uint32_t GetPinControl(bool &enabled /* @out */) const = 0;
++
++  // @text setViewingRestrictions
++  // @brief Sets the ViewingRestrictions.
++  // @details A JSON document that escribes the rating scheme(s) and ratings that are blocked.
++  // @param viewingRestrictions: A JSON document that describes the rating scheme(s) and ratings that are blocked.
++  virtual uint32_t SetViewingRestrictions(const string& viewingRestrictions /* @in @text viewingRestrictions */) = 0;
++
++  // @text getViewingRestrictions
++  // @brief Gets the current ViewingRestrictions.
++  // @param viewingRestrictions: A JSON document that escribes the rating scheme(s) and ratings that are blocked.
++  virtual uint32_t GetViewingRestrictions(string &viewingRestrictions /* @out @text viewingRestrictions */) const = 0;
++
++  // @text setViewingRestrictionsWindow
++  // @brief Sets the ViewingRestrictionsWindow.
++  // @details A project-specific representation of the time interval when viewing
++  // restrictions are to be applied, if applicable for the project
++  // @param viewingRestrictionsWindow: A project-specific representation of the time interval.Eg: "ALWAYS"
++  virtual uint32_t SetViewingRestrictionsWindow(const string &viewingRestrictionsWindow /* @in @text viewingRestrictionsWindow */) = 0;
++  
++  // @text getViewingRestrictionsWindow
++  // @brief Gets the current ViewingRestrictionsWindow.
++  // @param viewingRestrictionsWindow: A project-specific representation of the time interval.Eg: "ALWAYS"
++  virtual uint32_t GetViewingRestrictionsWindow(string &viewingRestrictionsWindow /* @out @text viewingRestrictionsWindow */) const = 0;
++
++  // @text setLiveWatershed
++  // @brief Sets LiveWatershed ON/OFF.Whether project-specific watershed rules
++  // should be applied for live content, if applicable for the project.
++  // @param enabled: Enabled/Disabled
++  virtual uint32_t SetLiveWatershed(const bool enabled /* @in */) = 0;
++
++  // @text getLiveWatershed
++  // @brief Gets the LiveWatershed setting
++  // @param enabled: Enabled/Disabled
++  virtual uint32_t GetLiveWatershed(bool &enabled /* @out */) const = 0;
++
++  // @text setPlaybackWatershed
++  // @brief Sets PlaybackWatershed ON/OFF. Whether project-specific watershed rules
++  // should be applied for non-live content, if applicable for the project.
++  // @param enabled: Enabled/Disabled
++  virtual uint32_t SetPlaybackWatershed(const bool enabled /* @in */) = 0;
++
++  // @text getPlaybackWatershed
++  // @brief Gets the PlaybackWatershed setting
++  // @param enabled: Enabled/Disabled
++  virtual uint32_t GetPlaybackWatershed(bool &enabled /* @out */) const = 0;
++
++  // @text setBlockNotRatedContent
++  // @brief Sets BlockNotRatedContent ON/OFF. Whether content that is not rated should be
++  // blocked, if applicable for the project.
++  // @param enabled: Enabled/Disabled
++  virtual uint32_t SetBlockNotRatedContent(const bool enabled /* @in */) = 0;
++
++  // @text getBlockNotRatedContent
++  // @brief Gets the BlockNotRatedContent setting
++  // @param enabled: Enabled/Disabled
++  virtual uint32_t GetBlockNotRatedContent(bool &enabled /* @out */) const = 0;
++
++  // @text setPinOnPurchase
++  // @brief Sets PinOnPurchase ON/OFF.Whether a PIN challenge should be made
++  // when a purchase is attempted.
++  // @param enabled: Enabled/Disabled
++  virtual uint32_t SetPinOnPurchase(const bool enabled /* @in */) = 0;
++
++  // @text getPinOnPurchase
++  // @brief Gets the PinOnPurchase setting
++  // @param enabled: Enabled/Disabled
++  virtual uint32_t GetPinOnPurchase(bool &enabled /* @out */) const = 0;
++
 +};
 +} // namespace Exchange
 +} // namespace WPEFramework
-\ No newline at end of file
++
 diff --git a/interfaces/Ids.h b/interfaces/Ids.h
-index 64151cf..7aac530 100644
+index a37db24..293dd73 100644
 --- a/interfaces/Ids.h
 +++ b/interfaces/Ids.h
-@@ -360,7 +360,10 @@ namespace Exchange {
+@@ -354,7 +354,10 @@ namespace Exchange {
          ID_SCRIPT_ENGINE_NOTIFICATION                = ID_SCRIPT_ENGINE + 1,
  
          ID_TEXT_TO_SPEECH                            = RPC::IDS::ID_EXTERNAL_INTERFACE_OFFSET + 0x4C0,
 -        ID_TEXT_TO_SPEECH_NOTIFICATION               = ID_TEXT_TO_SPEECH + 1
 +        ID_TEXT_TO_SPEECH_NOTIFICATION               = ID_TEXT_TO_SPEECH + 1,
 +
-+        ID_USER_SETTINGS                             = RPC::IDS::ID_EXTERNAL_INTERFACE_OFFSET + 0x4D0,
++	ID_USER_SETTINGS                             = RPC::IDS::ID_EXTERNAL_INTERFACE_OFFSET + 0x4D0,
 +        ID_USER_SETTINGS_NOTIFICATION                = ID_USER_SETTINGS + 1
      };
  }

--- a/Tests/L2Tests/patches/Use_Legact_Alt_Based_On_ThunderTools_R4.4.3.patch
+++ b/Tests/L2Tests/patches/Use_Legact_Alt_Based_On_ThunderTools_R4.4.3.patch
@@ -1,0 +1,20 @@
+commit 810aae64cb31c907698e468b615797750094b847
+Author: Pesala Lakshmi Jwala Priya <plakshmijwalapriya@synamedia.com>
+Date:   Thu Aug 29 12:31:30 2024 +0530
+
+    Alt change
+
+diff --git a/Source/plugins/CMakeLists.txt b/Source/plugins/CMakeLists.txt
+index 4d362d54..cdb53cdc 100644
+--- a/Source/plugins/CMakeLists.txt
++++ b/Source/plugins/CMakeLists.txt
+@@ -29,7 +29,7 @@ ProxyStubGenerator(NAMESPACE "WPEFramework::PluginHost" INPUT "${CMAKE_CURRENT_S
+ ProxyStubGenerator(NAMESPACE "WPEFramework::PluginHost" INPUT "${CMAKE_CURRENT_SOURCE_DIR}/ISubSystem.h" OUTDIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
+ ProxyStubGenerator(NAMESPACE "WPEFramework::PluginHost" INPUT "${CMAKE_CURRENT_SOURCE_DIR}/IDispatcher.h" OUTDIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
+ 
+-JsonGenerator(CODE NAMESPACE WPEFramework::Exchange::Controller INPUT ${CMAKE_CURRENT_SOURCE_DIR}/IController.h OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/generated/jsonrpc" INCLUDE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/.." NO_INCLUDES)
++JsonGenerator(CODE NAMESPACE WPEFramework::Exchange::Controller INPUT ${CMAKE_CURRENT_SOURCE_DIR}/IController.h OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/generated/jsonrpc" INCLUDE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/.." NO_INCLUDES LEGACY_ALT)
+ 
+ add_library(${TARGET} SHARED
+         Channel.cpp
+

--- a/Tests/L2Tests/patches/Use_Legact_Alt_In_ThunderInterfaces_Based_On_ThunderTools_R4.4.3.patch
+++ b/Tests/L2Tests/patches/Use_Legact_Alt_In_ThunderInterfaces_Based_On_ThunderTools_R4.4.3.patch
@@ -1,0 +1,22 @@
+commit f6fd38dcb9f2f1eaf5617119580957228231191c
+Author: Pesala Lakshmi Jwala Priya <plakshmijwalapriya@synamedia.com>
+Date:   Thu Aug 29 12:17:41 2024 +0530
+
+    R4.4.3_change
+
+diff --git a/definitions/CMakeLists.txt b/definitions/CMakeLists.txt
+index adacc7b..53c5327 100644
+--- a/definitions/CMakeLists.txt
++++ b/definitions/CMakeLists.txt
+@@ -49,8 +49,8 @@ if(NOT GENERATOR_SEARCH_PATH)
+     set(GENERATOR_SEARCH_PATH ${CMAKE_SYSROOT}${CMAKE_INSTALL_PREFIX}/include/${NAMESPACE})
+ endif()
+ 
+-JsonGenerator(CODE INPUT ${JSON_FILE} OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/generated" INCLUDE_PATH ${GENERATOR_SEARCH_PATH} CPPIFDIR "${CMAKE_CURRENT_SOURCE_DIR}/../interfaces/")
+-JsonGenerator(CODE INPUT ${INTERFACE_FILE} OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/generated" INCLUDE_PATH ${GENERATOR_SEARCH_PATH})
++JsonGenerator(CODE INPUT ${JSON_FILE} OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/generated" INCLUDE_PATH ${GENERATOR_SEARCH_PATH} CPPIFDIR "${CMAKE_CURRENT_SOURCE_DIR}/../interfaces/" LEGACY_ALT)
++JsonGenerator(CODE INPUT ${INTERFACE_FILE} OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/generated" INCLUDE_PATH ${GENERATOR_SEARCH_PATH} LEGACY_ALT)
+ 
+ file(GLOB JSON_ENUM_SOURCES "${CMAKE_CURRENT_BINARY_DIR}/generated/JsonEnum*.cpp")
+ file(GLOB JSON_LINK_HEADERS "${CMAKE_CURRENT_BINARY_DIR}/generated/J*.h")
+

--- a/UserSettings/CHANGELOG.md
+++ b/UserSettings/CHANGELOG.md
@@ -18,8 +18,6 @@ All notable changes to this RDK Service will be documented in this file.
 
 ## [1.2.0] - 2024-09-17
 ### Added
-- Add CHANGELOG
-### Change
 - Added ParentalControl new properties in Usersetttings.
 
 ## [1.1.2] - 2024-08-26

--- a/UserSettings/CHANGELOG.md
+++ b/UserSettings/CHANGELOG.md
@@ -16,6 +16,11 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.1.3] - 2024-09-17
+### Added
+- Add CHANGELOG
+### Change
+- Added ParentalControl new properties in Usersetttings.
 
 ## [1.1.2] - 2024-08-26
 ### Fixed

--- a/UserSettings/CHANGELOG.md
+++ b/UserSettings/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
-## [1.1.3] - 2024-09-17
+## [1.2.0] - 2024-09-17
 ### Added
 - Add CHANGELOG
 ### Change

--- a/UserSettings/UserSettings.h
+++ b/UserSettings/UserSettings.h
@@ -104,6 +104,12 @@ namespace Plugin {
                     Exchange::JUserSettings::Event::OnPreferredClosedCaptionServiceChanged(_parent, service);
                 }
 
+                void OnPrivacyModeChanged(const string &privacyMode) override
+                {
+                    LOGINFO("PrivacyModeChanged: %s\n", privacyMode.c_str());
+                    Exchange::JUserSettings::Event::OnPrivacyModeChanged(_parent, privacyMode);
+                }
+
                 void OnPinControlChanged(const bool enabled) override
                 {
                     LOGINFO("PinControlChanged: %d\n", enabled);

--- a/UserSettings/UserSettings.h
+++ b/UserSettings/UserSettings.h
@@ -80,10 +80,10 @@ namespace Plugin {
                     Exchange::JUserSettings::Event::OnPreferredAudioLanguagesChanged(_parent, preferredLanguages);
                 }
 
-                void OnPresentationLanguageChanged(const string& presentationLanguages) override
+                void OnPresentationLanguageChanged(const string& presentationLanguage) override
                 {
-                    LOGINFO("PresentationLanguageChanged: %s\n", presentationLanguages.c_str());
-                    Exchange::JUserSettings::Event::OnPresentationLanguageChanged(_parent, presentationLanguages);
+                    LOGINFO("PresentationLanguageChanged: %s\n", presentationLanguage.c_str());
+                    Exchange::JUserSettings::Event::OnPresentationLanguageChanged(_parent, presentationLanguage);
                 }
 
                 void OnCaptionsChanged(bool enabled) override
@@ -104,10 +104,46 @@ namespace Plugin {
                     Exchange::JUserSettings::Event::OnPreferredClosedCaptionServiceChanged(_parent, service);
                 }
 
-                void OnPrivacyModeChanged(const string &privacyMode) override
+                void OnPinControlChanged(const bool enabled) override
                 {
-                    LOGINFO("PrivacyModeChanged: %s\n", privacyMode.c_str());
-                    Exchange::JUserSettings::Event::OnPrivacyModeChanged(_parent, privacyMode);
+                    LOGINFO("PinControlChanged: %d\n", enabled);
+                    Exchange::JUserSettings::Event::OnPinControlChanged(_parent, enabled);
+                }
+
+                void OnViewingRestrictionsChanged(const string& viewingRestrictions) override
+                {
+                    LOGINFO("ViewingRestrictionsChanged: %s\n", viewingRestrictions.c_str());
+                    Exchange::JUserSettings::Event::OnViewingRestrictionsChanged(_parent, viewingRestrictions);
+                }
+
+                void OnViewingRestrictionsWindowChanged(const string& viewingRestrictionsWindow) override
+                {
+                    LOGINFO("ViewingRestrictionsWindowChanged: %s\n", viewingRestrictionsWindow.c_str());
+                    Exchange::JUserSettings::Event::OnViewingRestrictionsWindowChanged(_parent, viewingRestrictionsWindow);
+                }
+
+                void OnLiveWatershedChanged(const bool enabled) override
+                {
+                    LOGINFO("LiveWatershedChanged: %d\n", enabled);
+                    Exchange::JUserSettings::Event::OnLiveWatershedChanged(_parent, enabled);
+                }
+
+                void OnPlaybackWatershedChanged(const bool enabled) override
+                {
+                    LOGINFO("PlaybackWatershedChanged: %d\n", enabled);
+                    Exchange::JUserSettings::Event::OnPlaybackWatershedChanged(_parent, enabled);
+                }
+
+                void OnBlockNotRatedContentChanged(const bool enabled) override
+                {
+                    LOGINFO("BlockNotRatedContentChanged: %d\n", enabled);
+                    Exchange::JUserSettings::Event::OnBlockNotRatedContentChanged(_parent, enabled);
+                }
+
+                void OnPinOnPurchaseChanged(const bool enabled) override
+                {
+                    LOGINFO("PinOnPurchaseChanged: %d\n", enabled);
+                    Exchange::JUserSettings::Event::OnPinOnPurchaseChanged(_parent, enabled);
                 }
 
             private:

--- a/UserSettings/UserSettingsImplementation.cpp
+++ b/UserSettings/UserSettingsImplementation.cpp
@@ -23,6 +23,10 @@
 #include <mutex>
 #include "tracing/Logging.h"
 
+#ifdef HAS_RBUS
+#define RBUS_COMPONENT_NAME "UserSettingsThunderPlugin"
+#define RBUS_PRIVACY_MODE_EVENT_NAME "Device.X_RDKCENTRAL-COM_UserSettings.PrivacyModeChanged"
+#endif
 
 namespace WPEFramework {
 namespace Plugin {
@@ -51,6 +55,9 @@ UserSettingsImplementation::UserSettingsImplementation()
 , _remotStoreObject(nullptr)
 , _storeNotification(*this)
 , _registeredEventHandlers(false)
+#ifdef HAS_RBUS
+, _rbusHandleStatus(RBUS_ERROR_NOT_INITIALIZED)
+#endif
 {
     LOGINFO("Create UserSettingsImplementation Instance");
 
@@ -128,6 +135,15 @@ UserSettingsImplementation::~UserSettingsImplementation()
         _remotStoreObject->Release();
     }
     _registeredEventHandlers = false;
+    
+#ifdef HAS_RBUS
+    if (RBUS_ERROR_SUCCESS == _rbusHandleStatus)
+    {
+        rbus_close(_rbusHandle);
+        _rbusHandleStatus = RBUS_ERROR_NOT_INITIALIZED;
+    }
+
+#endif
 }
 
 void UserSettingsImplementation::registerEventHandlers()
@@ -252,6 +268,14 @@ void UserSettingsImplementation::Dispatch(Event event, const JsonValue params)
              }
          break;
 
+         case PRIVACY_MODE_CHANGED:
+             while (index != _userSettingNotification.end())
+             {
+                 (*index)->OnPrivacyModeChanged(params.String());
+                 ++index;
+             }
+         break;
+
          case PIN_CONTROL_CHANGED:
               while (index != _userSettingNotification.end())
               {
@@ -342,6 +366,10 @@ void UserSettingsImplementation::ValueChanged(const Exchange::IStore2::ScopeType
     else if((ns.compare(USERSETTINGS_NAMESPACE) == 0) && (key.compare(USERSETTINGS_PREFERRED_CLOSED_CAPTIONS_SERVICE_KEY) == 0))
     {
         dispatchEvent(PREFERRED_CLOSED_CAPTIONS_SERVICE_CHANGED, JsonValue((string)value));
+    }
+    else if((ns.compare(USERSETTINGS_NAMESPACE) == 0) && (key.compare(USERSETTINGS_PRIVACY_MODE_KEY) == 0))
+    {
+        dispatchEvent(PRIVACY_MODE_CHANGED, JsonValue((string)value));
     }
     else if((ns.compare(USERSETTINGS_NAMESPACE) == 0) && (key.compare(USERSETTINGS_PIN_CONTROL_KEY) == 0))
     {
@@ -551,6 +579,99 @@ uint32_t UserSettingsImplementation::GetPreferredClosedCaptionService(string &se
     std::string value = "";
 
     status = GetUserSettingsValue(USERSETTINGS_PREFERRED_CLOSED_CAPTIONS_SERVICE_KEY, service);
+    return status;
+}
+
+uint32_t UserSettingsImplementation::SetPrivacyMode(const string& privacyMode)
+{
+    uint32_t status = Core::ERROR_GENERAL;
+
+    LOGINFO("privacyMode: %s", privacyMode.c_str());
+
+    if (privacyMode != "SHARE" && privacyMode != "DO_NOT_SHARE")
+    {
+        LOGERR("Wrong privacyMode value: '%s', returning default", privacyMode.c_str());
+        return status;
+    }
+
+    _adminLock.Lock();
+
+    ASSERT (nullptr != _remotStoreObject);
+
+    if (nullptr != _remotStoreObject)
+    {
+        uint32_t ttl = 0;
+        string oldPrivacyMode;
+        status = _remotStoreObject->GetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_PRIVACY_MODE_KEY, oldPrivacyMode, ttl);
+        LOGINFO("oldPrivacyMode: %s", oldPrivacyMode.c_str());
+
+        if (privacyMode != oldPrivacyMode)
+        {
+#ifdef HAS_RBUS
+            if (Core::ERROR_NONE == status)
+            {
+                if (RBUS_ERROR_SUCCESS != _rbusHandleStatus)
+                {
+                    _rbusHandleStatus = rbus_open(&_rbusHandle, RBUS_COMPONENT_NAME);
+                }
+
+                if (RBUS_ERROR_SUCCESS == _rbusHandleStatus)
+                {
+                    rbusValue_t value;
+                    rbusSetOptions_t opts = {true, 0};
+
+                    rbusValue_Init(&value);
+                    rbusValue_SetString(value, privacyMode.c_str());
+                    int rc = rbus_set(_rbusHandle, RBUS_PRIVACY_MODE_EVENT_NAME, value, &opts);
+                    if (rc != RBUS_ERROR_SUCCESS)
+                    {
+                        std::stringstream str;
+                        str << "Failed to set property " << RBUS_PRIVACY_MODE_EVENT_NAME << ": " << rc;
+                        LOGERR("%s", str.str().c_str());
+                    }
+                    rbusValue_Release(value);
+                }
+                else
+                {
+                    std::stringstream str;
+                    str << "rbus_open failed with error code " << _rbusHandleStatus;
+                    LOGERR("%s", str.str().c_str());
+                }
+            }
+#endif
+            status = _remotStoreObject->SetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_PRIVACY_MODE_KEY, privacyMode, 0);
+        }
+    }
+
+    _adminLock.Unlock();
+
+    return status;
+}
+
+uint32_t UserSettingsImplementation::GetPrivacyMode(string &privacyMode) const
+{
+    uint32_t status = Core::ERROR_NONE;
+    std::string value = "";
+    uint32_t ttl = 0;
+    privacyMode = "";
+
+    _adminLock.Lock();
+
+    ASSERT (nullptr != _remotStoreObject);
+
+    if (nullptr != _remotStoreObject)
+    {
+        _remotStoreObject->GetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_PRIVACY_MODE_KEY, privacyMode, ttl);
+    }
+
+    _adminLock.Unlock();
+    
+    if (privacyMode != "SHARE" && privacyMode != "DO_NOT_SHARE") 
+    {
+        LOGWARN("Wrong privacyMode value: '%s', returning default", privacyMode.c_str());
+        privacyMode = "SHARE";
+    }
+
     return status;
 }
 

--- a/UserSettings/UserSettingsImplementation.h
+++ b/UserSettings/UserSettingsImplementation.h
@@ -30,6 +30,10 @@
 #include <core/core.h>
 #include <plugins/plugins.h>
 
+#ifdef HAS_RBUS
+#include "rbus.h"
+#endif
+
 #define USERSETTINGS_NAMESPACE "UserSettings"
 
 #define USERSETTINGS_AUDIO_DESCRIPTION_KEY                    "audioDescription"
@@ -38,6 +42,7 @@
 #define USERSETTINGS_CAPTIONS_KEY                             "captions"
 #define USERSETTINGS_PREFERRED_CAPTIONS_LANGUAGES_KEY         "preferredCaptionsLanguages"
 #define USERSETTINGS_PREFERRED_CLOSED_CAPTIONS_SERVICE_KEY    "preferredClosedCaptionsService"
+#define USERSETTINGS_PRIVACY_MODE_KEY                         "privacyMode"
 #define USERSETTINGS_PIN_CONTROL_KEY                          "pinControl"
 #define USERSETTINGS_VIEWING_RESTRICTIONS_KEY                 "viewingRestrictions"
 #define USERSETTINGS_VIEWING_RESTRICTIONS_WINDOW_KEY          "viewingRestrictionsWindow"
@@ -103,6 +108,7 @@ namespace Plugin {
                 CAPTIONS_CHANGED,
                 PREFERRED_CAPTIONS_LANGUAGE_CHANGED,
                 PREFERRED_CLOSED_CAPTIONS_SERVICE_CHANGED,
+                PRIVACY_MODE_CHANGED,
                 PIN_CONTROL_CHANGED,
                 VIEWING_RESTRICTIONS_CHANGED,
                 VIEWING_RESTRICTIONS_WINDOW_CHANGED,
@@ -166,6 +172,8 @@ namespace Plugin {
         uint32_t GetPreferredCaptionsLanguages(string &preferredLanguages) const override;
         uint32_t SetPreferredClosedCaptionService(const string& service) override;
         uint32_t GetPreferredClosedCaptionService(string &service) const override;
+        uint32_t SetPrivacyMode(const string& privacyMode) override;
+        uint32_t GetPrivacyMode(string &privacyMode) const override;
         uint32_t SetPinControl(const bool enabled) override;
         uint32_t GetPinControl(bool &enabled) const override;
         uint32_t SetViewingRestrictions(const string& viewingRestrictions) override;
@@ -198,6 +206,10 @@ namespace Plugin {
         Core::Sink<Store2Notification> _storeNotification;
         bool _registeredEventHandlers;
 
+#ifdef HAS_RBUS
+        rbusError_t _rbusHandleStatus;
+        rbusHandle_t _rbusHandle;
+#endif
         void dispatchEvent(Event, const JsonValue &params);
         void Dispatch(Event event, const JsonValue params);
 

--- a/UserSettings/UserSettingsImplementation.h
+++ b/UserSettings/UserSettingsImplementation.h
@@ -30,13 +30,29 @@
 #include <core/core.h>
 #include <plugins/plugins.h>
 
-#ifdef HAS_RBUS
-#include "rbus.h"
-#endif
+#define USERSETTINGS_NAMESPACE "UserSettings"
+
+#define USERSETTINGS_AUDIO_DESCRIPTION_KEY                    "audioDescription"
+#define USERSETTINGS_PREFERRED_AUDIO_LANGUAGES_KEY            "preferredAudioLanguages"
+#define USERSETTINGS_PRESENTATION_LANGUAGE_KEY                "presentationLanguage"
+#define USERSETTINGS_CAPTIONS_KEY                             "captions"
+#define USERSETTINGS_PREFERRED_CAPTIONS_LANGUAGES_KEY         "preferredCaptionsLanguages"
+#define USERSETTINGS_PREFERRED_CLOSED_CAPTIONS_SERVICE_KEY    "preferredClosedCaptionsService"
+#define USERSETTINGS_PIN_CONTROL_KEY                          "pinControl"
+#define USERSETTINGS_VIEWING_RESTRICTIONS_KEY                 "viewingRestrictions"
+#define USERSETTINGS_VIEWING_RESTRICTIONS_WINDOW_KEY          "viewingRestrictionsWindow"
+#define USERSETTINGS_LIVE_WATERSHED_KEY                       "liveWaterShed"
+#define USERSETTINGS_PLAYBACK_WATERSHED_KEY                   "playbackWaterShed"
+#define USERSETTINGS_BLOCK_NOT_RATED_CONTENT_KEY              "blockNotRatedContent"
+#define USERSETTINGS_PIN_ON_PURCHASE_KEY                      "pinOnPurchase"
 
 namespace WPEFramework {
 namespace Plugin {
     class UserSettingsImplementation : public Exchange::IUserSettings{
+
+    public:
+        static const std::map<string, string> usersettingsDefaultMap;
+
     private:
         class Store2Notification : public Exchange::IStore2::INotification {
         private:
@@ -87,7 +103,13 @@ namespace Plugin {
                 CAPTIONS_CHANGED,
                 PREFERRED_CAPTIONS_LANGUAGE_CHANGED,
                 PREFERRED_CLOSED_CAPTIONS_SERVICE_CHANGED,
-                PRIVACY_MODE_CHANGED
+                PIN_CONTROL_CHANGED,
+                VIEWING_RESTRICTIONS_CHANGED,
+                VIEWING_RESTRICTIONS_WINDOW_CHANGED,
+                LIVE_WATERSHED_CHANGED,
+                PLAYBACK_WATERSHED_CHANGED,
+                BLOCK_NOT_RATED_CONTENT_CHANGED,
+                PIN_ON_PURCHASE_CHANGED
             };
 
         class EXTERNAL Job : public Core::IDispatch {
@@ -136,19 +158,33 @@ namespace Plugin {
         uint32_t GetAudioDescription(bool &enabled) const override;
         uint32_t SetPreferredAudioLanguages(const string& preferredLanguages) override;
         uint32_t GetPreferredAudioLanguages(string &preferredLanguages) const override;
-        uint32_t SetPresentationLanguage(const string& presentationLanguages) override;
-        uint32_t GetPresentationLanguage(string &presentationLanguages) const override;
+        uint32_t SetPresentationLanguage(const string& presentationLanguage) override;
+        uint32_t GetPresentationLanguage(string &presentationLanguage) const override;
         uint32_t SetCaptions(const bool enabled) override;
         uint32_t GetCaptions(bool &enabled) const override;
         uint32_t SetPreferredCaptionsLanguages(const string& preferredLanguages) override;
         uint32_t GetPreferredCaptionsLanguages(string &preferredLanguages) const override;
         uint32_t SetPreferredClosedCaptionService(const string& service) override;
         uint32_t GetPreferredClosedCaptionService(string &service) const override;
-        uint32_t SetPrivacyMode(const string& privacyMode) override;
-        uint32_t GetPrivacyMode(string &privacyMode) const override;
+        uint32_t SetPinControl(const bool enabled) override;
+        uint32_t GetPinControl(bool &enabled) const override;
+        uint32_t SetViewingRestrictions(const string& viewingRestrictions) override;
+        uint32_t GetViewingRestrictions(string &viewingRestrictions) const override;
+        uint32_t SetViewingRestrictionsWindow(const string& viewingRestrictionsWindow) override;
+        uint32_t GetViewingRestrictionsWindow(string &viewingRestrictionsWindow) const override;
+        uint32_t SetLiveWatershed(const bool enabled) override;
+        uint32_t GetLiveWatershed(bool &enabled) const override;
+        uint32_t SetPlaybackWatershed(const bool enabled) override;
+        uint32_t GetPlaybackWatershed(bool &enabled) const override;
+        uint32_t SetBlockNotRatedContent(const bool enabled) override;
+        uint32_t GetBlockNotRatedContent(bool &enabled) const override;
+        uint32_t SetPinOnPurchase(const bool enabled) override;
+        uint32_t GetPinOnPurchase(bool &enabled) const override;
 
         void registerEventHandlers();
         void ValueChanged(const Exchange::IStore2::ScopeType scope, const string& ns, const string& key, const string& value);
+
+    private:
         uint32_t SetUserSettingsValue(const string& key, const string& value);
         uint32_t GetUserSettingsValue(const string& key, string &value) const;
 
@@ -162,10 +198,6 @@ namespace Plugin {
         Core::Sink<Store2Notification> _storeNotification;
         bool _registeredEventHandlers;
 
-#ifdef HAS_RBUS
-        rbusError_t _rbusHandleStatus;
-        rbusHandle_t _rbusHandle;
-#endif
         void dispatchEvent(Event, const JsonValue &params);
         void Dispatch(Event event, const JsonValue params);
 


### PR DESCRIPTION
Reason for change:
Get/Set method names are updated in Usersetttings. (RDK-52180). PascalCase() for COMRPC and camelCase() for JSONRPC.
Test Procedure: Make full stack build and verify all the properties with get/set methods. Run L2 tests and verify test cases.
Risks: High