### PR TITLE
DELIA-66303: Getting Invalid information in response for org.rdk.System.getPlatformConfiguration

### DIFF
--- a/ResourceManager/ResourceManager.cpp
+++ b/ResourceManager/ResourceManager.cpp
@@ -396,6 +396,11 @@ namespace WPEFramework {
                     }
                 }
             }
+            
+	    if (!FromMessage(response, message, isResponseString))
+            {
+                return Core::ERROR_GENERAL;
+            }
 #elif (THUNDER_VERSION == 2)
             auto resp =  dispatcher_->Invoke(sThunderSecurityToken, channelId, *message);
 #else

--- a/SystemServices/platformcaps/platformcapsdata.h
+++ b/SystemServices/platformcaps/platformcapsdata.h
@@ -193,6 +193,11 @@ private:
                     }
                 }
             }
+            
+	    if (!FromMessage(response, message, isResponseString))
+            {
+                return Core::ERROR_GENERAL;
+            }
 #elif ((THUNDER_VERSION >= 4) && (THUNDER_VERSION_MINOR == 2))
         Core::JSONRPC::Context context(channelId, message->Id.Value(), "");
         auto resp = dispatcher_->Invoke(context, *message);


### PR DESCRIPTION
Reason for change: handled the Invoke Response value with respect to Thunder R4.4.1
Test Procedure: Verify in Jenkin Build
Risks: Medium
Signed-off-by: Thamim Razith tabbas651@cable.comcast.com