### PR TITLE
RDK-52316 : Content Protection service

### DIFF
--- a/.github/workflows/L2-ContentProtection.yml
+++ b/.github/workflows/L2-ContentProtection.yml
@@ -1,0 +1,35 @@
+name: L2-ContentProtection
+
+on:
+  push:
+    paths:
+      - ContentProtection/**
+      - .github/workflows/*ContentProtection*.yml
+  pull_request:
+    paths:
+      - ContentProtection/**
+      - .github/workflows/*ContentProtection*.yml
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: ${{github.repository}}
+
+      - name: Install cmake
+        run: |
+          sudo apt update
+          sudo apt install -y cmake
+
+      - name: Build Thunder
+        working-directory: ${{github.workspace}}
+        run: sh +x ${GITHUB_REPOSITORY}/.github/workflows/BuildThunder.sh
+
+      - name: Build
+        working-directory: ${{github.workspace}}
+        run: |
+          cmake -S ${GITHUB_REPOSITORY}/ContentProtection -B build/ContentProtection -DCMAKE_INSTALL_PREFIX="install" -DCMAKE_CXX_FLAGS="-Wall -Werror"
+          cmake --build build/ContentProtection --target install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -417,6 +417,10 @@ if(PLUGIN_MIGRATIONPREPARER)
 	add_subdirectory(MigrationPreparer)
 endif()
 
+if(PLUGIN_CONTENTPROTECTION)
+    add_subdirectory(ContentProtection)
+endif()
+
 if(WPEFRAMEWORK_CREATE_IPKG_TARGETS)
     set(CPACK_GENERATOR "DEB")
     set(CPACK_DEB_COMPONENT_INSTALL ON)

--- a/ContentProtection/CHANGELOG.md
+++ b/ContentProtection/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this RDK Service will be documented in this file.
+
+* Each RDK Service has a CHANGELOG file that contains all changes done so far. When version is updated, add a entry in the CHANGELOG.md at the top with user friendly information on what was changed with the new version. Please don't mention JIRA tickets in CHANGELOG.
+
+* Please Add entry in the CHANGELOG for each version change and indicate the type of change with these labels:
+    * **Added** for new features.
+    * **Changed** for changes in existing functionality.
+    * **Deprecated** for soon-to-be removed features.
+    * **Removed** for now removed features.
+    * **Fixed** for any bug fixes.
+    * **Security** in case of vulnerabilities.
+
+* Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development.
+
+* For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+
+## [1.0.0] - 2024-07-15
+### Added
+- Add CHANGELOG
+
+### Change
+- Reset API version to 1.0.0
+- Change README to inform how to update changelog and API version

--- a/ContentProtection/CMakeLists.txt
+++ b/ContentProtection/CMakeLists.txt
@@ -1,0 +1,44 @@
+# If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2022 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.14)
+
+set(PLUGIN_NAME ContentProtection)
+find_package(WPEFramework NAMES WPEFramework Thunder)
+set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
+
+set(CMAKE_CXX_STANDARD 11)
+
+set(PLUGIN_CONTENTPROTECTION_STARTUPORDER "" CACHE STRING "To configure startup order of the plugin")
+set(PLUGIN_CONTENTPROTECTION_AUTOSTART false CACHE STRING "To automatically start the plugin")
+
+add_library(${MODULE_NAME} SHARED
+        ContentProtection.cpp
+        Module.cpp
+)
+
+find_package(${NAMESPACE}Plugins REQUIRED)
+find_package(${NAMESPACE}Definitions REQUIRED)
+target_link_libraries(${MODULE_NAME} PRIVATE
+        ${NAMESPACE}Plugins::${NAMESPACE}Plugins
+        ${NAMESPACE}Definitions::${NAMESPACE}Definitions
+)
+
+install(TARGETS ${MODULE_NAME}
+        DESTINATION lib/${STORAGE_DIRECTORY}/plugins)
+
+write_config(${PLUGIN_NAME})

--- a/ContentProtection/ContentProtection.conf.in
+++ b/ContentProtection/ContentProtection.conf.in
@@ -1,0 +1,4 @@
+precondition = ["Platform"]
+callsign = "org.rdk.ContentProtection"
+autostart = "@PLUGIN_CONTENTPROTECTION_AUTOSTART@"
+startuporder = "@PLUGIN_CONTENTPROTECTION_STARTUPORDER@"

--- a/ContentProtection/ContentProtection.config
+++ b/ContentProtection/ContentProtection.config
@@ -1,0 +1,7 @@
+set(autostart ${PLUGIN_CONTENTPROTECTION_AUTOSTART})
+set(preconditions Platform)
+set(callsign "org.rdk.ContentProtection")
+
+if(PLUGIN_CONTENTPROTECTION_STARTUPORDER)
+set (startuporder ${PLUGIN_CONTENTPROTECTION_STARTUPORDER})
+endif()

--- a/ContentProtection/ContentProtection.cpp
+++ b/ContentProtection/ContentProtection.cpp
@@ -1,0 +1,95 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ContentProtection.h"
+
+#define API_VERSION_NUMBER_MAJOR 1
+#define API_VERSION_NUMBER_MINOR 0
+#define API_VERSION_NUMBER_PATCH 0
+
+namespace WPEFramework {
+namespace Plugin {
+
+    namespace {
+        static Metadata<ContentProtection> metadata(
+            // Version (Major, Minor, Patch)
+            API_VERSION_NUMBER_MAJOR, API_VERSION_NUMBER_MINOR, API_VERSION_NUMBER_PATCH,
+            // Preconditions
+            {},
+            // Terminations
+            {},
+            // Controls
+            {});
+    }
+
+    SERVICE_REGISTRATION(ContentProtection, API_VERSION_NUMBER_MAJOR, API_VERSION_NUMBER_MINOR, API_VERSION_NUMBER_PATCH);
+
+    const string ContentProtection::Initialize(PluginHost::IShell* service)
+    {
+        string result;
+
+        ASSERT(service != nullptr);
+
+        _implementation = Core::Service<Implementation>::Create<
+            Exchange::IContentProtection>(*this);
+        Exchange::JContentProtection::Register(*this, _implementation);
+
+        string token;
+        auto security = service->QueryInterfaceByCallsign<
+            PluginHost::IAuthenticate>("SecurityAgent");
+        if (security != nullptr) {
+            string payload = "http://localhost";
+            auto ret = security->CreateToken(
+                static_cast<uint16_t>(payload.length()),
+                reinterpret_cast<const uint8_t*>(payload.c_str()),
+                token);
+            if (ret != Core::ERROR_NONE) {
+                SYSLOG(Logging::Startup,
+                    (_T("Couldn't create token: %d"), ret));
+            }
+            security->Release();
+        }
+
+        Core::SystemInfo::SetEnvironment(_T("THUNDER_ACCESS"),
+            (_T("127.0.0.1:9998")));
+        _secManager = Core::ProxyType<JSONRPCLink>::Create(
+            _T("SecManager"), _T(""), "token=" + token);
+        _watermark = Core::ProxyType<JSONRPCLink>::Create(
+            _T("Watermark"), _T(""), "token=" + token);
+        Subscribe();
+
+        return result;
+    }
+
+    void ContentProtection::Deinitialize(PluginHost::IShell*)
+    {
+        Unsubscribe();
+        Exchange::JContentProtection::Unregister(*this);
+        if (_implementation != nullptr) {
+            _implementation->Release();
+        }
+    }
+
+    string ContentProtection::Information() const
+    {
+        return (string());
+    }
+
+} // namespace Plugin
+} // namespace WPEFramework

--- a/ContentProtection/ContentProtection.h
+++ b/ContentProtection/ContentProtection.h
@@ -1,0 +1,757 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "Module.h"
+#include <interfaces/IWatermark.h>
+#include <interfaces/json/JContentProtection.h>
+
+namespace WPEFramework {
+namespace Plugin {
+
+    class ContentProtection
+        : public PluginHost::IPlugin,
+          public PluginHost::JSONRPC {
+    private:
+        struct Session {
+            string ClientId;
+            Exchange::IContentProtection::KeySystem KeySystem;
+        };
+
+    private:
+        struct Watermark {
+            uint32_t SessionId;
+            bool AdjustVisibilityRequired;
+            uint32_t GraphicImageBufferKey;
+            uint32_t GraphicImageSize;
+        };
+
+    private:
+        template <typename OBJECT>
+        class Storage {
+        public:
+            void Set(uint32_t id, const OBJECT& item)
+            {
+                Core::SafeSyncType<Core::CriticalSection> lock(_lock);
+                auto it = _items.find(id);
+                if (it != _items.end()) {
+                    it->second = item;
+                } else {
+                    _items.emplace(id, item);
+                }
+            }
+            Core::OptionalType<OBJECT> Get(uint32_t id)
+            {
+                Core::SafeSyncType<Core::CriticalSection> lock(_lock);
+                Core::OptionalType<OBJECT> result;
+                auto it = _items.find(id);
+                if (it != _items.end()) {
+                    result = it->second;
+                }
+                return result;
+            }
+            void Delete(uint32_t id)
+            {
+                Core::SafeSyncType<Core::CriticalSection> lock(_lock);
+                _items.erase(id);
+            }
+
+        private:
+            Core::CriticalSection _lock;
+            std::map<uint32_t, OBJECT> _items;
+        };
+
+    private:
+        struct OnAddWatermarkParams : public Core::JSON::Container {
+            OnAddWatermarkParams()
+            {
+                Add(_T("sessionId"), &SessionId);
+                Add(_T("graphicId"), &GraphicId);
+                Add(_T("adjustVisibilityRequired"),
+                    &AdjustVisibilityRequired);
+                Add(_T("zIndex"), &ZIndex);
+                Add(_T("imageType"), &ImageType);
+                Add(_T("graphicImageBufferKey"), &GraphicImageBufferKey);
+                Add(_T("graphicImageSize"), &GraphicImageSize);
+            }
+            Core::JSON::DecUInt32 SessionId;
+            Core::JSON::DecUInt32 GraphicId;
+            Core::JSON::Boolean AdjustVisibilityRequired;
+            Core::JSON::DecUInt32 ZIndex;
+            Core::JSON::String ImageType;
+            Core::JSON::DecUInt32 GraphicImageBufferKey;
+            Core::JSON::DecUInt32 GraphicImageSize;
+        };
+
+        struct OnRemoveWatermarkParams : public Core::JSON::Container {
+            OnRemoveWatermarkParams()
+            {
+                Add(_T("graphicId"), &GraphicId);
+            }
+            Core::JSON::DecUInt32 GraphicId;
+        };
+
+        struct OnDisplayWatermarkParams : public Core::JSON::Container {
+            OnDisplayWatermarkParams()
+            {
+                Add(_T("hideWatermark"), &HideWatermark);
+            }
+            Core::JSON::Boolean HideWatermark;
+        };
+
+        struct OnWatermarkSessionParams : public Core::JSON::Container {
+            OnWatermarkSessionParams()
+            {
+                Add(_T("sessionId"), &SessionId);
+                Add(_T("conditionContext"), &ConditionContext);
+            }
+            Core::JSON::DecUInt32 SessionId;
+            Core::JSON::DecSInt32 ConditionContext;
+        };
+
+        struct OnUpdateWatermarkParams : public Core::JSON::Container {
+            OnUpdateWatermarkParams()
+            {
+                Add(_T("graphicId"), &GraphicId);
+                Add(_T("watermarkClutBufferKey"), &WatermarkClutBufferKey);
+                Add(_T("watermarkImageBufferKey"),
+                    &WatermarkImageBufferKey);
+            }
+            Core::JSON::DecUInt32 GraphicId;
+            Core::JSON::DecUInt32 WatermarkClutBufferKey;
+            Core::JSON::DecUInt32 WatermarkImageBufferKey;
+        };
+
+    private:
+        struct OnWatermarkRequestStatusParams : public Core::JSON::Container {
+            OnWatermarkRequestStatusParams()
+            {
+                Add(_T("id"), &Id);
+                Add(_T("type"), &Type);
+                Add(_T("success"), &Success);
+            }
+            Core::JSON::DecUInt32 Id;
+            Core::JSON::String Type;
+            Core::JSON::Boolean Success;
+        };
+
+        struct OnWatermarkRenderFailedParams : public Core::JSON::Container {
+            OnWatermarkRenderFailedParams()
+            {
+                Add(_T("image"), &Image);
+            }
+            Core::JSON::DecUInt32 Image;
+        };
+
+    private:
+        struct SetPlaybackSessionStateParams : public Core::JSON::Container {
+            SetPlaybackSessionStateParams()
+            {
+                Add(_T("clientId"), &ClientId);
+                Add(_T("sessionid"), &SessionId);
+                Add(_T("sessionstate"), &SessionState);
+            }
+            Core::JSON::String ClientId;
+            Core::JSON::DecUInt32 SessionId;
+            Core::JSON::EnumType<
+                Exchange::IContentProtection::State>
+                SessionState;
+        };
+
+        struct ClosePlaybackSessionParams : public Core::JSON::Container {
+            ClosePlaybackSessionParams()
+            {
+                Add(_T("clientId"), &ClientId);
+                Add(_T("sessionid"), &SessionId);
+            }
+            Core::JSON::String ClientId;
+            Core::JSON::DecUInt32 SessionId;
+        };
+
+        struct SetPlaybackSpeedStateParams : public Core::JSON::Container {
+            SetPlaybackSpeedStateParams()
+            {
+                Add(_T("sessionid"), &SessionId);
+                Add(_T("playbackSpeed"), &PlaybackSpeed);
+                Add(_T("playbackPosition"), &PlaybackPosition);
+            }
+            Core::JSON::DecUInt32 SessionId;
+            Core::JSON::DecSInt32 PlaybackSpeed;
+            Core::JSON::DecSInt32 PlaybackPosition;
+        };
+
+        struct LoadClutWatermarkParams : public Core::JSON::Container {
+            LoadClutWatermarkParams()
+            {
+                Add(_T("sessionId"), &SessionId);
+                Add(_T("graphicId"), &GraphicId);
+                Add(_T("watermarkClutBufferKey"), &WatermarkClutBufferKey);
+                Add(_T("watermarkImageBufferKey"), &WatermarkImageBufferKey);
+                Add(_T("clutPaletteSize"), &ClutPaletteSize);
+                Add(_T("clutPaletteFormat"), &ClutPaletteFormat);
+                Add(_T("watermarkWidth"), &WatermarkWidth);
+                Add(_T("watermarkHeight"), &WatermarkHeight);
+                Add(_T("aspectRatio"), &AspectRatio);
+            }
+            Core::JSON::DecUInt32 SessionId;
+            Core::JSON::DecUInt32 GraphicId;
+            Core::JSON::DecUInt32 WatermarkClutBufferKey;
+            Core::JSON::DecUInt32 WatermarkImageBufferKey;
+            Core::JSON::DecUInt32 ClutPaletteSize;
+            Core::JSON::String ClutPaletteFormat;
+            Core::JSON::DecUInt32 WatermarkWidth;
+            Core::JSON::DecUInt32 WatermarkHeight;
+            Core::JSON::Float AspectRatio;
+        };
+
+    private:
+        struct ShowWatermarkParams : public Core::JSON::Container {
+            ShowWatermarkParams()
+            {
+                Add(_T("show"), &Show);
+            }
+            Core::JSON::Boolean Show;
+        };
+
+        struct CreateWatermarkParams : public Core::JSON::Container {
+            CreateWatermarkParams()
+            {
+                Add(_T("id"), &Id);
+                Add(_T("zorder"), &Zorder);
+            }
+            Core::JSON::DecUInt32 Id;
+            Core::JSON::DecUInt32 Zorder;
+        };
+
+        struct DeleteWatermarkParams : public Core::JSON::Container {
+            DeleteWatermarkParams()
+            {
+                Add(_T("id"), &Id);
+            }
+            Core::JSON::DecUInt32 Id;
+        };
+
+        struct PaletteWatermarkParams : public Core::JSON::Container {
+            PaletteWatermarkParams()
+            {
+                Add(_T("id"), &Id);
+                Add(_T("imageKey"), &ImageKey);
+                Add(_T("imageWidth"), &ImageWidth);
+                Add(_T("imageHeight"), &ImageHeight);
+                Add(_T("clutKey"), &ClutKey);
+                Add(_T("clutSize"), &ClutSize);
+                Add(_T("clutType"), &ClutType);
+            }
+            Core::JSON::DecUInt32 Id;
+            Core::JSON::DecUInt32 ImageKey;
+            Core::JSON::DecUInt32 ImageWidth;
+            Core::JSON::DecUInt32 ImageHeight;
+            Core::JSON::DecUInt32 ClutKey;
+            Core::JSON::DecUInt32 ClutSize;
+            Core::JSON::String ClutType;
+        };
+
+        struct UpdateWatermarkParams : public Core::JSON::Container {
+            UpdateWatermarkParams()
+            {
+                Add(_T("id"), &Id);
+                Add(_T("key"), &Key);
+                Add(_T("size"), &Size);
+            }
+            Core::JSON::DecUInt32 Id;
+            Core::JSON::DecUInt32 Key;
+            Core::JSON::DecUInt32 Size;
+        };
+
+    private:
+        enum { Timeout = 1000 };
+
+    private:
+        using JSONRPCLink = WPEFramework::JSONRPC::SmartLinkType<
+            Core::JSON::IElement>;
+        using State
+            = Exchange::IContentProtection::INotification::Status::State;
+
+    private:
+        class Implementation : public Exchange::IContentProtection {
+        public:
+            Implementation(const Implementation&) = delete;
+            Implementation(Implementation&&) = delete;
+            Implementation& operator=(const Implementation&) = delete;
+            Implementation& operator=(Implementation&&) = delete;
+
+            explicit Implementation(ContentProtection& parent)
+                : _parent(parent)
+            {
+            }
+
+            BEGIN_INTERFACE_MAP(Implementation)
+            INTERFACE_ENTRY(IContentProtection)
+            END_INTERFACE_MAP
+
+        private:
+            uint32_t Register(
+                IContentProtection::INotification* notification) override
+            {
+                Core::SafeSyncType<Core::CriticalSection> lock(
+                    _parent._clientLock);
+                ASSERT(std::find(
+                           _parent._clients.begin(), _parent._clients.end(),
+                           notification)
+                    == _parent._clients.end());
+                notification->AddRef();
+                _parent._clients.push_back(notification);
+                return Core::ERROR_NONE;
+            }
+
+            uint32_t Unregister(
+                IContentProtection::INotification* notification) override
+            {
+                Core::SafeSyncType<Core::CriticalSection> lock(
+                    _parent._clientLock);
+                auto index = std::find(
+                    _parent._clients.begin(), _parent._clients.end(),
+                    notification);
+                ASSERT(index != _parent._clients.end());
+                if (index != _parent._clients.end()) {
+                    notification->Release();
+                    _parent._clients.erase(index);
+                }
+                return Core::ERROR_NONE;
+            }
+
+            uint32_t OpenDrmSession(const string& clientId,
+                KeySystem keySystem, const string& licenseRequest,
+                const string& initData, uint32_t& sessionId, string& response)
+                override
+            {
+                uint32_t result;
+                JsonObject out;
+                out.FromString(initData);
+                out["clientId"] = clientId;
+                out["keySystem"] = Core::JSON::EnumType<KeySystem>(keySystem)
+                                       .Data();
+                out["licenseRequest"] = licenseRequest;
+                JsonObject in;
+                result = _parent._secManager->Invoke<JsonObject, JsonObject>(
+                    Timeout, _T("openPlaybackSession"), out, in);
+                if (result == Core::ERROR_NONE) {
+                    if (!in["success"].Boolean()) {
+                        result = Core::ERROR_GENERAL;
+                    } else {
+                        sessionId = in["sessionId"].Number();
+                        in.ToString(response);
+
+                        _parent._sessionStorage.Set(sessionId,
+                            { clientId, keySystem });
+                    }
+                }
+                return result;
+            }
+
+            uint32_t SetDrmSessionState(uint32_t sessionId,
+                State sessionState) override
+            {
+                auto session = _parent._sessionStorage.Get(sessionId);
+                if (!session.IsSet()) {
+                    return Core::ERROR_ILLEGAL_STATE; // No such session
+                }
+
+                uint32_t result;
+                SetPlaybackSessionStateParams out;
+                out.ClientId = session.Value().ClientId;
+                out.SessionId = sessionId;
+                out.SessionState = sessionState;
+                JsonObject in;
+                result = _parent._secManager->Invoke<
+                    SetPlaybackSessionStateParams, JsonObject>(
+                    Timeout, _T("setPlaybackSessionState"), out, in);
+                if (result == Core::ERROR_NONE) {
+                    if (!in["success"].Boolean()) {
+                        result = Core::ERROR_GENERAL;
+                    }
+                }
+                return result;
+            }
+
+            uint32_t UpdateDrmSession(uint32_t sessionId,
+                const string& licenseRequest,
+                const string& initData, string& response) override
+            {
+                auto session = _parent._sessionStorage.Get(sessionId);
+                if (!session.IsSet()) {
+                    return Core::ERROR_ILLEGAL_STATE; // No such session
+                }
+
+                uint32_t result;
+                JsonObject out;
+                out.FromString(initData);
+                out["clientId"] = session.Value().ClientId;
+                out["sessionId"] = sessionId;
+                out["keySystem"] = Core::JSON::EnumType<KeySystem>(
+                    session.Value().KeySystem)
+                                       .Data();
+                out["licenseRequest"] = licenseRequest;
+                JsonObject in;
+                result = _parent._secManager->Invoke<
+                    JsonObject, JsonObject>(
+                    Timeout, _T("updatePlaybackSession"), out, in);
+                if (result == Core::ERROR_NONE) {
+                    if (!in["success"].Boolean()) {
+                        result = Core::ERROR_GENERAL;
+                    } else {
+                        in.ToString(response);
+                    }
+                }
+                return result;
+            }
+
+            uint32_t CloseDrmSession(uint32_t sessionId) override
+            {
+                auto session = _parent._sessionStorage.Get(sessionId);
+                if (!session.IsSet()) {
+                    return Core::ERROR_ILLEGAL_STATE; // No such session
+                }
+
+                uint32_t result;
+                ClosePlaybackSessionParams out;
+                out.ClientId = session.Value().ClientId;
+                out.SessionId = sessionId;
+                JsonObject in;
+                result = _parent._secManager->Invoke<
+                    ClosePlaybackSessionParams, JsonObject>(
+                    Timeout, _T("closePlaybackSession"), out, in);
+                if ((result == Core::ERROR_NONE) && !in["success"].Boolean()) {
+                    result = Core::ERROR_GENERAL;
+                }
+                return result;
+            }
+
+            uint32_t ShowWatermark(uint32_t /*sessionId*/,
+                bool show, bool /*localOverlay*/) override
+            {
+                uint32_t result;
+                ShowWatermarkParams out;
+                out.Show = show;
+                JsonObject in;
+                result = _parent._watermark->Invoke<
+                    ShowWatermarkParams, JsonObject>(
+                    Timeout, _T("showWatermark"), out, in);
+                if ((result == Core::ERROR_NONE) && !in["success"].Boolean()) {
+                    result = Core::ERROR_GENERAL;
+                }
+                return result;
+            }
+
+            uint32_t SetPlaybackPosition(uint32_t sessionId,
+                int32_t speed, long position) override
+            {
+                uint32_t result;
+                SetPlaybackSpeedStateParams out;
+                out.SessionId = sessionId;
+                out.PlaybackSpeed = speed;
+                out.PlaybackPosition = position;
+                JsonObject in;
+                result = _parent._secManager->Invoke<
+                    SetPlaybackSpeedStateParams, JsonObject>(
+                    Timeout, _T("setPlaybackSpeedState"), out, in);
+                if ((result == Core::ERROR_NONE) && !in["success"].Boolean()) {
+                    result = Core::ERROR_GENERAL;
+                }
+                return result;
+            }
+
+        private:
+            ContentProtection& _parent;
+        };
+
+    public:
+        ContentProtection(const ContentProtection&) = delete;
+        ContentProtection(ContentProtection&&) = delete;
+        ContentProtection& operator=(const ContentProtection&) = delete;
+        ContentProtection& operator=(ContentProtection&&) = delete;
+        ContentProtection() = default;
+
+        BEGIN_INTERFACE_MAP(ContentProtection)
+        INTERFACE_ENTRY(PluginHost::IPlugin)
+        INTERFACE_ENTRY(PluginHost::IDispatcher)
+        INTERFACE_AGGREGATE(Exchange::IContentProtection, _implementation)
+        END_INTERFACE_MAP
+
+    private:
+        const string Initialize(PluginHost::IShell* service) override;
+        void Deinitialize(PluginHost::IShell* service) override;
+        string Information() const override;
+
+    private:
+        void Subscribe()
+        {
+            ASSERT(_secManager->Subscribe<OnAddWatermarkParams>(
+                       Timeout, _T("onAddWatermark"),
+                       [&](const OnAddWatermarkParams& params) {
+                           _watermarkStorage.Set(
+                               params.GraphicId,
+                               { params.SessionId,
+                                   params.AdjustVisibilityRequired,
+                                   params.GraphicImageBufferKey,
+                                   params.GraphicImageSize });
+
+                           CreateWatermarkParams out;
+                           out.Id = params.GraphicId;
+                           out.Zorder = params.ZIndex;
+                           JsonObject in;
+                           if ((_watermark->Invoke<
+                                    CreateWatermarkParams, JsonObject>(
+                                    Timeout, _T("createWatermark"), out, in)
+                                   != Core::ERROR_NONE)
+                               || !in["success"].Boolean()) {
+                               TRACE(Trace::Error,
+                                   (_T("create %d failed"), params.GraphicId));
+                           }
+                       })
+                == Core::ERROR_NONE);
+            ASSERT(_secManager->Subscribe<OnRemoveWatermarkParams>(
+                       Timeout, _T("onRemoveWatermark"),
+                       [&](const OnRemoveWatermarkParams& params) {
+                           DeleteWatermarkParams out;
+                           out.Id = params.GraphicId;
+                           JsonObject in;
+                           if ((_watermark->Invoke<
+                                    DeleteWatermarkParams, JsonObject>(
+                                    Timeout, _T("deleteWatermark"), out, in)
+                                   != Core::ERROR_NONE)
+                               || !in["success"].Boolean()) {
+                               TRACE(Trace::Error,
+                                   (_T("delete %d failed"), params.GraphicId));
+                           }
+                       })
+                == Core::ERROR_NONE);
+            ASSERT(_secManager->Subscribe<OnDisplayWatermarkParams>(
+                       Timeout, _T("onDisplayWatermark"),
+                       [&](const OnDisplayWatermarkParams& params) {
+                           uint32_t result;
+                           ShowWatermarkParams out;
+                           out.Show = !params.HideWatermark;
+                           JsonObject in;
+                           result = _watermark->Invoke<
+                               ShowWatermarkParams, JsonObject>(
+                               Timeout, _T("showWatermark"), out, in);
+                           if ((result != Core::ERROR_NONE)
+                               || !in["success"].Boolean()) {
+                               TRACE(Trace::Error, (_T("show failed")));
+                           }
+                       })
+                == Core::ERROR_NONE);
+            ASSERT(_secManager->Subscribe<OnWatermarkSessionParams>(
+                       Timeout, _T("onWatermarkSession"),
+                       [&](const OnWatermarkSessionParams& params) {
+                           WatermarkStatusChanged(
+                               params.SessionId,
+                               { ((params.ConditionContext == 1)
+                                         ? State::GRANTED
+                                         : ((params.ConditionContext == 2)
+                                                   ? State::NOT_REQUIRED
+                                                   : ((params.ConditionContext == 3)
+                                                             ? State::DENIED
+                                                             : State::FAILED))),
+                                   params.ConditionContext });
+                       })
+                == Core::ERROR_NONE);
+            ASSERT(_secManager->Subscribe<OnUpdateWatermarkParams>(
+                       Timeout, _T("onUpdateWatermark"),
+                       [&](const OnUpdateWatermarkParams& params) {
+                           auto palette = _palettedImageDataStorage.Get(
+                               params.GraphicId);
+                           if (!palette.IsSet()) {
+                               TRACE(Trace::Error,
+                                   (_T("no palette %d"), params.GraphicId));
+                           } else {
+                               PaletteWatermarkParams out;
+                               out.Id = params.GraphicId;
+                               out.ImageKey = params.WatermarkImageBufferKey;
+                               out.ImageWidth = palette.Value().imageWidth;
+                               out.ImageHeight = palette.Value().imageHeight;
+                               out.ClutKey = params.WatermarkClutBufferKey;
+                               out.ClutSize = palette.Value().clutSize;
+                               out.ClutType = palette.Value().clutType;
+                               JsonObject in;
+                               if ((_watermark->Invoke<
+                                        PaletteWatermarkParams, JsonObject>(
+                                        Timeout, _T("modifyPalettedWatermark"),
+                                        out, in)
+                                       != Core::ERROR_NONE)
+                                   || !in["success"].Boolean()) {
+                                   TRACE(Trace::Error,
+                                       (_T("modify %d failed"),
+                                           params.GraphicId));
+                               }
+                           }
+                       })
+                == Core::ERROR_NONE);
+            ASSERT(_watermark->Subscribe<OnWatermarkRequestStatusParams>(
+                       Timeout, _T("onWatermarkRequestStatus"),
+                       [&](const OnWatermarkRequestStatusParams& params) {
+                           if (params.Type == "show") {
+                               if (!params.Success) {
+                                   TRACE(Trace::Error, (_T("show failed")));
+                               }
+                               // Watermark plugin does not tell
+                               // which call ended, can be any. Can't take this
+                               // information as a response
+                           } else if (!params.Success) {
+                               auto watermark = _watermarkStorage
+                                                    .Get(params.Id);
+                               if (watermark.IsSet()) {
+                                   TRACE(Trace::Error,
+                                       (_T("%s %d failed"),
+                                           params.Type.Value().c_str(),
+                                           params.Id));
+                               }
+                           } else if (params.Type == "create") {
+                               auto watermark = _watermarkStorage
+                                                    .Get(params.Id);
+                               if (watermark.IsSet()) {
+                                   UpdateWatermarkParams out;
+                                   out.Id = params.Id;
+                                   out.Key = watermark.Value()
+                                                 .GraphicImageBufferKey;
+                                   out.Size = watermark.Value()
+                                                  .GraphicImageSize;
+                                   JsonObject in;
+                                   if ((_watermark->Invoke<
+                                            UpdateWatermarkParams, JsonObject>(
+                                            Timeout, _T("updateWatermark"),
+                                            out, in)
+                                           != Core::ERROR_NONE)
+                                       || !in["success"].Boolean()) {
+                                       TRACE(Trace::Error,
+                                           (_T("update %d failed"),
+                                               params.Id));
+                                   }
+                               }
+                           } else if (params.Type == "update") {
+                               auto watermark = _watermarkStorage
+                                                    .Get(params.Id);
+                               if (watermark.IsSet()
+                                   && watermark.Value()
+                                       .AdjustVisibilityRequired) {
+                                   DeleteWatermarkParams out;
+                                   out.Id = params.Id;
+                                   PaletteWatermarkParams in;
+                                   if ((_watermark->Invoke<
+                                            DeleteWatermarkParams,
+                                            PaletteWatermarkParams>(
+                                            Timeout,
+                                            _T("getPalettedWatermark"),
+                                            out, in)
+                                           != Core::ERROR_NONE)
+                                       || !in.ImageWidth || !in.ImageHeight) {
+                                       TRACE(Trace::Error,
+                                           (_T("get %d failed"), params.Id));
+                                   } else {
+                                       _palettedImageDataStorage.Set(
+                                           params.Id,
+                                           { in.ImageKey,
+                                               in.ImageWidth,
+                                               in.ImageHeight,
+                                               in.ClutKey,
+                                               in.ClutSize,
+                                               in.ClutType });
+
+                                       LoadClutWatermarkParams out;
+                                       out.SessionId = watermark.Value()
+                                                           .SessionId;
+                                       out.GraphicId = params.Id;
+                                       out.WatermarkClutBufferKey = in.ClutKey;
+                                       out.WatermarkImageBufferKey
+                                           = in.ImageKey;
+                                       out.ClutPaletteSize = in.ClutSize;
+                                       out.ClutPaletteFormat = in.ClutType;
+                                       out.WatermarkWidth = in.ImageWidth;
+                                       out.WatermarkHeight = in.ImageHeight;
+                                       out.AspectRatio
+                                           = ((float)in.ImageWidth
+                                               / (float)in.ImageHeight);
+                                       JsonObject in2;
+                                       if ((_secManager->Invoke<
+                                                LoadClutWatermarkParams,
+                                                JsonObject>(
+                                                Timeout,
+                                                _T("loadClutWatermark"),
+                                                out, in2)
+                                               != Core::ERROR_NONE)
+                                           || !in2["success"].Boolean()) {
+                                           TRACE(Trace::Error,
+                                               (_T("load %d failed"),
+                                                   params.Id));
+                                       }
+                                   }
+                               }
+                           }
+                       })
+                == Core::ERROR_NONE);
+            ASSERT(_watermark->Subscribe<OnWatermarkRenderFailedParams>(
+                       Timeout, _T("onWatermarkRenderFailed"),
+                       [&](const OnWatermarkRenderFailedParams& params) {
+                           auto watermark = _watermarkStorage
+                                                .Get(params.Image);
+                           if (watermark.IsSet()) {
+                               WatermarkStatusChanged(
+                                   watermark.Value().SessionId,
+                                   { State::FAILED, 20001 });
+                           }
+                       })
+                == Core::ERROR_NONE);
+        }
+        void Unsubscribe()
+        {
+            _secManager->Unsubscribe(Timeout, _T("onAddWatermark"));
+            _secManager->Unsubscribe(Timeout, _T("onRemoveWatermark"));
+            _secManager->Unsubscribe(Timeout, _T("onDisplayWatermark"));
+            _secManager->Unsubscribe(Timeout, _T("onWatermarkSession"));
+            _secManager->Unsubscribe(Timeout, _T("onUpdateWatermark"));
+            _watermark->Unsubscribe(Timeout, _T("onWatermarkRequestStatus"));
+            _watermark->Unsubscribe(Timeout, _T("onWatermarkRenderFailed"));
+        }
+        void WatermarkStatusChanged(uint32_t sessionId,
+            const Exchange::IContentProtection::INotification::Status& status)
+        {
+            Exchange::JContentProtection::Event::WatermarkStatusChanged(
+                *this, sessionId, status);
+
+            Core::SafeSyncType<Core::CriticalSection> lock(_clientLock);
+            for (auto& i : _clients) {
+                i->WatermarkStatusChanged(sessionId, status);
+            }
+        }
+
+    private:
+        Exchange::IContentProtection* _implementation;
+        Core::ProxyType<JSONRPCLink> _secManager;
+        Core::ProxyType<JSONRPCLink> _watermark;
+        Storage<Session> _sessionStorage;
+        Storage<Watermark> _watermarkStorage;
+        Storage<Exchange::PalettedImageData> _palettedImageDataStorage;
+        std::list<Exchange::IContentProtection::INotification*> _clients;
+        Core::CriticalSection _clientLock;
+    };
+
+} // namespace Plugin
+} // namespace WPEFramework

--- a/ContentProtection/ContentProtectionPlugin.json
+++ b/ContentProtection/ContentProtectionPlugin.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://raw.githubusercontent.com/rdkcentral/rdkservices/main/Tools/json_generator/schemas/plugin.schema.json",
+  "info": {
+    "title": "ContentProtection Plugin",
+    "callsign": "org.rdk.ContentProtection",
+    "locator": "libWPEFrameworkContentProtection.so",
+    "status": "production",
+    "description": "The `ContentProtection` plugin proxies content security capabilities of the existing DRM plugins"
+  }
+}

--- a/ContentProtection/Module.cpp
+++ b/ContentProtection/Module.cpp
@@ -1,0 +1,22 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Module.h"
+
+MODULE_NAME_DECLARATION(BUILD_REFERENCE)

--- a/ContentProtection/Module.h
+++ b/ContentProtection/Module.h
@@ -1,0 +1,33 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#ifndef MODULE_NAME
+#define MODULE_NAME Plugin_ContentProtection
+#endif
+
+#include <plugins/plugins.h>
+#if (((THUNDER_VERSION_MAJOR >= 4) && (THUNDER_VERSION_MINOR == 4)) || ((THUNDER_VERSION >= 4) && !defined(THUNDER_VERSION_MINOR)))
+#include <definitions/definitions.h>
+#else
+#include <interfaces/definitions.h>
+#endif
+
+#undef EXTERNAL
+#define EXTERNAL


### PR DESCRIPTION
Reason for change: new service to proxy content security capabilities of the existing DRM plugins like SecManager & Watermark and provide a single unified interface.
Test Procedure: None
Risks: None
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>