### PR TITLE
RDKTV-30904: Observing telemetry marker 'WPE_ERR_IPVerWrng' when the device was up from deepsleep

### DIFF
--- a/NetworkManager/INetworkManager.h
+++ b/NetworkManager/INetworkManager.h
@@ -151,6 +151,11 @@ namespace WPEFramework
                 string           m_securityModeText;
             };
 
+            struct EXTERNAL WIFIScanFilter {
+                bool onFrequency = false;
+                std::string frequency;
+            };
+
             enum WiFiSignalQuality : uint8_t
             {
                 WIFI_SIGNAL_DISCONNECTED,

--- a/NetworkManager/NetworkManagerJsonRpc.cpp
+++ b/NetworkManager/NetworkManagerJsonRpc.cpp
@@ -684,6 +684,21 @@ namespace WPEFramework
         {
             LOGINFOMETHOD();
             uint32_t rc = Core::ERROR_GENERAL;
+            Exchange::INetworkManager::WIFIScanFilter filter{};
+
+            if (parameters.HasLabel("frequency"))
+            {
+                std::string filter_freq;
+                if (WPEFramework::Core::JSON::Variant::type::STRING == parameters["frequency"].Content())
+                    filter_freq = parameters["frequency"].String();
+
+		if (filter_freq.length())
+		{
+                    filter.onFrequency = true;
+                    filter.frequency = filter_freq;
+                }
+            }
+
             const Exchange::INetworkManager::WiFiFrequency frequency = static_cast <Exchange::INetworkManager::WiFiFrequency> (parameters["frequency"].Number());
 
             if (_NetworkManager)

--- a/NetworkManager/NetworkManagerRDKProxy.cpp
+++ b/NetworkManager/NetworkManagerRDKProxy.cpp
@@ -511,8 +511,22 @@ namespace WPEFramework
                         }
 
                         JsonArray ssids = eventDocument["getAvailableSSIDs"].Array();
+                        JsonArray result;
+
+                        for(int i=0; i<ssids.Length(); i++)
+                        {
+                            JsonObject object = ssids[i].Object();
+
+                            if(filter.onFrequency && object["frequency"].String() != filter.frequency)
+                            {
+                                LOGINFO("Frequency filter out %s != %s", object["frequency"].String().c_str(), filter.frequency.c_str());
+                                continue;
+                            }
+
+                            result.Add(object);
+                        }
                         string json;
-                        ssids.ToString(json);
+                        result.ToString(json);
 
                         ::_instance->ReportAvailableSSIDsEvent(json);
                     }


### PR DESCRIPTION
Reason for change: removed the Log line for ipversion which returned empty value. 
that is not required. Because device lost ip address in deep scenarios.
Test Procedure: Verify in custom build 
Risks: None
Signed-off-by: Thamim  Razith <tabbas651@cable.comcast.com>









