### PR TITLE
RDKVREFPLT-3253 RDKDEV-1082 - ResidentApp is not loading with latest …

### DIFF
--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -1989,8 +1989,7 @@ namespace WPEFramework {
                           JsonObject activateParams;
                           activateParams.Set("callsign",callsign.c_str());
                           JsonObject activateResult;
-                          auto thunderController = getThunderControllerClient();
-                          status = thunderController->Invoke<JsonObject, JsonObject>(RDKSHELL_THUNDER_TIMEOUT, "activate", activateParams, activateResult);
+			  status = JSONRPCDirectLink(mCurrentService, callsign).Invoke<JsonObject, JsonObject>(RDKSHELL_THUNDER_TIMEOUT, "activate", activateParams, activateResult);
                           gRdkShellMutex.lock();
                           std::cout << "Bootup Activating ResidentApp from RDKShell without Persistentstore wait with Status:" << status << std::endl;
                         }


### PR DESCRIPTION
RDKVREFPLT-3253 RDKDEV-1082 - ResidentApp is not loading with latest RDKShell changes

Reason for change: Use JSONRPCDirectLink calls instead of thunderController to address the thunder failure. With reference of https://code.rdkcentral.com/r/c/rdk/components/generic/rdk-oe/meta-rdk-video/+/100750

Test Procedure: Build and verify.
Risks: Low