### PR TITLE
 DELIA-65834 : Skipped new mode request

### DIFF
--- a/SystemServices/CHANGELOG.md
+++ b/SystemServices/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+## [3.2.2] - 2024-09-27
+### Fixed
+- Handled wpeframework crashes of SystemServices when there are multiple setMode requests.
+
 ## [3.2.1] - 2024-09-27
 ### Changed
 - DELIA-66303: Handled the Invoke Response value with respect to Thunder R4.4.1

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -1385,20 +1385,31 @@ namespace WPEFramework {
                 JsonObject& response)
         {
             bool changeMode  = true;
+            bool isTimerContext = false;
             JsonObject param;
             std::string oldMode = m_currentMode;
             bool result = true;
-
+	    getBoolParameter("timercontext", isTimerContext);
+	    if((!isTimerContext) && isTimerActive())
+            {
+		int actualDurationLeft = m_remainingDuration ? m_remainingDuration : 1;
+                populateResponseWithError(SysSrv_ModeChangeInProgress, response);
+		LOGERR("Mode change is already in progress.current mode is %s and it will be in progress for next %d seconds. Please try again later.\n",m_currentMode.c_str(),actualDurationLeft);
+                returnResponse(false);
+            }
             if (parameters.HasLabel("modeInfo")) {
                 param.FromString(parameters["modeInfo"].String());
                 if (param.HasLabel("duration") && param.HasLabel("mode")) {
                     int duration = param["duration"].Number();
                     std::string newMode = param["mode"].String();
-
+             	    if(duration>86400)
+                    {
+                        LOGWARN("Duration is more than 24 hours. Setting duration to 24 hours,which is maximum allowed duration to set\n");
+                        duration = 86400;
+                    }
                     LOGWARN("request to switch to mode '%s' from mode '%s' \
                             with duration %d\n", newMode.c_str(),
                             oldMode.c_str(), duration);
-
                     if (MODE_NORMAL != newMode && MODE_WAREHOUSE != newMode &&
                             MODE_EAS != newMode) {
                         LOGERR("value of new mode is incorrect, therefore \
@@ -1415,16 +1426,13 @@ namespace WPEFramework {
                         m_currentMode = MODE_NORMAL;
                         stopModeTimer();
                     }
-
                     if (changeMode) {
                         IARM_Bus_CommonAPI_SysModeChange_Param_t modeParam;
                         stringToIarmMode(oldMode, modeParam.oldMode);
                         stringToIarmMode(m_currentMode, modeParam.newMode);
-
                         if (IARM_RESULT_SUCCESS == IARM_Bus_Call(IARM_BUS_DAEMON_NAME,
                                     "DaemonSysModeChange", &modeParam, sizeof(modeParam))) {
                             LOGWARN("switched to mode '%s'\n", m_currentMode.c_str());
-
                             if (MODE_NORMAL != m_currentMode && duration < 0) {
                                 LOGWARN("duration is negative, therefore \
                                         mode timer stopped and Receiver will keep \
@@ -1446,6 +1454,7 @@ namespace WPEFramework {
                             command = "rm -f ";
                         }
                         command += WAREHOUSE_MODE_FILE;
+
                         /* TODO: replace with system alternate. */
                         int sysStat = system(command.c_str());
                         LOGINFO("system returned %d\n", sysStat);
@@ -1463,7 +1472,6 @@ namespace WPEFramework {
                 populateResponseWithError(SysSrv_MissingKeyValues, response);
                 result = false;
             }
-
             returnResponse(result);
         }
 
@@ -1475,14 +1483,21 @@ namespace WPEFramework {
             m_temp_settings.setValue("mode_duration", m_remainingDuration);
         }
 
-        void SystemServices::stopModeTimer()
+        void SystemServices::stopModeTimer(bool isDetachRequired)
         {
             m_remainingDuration = 0;
             m_operatingModeTimer.stop();
-
+            if(isDetachRequired)
+            {
+                m_operatingModeTimer.detach();
+            }
             //set values in temp file so they can be restored in receiver restarts / crashes
             // TODO: query & confirm time duration range.
             m_temp_settings.setValue("mode_duration", m_remainingDuration);
+        }
+        bool SystemServices::isTimerActive()
+        {
+            return m_operatingModeTimer.isActive();
         }
 
         /**
@@ -1492,12 +1507,13 @@ namespace WPEFramework {
         {
             if (m_remainingDuration > 0) {
                 m_remainingDuration--;
+                m_temp_settings.setValue("mode_duration", m_remainingDuration);
             } else {
-                m_operatingModeTimer.stop();
-               m_operatingModeTimer.detach();
+                stopModeTimer(true);
                 JsonObject parameters, param, response;
                 param["mode"] = "NORMAL";
                 param["duration"] = 0;
+                parameters["timercontext"] = true;
                 parameters["modeInfo"] = param;
                 if (_instance) {
                     _instance->setMode(parameters,response);
@@ -1505,9 +1521,6 @@ namespace WPEFramework {
                     LOGERR("_instance is NULL.\n");
                 }
             }
-
-            //set values in temp file so they can be restored in receiver restarts / crashes
-            m_temp_settings.setValue("mode_duration", m_remainingDuration);
         }
 
         /***

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -67,7 +67,7 @@ using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 3
 #define API_VERSION_NUMBER_MINOR 2
-#define API_VERSION_NUMBER_PATCH 1
+#define API_VERSION_NUMBER_PATCH 2
 
 #define MAX_REBOOT_DELAY 86400 /* 24Hr = 86400 sec */
 #define TR181_FW_DELAY_REBOOT "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.AutoReboot.fwDelayReboot"

--- a/SystemServices/SystemServices.h
+++ b/SystemServices/SystemServices.h
@@ -144,7 +144,8 @@ namespace WPEFramework {
                 std::string m_strRegion;
 
                 static void startModeTimer(int duration);
-                static void stopModeTimer();
+                static void stopModeTimer(bool isDetachRequired = false);
+                static bool isTimerActive();
                 static void updateDuration();
 				std::string  m_strStandardTerritoryList;
 #ifdef ENABLE_DEVICE_MANUFACTURER_INFO

--- a/SystemServices/SystemServicesHelper.cpp
+++ b/SystemServices/SystemServicesHelper.cpp
@@ -46,7 +46,8 @@ static const std::map<int, std::string> ErrCodeMap = {
     {SysSrv_LibcurlError, "LIbCurl service error"},
     {SysSrv_DynamicMemoryAllocationFailed, "Dynamic Memory Allocation Failed"},
     {SysSrv_ManufacturerDataReadFailed, "Manufacturer Data Read Failed"},
-    {SysSrv_KeyNotFound, "Key not found"}
+    {SysSrv_KeyNotFound, "Key not found"},
+    {SysSrv_ModeChangeInProgress, "Mode change is in progress"}
 };
 
 std::string getErrorDescription(int errCode)

--- a/SystemServices/SystemServicesHelper.h
+++ b/SystemServices/SystemServicesHelper.h
@@ -104,7 +104,8 @@ enum SysSrv_ErrorCode {
     SysSrv_LibcurlError,
     SysSrv_DynamicMemoryAllocationFailed,
     SysSrv_ManufacturerDataReadFailed,
-    SysSrv_KeyNotFound
+    SysSrv_KeyNotFound,
+    SysSrv_ModeChangeInProgress
 };
 
 enum FirmwareUpdateState {

--- a/SystemServices/cTimer.cpp
+++ b/SystemServices/cTimer.cpp
@@ -26,6 +26,7 @@
 cTimer::cTimer()
 {
     clear = false;
+    active = false;
     interval = 0;
 }
 
@@ -42,15 +43,17 @@ cTimer::~cTimer()
 Running this timer function as thread function
 */
 void cTimer::timerFunction() {
+    this->active = true;
     while (true) {
-         if (this->clear) {
+        if (this->clear) {
+            this->active = false;
             return;
-            }
+        }
         std::this_thread::sleep_for(std::chrono::milliseconds(interval));
-         if (this->clear) {
+        if (this->clear) {
+            this->active = false;
             return;
-            }
-
+        }
         this->callBack_function();
     }
 }
@@ -74,19 +77,24 @@ bool cTimer::start()
  */
 void cTimer::stop()
 {
-       this->clear = true;
+    this->clear = true;
+}
+
+bool cTimer::isActive()
+{
+    return this->active;
 }
 
 void cTimer::detach()
 {
-        timerThread.detach();
+    timerThread.detach();
 }
 
 void cTimer::join()
 {
-       if (timerThread.joinable()) {
-               timerThread.join();
-        }
+    if (timerThread.joinable()) {
+        timerThread.join();
+    }
 }
 
 /***
@@ -100,4 +108,3 @@ void cTimer::setInterval(void (*function)(), int val)
     this->callBack_function = function;
     this->interval = val;
 }
-

--- a/SystemServices/cTimer.h
+++ b/SystemServices/cTimer.h
@@ -25,6 +25,7 @@ using namespace std;
 class cTimer{
     private:
         bool clear;
+        bool active;
         int interval;
         void (*callBack_function)() = NULL;
         std::thread timerThread;
@@ -57,6 +58,7 @@ class cTimer{
         void stop();
        void detach();
        void join();
+        bool isActive();
 
         /***
          * @brief        : Set interval in which the given function should be invoked.

--- a/Tests/L1Tests/tests/test_SystemServices.cpp
+++ b/Tests/L1Tests/tests/test_SystemServices.cpp
@@ -38,7 +38,6 @@
 using namespace WPEFramework;
 
 using ::testing::NiceMock;
-
 class SystemServicesTest : public ::testing::Test {
 protected:
     Core::ProxyType<Plugin::SystemServices> plugin;
@@ -859,8 +858,11 @@ TEST_F(SystemServicesTest, updateFirmware)
 
 TEST_F(SystemServicesTest, Mode)
 {
+    NiceMock<ServiceMock> service;
+    EXPECT_EQ(string(""), plugin->Initialize(&service));
+
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getMode"), _T("{}"), response));
-    EXPECT_EQ(response, string("{\"modeInfo\":{\"mode\":\"\",\"duration\":0},\"success\":true}"));
+    EXPECT_EQ(response, string("{\"modeInfo\":{\"mode\":\"NORMAL\",\"duration\":0},\"success\":true}"));
 
     EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("setMode"), _T("{}"), response));
     EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("setMode"), _T("{\"modeInfo\":{}}"), response));
@@ -871,13 +873,18 @@ TEST_F(SystemServicesTest, Mode)
             [](const char* ownerName, const char* methodName, void* arg, size_t argLen) {
                 EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_DAEMON_NAME)));
                 EXPECT_EQ(string(methodName), string(_T("DaemonSysModeChange")));
-                return IARM_RESULT_SUCCESS;
+		return IARM_RESULT_SUCCESS;
             });
 
     ON_CALL(*p_wrapsImplMock, system(::testing::_))
         .WillByDefault(::testing::Invoke(
             [&](const char* command) {
-                EXPECT_EQ(string(command), string(_T("rm -f /opt/warehouse_mode_active")));
+                EXPECT_TRUE(
+                    strcmp(command, "touch /opt/warehouse_mode_active") == 0 ||
+                    strcmp(command, "rm -f /opt/warehouse_mode_active") == 0 ||
+                    strcmp(command, "touch /opt/eas_mode_active") == 0 ||
+                    strcmp(command, "rm -f /opt/eas_mode_active") == 0
+                );
                 return 0;
             }));
 
@@ -886,6 +893,25 @@ TEST_F(SystemServicesTest, Mode)
 
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getMode"), _T("{}"), response));
     EXPECT_EQ(response, string("{\"modeInfo\":{\"mode\":\"NORMAL\",\"duration\":0},\"success\":true}"));
+
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("setMode"), _T("{\"modeInfo\":{\"mode\":\"EAS\",\"duration\":10}}"), response));
+    EXPECT_EQ(response, string("{\"success\":true}"));
+
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getMode"), _T("{}"), response));
+    EXPECT_THAT(response, ::testing::MatchesRegex(_T("\\{"
+                                                 "\"modeInfo\":\\{"
+                                                 "\"mode\":\"EAS\","
+                                                 "\"duration\":(10|[1-9])"
+                                                 "\\},"
+                                                 "\"success\":true"
+                                                 "\\}")));
+
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("setMode"), _T("{\"modeInfo\":{\"mode\":\"WAREHOUSE\",\"duration\":5}}"), response));
+    sleep(12);
+    
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("setMode"), _T("{\"modeInfo\":{\"mode\":\"WAREHOUSE\",\"duration\":5}}"), response));
+    EXPECT_EQ(response, string("{\"success\":true}"));
+
 }
 
 TEST_F(SystemServicesTest, setDeepSleepTimer)


### PR DESCRIPTION
 DELIA-65834 : Skipped new mode request

Reason for change: Returning error in case of new mode request thereby avoiding crash.
Test Procedure: 1.Set device to any of the modes(WAREHOUSE/EAS/NORMAL) for 30s.
                         2.During that 30s,again make a request to set the same/different mode again.
                         3.Check for crashes.
Signed-off-by: Soundaryaa Sitaram<Soundaryaa_Sitaram@comcast.com>