### PR TITLE
RDKTV-32644: Remove ODM specific apis from tvsettings HAL to make it …

### DIFF
--- a/AVOutput/AVOutputTV.cpp
+++ b/AVOutput/AVOutputTV.cpp
@@ -29,12 +29,6 @@
 static bool filmMakerMode= false;
 static bool m_isDalsEnabled = false;
 
-const char* dolbyVisionMode[] = {
-    [tvDolbyMode_Dark] = "dark",
-    [tvDolbyMode_Bright] = "bright",
-    [tvDolbyMode_Game] = "game"
-};
-
 namespace WPEFramework {
 namespace Plugin {
 
@@ -2286,68 +2280,26 @@ namespace Plugin {
 
     uint32_t AVOutputTV::getSupportedDolbyVisionModes(const JsonObject& parameters, JsonObject& response)
     {
+
         LOGINFO("Entry\n");
-
-        tvDolbyMode_t *dvModes;  
+        pic_modes_t *dvModes;
         unsigned short totalAvailable = 0;
-
-        tvError_t ret = GetTVSupportedDolbyVisionModes(&dvModes, &totalAvailable);
-        
+        tvError_t ret = GetTVSupportedDolbyVisionModesODM(&dvModes,&totalAvailable);
         if(ret != tvERROR_NONE) {
             returnResponse(false);
         }
         else {
             JsonArray SupportedDVModes;
 
-            // Loop through tvDolbyMode_t instead of pic_modes_t
-            for(int count = 0; count < totalAvailable; count++) {
-                // Map the tvDolbyMode_t enum values to strings
-                switch(dvModes[count]) {
-                    case tvDolbyMode_Invalid:
-                        SupportedDVModes.Add("invalid");
-                        break;
-                    case tvDolbyMode_Dark:
-                        SupportedDVModes.Add("Dolby Dark");
-                        break;
-                    case tvDolbyMode_Bright:
-                        SupportedDVModes.Add("Dolby Bright");
-                        break;
-                    case tvDolbyMode_Game:
-                        SupportedDVModes.Add("Dolby Game");
-                        break;
-                    case tvHDR10Mode_Dark:
-                        SupportedDVModes.Add("HDR10 Dark");
-                        break;
-                    case tvHDR10Mode_Bright:
-                        SupportedDVModes.Add("HDR10 Bright");
-                        break;
-                    case tvHDR10Mode_Game:
-                        SupportedDVModes.Add("HDR10 Game");
-                        break;
-                    case tvHLGMode_Dark:
-                        SupportedDVModes.Add("HLG Dark");
-                        break;
-                    case tvHLGMode_Bright:
-                        SupportedDVModes.Add("HLG Bright");
-                        break;
-                    case tvHLGMode_Game:
-                        SupportedDVModes.Add("HLG Game");
-                        break;
-                    default:
-                        SupportedDVModes.Add("invalid");
-                        break;
-                }
+            for(int count = 0;count <totalAvailable;count++ ) {
+                SupportedDVModes.Add(dvModes[count].name);
             }
 
             response["supportedDVModes"] = SupportedDVModes;
             LOGINFO("Exit\n");
-            // Adding debug print to verify the response
-            LOGINFO("Supported Dolby Vision Modes:");
-            for (size_t i = 0; i < SupportedDVModes.Length(); i++) {
-                LOGINFO("Mode[%zu]: %s", i, SupportedDVModes[i].String().c_str());
-            }
             returnResponse(true);
         }
+
     }
 
     uint32_t AVOutputTV::getDolbyVisionMode(const JsonObject& parameters, JsonObject& response)
@@ -2424,11 +2376,7 @@ namespace Plugin {
 
         if( isSetRequired("Current",source,"DV") ) {
             LOGINFO("Proceed with setDolbyVisionMode\n\n");
-            // Get the Dolby mode index as an integer (enum value)
-            int dolbyMode = getDolbyModeIndex(value.c_str());
-
-            // Call the non-ODM API with the Dolby mode enum value
-            ret = SetTVDolbyVisionMode((tvDolbyMode_t)dolbyMode);
+            ret = SetTVDolbyVisionModeODM(value.c_str());
         }
 
         if(ret != tvERROR_NONE) {
@@ -2487,8 +2435,9 @@ namespace Plugin {
                 getParamIndex("Current","Current", format,sourceIndex,pqIndex,formatIndex);
                 int err = getLocalparam("DolbyVisionMode",formatIndex,pqIndex,sourceIndex, dolbyMode, PQ_PARAM_DOLBY_MODE);
                 if( err == 0 ) {
-                    LOGINFO("%s : getLocalparam success format :%d source : %d format : %d dolbyvalue : %s\n",__FUNCTION__,formatIndex, sourceIndex, pqIndex, dolbyVisionMode[dolbyMode]);
-                    ret = SetTVDolbyVisionMode((tvDolbyMode_t)dolbyMode);
+                    std::string dolbyModeValue = getDolbyModeStringFromEnum((tvDolbyMode_t)dolbyMode);
+                    LOGINFO("%s : getLocalparam success format :%d source : %d format : %d dolbyvalue : %s\n",__FUNCTION__,formatIndex, sourceIndex, pqIndex, dolbyModeValue.c_str());
+                    ret = SetTVDolbyVisionModeODM(dolbyModeValue.c_str());
                 }
                 else {
                     LOGERR("%s : GetLocalParam Failed \n",__FUNCTION__);
@@ -2874,8 +2823,8 @@ namespace Plugin {
                     err = getLocalParam(rfc_caller_id, tr181_param_name.c_str(), &param);
                     if ( tr181Success == err ) {
                         //get curren source and if matches save for that alone
-                        tvVideoSrcType_t current_source = VIDEO_SOURCE_IP;
-                        GetCurrentSource(&current_source);
+                        int current_source = VIDEO_SOURCE_IP;
+                        GetCurrentVideoSource(&current_source);
 
                         tvVideoFormatType_t current_format = VIDEO_FORMAT_NONE;
                         GetCurrentVideoFormat(&current_format);
@@ -3132,9 +3081,9 @@ namespace Plugin {
     uint32_t AVOutputTV::getVideoSource(const JsonObject& parameters,JsonObject& response)
     {
         LOGINFO("Entry\n");
-        tvVideoSrcType_t currentSource = VIDEO_SOURCE_IP;
+        int currentSource = VIDEO_SOURCE_IP;
 
-        tvError_t ret = GetCurrentSource(&currentSource);
+        tvError_t ret = GetCurrentVideoSource(&currentSource);
         if(ret != tvERROR_NONE) {
             response["currentVideoSource"] = "NONE";
             returnResponse(false);

--- a/AVOutput/AVOutputTV.h
+++ b/AVOutput/AVOutputTV.h
@@ -70,6 +70,17 @@
 
 #define PANEL_ID_OFFSET 0x9000004
 #define MMC_DEVICE      ("/dev/mmcblk0")
+
+
+static constexpr unsigned int CONTENT_FORMAT_NONE = 0x00;
+static constexpr unsigned int CONTENT_FORMAT_SDR = 0x01;
+static constexpr unsigned int CONTENT_FORMAT_HLG = 0x02;
+static constexpr unsigned int CONTENT_FORMAT_HDR10 = 0x03;
+static constexpr unsigned int CONTENT_FORMAT_HDR10PLUS = 0x04;
+static constexpr unsigned int CONTENT_FORMAT_DV = 0x05;
+static constexpr unsigned int CONTENT_FORMAT_MAX = 0x06;
+
+
 namespace WPEFramework {
 namespace Plugin {
 
@@ -214,11 +225,13 @@ class AVOutputTV : public AVOutputBase {
 		int getLocalparam(std::string forParam,int formatIndex,int pqIndex,int sourceIndex,int &value,
 		  tvPQParameterIndex_t pqParamIndex ,bool cms=false,int tunnel_type=0);
 		tvDataComponentColor_t getComponentColorEnum(std::string colorName);
+		int getDolbyParams(tvContentFormatType_t format, std::string &s, std::string source = "");
 		tvError_t getParamsCaps(std::vector<std::string> &range, std::vector<std::string> &pqmode, std::vector<std::string> &source, std::vector<std::string> &format,std::string param );
 		tvError_t getParamsCaps(std::vector<std::string> &range, std::vector<std::string> &pqmode, std::vector<std::string> &source,
 		                        std::vector<std::string> &format,std::string param , std::string & isPlatformSupport,
 				std::vector<std::string> & index);
-		int GetPanelID(char *panelid);	
+		int GetPanelID(char *panelid);
+		int ConvertHDRFormatToContentFormat(tvVideoFormatType_t hdrFormat);
 		void getDimmingModeStringFromEnum(int value, std::string &toStore);
 		void getColorTempStringFromEnum(int value, std::string &toStore);
 		int getCurrentPictureMode(char *picMode);


### PR DESCRIPTION
…generic

Reason for change: Remove ODM APIs
Test Procedure: as per jira
Risks: None
Priority: P1
Signed-off-by: Arjun <arjun.binu@sky.uk>