### PR TITLE
RDKDEV-1095 - RDKServices : Wpeframework is restarting when an invalid parameter is passed to the HdmiCecSource plugin API

### DIFF
--- a/HdmiCecSource/HdmiCecSource.cpp
+++ b/HdmiCecSource/HdmiCecSource.cpp
@@ -643,16 +643,21 @@ namespace WPEFramework
        }
 	   uint32_t HdmiCecSource::sendRemoteKeyPressWrapper(const JsonObject& parameters, JsonObject& response)
 		{
-            returnIfParamNotFound(parameters, "logicalAddress");
+            		returnIfParamNotFound(parameters, "logicalAddress");
 			returnIfParamNotFound(parameters, "keyCode");
 			string logicalAddress = parameters["logicalAddress"].String();
 			string keyCode = parameters["keyCode"].String();
 			SendKeyInfo keyInfo;
-			keyInfo.logicalAddr = stoi(logicalAddress);
-			keyInfo.keyCode     = stoi(keyCode);
+			try {
+			   keyInfo.logicalAddr = stoi(logicalAddress);
+			   keyInfo.keyCode     = stoi(keyCode);
+			} catch (const std::invalid_argument& e) {
+			   std::cerr << "Invalid input: " << e.what() << std::endl;
+			   returnResponse(false);
+			}
 			std::unique_lock<std::mutex> lk(m_sendKeyEventMutex);
 			m_SendKeyQueue.push(keyInfo);
-            m_sendKeyEventThreadRun = true;
+            		m_sendKeyEventThreadRun = true;
 			m_sendKeyCV.notify_one();
 			LOGINFO("Post send key press event to queue size:%d \n",(int)m_SendKeyQueue.size());
 			returnResponse(true);


### PR DESCRIPTION
RDKDEV-1095 - RDKServices : Wpeframework is restarting when an invalid parameter is passed to the HdmiCecSource plugin API

Reason for change: For invalid argument of logicaladdress and keycode wpeframework is restarting due to stoi() conversion ,					to avoid that added the proper try catch check

Test Procedure: Build and verify.

Risks: Low

Signed-off-by: Dhivya Priya M <dhivyapriya_murugesan@comcast.com>