### PR TITLE
RDKTV-32602: Update MiracastService unit test based on getRFCParameter API

### DIFF
--- a/Miracast/CHANGELOG.md
+++ b/Miracast/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this RDK Service will be documented in this file.
 ## [1.0.9] - 2024-08-27
 ### Fixed
 - Increase scan interval to 5 sec and added RFC support.
+- Fixed the MiracastService unit test failure
 
 ## [1.0.8] - 2024-07-03
 ### Fixed


### PR DESCRIPTION
RDKTV-32602: Update MiracastService unit test based on getRFCParameter API

Signed-off-by: yuvaramachandran_gurusamy <yuvaramachandran_gurusamy@comcast.com>