### PR TITLE
RDKTV-30669 : Do not print the response JSONData as its flooding

### DIFF
--- a/Network/CHANGELOG.md
+++ b/Network/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.3.14] - 2024-09-20
+### Fixed
+- Stop printing the logs for getInterfaces(), getDefaultInterface() and getIPSettings2()
+
 ## [1.3.13] - 2024-07-19
 ### Fixed
 - Fix for TV is not going to deep sleep

--- a/Network/Network.cpp
+++ b/Network/Network.cpp
@@ -35,7 +35,7 @@ using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 3
-#define API_VERSION_NUMBER_PATCH 13
+#define API_VERSION_NUMBER_PATCH 14
 
 /* Netsrvmgr Based Macros & Structures */
 #define IARM_BUS_NM_SRV_MGR_NAME "NET_SRV_MGR"
@@ -405,7 +405,8 @@ typedef struct _IARM_BUS_NetSrvMgr_Iface_EventData_t {
                 LOGWARN ("Network plugin not initialised yet returning from %s", __FUNCTION__);
             }
 
-            returnResponse(result)
+            response["success"] = result;
+            return (result ? WPEFramework::Core::ERROR_NONE : WPEFramework::Core::ERROR_GENERAL);
         }
 
         uint32_t Network::getDefaultInterface (const JsonObject& parameters, JsonObject& response)
@@ -434,7 +435,8 @@ typedef struct _IARM_BUS_NetSrvMgr_Iface_EventData_t {
                 LOGWARN ("Network plugin not initialised yet returning from %s", __FUNCTION__);
             }
 
-            returnResponse(result)
+            response["success"] = result;
+            return (result ? WPEFramework::Core::ERROR_NONE : WPEFramework::Core::ERROR_GENERAL);
         }
 
         uint32_t Network::setDefaultInterface (const JsonObject& parameters, JsonObject& response)
@@ -1033,7 +1035,8 @@ typedef struct _IARM_BUS_NetSrvMgr_Iface_EventData_t {
                 LOGWARN ("Network plugin not initialised yet returning from %s", __FUNCTION__);
             }
 
-            returnResponse(result)
+            response["success"] = result;
+            return (result ? WPEFramework::Core::ERROR_NONE : WPEFramework::Core::ERROR_GENERAL);
         }
 
         bool Network::getIPIARMWrapper(IARM_BUS_NetSrvMgr_Iface_Settings_t& iarmData, const string interface, const string ipversion)
@@ -1073,7 +1076,6 @@ typedef struct _IARM_BUS_NetSrvMgr_Iface_EventData_t {
             }
             else if (Utils::String::equal(ipversion, "IPV6") && m_useIpv6Cache && Utils::String::equal(interface, m_ipv6Cache.interface))
             {
-                LOGINFO("Reading Ipv6 cache");
                 memcpy(&iarmData, &m_ipv6Cache, sizeof(m_ipv6Cache));
                 result = true;
             }

--- a/NetworkManager/service/Network.conf.in
+++ b/NetworkManager/service/Network.conf.in
@@ -1,4 +1,4 @@
-autostart = "true"
+autostart = "false"
 callsign= "org.rdk.Network"
 
 test = JSON()

--- a/NetworkManager/service/Network.config
+++ b/NetworkManager/service/Network.config
@@ -1,4 +1,4 @@
-set(autostart true)
+set(autostart false)
 set(callsign "org.rdk.Network")
 
 map()

--- a/NetworkManager/service/NetworkManager.conf.in
+++ b/NetworkManager/service/NetworkManager.conf.in
@@ -1,4 +1,4 @@
-autostart = "true"
+autostart = "false"
 callsign= "org.rdk.NetworkManager"
 
 test = JSON()

--- a/NetworkManager/service/NetworkManager.config
+++ b/NetworkManager/service/NetworkManager.config
@@ -1,4 +1,4 @@
-set(autostart true)
+set(autostart false)
 set(callsign "org.rdk.NetworkManager")
 
 map()

--- a/NetworkManager/service/WiFiManager.conf.in
+++ b/NetworkManager/service/WiFiManager.conf.in
@@ -1,4 +1,4 @@
-autostart = "true"
+autostart = "false"
 callsign= "org.rdk.Wifi"
 
 test = JSON()

--- a/NetworkManager/service/WiFiManager.config
+++ b/NetworkManager/service/WiFiManager.config
@@ -1,4 +1,4 @@
-set(autostart true)
+set(autostart false)
 set(callsign "org.rdk.Wifi")
 
 map()

--- a/docs/api/NetworkPlugin.md
+++ b/docs/api/NetworkPlugin.md
@@ -2,7 +2,7 @@
 <a name="NetworkPlugin"></a>
 # NetworkPlugin
 
-**Version: [1.3.9](https://github.com/rdkcentral/rdkservices/blob/main/Network/CHANGELOG.md)**
+**Version: [1.3.14](https://github.com/rdkcentral/rdkservices/blob/main/Network/CHANGELOG.md)**
 
 A org.rdk.Network plugin for Thunder framework.
 


### PR DESCRIPTION
Reason for change: Identified that some rogue component is calling getInterfaces(), getDefaultInterface() and getIPSettings2() every 1 min.
These JSONRPC Methods was printing responses to the console (log file). But since its every 1 min, these 3 response lines are keep printing and the log file is getting bigger and rotates.
Sometimes we discard old rotated logs & take last few rotated files. But upon issue reported from field and when developer looks for log, the initial log wont present due to the rotation.

There are multiple plugins printing unnecessary logs that contributes to the log rotation and this lines prints important role in triaging but given the rogue component is NOT identified, we had to comment out this line to save the space.
Test Procedure: verify wpeframework.log
Risks: Medium
Signed-off-by: Karunakaran A <karunakaran_amirthalingam@cable.comcast.com>