### PR TITLE
RDK-52196: [SECVULN] Unsafe Use of strncpy C Functions

### DIFF
--- a/AVOutput/AVOutputTVHelper.cpp
+++ b/AVOutput/AVOutputTVHelper.cpp
@@ -655,6 +655,7 @@ namespace Plugin {
             }
         }
         strncpy(rfc_caller_id,PQFileName.c_str(),PQFileName.size());
+        rfc_caller_id[sizeof(rfc_caller_id) - 1] = '\0';
         LOGINFO("%s : Default tvsettings file : %s\n",__FUNCTION__,rfc_caller_id);
     }
 
@@ -1419,6 +1420,7 @@ namespace Plugin {
         tr181ErrorCode_t err = getLocalParam(rfc_caller_id, tr181_param_name.c_str(), &param);
         if ( err == tr181Success ) {
             strncpy(picMode, param.value, strlen(param.value)+1);
+            picMode[sizeof(picMode) - 1] = '\0';
             LOGINFO("getLocalParam success, mode = %s\n", picMode);
             return 1;
         }

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -2153,6 +2153,7 @@ namespace WPEFramework {
             {
                 IARM_Bus_PWRMgr_StandbyVideoState_Param_t param;
                 strncpy(param.port, portname.c_str(), PWRMGR_MAX_VIDEO_PORT_NAME_LENGTH);
+                param.port[sizeof(param.port) - 1] = '\0';
                 if(IARM_RESULT_SUCCESS != IARM_Bus_Call(IARM_BUS_PWRMGR_NAME, IARM_BUS_PWRMGR_API_GetStandbyVideoState, &param, sizeof(param)))
                 {
                     LOGERR("Port: %s. enable:%d", param.port, param.isEnabled);
@@ -2176,6 +2177,7 @@ namespace WPEFramework {
             {
                 dsMgrStandbyVideoStateParam_t param;
                 strncpy(param.port, portname.c_str(), PWRMGR_MAX_VIDEO_PORT_NAME_LENGTH);
+                param.port[sizeof(param.port) - 1] = '\0';
                 if(IARM_RESULT_SUCCESS != IARM_Bus_Call(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_API_GetStandbyVideoState, &param, sizeof(param)))
                 {
                     LOGERR("Port: %s. enable:%d", param.port, param.isEnabled);

--- a/Miracast/MiracastPlayer/MiracastPlayer.cpp
+++ b/Miracast/MiracastPlayer/MiracastPlayer.cpp
@@ -187,9 +187,13 @@ namespace WPEFramework
 				sink_dev_ip = device_parameters["sink_dev_ip"].String();
 
 				strncpy( rtsp_hldr_msgq_data.source_dev_ip, source_dev_ip.c_str() , sizeof(rtsp_hldr_msgq_data.source_dev_ip));
+				rtsp_hldr_msgq_data.source_dev_ip[sizeof(rtsp_hldr_msgq_data.source_dev_ip) - 1] = '\0';
 				strncpy( rtsp_hldr_msgq_data.source_dev_mac, source_dev_mac.c_str() , sizeof(rtsp_hldr_msgq_data.source_dev_mac));
+				rtsp_hldr_msgq_data.source_dev_mac[sizeof(rtsp_hldr_msgq_data.source_dev_mac) - 1] = '\0';
 				strncpy( rtsp_hldr_msgq_data.source_dev_name, source_dev_name.c_str() , sizeof(rtsp_hldr_msgq_data.source_dev_name));
+				rtsp_hldr_msgq_data.source_dev_name[sizeof(rtsp_hldr_msgq_data.source_dev_name) - 1] = '\0';
 				strncpy( rtsp_hldr_msgq_data.sink_dev_ip, sink_dev_ip.c_str() , sizeof(rtsp_hldr_msgq_data.sink_dev_ip));
+				rtsp_hldr_msgq_data.sink_dev_ip[sizeof(rtsp_hldr_msgq_data.sink_dev_ip) - 1] = '\0';
 
 				rtsp_hldr_msgq_data.state = RTSP_START_RECEIVE_MSGS;
 				success = true;

--- a/Miracast/MiracastService/MiracastController.cpp
+++ b/Miracast/MiracastService/MiracastController.cpp
@@ -464,6 +464,7 @@ void MiracastController::remove_P2PGroupInstance(void)
         if ( true == m_groupInfo->isGO )
         {
             strncpy( commandBuffer , "ps -ax | awk '/dnsmasq -p0 -i/ && !/grep/ {print $1}' | xargs kill -9" , sizeof(commandBuffer));
+            commandBuffer[sizeof(commandBuffer) - 1] = '\0';
             MIRACASTLOG_INFO("Terminate old dnsmasq instance: [%s]",commandBuffer);
             MiracastCommon::execute_SystemCommand(commandBuffer);
             memset( commandBuffer , 0x00 , sizeof(commandBuffer));
@@ -475,6 +476,7 @@ void MiracastController::remove_P2PGroupInstance(void)
         else
         {
             strncpy( commandBuffer , "ps -ax | awk '/p2p_udhcpc/ && !/grep/ {print $1}' | xargs kill -9" , sizeof(commandBuffer));
+            commandBuffer[sizeof(commandBuffer) - 1] = '\0';
             MIRACASTLOG_INFO("Terminate old udhcpc p2p instance : [%s]", commandBuffer);
             MiracastCommon::execute_SystemCommand(commandBuffer);
         }
@@ -1394,6 +1396,7 @@ void MiracastController::restart_session_discovery(std::string& mac_address)
     if ( !mac_address.empty())
     {
         strncpy(controller_msgq_data.source_dev_mac, mac_address.c_str(),sizeof(controller_msgq_data.source_dev_mac));
+        controller_msgq_data.source_dev_mac[sizeof(controller_msgq_data.source_dev_mac) - 1] = '\0';
     }
     controller_msgq_data.state = CONTROLLER_RESTART_DISCOVERING;
     send_thundermsg_to_controller_thread(controller_msgq_data);
@@ -1419,6 +1422,7 @@ void MiracastController::accept_client_connection(std::string is_accepted)
     {
         MIRACASTLOG_INFO("[MIRACAST_SERVICE_ACCEPT_CLIENT]");
         strncpy(controller_msgq_data.source_dev_mac, m_current_device_mac_addr.c_str(),sizeof(controller_msgq_data.source_dev_mac));
+        controller_msgq_data.source_dev_mac[sizeof(controller_msgq_data.source_dev_mac) - 1] = '\0';
         controller_msgq_data.state = CONTROLLER_CONNECT_REQ_FROM_THUNDER;
     }
     else
@@ -1448,9 +1452,13 @@ void MiracastController::switch_launch_request_context(std::string& source_dev_i
                             sink_dev_ip.c_str(),
                             source_dev_name.c_str());
         strncpy(controller_msgq_data.source_dev_ip, source_dev_ip.c_str(),sizeof(controller_msgq_data.source_dev_ip));
+        controller_msgq_data.source_dev_ip[sizeof(controller_msgq_data.source_dev_ip) - 1] = '\0';
         strncpy(controller_msgq_data.source_dev_mac, source_dev_mac.c_str(),sizeof(controller_msgq_data.source_dev_mac));
+        controller_msgq_data.source_dev_mac[sizeof(controller_msgq_data.source_dev_mac) - 1] = '\0';
         strncpy(controller_msgq_data.source_dev_name, source_dev_name.c_str(),sizeof(controller_msgq_data.source_dev_name));
+        controller_msgq_data.source_dev_name[sizeof(controller_msgq_data.source_dev_name) - 1] = '\0';
         strncpy(controller_msgq_data.sink_dev_ip, sink_dev_ip.c_str(),sizeof(controller_msgq_data.sink_dev_ip));
+        controller_msgq_data.sink_dev_ip[sizeof(controller_msgq_data.sink_dev_ip) - 1] = '\0';
         controller_msgq_data.state = CONTROLLER_SWITCH_LAUNCH_REQ_CTX;
         send_thundermsg_to_controller_thread(controller_msgq_data);
     }

--- a/Miracast/MiracastService/MiracastService.cpp
+++ b/Miracast/MiracastService/MiracastService.cpp
@@ -1049,6 +1049,7 @@ namespace WPEFramework
 				{
 					MIRACASTLOG_INFO("!!! NEED TO STOP ONGOING SESSION !!!");
 					strncpy(commandBuffer,"curl -H \"Authorization: Bearer `WPEFrameworkSecurityUtility | cut -d '\"' -f 4`\" --header \"Content-Type: application/json\" --request POST --data '{\"jsonrpc\":\"2.0\", \"id\":3,\"method\":\"org.rdk.MiracastPlayer.1.stopRequest\", \"params\":{\"reason\": \"NEW_CONNECTION\"}}' http://127.0.0.1:9998/jsonrpc",sizeof(commandBuffer));
+					commandBuffer[sizeof(commandBuffer) - 1] = '\0';
 					MIRACASTLOG_INFO("Stopping old Session by [%s]",commandBuffer);
 					MiracastCommon::execute_SystemCommand(commandBuffer);
 					sleep(1);

--- a/Network/Network.cpp
+++ b/Network/Network.cpp
@@ -859,10 +859,15 @@ typedef struct _IARM_BUS_NetSrvMgr_Iface_EventData_t {
                 iarmData.ipversion[sizeof(iarmData.ipversion) - 1] = '\0';
                 iarmData.autoconfig = autoconfig;
                 strncpy(iarmData.ipaddress, ipaddr.c_str(), 16);
+                iarmData.ipaddress[sizeof(iarmData.ipaddress) - 1] = '\0';
                 strncpy(iarmData.netmask, netmask.c_str(), 16);
+                iarmData.netmask[sizeof(iarmData.netmask) - 1] = '\0';
                 strncpy(iarmData.gateway, gateway.c_str(), 16);
+                iarmData.gateway[sizeof(iarmData.gateway) - 1] = '\0';
                 strncpy(iarmData.primarydns, primarydns.c_str(), 16);
+                iarmData.primarydns[sizeof(iarmData.primarydns) - 1] = '\0';
                 strncpy(iarmData.secondarydns, secondarydns.c_str(), 16);
+                iarmData.secondarydns[sizeof(iarmData.secondarydns) - 1] = '\0';
                 iarmData.isSupported = false;
 
                 if (!autoconfig)

--- a/NetworkManager/NetworkManagerRDKProxy.cpp
+++ b/NetworkManager/NetworkManagerRDKProxy.cpp
@@ -691,8 +691,10 @@ namespace WPEFramework
             //TODO: Fix netsrvmgr to accept eth0 & wlan0
             if ("wlan0" == interface)
                 strncpy(iarmData.setInterface, "WIFI", INTERFACE_SIZE);
+                iarmData.setInterface[sizeof(iarmData.setInterface) - 1] = '\0';
             else if ("eth0" == interface)
                 strncpy(iarmData.setInterface, "ETHERNET", INTERFACE_SIZE);
+                iarmData.setInterface[sizeof(iarmData.setInterface) - 1] = '\0';
             else
             {
                 rc = Core::ERROR_BAD_REQUEST;
@@ -721,8 +723,10 @@ namespace WPEFramework
             //TODO: Fix netsrvmgr to accept eth0 & wlan0
             if ("wlan0" == interface)
                 strncpy(iarmData.setInterface, "WIFI", INTERFACE_SIZE);
+                iarmData.setInterface[sizeof(iarmData.setInterface) - 1] = '\0';
             else if ("eth0" == interface)
                 strncpy(iarmData.setInterface, "ETHERNET", INTERFACE_SIZE);
+                iarmData.setInterface[sizeof(iarmData.setInterface) - 1] = '\0';
             else
             {
                 rc = Core::ERROR_BAD_REQUEST;
@@ -753,8 +757,10 @@ namespace WPEFramework
             //TODO: Fix netsrvmgr to accept eth0 & wlan0
             if ("wlan0" == interface)
                 strncpy(iarmData.setInterface, "WIFI", INTERFACE_SIZE);
+                iarmData.setInterface[sizeof(iarmData.setInterface) - 1] = '\0';
             else if ("eth0" == interface)
                 strncpy(iarmData.setInterface, "ETHERNET", INTERFACE_SIZE);
+                iarmData.setInterface[sizeof(iarmData.setInterface) - 1] = '\0';
             else
             {
                 rc = Core::ERROR_BAD_REQUEST;
@@ -813,10 +819,13 @@ namespace WPEFramework
             //TODO: Fix netsrvmgr to accept eth0 & wlan0
             if ("wlan0" == interface)
                 strncpy(iarmData.interface, "WIFI", INTERFACE_SIZE);
+                iarmData.interface[sizeof(iarmData.interface) - 1] = '\0';
             else if ("eth0" == interface)
                 strncpy(iarmData.interface, "ETHERNET", INTERFACE_SIZE);
+                iarmData.interface[sizeof(iarmData.interface) - 1] = '\0';
 
             strncpy(iarmData.ipversion, ipversion.c_str(), 16);
+            iarmData.ipversion[sizeof(iarmData.ipversion) - 1] = '\0';
             iarmData.isSupported = true;
             NMLOG_INFO("NetworkManagerImplementation::GetIPSettings - Before Calling IARM");
             if (IARM_RESULT_SUCCESS == IARM_Bus_Call (IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_NETSRVMGR_API_getIPSettings, (void *)&iarmData, sizeof(iarmData)))
@@ -892,8 +901,10 @@ const string CIDR_PREFIXES[CIDR_NETMASK_IP_LEN] = {
                 //TODO: Fix netsrvmgr to accept eth0 & wlan0
                 if ("wlan0" == interface)
                     strncpy(iarmData.interface, "WIFI", INTERFACE_SIZE);
+                    iarmData.interface[sizeof(iarmData.interface) - 1] = '\0';
                 else if ("eth0" == interface)
                     strncpy(iarmData.interface, "ETHERNET", INTERFACE_SIZE);
+                    iarmData.interface[sizeof(iarmData.interface) - 1] = '\0';
                 else
                 {
                     rc = Core::ERROR_BAD_REQUEST;
@@ -901,6 +912,7 @@ const string CIDR_PREFIXES[CIDR_NETMASK_IP_LEN] = {
                 }
                 /* IP version */
                 strncpy(iarmData.ipversion, ipversion.c_str(), 16);
+                iarmData.ipversion[sizeof(iarmData.ipversion) - 1] = '\0';
 
                 if (!address.m_autoConfig)
                 {
@@ -954,10 +966,15 @@ const string CIDR_PREFIXES[CIDR_NETMASK_IP_LEN] = {
                         if (Core::ERROR_NONE == rc)
                         {
                             strncpy(iarmData.ipaddress, address.m_ipAddress.c_str(), 16);
+                            iarmData.ipaddress[sizeof(iarmData.ipaddress) - 1] = '\0';
                             strncpy(iarmData.netmask, netmask.c_str(), 16);
+                            iarmData.netmask[sizeof(iarmData.netmask) - 1] = '\0';
                             strncpy(iarmData.gateway, address.m_gateway.c_str(), 16);
+                            iarmData.gateway[sizeof(iarmData.gateway) - 1] = '\0';
                             strncpy(iarmData.primarydns, address.m_primaryDns.c_str(), 16);
+                            iarmData.primarydns[sizeof(iarmData.primarydns) - 1] = '\0';
                             strncpy(iarmData.secondarydns, address.m_secondaryDns.c_str(), 16);
+                            iarmData.secondarydns[sizeof(iarmData.secondarydns) - 1] = '\0';
                         }
                     }
                 }
@@ -1067,7 +1084,9 @@ const string CIDR_PREFIXES[CIDR_NETMASK_IP_LEN] = {
             memset(&param, 0, sizeof(param));
 
             strncpy(param.data.connect.ssid, ssid.m_ssid.c_str(), SSID_SIZE - 1);
+            param.data.connect.ssid[sizeof(param.data.connect.ssid) - 1] = '\0';
             strncpy(param.data.connect.passphrase, ssid.m_passphrase.c_str(), PASSPHRASE_BUFF - 1);
+            param.data.connect.passphrase[sizeof(param.data.connect.passphrase) - 1] = '\0';
             param.data.connect.security_mode = (SsidSecurity) ssid.m_securityMode;
 
             IARM_Result_t retVal = IARM_Bus_Call(IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_WIFI_MGR_API_saveSSID, (void *)&param, sizeof(param));

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -659,6 +659,7 @@ namespace WPEFramework {
 
             IARM_Bus_PWRMgr_RebootParam_t rebootParam;
             strncpy(rebootParam.requestor, "SystemServices", sizeof(rebootParam.requestor));
+            rebootParam.requestor[sizeof(rebootParam.requestor) - 1] = '\0';
             strncpy(rebootParam.reboot_reason_custom, customReason.c_str(), sizeof(rebootParam.reboot_reason_custom));
             rebootParam.reboot_reason_custom[sizeof(rebootParam.reboot_reason_custom) - 1] = '\0';
             strncpy(rebootParam.reboot_reason_other, otherReason.c_str(), sizeof(rebootParam.reboot_reason_other));

--- a/WifiManager/impl/WifiManagerState.cpp
+++ b/WifiManager/impl/WifiManagerState.cpp
@@ -114,6 +114,7 @@ uint32_t WifiManagerState::setEnabled(const JsonObject &parameters, JsonObject &
     memset(&param, 0, sizeof(param));
 
     strncpy(param.setInterface, "WIFI", INTERFACE_SIZE - 1);
+    param.setInterface[sizeof(param.setInterface) - 1] = '\0';
     param.isInterfaceEnabled = parameters["enable"].Boolean();
     bool persist_t = false;
     getDefaultBoolParameter("persist", persist_t, false);

--- a/WifiManager/impl/WifiManagerWPS.cpp
+++ b/WifiManager/impl/WifiManagerWPS.cpp
@@ -142,7 +142,9 @@ namespace WPEFramework
             memset(&param, 0, sizeof(param));
 
             strncpy(param.data.connect.ssid, parameters["ssid"].String().c_str(), SSID_SIZE - 1);
+            param.data.connect.ssid[sizeof(param.data.connect.ssid) - 1] = '\0';
             strncpy(param.data.connect.passphrase, parameters["passphrase"].String().c_str(), PASSPHRASE_BUFF - 1);
+            param.data.connect.passphrase[sizeof(param.data.connect.passphrase) - 1] = '\0';
             param.data.connect.security_mode = static_cast<SsidSecurity>(parameters["securityMode"].Number());
 
             IARM_Result_t retVal = IARM_Bus_Call(IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_WIFI_MGR_API_saveSSID, (void *)&param, sizeof(param));

--- a/XCast/XCast.cpp
+++ b/XCast/XCast.cpp
@@ -602,6 +602,7 @@ void XCast::updateDynamicAppCache(JsonArray applications)
                     memset ((void*)pDynamicAppConfig, '0', sizeof(DynamicAppConfig));
                     memset (pDynamicAppConfig->appName, '\0', sizeof(pDynamicAppConfig->appName));
                     strncpy (pDynamicAppConfig->appName, itrName.c_str(), sizeof(pDynamicAppConfig->appName) - 1);
+                    pDynamicAppConfig->appName[sizeof(pDynamicAppConfig->appName) - 1] = '\0';
                     memset (pDynamicAppConfig->prefixes, '\0', sizeof(pDynamicAppConfig->prefixes));
                     memset (pDynamicAppConfig->cors, '\0', sizeof(pDynamicAppConfig->cors));
                     memset (pDynamicAppConfig->query, '\0', sizeof(pDynamicAppConfig->query));
@@ -620,6 +621,7 @@ void XCast::updateDynamicAppCache(JsonArray applications)
                     LOGINFO("%s, size:%d", itrPrefix.c_str(), (int)strlen (itrPrefix.c_str()));
                     for (DynamicAppConfig* pDynamicAppConfig : appConfigListTemp) {
                         strncpy (pDynamicAppConfig->prefixes, itrPrefix.c_str(), sizeof(pDynamicAppConfig->prefixes) - 1);
+                        pDynamicAppConfig->prefixes[sizeof(pDynamicAppConfig->prefixes) - 1] = '\0';
                     }
                 }
             }
@@ -635,6 +637,7 @@ void XCast::updateDynamicAppCache(JsonArray applications)
                     LOGINFO("%s, size:%d", itrCor.c_str(), (int)strlen (itrCor.c_str()));
                     for (DynamicAppConfig* pDynamicAppConfig : appConfigListTemp) {
                         strncpy (pDynamicAppConfig->cors, itrCor.c_str(), sizeof(pDynamicAppConfig->cors) - 1);
+                        pDynamicAppConfig->cors[sizeof(pDynamicAppConfig->cors) - 1] = '\0';
                     }
                 }
             }
@@ -687,9 +690,11 @@ void XCast::updateDynamicAppCache(JsonArray applications)
                 for (DynamicAppConfig* pDynamicAppConfig : appConfigListTemp) {
                     if (jLaunchParam.HasLabel("query")) {
                         strncpy (pDynamicAppConfig->query, jQuery.c_str(), sizeof(pDynamicAppConfig->query) - 1);
+                        pDynamicAppConfig->query[sizeof(pDynamicAppConfig->query) - 1] = '\0';
                     }
                     if (jLaunchParam.HasLabel("payload")) {
                         strncpy (pDynamicAppConfig->payload, jPayload.c_str(), sizeof(pDynamicAppConfig->payload) - 1);
+                        pDynamicAppConfig->payload[sizeof(pDynamicAppConfig->payload) - 1] = '\0';
                     }
                 }
 

--- a/XCast/XCast.cpp
+++ b/XCast/XCast.cpp
@@ -943,19 +943,21 @@ void XCast::getUrlFromAppLaunchParams (const char *app_name, const char *payload
             int has_query = query_string && strlen(query_string);
             int has_payload = 0;
             if (has_query) {
-                strcat(url, query_string);
+                snprintf(url + strlen(url), url_len, "%s", query_string);
                 url_len -= strlen(query_string);
             }
             if(payload && strlen(payload)) {
-                if (has_query) url_len -=1;  //for &
                 const char payload_key[] = "dialpayload=";
-                url_len -= sizeof(payload_key) - 1;
-                url_len -= strlen(payload);
                 if(url_len >= 0){
-                    if (has_query) strcat(url, "&");
-                    strcat(url, payload_key);
-                    strcat(url, payload);
-                    has_payload = 1;
+                    if (has_query) {
+                        snprintf(url + strlen(url), url_len, "%s", "&");
+                        url_len -= 1;
+                    }
+                    if(url_len >= 0) {
+                        snprintf(url + strlen(url), url_len, "%s%s", payload_key, payload);
+                        url_len -= strlen(payload_key) + strlen(payload);
+                        has_payload = 1;
+                    }
                 }
                 else {
                     LOGINFO("there is no enough room for payload\r\n");
@@ -963,9 +965,14 @@ void XCast::getUrlFromAppLaunchParams (const char *app_name, const char *payload
             }
 
         if(additional_data_url != NULL){
-                if (has_query || has_payload) strcat(url, "&");
-                strcat(url, "additionalDataUrl=");
-            strcat(url, additional_data_url);
+                if ((has_query || has_payload) && url_len >= 0) {
+                    snprintf(url + strlen(url), url_len, "%s", "&");
+                    url_len -= 1;
+                }
+                if (url_len >= 0) {
+                    snprintf(url + strlen(url), url_len, "additionalDataUrl=%s", additional_data_url);
+                    url_len -= strlen(additional_data_url) + 18;
+                }
             }
             LOGINFO(" url is [%s]\r\n", url);
     }


### PR DESCRIPTION
Reason for change: Resolve security vulnerabilities in rdkservices
Test Procedure: See ticket
Risks: Low
Priority: P1