### PR TITLE
RDKDEV-1089 - ResidentApp is not loading with latest RDKShell changes

### DIFF
--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -1937,8 +1937,7 @@ namespace WPEFramework {
                    JsonObject activateParams,response;
                    activateParams.Set("callsign",callsign.c_str());
                    JsonObject activateResult;
-                   auto thunderController = getThunderControllerClient();
-                   status = thunderController->Invoke<JsonObject, JsonObject>(RDKSHELL_THUNDER_TIMEOUT, "activate", activateParams, activateResult);
+		   status = JSONRPCDirectLink(mCurrentService, callsign).Invoke<JsonObject, JsonObject>(RDKSHELL_THUNDER_TIMEOUT, "activate", activateParams, activateResult);
                    std::cout << "Activating ResidentApp from RDKShell during bootup with Status:" << status << std::endl;
                    if (status > 0){
                            response["message"] = "resident app launch failed";


### PR DESCRIPTION
Reason for change: Use JSONRPCDirectLink calls instead of thunderController to address the thunder failure. With reference of https://code.rdkcentral.com/r/c/rdk/components/generic/rdk-oe/meta-rdk-video/+/100750

Test Procedure: Build and verify.

Risks: Low