### PR TITLE
RDKTV-33096: Wpeframework crash with signature RDKShell::subscribeForSystemEvent and fingerprint 48714301

### DIFF
--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -947,9 +947,7 @@ namespace WPEFramework {
                 }
 		else if (requestName.compare("susbscribeSystemEvent") == 0)
                 {
-                   gSubscribeMutex.lock();
 		   subscribeForSystemEvent("onSystemPowerStateChanged");
-		   gSubscribeMutex.unlock();
                    std::cout << "subscribed system event " << std::endl;
                    JsonObject joGetParams;
                     JsonObject joGetResult;
@@ -8164,6 +8162,7 @@ namespace WPEFramework {
 
         int32_t RDKShell::subscribeForSystemEvent(std::string event)
         {
+	    gSubscribeMutex.lock();
             int32_t status = Core::ERROR_GENERAL;
 
             PluginHost::IShell::state state;
@@ -8204,6 +8203,7 @@ namespace WPEFramework {
             else
                 std::cout << "No Connection to SystemServices" << std::endl;
 
+	    gSubscribeMutex.unlock();
             return status;
         }
         


### PR DESCRIPTION
Reason for change: adding lock-unlock in
RDKShell::subscribeForSystemEvent() for proper synchronization Test Procedure: as mentioned in RDKTV-33096
Risks: Low
Priority: P1
Signed-off-by:Boopathi Vanavarayan <boopathi_vanavarayan@comcast.com>