### PR TITLE
DELIA-66510: [WPEFramework] Remove ASSERT from RELEASE build

### DIFF
--- a/RialtoServerManager/RialtoServerManager.cpp
+++ b/RialtoServerManager/RialtoServerManager.cpp
@@ -201,7 +201,7 @@ namespace Plugin {
         _service->Unregister(&_notification);
 
         RPC::IRemoteConnection* connection(_service->RemoteConnection(_connectionId));
-        uint32_t result = _object->Release();
+        VARIABLE_IS_NOT_USED uint32_t result = _object->Release();
         ASSERT(result == Core::ERROR_DESTRUCTION_SUCCEEDED);
 
         if (connection != nullptr) {


### PR DESCRIPTION
Reason for change: resolve the compilation error for RialtoServerManager plugin in Sky builds
Test Procedure: Ensure the Assert Log will not show in wpeframework.log
Risks: Medium
Signed-off-by: Thamim Razith tabbas651@cable.comcast.com