### PR TITLE
RDK-52700: RialtoServer manager plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -409,6 +409,10 @@ if (PLUGIN_ANALYTICS)
     add_subdirectory(Analytics)
 endif()
 
+if(PLUGIN_RIALTOSERVERMANAGER)
+    add_subdirectory(RialtoServerManager)
+endif()
+
 if(WPEFRAMEWORK_CREATE_IPKG_TARGETS)
     set(CPACK_GENERATOR "DEB")
     set(CPACK_DEB_COMPONENT_INSTALL ON)

--- a/RialtoServerManager/CMakeLists.txt
+++ b/RialtoServerManager/CMakeLists.txt
@@ -1,0 +1,63 @@
+# If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2024 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+find_package(${NAMESPACE}Plugins REQUIRED)
+
+set(PLUGIN_NAME RialtoServerManager)
+set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
+set(PLUGIN_RIALTO_SERVER_MANAGER_IMPLEMENTATION "${MODULE_NAME}Impl" CACHE STRING "Specify a library with a RialtoServerManager implementation." )
+
+set(PLUGIN_RIALTO_SERVER_MANAGER_AUTOSTART "false" CACHE STRING "Automatically start RialtoServerManager plugin")
+set(PLUGIN_RIALTO_SERVER_MANAGER_MODE "Local" CACHE STRING "Controls if the plugin should run in its own process, in process or remote")
+set(PLUGIN_RIALTO_SERVER_MANAGER_DIR "" CACHE STRING "Home directory of RialtoServer files")
+set(PLUGIN_RIALTO_SERVER_MANAGER_HOST_ENVS "" CACHE STRING "Environment variables for RialtoServer host process (WPEFramework process)")
+set(PLUGIN_RIALTO_SERVER_MANAGER_SESSION_ENVS "" CACHE STRING "Environment variables for Rialto Server Session process")
+set(PLUGIN_RIALTO_SERVER_MANAGER_SESSION_PLATFORM_ENVS "" CACHE STRING "Platform specific environment for Rialto Session process. If not set all Host environment variables will be passed to the session process")
+
+
+add_library(${MODULE_NAME} SHARED
+        RialtoServerManager.cpp
+        Module.cpp)
+set_target_properties(${MODULE_NAME} PROPERTIES
+        CXX_STANDARD 11
+        CXX_STANDARD_REQUIRED YES)
+target_link_libraries(${MODULE_NAME}
+        PRIVATE
+        ${NAMESPACE}Plugins::${NAMESPACE}Plugins)
+
+add_library(${PLUGIN_RIALTO_SERVER_MANAGER_IMPLEMENTATION} SHARED
+        RialtoServerManagerImpl.cpp
+        Module.cpp)
+
+set_target_properties(${PLUGIN_RIALTO_SERVER_MANAGER_IMPLEMENTATION} PROPERTIES
+        CXX_STANDARD 11
+        CXX_STANDARD_REQUIRED YES)
+
+target_link_libraries(${PLUGIN_RIALTO_SERVER_MANAGER_IMPLEMENTATION}
+        PRIVATE
+        ${NAMESPACE}Plugins::${NAMESPACE}Plugins
+        RialtoServerManager)
+
+add_dependencies(${MODULE_NAME} ${PLUGIN_RIALTO_SERVER_MANAGER_IMPLEMENTATION})
+
+# Library definition section
+install(TARGETS ${MODULE_NAME}
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/${STORAGE_DIRECTORY}/plugins)
+install(TARGETS ${PLUGIN_RIALTO_SERVER_MANAGER_IMPLEMENTATION}
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/${STORAGE_DIRECTORY}/plugins)
+
+write_config(${PLUGIN_NAME})

--- a/RialtoServerManager/Module.cpp
+++ b/RialtoServerManager/Module.cpp
@@ -1,0 +1,22 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2024 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Module.h"
+
+MODULE_NAME_DECLARATION(BUILD_REFERENCE)

--- a/RialtoServerManager/Module.h
+++ b/RialtoServerManager/Module.h
@@ -1,0 +1,32 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2024 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __MODULE_PLUGIN_RIALTO_SERVER_MANAGER_MODULE_H
+#define __MODULE_PLUGIN_RIALTO_SERVER_MANAGER_MODULE_H
+
+#ifndef MODULE_NAME
+#define MODULE_NAME Plugin_RialtoServerManager
+#endif
+
+#include <plugins/plugins.h>
+
+#undef EXTERNAL
+#define EXTERNAL
+
+#endif // __MODULE_PLUGIN_RIALTO_SERVER_MANAGER_MODULE_H

--- a/RialtoServerManager/RialtoServerManager.conf.in
+++ b/RialtoServerManager/RialtoServerManager.conf.in
@@ -1,0 +1,64 @@
+precondition = []
+autostart = "@PLUGIN_RIALTO_SERVER_MANAGER_AUTOSTART@"
+
+configuration = JSON()
+
+rootobject = JSON()
+rootobject.add("locator", "lib@PLUGIN_RIALTO_SERVER_MANAGER_IMPLEMENTATION@.so")
+rootobject.add("mode", "@PLUGIN_RIALTO_SERVER_MANAGER_MODE@")
+configuration.add("root", rootobject)
+
+if ("@PLUGIN_RIALTO_SERVER_MANAGER_DIR@"):
+    configuration.add("rialtodir", "@PLUGIN_RIALTO_SERVER_MANAGER_DIR@")
+
+gstplugins = [
+    "libgstapp.so",
+    "libgstaudioconvert.so",
+    "libgstaudioparsers.so",
+    "libgstaudioresample.so",
+    "libgstautodetect.so",
+    "libgstcoreelements.so",
+    "libgsticydemux.so",
+    "libgstid3demux.so",
+    "libgstisomp4.so",
+    "libgstmatroska.so",
+    "libgstopusparse.so",
+    "libgstplayback.so",
+    "libgstrialtosinks.so",
+    "libgsttypefindfunctions.so",
+    "libgstvideoparsersbad.so",
+    "libgstwavparse.so"
+]
+configuration.add("gstplugins", gstplugins)
+
+filelinks = [
+    { "src": "/usr/lib/libocdmRialto.so.1.0.0", "dest": "libocdm.so.4" }
+]
+configuration.add("libs", filelinks)
+
+defaultHostEnvs = "\
+WEBKIT_GST_QUIRKS=rialto;\
+WEBKIT_GST_HOLE_PUNCH_QUIRK=rialto;\
+RIALTO_SOCKET_PATH=/tmp/rialto-0;\
+LD_LIBRARY_PATH=/tmp/rialto/lib;\
+GST_PLUGIN_SYSTEM_PATH=/tmp/rialto/gst;\
+GST_REGISTRY=/tmp/rialto/rialto-client-gstreamer-cache.bin;\
+"
+if ("@PLUGIN_RIALTO_SERVER_MANAGER_HOST_ENVS@"):
+    configuration.add("hostenvvars", "@PLUGIN_RIALTO_SERVER_MANAGER_HOST_ENVS@")
+else:
+    configuration.add("hostenvvars", defaultHostEnvs)
+
+defaultSessionPlatformEnvs = "\
+WESTEROS_SINK_LOW_MEM_MODE=1;\
+XDG_RUNTIME_DIR=/run;\
+RIALTO_SINKS_RANK=0;\
+GST_REGISTRY=/tmp/rialto/rialto-server-gstreamer-cache.bin;\
+WAYLAND_DISPLAY=wst-residentapp;\
+"
+if ("@PLUGIN_RIALTO_SERVER_MANAGER_SESSION_ENVS@"):
+    configuration.add("sessionenvs", "@PLUGIN_RIALTO_SERVER_MANAGER_SESSION_ENVS@")
+else:
+    configuration.add("sessionenvs", defaultSessionPlatformEnvs)
+
+configuration.add("sessionplatformenvs", "@PLUGIN_RIALTO_SERVER_MANAGER_SESSION_PLATFORM_ENVS@")

--- a/RialtoServerManager/RialtoServerManager.config
+++ b/RialtoServerManager/RialtoServerManager.config
@@ -1,0 +1,10 @@
+set(autostart ${PLUGIN_RIALTO_SERVER_AUTOSTART})
+
+map()
+    key(root)
+    map()
+        kv(mode ${PLUGIN_RIALTO_SERVER_MODE})
+        kv(locator lib${PLUGIN_RIALTO_SERVER_IMPLEMENTATION}.so)
+    end()
+end()
+ans(configuration)

--- a/RialtoServerManager/RialtoServerManager.cpp
+++ b/RialtoServerManager/RialtoServerManager.cpp
@@ -1,0 +1,238 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2024 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "RialtoServerManager.h"
+
+#define API_VERSION_NUMBER_MAJOR 1
+#define API_VERSION_NUMBER_MINOR 0
+#define API_VERSION_NUMBER_PATCH 0
+
+namespace {
+namespace {
+    static const string s_gstPluginsSrcPath = "/usr/lib/gstreamer-1.0";
+
+    static const string s_rialtoDir = "/tmp/rialto";
+    static const string s_rialtoGstPluginsSubdir = "/gst";
+    static const string s_rialtoLibSubdir = "/lib";
+}
+}
+
+namespace WPEFramework {
+namespace {
+    static Plugin::Metadata<Plugin::RialtoServerManager> metadata(
+        // Version (Major, Minor, Patch)
+        API_VERSION_NUMBER_MAJOR, API_VERSION_NUMBER_MINOR, API_VERSION_NUMBER_PATCH,
+        // Preconditions
+        {},
+        // Terminations
+        {},
+        // Controls
+        {}
+    );
+}
+
+namespace Plugin {
+
+    SERVICE_REGISTRATION(RialtoServerManager, API_VERSION_NUMBER_MAJOR, API_VERSION_NUMBER_MINOR, API_VERSION_NUMBER_PATCH);
+
+    bool RialtoServerManager::setupRialtoEnvironment()
+    {
+        if (_config.RialtoDir.IsSet() && !_config.RialtoDir.Value().empty()) {
+            _rialtoHome = _config.RialtoDir.Value();
+        } else {
+            _rialtoHome = s_rialtoDir;
+        }
+
+        Core::Directory dir(_rialtoHome.c_str());
+        if (!dir.CreatePath())
+            return false;
+
+        if (!prepareGstPlugins())
+            return false;
+
+        // create addional libs links
+        if (_config.Libs.IsSet() && _config.Libs.Length() > 0) {
+            const string rialtoLibDir = _rialtoHome + s_rialtoLibSubdir;
+            Core::Directory dir(rialtoLibDir.c_str());
+            if (!dir.CreatePath()) {
+                return false;
+            }
+
+            Core::JSON::ArrayType<RialtoServerManagerConfig::Config::FileLink>::Iterator index(_config.Libs.Elements());
+            while (index.Next()) {
+                Core::File file(index.Current().Src.Value());
+                if (!file.Exists())
+                    continue;
+                string target = rialtoLibDir + "/" + index.Current().Src.Value();
+                // if "dest" is set, use it as target
+                if (index.Current().Dest.IsSet() && !index.Current().Dest.Value().empty()) {
+                    target = rialtoLibDir + "/" + index.Current().Dest.Value();
+                }
+                file.Link(target);
+            }
+        }
+
+        auto envs = RialtoServerManagerConfig::parseEnvs(_config.HostEnvVars);
+        for (auto& var : envs) {
+            string value;
+            bool isSet = Core::SystemInfo::GetEnvironment(var.first, value);
+            _environment.push_back({var.first, isSet ? Core::OptionalType<string>(value) : Core::OptionalType<string>()});
+
+            Core::SystemInfo::SetEnvironment(var.first, var.second);
+        }
+        return true;
+    }
+
+    void RialtoServerManager::restoreEnvironment()
+    {
+        Core::File file(_rialtoHome);
+        Core::Directory dir(file.Name().c_str());
+        dir.Destroy();
+        // destroy top dir
+        file.Destroy();
+
+        // restore previous environment
+        for (auto& var : _environment) {
+            if (var.second.IsSet()) {
+                Core::SystemInfo::SetEnvironment(var.first, var.second.Value());
+            } else {
+                Core::SystemInfo::SetEnvironment(var.first, nullptr);
+            }
+        }
+    }
+
+    bool RialtoServerManager::prepareGstPlugins() {
+        if (!_config.GstPlugins.IsSet() || _config.GstPlugins.Length() == 0) {
+            return true;
+        }
+        // create soft links /tmp/rialto/* /usr/lib/gstreamer-1.0/*
+        const string rialtoGstPluginsDir = _rialtoHome + s_rialtoGstPluginsSubdir;
+        Core::Directory dir(rialtoGstPluginsDir.c_str());
+        if (!dir.CreatePath()) {
+            return false;
+        }
+
+        Core::JSON::ArrayType<Core::JSON::String>::Iterator index(_config.GstPlugins.Elements());
+        while (index.Next()) {
+            Core::File file(s_gstPluginsSrcPath + "/" + index.Current().Value());
+            if (!file.Exists())
+                continue;
+            file.Link(rialtoGstPluginsDir + "/" + index.Current().Value());
+        }
+        return true;
+    }
+
+    void RialtoServerManager::cleanUp(bool releaseObject)
+    {
+        if (releaseObject) {
+            if (_object != nullptr) {
+                _object->Release();
+            }
+        }
+        _object = nullptr;
+        _service->Unregister(&_notification);
+        _service = nullptr;
+    }
+
+    /* virtual */ const string RialtoServerManager::Initialize(PluginHost::IShell* service)
+    {
+        string result;
+
+        ASSERT(_service == nullptr);
+
+        _connectionId = 0;
+
+        if (!_config.FromString(service->ConfigLine())) {
+            result = _T("Failed to parse config line");
+            return result;
+        }
+
+        _service = service;
+
+        // Register the Process::Notification stuff. The Remote process might die before we get a
+        // change to "register" the sink for these events !!! So do it ahead of instantiation.
+        _service->Register(&_notification);
+
+        _object = _service->Root<Exchange::IConfiguration>(_connectionId, WPEFramework::RPC::CommunicationTimeOut, _T("RialtoServerManagerImpl"));
+        ASSERT(_connectionId != 0);
+
+        if (_object == nullptr) {
+            result = _T("RialtoServerManager could not be instantiated.");
+            cleanUp(false);
+            return result;
+        }
+
+        if (_object->Configure(_service) != 0) {
+            result = _T("Failed to configure RialtoServerManager.");
+            cleanUp(true);
+            return result;
+        }
+
+        if (!setupRialtoEnvironment()) {
+            result = _T("Failed to setup Rialto environment.");
+            return result;
+        }
+
+        TRACE(Trace::Information, (_T("RialtoServerManager is running")));
+        return result;
+    }
+
+    /*virtual*/ void RialtoServerManager::Deinitialize(PluginHost::IShell* service)
+    {
+        ASSERT(_service == service);
+        ASSERT(_object != nullptr);
+
+        _service->Unregister(&_notification);
+
+        RPC::IRemoteConnection* connection(_service->RemoteConnection(_connectionId));
+        uint32_t result = _object->Release();
+        ASSERT(result == Core::ERROR_DESTRUCTION_SUCCEEDED);
+
+        if (connection != nullptr) {
+            connection->Terminate();
+            connection->Release();
+        }
+
+        // Deinitialize what we initialized..
+        _object = nullptr;
+        _service = nullptr;
+
+        restoreEnvironment();
+        TRACE(Trace::Information, (_T("RialtoServerManager is closed")));
+    }
+
+    /* virtual */ string RialtoServerManager::Information() const
+    {
+        // No additional info to report.
+        return (nullptr);
+    }
+
+    void RialtoServerManager::Deactivated(RPC::IRemoteConnection* connection)
+    {
+        if (connection->Id() == _connectionId) {
+
+            ASSERT(_service != nullptr);
+
+            Core::IWorkerPool::Instance().Submit(PluginHost::IShell::Job::Create(_service,
+                PluginHost::IShell::DEACTIVATED,
+                PluginHost::IShell::FAILURE));
+        }
+    }
+}
+} //namespace WPEFramework::Plugin

--- a/RialtoServerManager/RialtoServerManager.h
+++ b/RialtoServerManager/RialtoServerManager.h
@@ -1,0 +1,107 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2024 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __RIALTO_SERVER_MANAGER_H
+#define __RIALTO_SERVER_MANAGER_H
+
+#include "Module.h"
+#include "RialtoServerManagerConfig.h"
+#include <interfaces/IConfiguration.h>
+
+#include <vector>
+
+namespace WPEFramework {
+namespace Plugin {
+
+    class RialtoServerManager : public PluginHost::IPlugin {
+    private:
+        RialtoServerManager(const RialtoServerManager&) = delete;
+        RialtoServerManager& operator=(const RialtoServerManager&) = delete;
+
+        class Notification : public RPC::IRemoteConnection::INotification {
+        private:
+            Notification() = delete;
+            Notification(const Notification&) = delete;
+            Notification& operator=(const Notification&) = delete;
+
+        public:
+            explicit Notification(RialtoServerManager* parent)
+                : _parent(*parent)
+            {
+                ASSERT(parent != nullptr);
+            }
+            ~Notification()
+            {
+            }
+
+        public:
+            virtual void Activated(RPC::IRemoteConnection*)
+            {
+            }
+            virtual void Deactivated(RPC::IRemoteConnection* connection)
+            {
+                _parent.Deactivated(connection);
+            }
+
+            BEGIN_INTERFACE_MAP(Notification)
+            INTERFACE_ENTRY(RPC::IRemoteConnection::INotification)
+            END_INTERFACE_MAP
+
+        private:
+            RialtoServerManager& _parent;
+        };
+
+
+    public:
+        RialtoServerManager()
+            : _notification(this) {}
+        virtual ~RialtoServerManager() {}
+
+    public:
+        BEGIN_INTERFACE_MAP(OCDM)
+        INTERFACE_ENTRY(PluginHost::IPlugin)
+        END_INTERFACE_MAP
+
+    public:
+        //  IPlugin methods
+        virtual const string Initialize(PluginHost::IShell* service);
+        virtual void Deinitialize(PluginHost::IShell* service);
+        virtual string Information() const;
+
+    private:
+        void Deactivated(RPC::IRemoteConnection* connection);
+
+        bool setupRialtoEnvironment();
+        void restoreEnvironment();
+        bool prepareGstPlugins();
+
+        void cleanUp(bool releaseObject);
+        uint32_t _connectionId {};
+        PluginHost::IShell* _service {nullptr};
+        Exchange::IConfiguration* _object {nullptr};
+        Core::Sink<Notification> _notification;
+
+        RialtoServerManagerConfig::Config _config;
+        std::vector<std::pair<string, Core::OptionalType<string>>> _environment;
+        string _rialtoHome;
+    };
+} //namespace Plugin
+} //namespace WPEFramework
+
+#endif // __RIALTO_SERVER_MANAGER_H

--- a/RialtoServerManager/RialtoServerManagerConfig.h
+++ b/RialtoServerManager/RialtoServerManagerConfig.h
@@ -1,0 +1,119 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2024 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __RIALTO_SERVER_MANAGER_CONFIG_H
+#define __RIALTO_SERVER_MANAGER_CONFIG_H
+
+#include "Module.h"
+
+namespace WPEFramework {
+namespace Plugin {
+namespace RialtoServerManagerConfig {
+
+    static std::vector<std::pair<string, string>> parseEnvs(const Core::JSON::String& envs) {
+        if (!envs.IsSet() || envs.Value().empty())
+            return {};
+
+        string envsStr = envs.Value();
+        std::vector<std::pair<string, string>> result;
+
+        size_t pos = 0;
+        while ((pos = envsStr.find(";")) != std::string::npos)
+        {
+            string singleEnvStr = envsStr.substr(0, pos);
+            size_t equalPos = singleEnvStr.find("=");
+            if (equalPos != std::string::npos) {
+                string name = singleEnvStr.substr(0, equalPos);
+                string value = singleEnvStr.substr(equalPos + 1);
+                result.push_back({name, value});
+            }
+            envsStr.erase(0, pos + 1);
+        }
+        return result;
+    }
+
+    class Config : public Core::JSON::Container {
+    private:
+        Config(const Config&) = delete;
+        Config& operator=(const Config&) = delete;
+    public:
+        class FileLink : public Core::JSON::Container {
+            public:
+                FileLink(const FileLink& origin)
+                    : Core::JSON::Container()
+                    , Src(origin.Src)
+                    , Dest(origin.Dest)
+                {
+                    Add(_T("src"), &Src);
+                    Add(_T("dest"), &Dest);
+                }
+                FileLink& operator=(const FileLink&) = delete;
+
+                FileLink()
+                    : Core::JSON::Container()
+                    , Src("")
+                    , Dest("")
+                {
+                    Add(_T("src"), &Src);
+                    Add(_T("dest"), &Dest);
+                }
+                ~FileLink() = default;
+
+            public:
+                Core::JSON::String Src;
+                Core::JSON::String Dest;
+            };
+
+        public:
+            Config()
+                : Core::JSON::Container()
+                , RialtoDir()
+                , GstPlugins()
+                , Libs()
+                , HostEnvVars()
+                , SessionEnvs()
+                , SessionPlatformEnvs()
+            {
+                Add(_T("rialtodir"), &RialtoDir);
+                Add(_T("gstplugins"), &GstPlugins);
+                Add(_T("libs"), &Libs);
+                Add(_T("hostenvvars"), &HostEnvVars);
+
+                Add(_T("sessionenvs"), &SessionEnvs);
+                Add(_T("sessionplatformenvs"), &SessionPlatformEnvs);
+            }
+            ~Config()
+            {
+            }
+
+        public:
+            Core::JSON::String RialtoDir;
+            Core::JSON::ArrayType<Core::JSON::String> GstPlugins;
+            Core::JSON::ArrayType<FileLink> Libs;
+            Core::JSON::String HostEnvVars;
+
+            Core::JSON::String SessionEnvs;
+            Core::JSON::String SessionPlatformEnvs;
+        };
+
+} // namespace RialtoServerManagerConfig
+} // namespace Plugin
+} // namespace WPEFramework
+
+#endif // __RIALTO_SERVER_MANAGER_CONFIG_H

--- a/RialtoServerManager/RialtoServerManagerImpl.cpp
+++ b/RialtoServerManager/RialtoServerManagerImpl.cpp
@@ -1,0 +1,114 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2024 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Module.h"
+#include "RialtoServerManagerConfig.h"
+#include <interfaces/IConfiguration.h>
+
+#include <rialto/IServerManagerService.h>
+#include <rialto/ServerManagerServiceFactory.h>
+
+namespace {
+    static const string s_defaultAppName = "ExampleApp";
+}
+
+namespace WPEFramework {
+namespace Plugin {
+    class RialtoServerManagerImpl : public Exchange::IConfiguration {
+    private:
+        RialtoServerManagerImpl(const RialtoServerManagerImpl&) = delete;
+        RialtoServerManagerImpl& operator=(const RialtoServerManagerImpl&) = delete;
+
+    public:
+        class RialtoServerManagerStateObserver : public rialto::servermanager::service::IStateObserver {
+        public:
+            RialtoServerManagerStateObserver() = default;
+            virtual ~RialtoServerManagerStateObserver() = default;
+
+            void stateChanged(const std::string &appId, const firebolt::rialto::common::SessionServerState &state) override {
+                TRACE(Trace::Information, (_T("[RialtoServerManagerImpl] app state changed %s %u"), appId.c_str(), (unsigned)state));
+            }
+        };
+
+        RialtoServerManagerImpl() {}
+        virtual ~RialtoServerManagerImpl() {
+            TRACE(Trace::Information, (_T("[RialtoServerManagerImpl] destroyed")));
+        }
+
+        uint32_t Configure(PluginHost::IShell* service) {
+            if (_config.FromString(service->ConfigLine()) == false) {
+                TRACE(Trace::Error, (_T("[RialtoServerManagerImpl] Failed to parse config line")));
+                return 1;
+            }
+
+            _stateObserver = std::make_shared<RialtoServerManagerStateObserver>();
+            _serverManagerService = rialto::servermanager::service::create(_stateObserver, getRialtoServerConfig());
+            if (!_serverManagerService) {
+                TRACE(Trace::Error, (_T("[RialtoServerManagerImpl] Failed to create ServerManagerService")));
+                return 1;
+            }
+
+            const string appName = s_defaultAppName;
+            if (!_serverManagerService->initiateApplication(appName, firebolt::rialto::common::SessionServerState::ACTIVE, {})) {
+                TRACE(Trace::Error, (_T("[RialtoServerManagerImpl] Failed to initiate application")));
+                return 1;
+            }
+
+            auto socket = _serverManagerService->getAppConnectionInfo(appName);
+            TRACE(Trace::Information, (_T("[RialtoServerManagerImpl] initialized, app connection info: %s"), socket.c_str()));
+
+            return 0;
+        }
+    private:
+        firebolt::rialto::common::ServerManagerConfig getRialtoServerConfig() {
+            firebolt::rialto::common::ServerManagerConfig config;
+            config.sessionServerEnvVars = {};
+            auto sessionEnvs = RialtoServerManagerConfig::parseEnvs(_config.SessionEnvs);
+            for (const auto& env : sessionEnvs) {
+                config.sessionServerEnvVars.push_back(env.first + "=" + env.second);
+            }
+
+            auto platformEnvs = RialtoServerManagerConfig::parseEnvs(_config.SessionPlatformEnvs);
+            if (platformEnvs.empty()) {
+                // Pass everything from current environment
+                for (char **env = environ; *env != 0; env++) {
+                    config.sessionServerEnvVars.push_back(*env);
+                }
+            } else {
+                for (const auto& env : platformEnvs) {
+                    config.sessionServerEnvVars.push_back(env.first + "=" + env.second);
+                }
+            }
+            return config;
+        }
+
+    private:
+        std::unique_ptr<rialto::servermanager::service::IServerManagerService> _serverManagerService;
+        std::shared_ptr<RialtoServerManagerStateObserver> _stateObserver;
+        RialtoServerManagerConfig::Config _config;
+
+    public:
+        BEGIN_INTERFACE_MAP(RialtoServerManagerImpl)
+        INTERFACE_ENTRY(Exchange::IConfiguration)
+        END_INTERFACE_MAP
+    };
+
+    SERVICE_REGISTRATION(RialtoServerManagerImpl, 1, 0);
+}
+} /* namespace WPEFramework::Plugin */


### PR DESCRIPTION
Implement simple Rialto server manager that contains basic configuration and starts Rialto server.
All apps started after this service will use
Rialto environment.
It will restore default environment after deactivation.

Reason for change: Add RialtoServer manager plugin
Test Procedure: See Jira ticket
Priority: P1
Risks: Low (disabled by default)