### PR TITLE
DELIA-66303: Getting Invalid information in response for org.rdk.System.getPlatformConfiguration

### DIFF
--- a/ResourceManager/CHANGELOG.md
+++ b/ResourceManager/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+## [1.0.3] - 2024-09-27
+### Changed
+- DELIA-66303: Handled the Invoke Response value with respect to Thunder R4.4.1
 
 ## [1.0.2] - 2024-05-31
 ### Changed

--- a/ResourceManager/ResourceManager.cpp
+++ b/ResourceManager/ResourceManager.cpp
@@ -22,7 +22,7 @@
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 1
+#define API_VERSION_NUMBER_PATCH 3
 
 static std::string sThunderSecurityToken;
 //methods
@@ -395,6 +395,11 @@ namespace WPEFramework {
                         message->Error.Text = output;
                     }
                 }
+            }
+
+            if (!FromMessage(response, message, isResponseString))
+            {
+                return Core::ERROR_GENERAL;
             }
 #elif (THUNDER_VERSION == 2)
             auto resp =  dispatcher_->Invoke(sThunderSecurityToken, channelId, *message);

--- a/SystemServices/CHANGELOG.md
+++ b/SystemServices/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+## [3.2.1] - 2024-09-27
+### Changed
+- DELIA-66303: Handled the Invoke Response value with respect to Thunder R4.4.1
+
 ## [3.2.0] - 2024-09-17
 ### Added
 - Added onRecoveryStateChange event.

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -67,7 +67,7 @@ using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 3
 #define API_VERSION_NUMBER_MINOR 2
-#define API_VERSION_NUMBER_PATCH 0
+#define API_VERSION_NUMBER_PATCH 1
 
 #define MAX_REBOOT_DELAY 86400 /* 24Hr = 86400 sec */
 #define TR181_FW_DELAY_REBOOT "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.AutoReboot.fwDelayReboot"

--- a/SystemServices/platformcaps/platformcapsdata.h
+++ b/SystemServices/platformcaps/platformcapsdata.h
@@ -193,6 +193,11 @@ private:
                     }
                 }
             }
+
+            if (!FromMessage(response, message, isResponseString))
+            {
+                return Core::ERROR_GENERAL;
+            }
 #elif ((THUNDER_VERSION >= 4) && (THUNDER_VERSION_MINOR == 2))
         Core::JSONRPC::Context context(channelId, message->Id.Value(), "");
         auto resp = dispatcher_->Invoke(context, *message);


### PR DESCRIPTION
Reason for change: handled the Invoke Response value with respect to Thunder R4.4.1
Test Procedure: Verify in Jenkin Build
Risks: Medium
Signed-off-by: Thamim Razith tabbas651@cable.comcast.com