### PR TITLE
RDK-53379: Deprecate DelayOffset APIs from DisplaySettings Thunder plugin(main branch)

### DIFF
--- a/DisplaySettings/CHANGELOG.md
+++ b/DisplaySettings/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [2.0.0] - 2024-10-15
+### Removed
+- Get and Set Delay Offset support has been removed.
+
 ## [1.4.7] - 2024-08-30
 ### Added
 - Clear the SAD upon receiving the hotplug-out event.

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -83,9 +83,9 @@ using namespace std;
 #define ZOOM_SETTINGS_FILE      "/opt/persistent/rdkservices/zoomSettings.json"
 #define ZOOM_SETTINGS_DIRECTORY "/opt/persistent/rdkservices"
 
-#define API_VERSION_NUMBER_MAJOR 1
-#define API_VERSION_NUMBER_MINOR 4
-#define API_VERSION_NUMBER_PATCH 7
+#define API_VERSION_NUMBER_MAJOR 2
+#define API_VERSION_NUMBER_MINOR 0
+#define API_VERSION_NUMBER_PATCH 0
 
 static bool isCecEnabled = false;
 static bool isResCacheUpdated = false;
@@ -345,8 +345,6 @@ namespace WPEFramework {
 
             registerMethodLockedApi("getAudioDelay", &DisplaySettings::getAudioDelay, this);
             registerMethodLockedApi("setAudioDelay", &DisplaySettings::setAudioDelay, this);
-            registerMethodLockedApi("getAudioDelayOffset", &DisplaySettings::getAudioDelayOffset, this);
-            registerMethodLockedApi("setAudioDelayOffset", &DisplaySettings::setAudioDelayOffset, this);
             registerMethodLockedApi("getSinkAtmosCapability", &DisplaySettings::getSinkAtmosCapability, this);
             registerMethodLockedApi("setAudioAtmosOutputMode", &DisplaySettings::setAudioAtmosOutputMode, this);
             registerMethodLockedApi("setForceHDRMode", &DisplaySettings::setForceHDRMode, this);
@@ -3923,127 +3921,6 @@ namespace WPEFramework {
             catch (const device::Exception& err)
             {
                 LOG_DEVICE_EXCEPTION2(audioPort, sAudioDelayMs);
-                success = false;
-            }
-            returnResponse(success);
-        }
-
-        uint32_t DisplaySettings::getAudioDelayOffset (const JsonObject& parameters, JsonObject& response) 
-        {   //sample servicemanager response:
-            LOGINFOMETHOD();
-
-            bool success = true;
-            string audioPort = parameters["audioPort"].String();//empty value will browse all ports
-
-            if (!checkPortName(audioPort))
-                audioPort = "HDMI0";
-
-            uint32_t audioDelayOffsetMs = 0;
-            try
-            {
-                /* Return the sound mode of the audio ouput connected to the specified audioPort */
-                /* Check if HDMI is connected - Return (default) Stereo Mode if not connected */
-                if (audioPort.empty())
-                {
-                    std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
-                    if (isDisplayConnected(strVideoPort))
-                    {
-                        audioPort = "HDMI0";
-                    }
-                    else
-                    {
-                        /*  * If HDMI is not connected
-                            * Get the SPDIF if it is supported by platform
-                            * If Platform does not have connected ports. Default to HDMI.
-                        */
-                        audioPort = "HDMI0";
-                        device::List<device::VideoOutputPort> vPorts = device::Host::getInstance().getVideoOutputPorts();
-                        for (size_t i = 0; i < vPorts.size(); i++)
-                        {
-                            device::VideoOutputPort &vPort = vPorts.at(i);
-                            if (isDisplayConnected(vPort.getName()))
-                            {
-                                audioPort = "SPDIF0";
-                                break;
-                            }
-                        }
-                    }
-                }
-
-                device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
-                aPort.getAudioDelayOffset (audioDelayOffsetMs);
-				response["audioDelayOffset"] = std::to_string(audioDelayOffsetMs);
-            }
-            catch (const device::Exception& err)
-            {
-                LOG_DEVICE_EXCEPTION1(audioPort);
-                success = false;
-            }
-
-            returnResponse(success);
-        }
-
-        uint32_t DisplaySettings::setAudioDelayOffset (const JsonObject& parameters, JsonObject& response)
-        {   //sample servicemanager response:
-            LOGINFOMETHOD();
-
-            returnIfParamNotFound(parameters, "audioDelayOffset");
-
-            string sAudioDelayOffsetMs = parameters["audioDelayOffset"].String();
-            int audioDelayOffsetMs = 0;
-            try
-            {
-                audioDelayOffsetMs = stoi(sAudioDelayOffsetMs);
-            }
-            catch (const std::exception &err)
-            {
-                LOGERR("Failed to parse audioDelayOffset '%s'", sAudioDelayOffsetMs.c_str());
-                returnResponse(false);
-            }
-
-            bool success = true;
-            string audioPort = parameters["audioPort"].String();//empty value will browse all ports
-
-            if (!checkPortName(audioPort))
-                audioPort = "HDMI0";
-
-            try
-            {
-                /* Return the sound mode of the audio ouput connected to the specified audioPort */
-                /* Check if HDMI is connected - Return (default) Stereo Mode if not connected */
-                if (audioPort.empty())
-                {
-                    std::string strVideoPort = device::Host::getInstance().getDefaultVideoPortName();
-                    if (isDisplayConnected(strVideoPort))
-                    {
-                        audioPort = "HDMI0";
-                    }
-                    else
-                    {
-                        /*  * If HDMI is not connected
-                            * Get the SPDIF if it is supported by platform
-                            * If Platform does not have connected ports. Default to HDMI.
-                        */
-                        audioPort = "HDMI0";
-                        device::List<device::VideoOutputPort> vPorts = device::Host::getInstance().getVideoOutputPorts();
-                        for (size_t i = 0; i < vPorts.size(); i++)
-                        {
-                            device::VideoOutputPort &vPort = vPorts.at(i);
-                            if (isDisplayConnected(vPort.getName()))
-                            {
-                                audioPort = "SPDIF0";
-                                break;
-                            }
-                        }
-                    }
-                }
-
-                device::AudioOutputPort aPort = device::Host::getInstance().getAudioOutputPort(audioPort);
-                aPort.setAudioDelayOffset (audioDelayOffsetMs);
-            }
-            catch (const device::Exception& err)
-            {
-                LOG_DEVICE_EXCEPTION2(audioPort, sAudioDelayOffsetMs);
                 success = false;
             }
             returnResponse(success);

--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -100,8 +100,6 @@ namespace WPEFramework {
 	    uint32_t getSupportedMS12AudioProfiles(const JsonObject& parameters, JsonObject& response);
             uint32_t getAudioDelay(const JsonObject& parameters, JsonObject& response);
             uint32_t setAudioDelay(const JsonObject& parameters, JsonObject& response);
-            uint32_t getAudioDelayOffset(const JsonObject& parameters, JsonObject& response);
-            uint32_t setAudioDelayOffset(const JsonObject& parameters, JsonObject& response);
             uint32_t getSinkAtmosCapability(const JsonObject& parameters, JsonObject& response);
             uint32_t setAudioAtmosOutputMode(const JsonObject& parameters, JsonObject& response);
             uint32_t getTVHDRCapabilities(const JsonObject& parameters, JsonObject& response);

--- a/DisplaySettings/DisplaySettings.json
+++ b/DisplaySettings/DisplaySettings.json
@@ -15,11 +15,6 @@
             "type": "string",
             "example": "0"
         },
-        "audioDelayOffset": {
-            "summary": "Delay offset (in ms) on the selected audio port",
-            "type": "string",
-            "example": "0"
-        },
         "supportedAudioFormat": {
             "summary": "A list of supported audio formats",
             "type": "array",
@@ -294,35 +289,6 @@
                 },
                 "required": [
                     "audioDelay",
-                    "success"
-                ]
-            }
-        },
-        "getAudioDelayOffset":{
-            "summary": "Returns the audio delay offset (in ms) on the selected audio port. If the `audioPort` argument is not specified, it will browse all ports (checking HDMI0 first). If there is no display connected, then it defaults to `HDMI0`.",
-            "params": {
-                "type":"object",
-                "properties": {
-                    "audioPort": {
-                        "$ref": "#/definitions/audioPort0"
-                    }
-                },
-                "required": [
-                    "audioPort"
-                ]
-            },
-            "result": {
-                "type":"object",
-                "properties": {
-                    "audioDelayOffset": {
-                        "$ref": "#/definitions/audioDelayOffset"
-                    },
-                    "success": {
-                        "$ref": "#/common/success"
-                    }
-                },
-                "required": [
-                    "audioDelayOffset",
                     "success"
                 ]
             }
@@ -1968,28 +1934,7 @@
                 "$ref": "#/common/result"
             }
         },
-        "setAudioDelayOffset":{
-            "summary": "Sets the audio delay offset (in ms) on the selected audio port. If the `audioPort` argument is not specified, it will browse all ports (checking HDMI0 first). If there is no display connected, then it defaults to `HDMI0`.",
-            "params": {
-                "type":"object",
-                "properties": {
-                    "audioPort": {
-                        "$ref": "#/definitions/audioPort0"
-                    },
-                    "audioDelayOffset": {
-                        "$ref": "#/definitions/audioDelayOffset"
-                    }
-                },
-                "required": [
-                    "audioPort",
-                    "audioDelayOffset"
-                ]
-            },
-            "result": {
-                "$ref": "#/common/result"
-            }
-        },
-        "setBassEnhancer":{
+	 "setBassEnhancer":{
             "summary": "Sets the Bass Enhancer. Bass Enhancer provides the consumer a single control to apply a fixed bass boost to correct for a lack of bass reproduction in the playback system.",
             "params": {
                 "type":"object",

--- a/DisplaySettings/DisplaySettings.json
+++ b/DisplaySettings/DisplaySettings.json
@@ -1934,7 +1934,7 @@
                 "$ref": "#/common/result"
             }
         },
-	 "setBassEnhancer":{
+	"setBassEnhancer":{
             "summary": "Sets the Bass Enhancer. Bass Enhancer provides the consumer a single control to apply a fixed bass boost to correct for a lack of bass reproduction in the playback system.",
             "params": {
                 "type":"object",

--- a/docs/api/DisplaySettingsPlugin.md
+++ b/docs/api/DisplaySettingsPlugin.md
@@ -50,7 +50,6 @@ DisplaySettings interface methods:
 | [enableSurroundDecoder](#enableSurroundDecoder) | Enables or disables Surround Decoder capability |
 | [getActiveInput](#getActiveInput) | Returns `true` if the STB HDMI output is currently connected to the active input of the sink device (determined by `RxSense`) |
 | [getAudioDelay](#getAudioDelay) | Returns the audio delay (in ms) on the selected audio port |
-| [getAudioDelayOffset](#getAudioDelayOffset) | Returns the audio delay offset (in ms) on the selected audio port |
 | [getAudioFormat](#getAudioFormat) | Returns the currently set audio format |
 | [getBassEnhancer](#getBassEnhancer) | Returns the current status of the Bass Enhancer settings |
 | [getConnectedAudioPorts](#getConnectedAudioPorts) | Returns connected audio output ports (a subset of the ports supported on the device) |
@@ -108,7 +107,6 @@ DisplaySettings interface methods:
 | [resetVolumeLeveller](#resetVolumeLeveller) | Resets the Volume Leveller level to default volume value |
 | [setAudioAtmosOutputMode](#setAudioAtmosOutputMode) | Sets ATMOS audio output mode (on HDMI0) |
 | [setAudioDelay](#setAudioDelay) | Sets the audio delay (in ms) on the selected audio port |
-| [setAudioDelayOffset](#setAudioDelayOffset) | Sets the audio delay offset (in ms) on the selected audio port |
 | [setBassEnhancer](#setBassEnhancer) | Sets the Bass Enhancer |
 | [setCurrentResolution](#setCurrentResolution) | Sets the current resolution |
 | [setDialogEnhancement](#setDialogEnhancement) | Sets the Dialog Enhancer level |
@@ -287,58 +285,6 @@ No Events
     "id": 42,
     "result": {
         "audioDelay": "0",
-        "success": true
-    }
-}
-```
-
-<a name="getAudioDelayOffset"></a>
-## *getAudioDelayOffset*
-
-Returns the audio delay offset (in ms) on the selected audio port. If the `audioPort` argument is not specified, it will browse all ports (checking HDMI0 first). If there is no display connected, then it defaults to `HDMI0`.
-
-### Events
-
-No Events
-
-### Parameters
-
-| Name | Type | Description |
-| :-------- | :-------- | :-------- |
-| params | object |  |
-| params.audioPort | string | Audio port name |
-
-### Result
-
-| Name | Type | Description |
-| :-------- | :-------- | :-------- |
-| result | object |  |
-| result.audioDelayOffset | string | Delay offset (in ms) on the selected audio port |
-| result.success | boolean | Whether the request succeeded |
-
-### Example
-
-#### Request
-
-```json
-{
-    "jsonrpc": "2.0",
-    "id": 42,
-    "method": "org.rdk.DisplaySettings.getAudioDelayOffset",
-    "params": {
-        "audioPort": "HDMI0"
-    }
-}
-```
-
-#### Response
-
-```json
-{
-    "jsonrpc": "2.0",
-    "id": 42,
-    "result": {
-        "audioDelayOffset": "0",
         "success": true
     }
 }
@@ -3277,58 +3223,6 @@ No Events
     "params": {
         "audioPort": "HDMI0",
         "audioDelay": "0"
-    }
-}
-```
-
-#### Response
-
-```json
-{
-    "jsonrpc": "2.0",
-    "id": 42,
-    "result": {
-        "success": true
-    }
-}
-```
-
-<a name="setAudioDelayOffset"></a>
-## *setAudioDelayOffset*
-
-Sets the audio delay offset (in ms) on the selected audio port. If the `audioPort` argument is not specified, it will browse all ports (checking HDMI0 first). If there is no display connected, then it defaults to `HDMI0`.
-
-### Events
-
-No Events
-
-### Parameters
-
-| Name | Type | Description |
-| :-------- | :-------- | :-------- |
-| params | object |  |
-| params.audioPort | string | Audio port name |
-| params.audioDelayOffset | string | Delay offset (in ms) on the selected audio port |
-
-### Result
-
-| Name | Type | Description |
-| :-------- | :-------- | :-------- |
-| result | object |  |
-| result.success | boolean | Whether the request succeeded |
-
-### Example
-
-#### Request
-
-```json
-{
-    "jsonrpc": "2.0",
-    "id": 42,
-    "method": "org.rdk.DisplaySettings.setAudioDelayOffset",
-    "params": {
-        "audioPort": "HDMI0",
-        "audioDelayOffset": "0"
     }
 }
 ```


### PR DESCRIPTION
Get and Set Delay Offset APIs have been removed from DisplaySettings Plugin and Device Settings module