### PR TITLE
DELIA-66306 : Fix idle connection

### DIFF
--- a/.github/workflows/BuildThunder.sh
+++ b/.github/workflows/BuildThunder.sh
@@ -8,9 +8,9 @@ set -e
 ############################
 # 1. Install Dependencies
 
-sudo apt install -y build-essential cmake ninja-build libusb-1.0-0-dev zlib1g-dev libssl-dev
+sudo apt install -y build-essential pkg-config cmake ninja-build libusb-1.0-0-dev zlib1g-dev libssl-dev
 
-pip install jsonref
+PIP_BREAK_SYSTEM_PACKAGES=1 pip install jsonref
 
 ############################
 # 2. Build Thunder Tools

--- a/CloudStore/CMakeLists.txt
+++ b/CloudStore/CMakeLists.txt
@@ -78,7 +78,13 @@ add_custom_target(protoc
 )
 add_dependencies(${PLUGIN_IMPLEMENTATION} protoc)
 
-target_link_libraries(${PLUGIN_IMPLEMENTATION} PRIVATE grpc++)
+find_package(gRPC CONFIG)
+if (gRPC_FOUND)
+    set(GRPC_LIBS gRPC::grpc++)
+else ()
+    set(GRPC_LIBS grpc++)
+endif ()
+target_link_libraries(${PLUGIN_IMPLEMENTATION} PRIVATE ${GRPC_LIBS})
 find_program(GRPC_CPP_PLUGIN grpc_cpp_plugin REQUIRED)
 
 add_custom_target(protoc-gen-grpc

--- a/CloudStore/Module.h
+++ b/CloudStore/Module.h
@@ -30,14 +30,13 @@
 #endif
 
 #define URI_ENV "CLOUDSTORE_URI"
+#define TOKEN_ENV "CLOUDSTORE_TOKEN"
 #define IARM_INIT_NAME "Thunder_Plugins"
 #define URI_RFC "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.CloudStore.Uri"
 #define PARTNER_ID_FILENAME "/opt/www/authService/partnerId3.dat"
 #define ACCOUNT_ID_FILENAME "/opt/www/authService/said.dat"
 #define DEVICE_ID_FILENAME "/opt/www/authService/xdeviceid.dat"
-#define SECURITY_AGENT_FILENAME "/tmp/SecurityAgent/token"
 #define IARM_TIMEOUT 1000
-#define COM_RPC_TIMEOUT 1000
 #define JSON_RPC_TIMEOUT 2000
 #define GRPC_TIMEOUT 3000
 

--- a/CloudStore/grpc/Store2.h
+++ b/CloudStore/grpc/Store2.h
@@ -69,12 +69,13 @@ namespace Plugin {
 
         public:
             Store2()
-                : Store2(getenv(URI_ENV))
+                : Store2(getenv(URI_ENV), getenv(TOKEN_ENV))
             {
             }
-            Store2(const string& uri)
+            Store2(const string& uri, const string& token)
                 : IStore2()
                 , _uri(uri)
+                , _token(token)
                 , _authorization((_uri.find("localhost") == string::npos) && (_uri.find("0.0.0.0") == string::npos))
             {
                 Open();
@@ -84,6 +85,8 @@ namespace Plugin {
         private:
             void Open()
             {
+                grpc::ChannelArguments args;
+                args.SetInt(GRPC_ARG_CLIENT_IDLE_TIMEOUT_MS, 30 * 1000 /*30 sec*/);
                 std::shared_ptr<grpc::ChannelCredentials> creds;
                 if (_authorization) {
                     creds = grpc::SslCredentials(grpc::SslCredentialsOptions());
@@ -91,7 +94,7 @@ namespace Plugin {
                     creds = grpc::InsecureChannelCredentials();
                 }
                 _stub = ::distp::gateway::secure_storage::v1::SecureStorageService::NewStub(
-                    grpc::CreateChannel(_uri, creds));
+                    grpc::CreateCustomChannel(_uri, creds, args));
             }
 
         private:
@@ -115,39 +118,6 @@ namespace Plugin {
 #endif
                 return true;
             }
-            string GetSecurityToken() const
-            {
-                // Get actual token, as it may change at any time...
-                string result;
-
-                const char* endpoint = ::getenv(_T("SECURITYAGENT_PATH"));
-                if (endpoint == nullptr) {
-                    endpoint = SECURITY_AGENT_FILENAME;
-                }
-                auto engine = Core::ProxyType<RPC::InvokeServerType<1, 0, 4>>::Create();
-                auto client = Core::ProxyType<RPC::CommunicatorClient>::Create(
-                    Core::NodeId(endpoint),
-                    Core::ProxyType<Core::IIPCServer>(engine));
-
-                auto interface = client->Open<PluginHost::IAuthenticate>(
-                    _T("SecurityAgent"),
-                    static_cast<uint32_t>(~0),
-                    COM_RPC_TIMEOUT); // Timeout
-                if (interface != nullptr) {
-                    string payload = _T("http://localhost");
-                    // If main process is out of threads, this can time out, and IPC will mess up...
-                    auto error = interface->CreateToken(
-                        static_cast<uint16_t>(payload.length()),
-                        reinterpret_cast<const uint8_t*>(payload.c_str()),
-                        result);
-                    if (error != Core::ERROR_NONE) {
-                        TRACE(Trace::Error, (_T("security token error %d"), error));
-                    }
-                    interface->Release();
-                }
-
-                return result;
-            }
             string GetToken() const
             {
                 // Get actual token, as it may change at any time...
@@ -155,7 +125,7 @@ namespace Plugin {
 
                 Core::SystemInfo::SetEnvironment(_T("THUNDER_ACCESS"), (_T("127.0.0.1:9998")));
                 auto link = Core::ProxyType<JSONRPC::LinkType<Core::JSON::IElement>>::Create(
-                    _T("org.rdk.AuthService"), _T(""), false, "token=" + GetSecurityToken());
+                    _T("org.rdk.AuthService"), _T(""), false, "token=" + _token);
 
                 JsonObject json;
                 auto status = link->Invoke<JsonObject, JsonObject>(
@@ -430,6 +400,7 @@ namespace Plugin {
 
         private:
             const string _uri;
+            const string _token;
             const bool _authorization;
             std::unique_ptr<::distp::gateway::secure_storage::v1::SecureStorageService::Stub> _stub;
             std::list<INotification*> _clients;

--- a/CloudStore/grpc/l0test/CMakeLists.txt
+++ b/CloudStore/grpc/l0test/CMakeLists.txt
@@ -46,7 +46,13 @@ add_custom_target(protoc
 )
 add_dependencies(${PROJECT_NAME} protoc)
 
-target_link_libraries(${PROJECT_NAME} PRIVATE grpc++)
+find_package(gRPC CONFIG)
+if (gRPC_FOUND)
+    set(GRPC_LIBS gRPC::grpc++)
+else ()
+    set(GRPC_LIBS grpc++)
+endif ()
+target_link_libraries(${PROJECT_NAME} PRIVATE ${GRPC_LIBS})
 find_program(GRPC_CPP_PLUGIN grpc_cpp_plugin REQUIRED)
 
 add_custom_target(protoc-gen-grpc

--- a/CloudStore/grpc/l0test/Store2Test.cpp
+++ b/CloudStore/grpc/l0test/Store2Test.cpp
@@ -48,7 +48,7 @@ protected:
         : workerPool(WPEFramework::Core::ProxyType<WorkerPoolImplementation>::Create(
               WPEFramework::Core::Thread::DefaultStackSize()))
         , server(kUri, &service)
-        , store2(WPEFramework::Core::ProxyType<Store2>::Create(kUri))
+        , store2(WPEFramework::Core::ProxyType<Store2>::Create(kUri, ""))
     {
         WPEFramework::Core::IWorkerPool::Assign(&(*workerPool));
     }

--- a/CloudStore/grpc/l2test/CMakeLists.txt
+++ b/CloudStore/grpc/l2test/CMakeLists.txt
@@ -41,7 +41,13 @@ add_custom_target(protoc
 )
 add_dependencies(${PROJECT_NAME} protoc)
 
-target_link_libraries(${PROJECT_NAME} PRIVATE grpc++)
+find_package(gRPC CONFIG)
+if (gRPC_FOUND)
+    set(GRPC_LIBS gRPC::grpc++)
+else ()
+    set(GRPC_LIBS grpc++)
+endif ()
+target_link_libraries(${PROJECT_NAME} PRIVATE ${GRPC_LIBS})
 find_program(GRPC_CPP_PLUGIN grpc_cpp_plugin REQUIRED)
 
 add_custom_target(protoc-gen-grpc

--- a/CloudStore/l0test/ServiceMock.h
+++ b/CloudStore/l0test/ServiceMock.h
@@ -52,7 +52,7 @@ public:
     MOCK_METHOD(void, Register, (IShell::ICOMLink::INotification*), (override));
     MOCK_METHOD(void, Unregister, (const IShell::ICOMLink::INotification*), (override));
     MOCK_METHOD(WPEFramework::RPC::IRemoteConnection*, RemoteConnection, (const uint32_t), (override));
-    MOCK_METHOD(void*, Instantiate, (const WPEFramework::RPC::Object&, const uint32_t, uint32_t&), (override));
+    MOCK_METHOD(void*, Instantiate, (WPEFramework::RPC::Object&, const uint32_t, uint32_t&), (override));
     MOCK_METHOD(WPEFramework::RPC::IStringIterator*, GetLibrarySearchPaths, (const string&), (const, override));
     BEGIN_INTERFACE_MAP(ServiceMock)
     INTERFACE_ENTRY(IShell)


### PR DESCRIPTION
Reason for change: When connection was idle but not
shut down RPC fails with Connection reset by peer.
Set up idle timer.
Log uri, and get security token on startup only.