### PR TITLE
DELIA-66249: Pairing request is posted to btmgr instead of connection

### DIFF
--- a/Bluetooth/Bluetooth.cpp
+++ b/Bluetooth/Bluetooth.cpp
@@ -796,7 +796,7 @@ namespace WPEFramework
                 lstBtrMgrEvtRsp.m_eventType = BTRMGR_EVENT_RECEIVED_EXTERNAL_CONNECT_REQUEST;
                 lstBtrMgrEvtRsp.m_eventResp = Utils::String::equal(respValue, "ACCEPTED") ? 1 : 0;
             }
-            else if (eventType.compare == EVT_PLAYBACK_REQUEST) {
+            else if (eventType == EVT_PLAYBACK_REQUEST) {
                 lstBtrMgrEvtRsp.m_eventType = BTRMGR_EVENT_RECEIVED_EXTERNAL_PLAYBACK_REQUEST;
                 lstBtrMgrEvtRsp.m_eventResp = Utils::String::equal(respValue, "ACCEPTED") ? 1 : 0;
             }


### PR DESCRIPTION
Reason for change: Using the == operator in the if check directly checks for string equality.
Priority: P1
Test Procedure: Test the auto-connect feature for BT gamepads from UI.
Risks: Medium
Signed-off-by: Natraj Muthusamy <Natraj_Muthusamy@comcast.com>