### PR TITLE
RDK-52180: Add ParentalControl new properties in Usersetttings.

### DIFF
--- a/.github/workflows/L2-tests-R4-4-1.yml
+++ b/.github/workflows/L2-tests-R4-4-1.yml
@@ -60,6 +60,11 @@ jobs:
             ninja -C build
             sudo ninja -C build install
 
+      - name: Checkout rdkservices
+        uses: actions/checkout@v3
+        with:
+          path: rdkservices
+
       - name: Checkout Thunder
         uses: actions/checkout@v3
         with:
@@ -67,13 +72,19 @@ jobs:
           path: Thunder
           ref: ${{env.THUNDER_REF}}
 
+      - name: Apply patches Thunder
+        run: |
+          cd ${{github.workspace}}/Thunder
+          patch -p1 < ${{github.workspace}}/rdkservices/Tests/L2Tests/patches/Use_Legact_Alt_Based_On_ThunderTools_R4.4.3.patch
+          cd -
+
       - name: Checkout ThunderTools
         if: steps.cache.outputs.cache-hit != 'true'
         uses: actions/checkout@v3
         with:
           repository: rdkcentral/ThunderTools
           path: ThunderTools
-          ref: ${{env.THUNDER_REF}}
+          ref: R4.4.3
 
       - name: Build ThunderTools
         if: steps.cache.outputs.cache-hit != 'true'
@@ -89,11 +100,6 @@ jobs:
           cmake --build build/ThunderTools -j8
           &&
           cmake --install build/ThunderTools
-
-      - name: Checkout rdkservices
-        uses: actions/checkout@v3
-        with:
-          path: rdkservices
 
       - name: Checkout rdkservices
         run: |
@@ -138,6 +144,7 @@ jobs:
               patch -p1 < ${{github.workspace}}/rdkservices/Tests/L2Tests/patches/0007-RDK-IDeviceInfo-Changes.patch
               patch -p1 < ${{github.workspace}}/rdkservices/Tests/L2Tests/patches/0001-RDK-45037-Secure-Storage-Thunder-Plugin.patch
               patch -p1 < ${{github.workspace}}/rdkservices/Tests/L2Tests/patches/RDKV-48604-User-Settings-Thunder-Plugin.patch
+              patch -p1 < ${{github.workspace}}/rdkservices/Tests/L2Tests/patches/Use_Legact_Alt_In_ThunderInterfaces_Based_On_ThunderTools_R4.4.3.patch
               cd ..
 
       - name: Build ThunderInterfaces

--- a/Tests/L2Tests/L2TestsPlugin/tests/UserSettings_L2Test.cpp
+++ b/Tests/L2Tests/L2TestsPlugin/tests/UserSettings_L2Test.cpp
@@ -21,13 +21,20 @@ using ::WPEFramework::Exchange::IStore2;
 using ::WPEFramework::Exchange::IUserSettings;
 
 typedef enum : uint32_t {
-    UserSettings_OnAudioDescriptionChanged = 0x00000001,
-    UserSettings_OnPreferredAudioLanguagesChanged = 0x00000002,
-    UserSettings_OnPresentationLanguageChanged = 0x00000003,
-    UserSettings_OnCaptionsChanged = 0x00000004,
-    UserSettings_OnPreferredCaptionsLanguagesChanged = 0x00000005,
-    UserSettings_OnPreferredClosedCaptionServiceChanged = 0x00000006,
-    UserSettings_OnPrivacyModeChanged = 0x00000007,
+    UserSettings_onAudioDescriptionChanged = 0x00000001,
+    UserSettings_onPreferredAudioLanguagesChanged = 0x00000002,
+    UserSettings_onPresentationLanguageChanged = 0x00000003,
+    UserSettings_onCaptionsChanged = 0x00000004,
+    UserSettings_onPreferredCaptionsLanguagesChanged = 0x00000005,
+    UserSettings_onPreferredClosedCaptionServiceChanged = 0x00000006,
+    UserSettings_onPrivacyModeChanged = 0x00000007,
+    UserSettings_onPinControlChanged = 0x00000008,
+    UserSettings_onViewingRestrictionsChanged = 0x00000009,
+    UserSettings_onViewingRestrictionsWindowChanged = 0x0000000a,
+    UserSettings_onLiveWatershedChanged = 0x0000000b,
+    UserSettings_onPlaybackWatershedChanged = 0x0000000c,
+    UserSettings_onBlockNotRatedContentChanged = 0x0000000d,
+    UserSettings_onPinOnPurchaseChanged = 0x0000000e,
     UserSettings_StateInvalid = 0x00000000
 }UserSettingsL2test_async_events_t;
 
@@ -37,14 +44,20 @@ class AsyncHandlerMock_UserSetting
         AsyncHandlerMock_UserSetting()
         {
         }
-        MOCK_METHOD(void, OnAudioDescriptionChanged, (const bool enabled));
-        MOCK_METHOD(void, OnPreferredAudioLanguagesChanged, (const string preferredLanguages));
-        MOCK_METHOD(void, OnPresentationLanguageChanged, (const string presentationLanguages));
-        MOCK_METHOD(void, OnCaptionsChanged, (bool enabled));
-        MOCK_METHOD(void, OnPreferredCaptionsLanguagesChanged, (const string preferredLanguages));
-        MOCK_METHOD(void, OnPreferredClosedCaptionServiceChanged, (const string service));
-        MOCK_METHOD(void, OnPrivacyModeChanged, (const string privacyMode));
-
+        MOCK_METHOD(void, onAudioDescriptionChanged, (const bool enabled));
+        MOCK_METHOD(void, onPreferredAudioLanguagesChanged, (const string preferredLanguages));
+        MOCK_METHOD(void, onPresentationLanguageChanged, (const string presentationLanguage));
+        MOCK_METHOD(void, onCaptionsChanged, (const bool enabled));
+        MOCK_METHOD(void, onPreferredCaptionsLanguagesChanged, (const string preferredLanguages));
+        MOCK_METHOD(void, onPreferredClosedCaptionServiceChanged, (const string service));
+        MOCK_METHOD(void, onPrivacyModeChanged, (const string privacyMode));
+        MOCK_METHOD(void, onPinControlChanged, (const bool enabled));
+        MOCK_METHOD(void, onViewingRestrictionsChanged, (const string viewingRestrictions));
+        MOCK_METHOD(void, onViewingRestrictionsWindowChanged, (const string viewingRestrictionsWindow));
+        MOCK_METHOD(void, onLiveWatershedChanged, (const bool enabled));
+        MOCK_METHOD(void, onPlaybackWatershedChanged, (const bool enabled));
+        MOCK_METHOD(void, onBlockNotRatedContentChanged, (const bool enabled));
+        MOCK_METHOD(void, onPinOnPurchaseChanged, (const bool enabled));
 };
 
 class NotificationHandler : public Exchange::IUserSettings::INotification {
@@ -74,7 +87,7 @@ class NotificationHandler : public Exchange::IUserSettings::INotification {
 
             TEST_LOG("OnAudioDescriptionChanged received: %s\n", str.c_str());
             /* Notify the requester thread. */
-            m_event_signalled |= UserSettings_OnAudioDescriptionChanged;
+            m_event_signalled |= UserSettings_onAudioDescriptionChanged;
             m_condition_variable.notify_one();
         }
 
@@ -85,19 +98,19 @@ class NotificationHandler : public Exchange::IUserSettings::INotification {
 
             TEST_LOG("OnPreferredAudioLanguagesChanged received: %s\n", preferredLanguages.c_str());
             /* Notify the requester thread. */
-            m_event_signalled |= UserSettings_OnPreferredAudioLanguagesChanged;
+            m_event_signalled |= UserSettings_onPreferredAudioLanguagesChanged;
             m_condition_variable.notify_one();
 
         }
 
-        void OnPresentationLanguageChanged(const string& presentationLanguages) override
+        void OnPresentationLanguageChanged(const string& presentationLanguage) override
         {
             TEST_LOG("OnPresentationLanguageChanged event triggered ***\n");
             std::unique_lock<std::mutex> lock(m_mutex);
 
-            TEST_LOG("OnPresentationLanguageChanged received: %s\n", presentationLanguages.c_str());
+            TEST_LOG("OnPresentationLanguageChanged received: %s\n", presentationLanguage.c_str());
             /* Notify the requester thread. */
-            m_event_signalled |= UserSettings_OnPresentationLanguageChanged;
+            m_event_signalled |= UserSettings_onPresentationLanguageChanged;
             m_condition_variable.notify_one();
 
         }
@@ -110,7 +123,7 @@ class NotificationHandler : public Exchange::IUserSettings::INotification {
 
             TEST_LOG("OnCaptionsChanged received: %s\n", str.c_str());
             /* Notify the requester thread. */
-            m_event_signalled |= UserSettings_OnCaptionsChanged;
+            m_event_signalled |= UserSettings_onCaptionsChanged;
             m_condition_variable.notify_one();
 
         }
@@ -122,7 +135,7 @@ class NotificationHandler : public Exchange::IUserSettings::INotification {
 
             TEST_LOG("OnPreferredAudioLanguagesChanged received: %s\n", preferredLanguages.c_str());
             /* Notify the requester thread. */
-            m_event_signalled |= UserSettings_OnPreferredCaptionsLanguagesChanged;
+            m_event_signalled |= UserSettings_onPreferredCaptionsLanguagesChanged;
             m_condition_variable.notify_one();
 
         }
@@ -134,9 +147,8 @@ class NotificationHandler : public Exchange::IUserSettings::INotification {
 
             TEST_LOG("OnPreferredClosedCaptionServiceChanged received: %s\n", service.c_str());
             /* Notify the requester thread. */
-            m_event_signalled |= UserSettings_OnPreferredClosedCaptionServiceChanged;
+            m_event_signalled |= UserSettings_onPreferredClosedCaptionServiceChanged;
             m_condition_variable.notify_one();
-
         }
 
         void OnPrivacyModeChanged(const string& privacyMode) override
@@ -146,9 +158,92 @@ class NotificationHandler : public Exchange::IUserSettings::INotification {
 
             TEST_LOG("OnPrivacyModeChanged received: %s\n", privacyMode.c_str());
             /* Notify the requester thread. */
-            m_event_signalled |= UserSettings_OnPrivacyModeChanged;
+            m_event_signalled |= UserSettings_onPrivacyModeChanged;
+            m_condition_variable.notify_one();
+        }
+
+        void OnPinControlChanged(const bool enabled) override
+        {
+            TEST_LOG("OnPinControlChanged event triggered ***\n");
+            std::unique_lock<std::mutex> lock(m_mutex);
+            std::string str = enabled ? "true" : "false";
+
+            TEST_LOG("OnPinControlChanged received: %s\n", str.c_str());
+            /* Notify the requester thread. */
+            m_event_signalled |= UserSettings_onPinControlChanged;
+            m_condition_variable.notify_one();
+        }
+
+        void OnViewingRestrictionsChanged(const string& viewingRestrictions) override
+        {
+            TEST_LOG("OnViewingRestrictionsChanged event triggered ***\n");
+            std::unique_lock<std::mutex> lock(m_mutex);
+
+            TEST_LOG("OnViewingRestrictionsChanged received: %s\n", viewingRestrictions.c_str());
+            /* Notify the requester thread. */
+            m_event_signalled |= UserSettings_onViewingRestrictionsChanged;
             m_condition_variable.notify_one();
 
+        }
+
+        void OnViewingRestrictionsWindowChanged(const string& viewingRestrictionsWindow) override
+        {
+            TEST_LOG("OnViewingRestrictionsWindowChanged event triggered ***\n");
+            std::unique_lock<std::mutex> lock(m_mutex);
+
+            TEST_LOG("OnViewingRestrictionsWindowChanged received: %s\n", viewingRestrictionsWindow.c_str());
+            /* Notify the requester thread. */
+            m_event_signalled |= UserSettings_onViewingRestrictionsWindowChanged;
+            m_condition_variable.notify_one();
+
+        }
+
+        void OnLiveWatershedChanged(const bool enabled) override
+        {
+            TEST_LOG("OnLiveWatershedChanged event triggered ***\n");
+            std::unique_lock<std::mutex> lock(m_mutex);
+            std::string str = enabled ? "true" : "false";
+
+            TEST_LOG("OnLiveWatershedChanged received: %s\n", str.c_str());
+            /* Notify the requester thread. */
+            m_event_signalled |= UserSettings_onLiveWatershedChanged;
+            m_condition_variable.notify_one();
+        }
+
+        void OnPlaybackWatershedChanged(const bool enabled) override
+        {
+            TEST_LOG("OnPlaybackWatershedChanged event triggered ***\n");
+            std::unique_lock<std::mutex> lock(m_mutex);
+            std::string str = enabled ? "true" : "false";
+
+            TEST_LOG("OnPlaybackWatershedChanged received: %s\n", str.c_str());
+            /* Notify the requester thread. */
+            m_event_signalled |= UserSettings_onPlaybackWatershedChanged;
+            m_condition_variable.notify_one();
+        }
+
+        void OnBlockNotRatedContentChanged(const bool enabled) override
+        {
+            TEST_LOG("OnBlockNotRatedContentChanged event triggered ***\n");
+            std::unique_lock<std::mutex> lock(m_mutex);
+            std::string str = enabled ? "true" : "false";
+
+            TEST_LOG("OnBlockNotRatedContentChanged received: %s\n", str.c_str());
+            /* Notify the requester thread. */
+            m_event_signalled |= UserSettings_onBlockNotRatedContentChanged;
+            m_condition_variable.notify_one();
+        }
+
+        void OnPinOnPurchaseChanged(const bool enabled) override
+        {
+            TEST_LOG("OnPinOnPurchaseChanged event triggered ***\n");
+            std::unique_lock<std::mutex> lock(m_mutex);
+            std::string str = enabled ? "true" : "false";
+
+            TEST_LOG("OnPinOnPurchaseChanged received: %s\n", str.c_str());
+            /* Notify the requester thread. */
+            m_event_signalled |= UserSettings_onPinOnPurchaseChanged;
+            m_condition_variable.notify_one();
         }
 
         uint32_t WaitForRequestStatus(uint32_t timeout_ms, UserSettingsL2test_async_events_t expected_status)
@@ -179,12 +274,19 @@ protected:
     public:
     UserSettingTest();
 
-      void OnAudioDescriptionChanged(const bool enabled);
-      void OnPreferredAudioLanguagesChanged(const string preferredLanguages);
-      void OnPresentationLanguageChanged(const string presentationLanguages);
-      void OnCaptionsChanged(bool enabled);
-      void OnPreferredCaptionsLanguagesChanged(const string preferredLanguages);
-      void OnPreferredClosedCaptionServiceChanged(const string service);
+      void onAudioDescriptionChanged(const bool enabled);
+      void onPreferredAudioLanguagesChanged(const string preferredLanguages);
+      void onPresentationLanguageChanged(const string presentationLanguage);
+      void onCaptionsChanged(bool enabled);
+      void onPreferredCaptionsLanguagesChanged(const string preferredLanguages);
+      void onPreferredClosedCaptionServiceChanged(const string service);
+      void onPinControlChanged(const bool enabled);
+      void onViewingRestrictionsChanged(const string viewingRestrictions);
+      void onViewingRestrictionsWindowChanged(const string viewingRestrictionsWindow);
+      void onLiveWatershedChanged(const bool enabled);
+      void onPlaybackWatershedChanged(const bool enabled);
+      void onBlockNotRatedContentChanged(const bool enabled);
+      void onPinOnPurchaseChanged(const bool enabled);
 
       uint32_t WaitForRequestStatus(uint32_t timeout_ms,UserSettingsL2test_async_events_t expected_status);
       uint32_t CreateUserSettingInterfaceObjectUsingComRPCConnection();
@@ -228,11 +330,26 @@ UserSettingTest::~UserSettingTest()
     uint32_t status = Core::ERROR_GENERAL;
 
     ON_CALL(*p_rBusApiImplMock, rbus_close(::testing::_ ))
-        .WillByDefault(
-           ::testing::Return(RBUS_ERROR_SUCCESS));
+    .WillByDefault(
+    ::testing::Return(RBUS_ERROR_SUCCESS));
 
     status = DeactivateService("org.rdk.UserSettings");
     EXPECT_EQ(Core::ERROR_NONE, status);
+
+    status = DeactivateService("org.rdk.PersistentStore");
+    EXPECT_EQ(Core::ERROR_NONE, status);
+
+    sleep(5);
+    int file_status = remove("/tmp/secure/persistent/rdkservicestore");
+    // Check if the file has been successfully removed
+    if (file_status != 0)
+    {
+        TEST_LOG("Error deleting file[/tmp/secure/persistent/rdkservicestore]");
+    }
+    else
+    {
+        TEST_LOG("File[/tmp/secure/persistent/rdkservicestore] successfully deleted");
+    }
 }
 
 uint32_t UserSettingTest::WaitForRequestStatus(uint32_t timeout_ms, UserSettingsL2test_async_events_t expected_status)
@@ -254,6 +371,7 @@ uint32_t UserSettingTest::WaitForRequestStatus(uint32_t timeout_ms, UserSettings
     signalled = m_event_signalled;
     return signalled;
 }
+
 uint32_t UserSettingTest::CreateUserSettingInterfaceObjectUsingComRPCConnection()
 {
     uint32_t return_value =  Core::ERROR_GENERAL;
@@ -284,7 +402,7 @@ uint32_t UserSettingTest::CreateUserSettingInterfaceObjectUsingComRPCConnection(
     return return_value;
 }
 
-void UserSettingTest::OnAudioDescriptionChanged(const bool enabled)
+void UserSettingTest::onAudioDescriptionChanged(const bool enabled)
 {
     TEST_LOG("OnAudioDescriptionChanged event triggered ***\n");
     std::unique_lock<std::mutex> lock(m_mutex);
@@ -293,11 +411,11 @@ void UserSettingTest::OnAudioDescriptionChanged(const bool enabled)
     TEST_LOG("OnAudioDescriptionChanged received: %s\n", str.c_str());
 
     /* Notify the requester thread. */
-    m_event_signalled |= UserSettings_OnAudioDescriptionChanged;
+    m_event_signalled |= UserSettings_onAudioDescriptionChanged;
     m_condition_variable.notify_one();
 }
 
-void UserSettingTest::OnPreferredAudioLanguagesChanged(const string preferredLanguages)
+void UserSettingTest::onPreferredAudioLanguagesChanged(const string preferredLanguages)
 {
     TEST_LOG("OnPreferredAudioLanguagesChanged event triggered ***\n");
     std::unique_lock<std::mutex> lock(m_mutex);
@@ -305,23 +423,23 @@ void UserSettingTest::OnPreferredAudioLanguagesChanged(const string preferredLan
     TEST_LOG("OnPreferredAudioLanguagesChanged received: %s\n", preferredLanguages.c_str());
 
     /* Notify the requester thread. */
-    m_event_signalled |= UserSettings_OnPreferredAudioLanguagesChanged;
+    m_event_signalled |= UserSettings_onPreferredAudioLanguagesChanged;
     m_condition_variable.notify_one();
 }
 
-void UserSettingTest::OnPresentationLanguageChanged(const string presentationLanguages)
+void UserSettingTest::onPresentationLanguageChanged(const string presentationLanguage)
 {
     TEST_LOG("OnPresentationLanguageChanged event triggered ***\n");
     std::unique_lock<std::mutex> lock(m_mutex);
 
-    TEST_LOG("OnPresentationLanguageChanged received: %s\n", presentationLanguages.c_str());
+    TEST_LOG("OnPresentationLanguageChanged received: %s\n", presentationLanguage.c_str());
 
     /* Notify the requester thread. */
-    m_event_signalled |= UserSettings_OnPresentationLanguageChanged;
+    m_event_signalled |= UserSettings_onPresentationLanguageChanged;
     m_condition_variable.notify_one();
 }
 
-void UserSettingTest::OnCaptionsChanged(bool enabled)
+void UserSettingTest::onCaptionsChanged(bool enabled)
 {
     TEST_LOG("OnCaptionsChanged event triggered ***\n");
     std::unique_lock<std::mutex> lock(m_mutex);
@@ -330,11 +448,11 @@ void UserSettingTest::OnCaptionsChanged(bool enabled)
     TEST_LOG("OnCaptionsChanged received: %s\n", str.c_str());
 
     /* Notify the requester thread. */
-    m_event_signalled |= UserSettings_OnCaptionsChanged;
+    m_event_signalled |= UserSettings_onCaptionsChanged;
     m_condition_variable.notify_one();
 }
 
-void UserSettingTest::OnPreferredCaptionsLanguagesChanged(const string preferredLanguages)
+void UserSettingTest::onPreferredCaptionsLanguagesChanged(const string preferredLanguages)
 {
     TEST_LOG("OnPreferredCaptionsLanguagesChanged event triggered ***\n");
     std::unique_lock<std::mutex> lock(m_mutex);
@@ -342,11 +460,11 @@ void UserSettingTest::OnPreferredCaptionsLanguagesChanged(const string preferred
     TEST_LOG("OnPreferredAudioLanguagesChanged received: %s\n", preferredLanguages.c_str());
 
     /* Notify the requester thread. */
-    m_event_signalled |= UserSettings_OnPreferredCaptionsLanguagesChanged;
+    m_event_signalled |= UserSettings_onPreferredCaptionsLanguagesChanged;
     m_condition_variable.notify_one();
 }
 
-void UserSettingTest::OnPreferredClosedCaptionServiceChanged(const string service)
+void UserSettingTest::onPreferredClosedCaptionServiceChanged(const string service)
 {
     TEST_LOG("OnPreferredClosedCaptionServiceChanged event triggered ***\n");
     std::unique_lock<std::mutex> lock(m_mutex);
@@ -354,7 +472,91 @@ void UserSettingTest::OnPreferredClosedCaptionServiceChanged(const string servic
     TEST_LOG("OnPreferredClosedCaptionServiceChanged received: %s\n", service.c_str());
 
     /* Notify the requester thread. */
-    m_event_signalled |= UserSettings_OnPreferredClosedCaptionServiceChanged;
+    m_event_signalled |= UserSettings_onPreferredClosedCaptionServiceChanged;
+    m_condition_variable.notify_one();
+}
+
+void UserSettingTest::onPinControlChanged(bool enabled)
+{
+    TEST_LOG("OnPinControlChanged event triggered ***\n");
+    std::unique_lock<std::mutex> lock(m_mutex);
+    std::string str = enabled ? "true" : "false";
+
+    TEST_LOG("OnPinControlChanged received: %s\n", str.c_str());
+    /* Notify the requester thread. */
+    m_event_signalled |= UserSettings_onPinControlChanged;
+    m_condition_variable.notify_one();
+}
+
+void UserSettingTest::onViewingRestrictionsChanged(const string viewingRestrictions)
+{
+    TEST_LOG("OnViewingRestrictionsChanged event triggered ***\n");
+    std::unique_lock<std::mutex> lock(m_mutex);
+
+    TEST_LOG("OnViewingRestrictionsChanged received: %s\n", viewingRestrictions.c_str());
+    /* Notify the requester thread. */
+    m_event_signalled |= UserSettings_onViewingRestrictionsChanged;
+    m_condition_variable.notify_one();
+
+}
+
+void UserSettingTest::onViewingRestrictionsWindowChanged(const string viewingRestrictionsWindow)
+{
+    TEST_LOG("OnViewingRestrictionsWindowChanged event triggered ***\n");
+    std::unique_lock<std::mutex> lock(m_mutex);
+
+    TEST_LOG("OnViewingRestrictionsWindowChanged received: %s\n", viewingRestrictionsWindow.c_str());
+    /* Notify the requester thread. */
+    m_event_signalled |= UserSettings_onViewingRestrictionsWindowChanged;
+    m_condition_variable.notify_one();
+
+}
+
+void UserSettingTest::onLiveWatershedChanged(const bool enabled)
+{
+    TEST_LOG("OnLiveWatershedChanged event triggered ***\n");
+    std::unique_lock<std::mutex> lock(m_mutex);
+    std::string str = enabled ? "true" : "false";
+
+    TEST_LOG("OnLiveWatershedChanged received: %s\n", str.c_str());
+    /* Notify the requester thread. */
+    m_event_signalled |= UserSettings_onLiveWatershedChanged;
+    m_condition_variable.notify_one();
+}
+
+void UserSettingTest::onPlaybackWatershedChanged(const bool enabled)
+{
+    TEST_LOG("OnPlaybackWatershedChanged event triggered ***\n");
+    std::unique_lock<std::mutex> lock(m_mutex);
+    std::string str = enabled ? "true" : "false";
+
+    TEST_LOG("OnPlaybackWatershedChanged received: %s\n", str.c_str());
+    /* Notify the requester thread. */
+    m_event_signalled |= UserSettings_onPlaybackWatershedChanged;
+    m_condition_variable.notify_one();
+}
+
+void UserSettingTest::onBlockNotRatedContentChanged(const bool enabled)
+{
+    TEST_LOG("OnBlockNotRatedContentChanged event triggered ***\n");
+    std::unique_lock<std::mutex> lock(m_mutex);
+    std::string str = enabled ? "true" : "false";
+
+    TEST_LOG("OnBlockNotRatedContentChanged received: %s\n", str.c_str());
+    /* Notify the requester thread. */
+    m_event_signalled |= UserSettings_onBlockNotRatedContentChanged;
+    m_condition_variable.notify_one();
+}
+
+void UserSettingTest::onPinOnPurchaseChanged(const bool enabled)
+{
+    TEST_LOG("OnPinOnPurchaseChanged event triggered ***\n");
+    std::unique_lock<std::mutex> lock(m_mutex);
+    std::string str = enabled ? "true" : "false";
+
+    TEST_LOG("OnPinOnPurchaseChanged received: %s\n", str.c_str());
+    /* Notify the requester thread. */
+    m_event_signalled |= UserSettings_onPinOnPurchaseChanged;
     m_condition_variable.notify_one();
 }
 
@@ -377,282 +579,16 @@ MATCHER_P(MatchRequestStatusBool, expected, "")
     return expected == actual;
 }
 
-TEST_F(UserSettingTest,AudioDescriptionSuccess)
+/* Activating UserSettings and Persistent store plugins and UserSettings namespace has no entries in db.
+   So that we can verify whether UserSettings plugin is receiving default values from PersistentStore or not*/
+TEST_F(UserSettingTest, VerifyDefaultValues)
 {
-    JSONRPC::LinkType<Core::JSON::IElement> jsonrpc(USERSETTING_CALLSIGN, USERSETTINGL2TEST_CALLSIGN);
-    StrictMock<AsyncHandlerMock_UserSetting> async_handler;
     uint32_t status = Core::ERROR_GENERAL;
-    JsonObject params;
-    JsonObject result_json;
-    Core::JSON::Boolean result_bool;
-    bool expected_enabled = true;
     uint32_t signalled = UserSettings_StateInvalid;
-
-    TEST_LOG("Testing AudioDescriptionSuccess");
-
-    status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
-                                       _T("onaudiodescriptionchanged"),
-                                       [this, &async_handler](const JsonObject& parameters) {
-                                           bool enabled = parameters["enabled"].Boolean();
-                                           async_handler.OnAudioDescriptionChanged(enabled);
-                                       });
-
-    EXPECT_EQ(Core::ERROR_NONE, status);
-
-    EXPECT_CALL(async_handler, OnAudioDescriptionChanged(MatchRequestStatusBool(expected_enabled)))
-        .WillOnce(Invoke(this, &UserSettingTest::OnAudioDescriptionChanged));
-
-    params["value"] = true;
-    status = InvokeServiceMethod("org.rdk.UserSettings", "setaudiodescription", params, result_json);
-    EXPECT_EQ(status,Core::ERROR_NONE);
-
-    signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_OnAudioDescriptionChanged);
-    EXPECT_TRUE(signalled & UserSettings_OnAudioDescriptionChanged);
-
-    /* Unregister for events. */
-    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("onaudiodescriptionchanged"));
-
-    EXPECT_EQ(status,Core::ERROR_NONE);
-    if (status != Core::ERROR_NONE) {
-        TEST_LOG("Expected Core::ERROR_NONE (0) but got: %u", status);
-    }
-
-    status = InvokeServiceMethod("org.rdk.UserSettings", "getaudiodescription", result_bool);
-    EXPECT_EQ(status, Core::ERROR_NONE);
-
-    TEST_LOG("result_bool: %d", result_bool.Value());
-    EXPECT_TRUE(result_bool.Value());
-}
-
-TEST_F(UserSettingTest,PreferredAudioLanguagesSuccess)
-{
-    JSONRPC::LinkType<Core::JSON::IElement> jsonrpc(USERSETTING_CALLSIGN, USERSETTINGL2TEST_CALLSIGN);
-    StrictMock<AsyncHandlerMock_UserSetting> async_handler;
-    uint32_t status = Core::ERROR_GENERAL;
-    JsonObject params;
-    JsonObject result_json;
-    Core::JSON::String result_string;
-    std::string preferredLanguages = "en,fr,es";
-    uint32_t signalled = UserSettings_StateInvalid;
-
-    TEST_LOG("Testing PreferredAudioLanguagesSuccess");
-
-    status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
-                                           _T("onpreferredaudiolanguageschanged"),
-                                           [&async_handler](const JsonObject& parameters) {
-                                           std::string preferredLanguages = parameters["preferredLanguages"].String();
-                                           async_handler.OnPreferredAudioLanguagesChanged(preferredLanguages);
-                                       });
-
-    EXPECT_EQ(Core::ERROR_NONE, status);
-
-    EXPECT_CALL(async_handler, OnPreferredAudioLanguagesChanged(MatchRequestStatusString(preferredLanguages)))
-        .WillOnce(Invoke(this, &UserSettingTest::OnPreferredAudioLanguagesChanged));
-
-    params["value"] = preferredLanguages;
-    status = InvokeServiceMethod("org.rdk.UserSettings", "setpreferredaudiolanguages", params, result_json);
-    EXPECT_EQ(status,Core::ERROR_NONE);
-
-    signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_OnPreferredAudioLanguagesChanged);
-    EXPECT_TRUE(signalled & UserSettings_OnPreferredAudioLanguagesChanged);
-
-    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("onpreferredaudiolanguageschanged"));
-
-    EXPECT_EQ(status,Core::ERROR_NONE);
-    if (status != Core::ERROR_NONE) {
-        TEST_LOG("Expected Core::ERROR_NONE (0) but got: %u", status);
-    }
-
-    status = InvokeServiceMethod("org.rdk.UserSettings", "getpreferredaudiolanguages", result_string);
-    EXPECT_EQ(status,Core::ERROR_NONE);
-
-    EXPECT_EQ(result_string.Value(), preferredLanguages);
-}
-
-TEST_F(UserSettingTest,PresentationLanguageSuccess)
-{
-    JSONRPC::LinkType<Core::JSON::IElement> jsonrpc(USERSETTING_CALLSIGN, USERSETTINGL2TEST_CALLSIGN);
-    StrictMock<AsyncHandlerMock_UserSetting> async_handler;
-    uint32_t status = Core::ERROR_GENERAL;
-    JsonObject params;
-    JsonObject result_json;
-    Core::JSON::String result_string;
-    std::string presentationLanguage = "en";
-    uint32_t signalled = UserSettings_StateInvalid;
-
-    TEST_LOG("Testing PresentationLanguageSuccess");
-
-    status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
-                                           _T("onpresentationlanguagechanged"),
-                                           [&async_handler](const JsonObject& parameters) {
-                                           std::string presentationLanguage = parameters["presentationLanguages"].String();
-                                           async_handler.OnPresentationLanguageChanged(presentationLanguage);
-                                       });
-
-    EXPECT_EQ(Core::ERROR_NONE, status);
-
-    EXPECT_CALL(async_handler, OnPresentationLanguageChanged(MatchRequestStatusString(presentationLanguage)))
-        .WillOnce(Invoke(this, &UserSettingTest::OnPresentationLanguageChanged));
-
-    params["value"] = "en";
-    status = InvokeServiceMethod("org.rdk.UserSettings", "setpresentationlanguage", params, result_json);
-    EXPECT_EQ(status,Core::ERROR_NONE);
-
-    signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_OnPresentationLanguageChanged);
-    EXPECT_TRUE(signalled & UserSettings_OnPresentationLanguageChanged);
-
-    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("onpresentationlanguagechanged"));
-
-    EXPECT_EQ(status,Core::ERROR_NONE);
-    if (status != Core::ERROR_NONE) {
-        TEST_LOG("Expected Core::ERROR_NONE (0) but got: %u", status);
-    }
-
-    status = InvokeServiceMethod("org.rdk.UserSettings", "getpresentationlanguage", result_string);
-    EXPECT_EQ(status,Core::ERROR_NONE);
-
-    EXPECT_EQ(result_string.Value(), presentationLanguage);
-}
-
-TEST_F(UserSettingTest,SetCaptionsSuccess)
-{
-    JSONRPC::LinkType<Core::JSON::IElement> jsonrpc(USERSETTING_CALLSIGN, USERSETTINGL2TEST_CALLSIGN);
-    StrictMock<AsyncHandlerMock_UserSetting> async_handler;
-    uint32_t status = Core::ERROR_GENERAL;
-    JsonObject params;
-    JsonObject result_json;
-    Core::JSON::Boolean result_bool;
-    bool expected_enabled = true;
-    uint32_t signalled = UserSettings_StateInvalid;
-
-    TEST_LOG("Testing SetCaptionsSuccess");
-
-    status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
-                                       _T("oncaptionschanged"),
-                                       [this, &async_handler](const JsonObject& parameters) {
-                                           bool enabled = parameters["enabled"].Boolean();
-                                           async_handler.OnCaptionsChanged(enabled);
-                                       });
-
-    EXPECT_EQ(Core::ERROR_NONE, status);
-
-    EXPECT_CALL(async_handler, OnCaptionsChanged(MatchRequestStatusBool(expected_enabled)))
-        .WillOnce(Invoke(this, &UserSettingTest::OnCaptionsChanged));
-
-    params["value"] = true;
-    status = InvokeServiceMethod("org.rdk.UserSettings", "setcaptions", params, result_json);
-    EXPECT_EQ(status,Core::ERROR_NONE);
-
-    signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_OnCaptionsChanged);
-    EXPECT_TRUE(signalled & UserSettings_OnCaptionsChanged);
-
-    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("oncaptionschanged"));
-
-    EXPECT_EQ(status,Core::ERROR_NONE);
-    if (status != Core::ERROR_NONE) {
-        TEST_LOG("Expected Core::ERROR_NONE (0) but got: %u", status);
-    }
-
-    status = InvokeServiceMethod("org.rdk.UserSettings", "getcaptions", result_bool);
-    EXPECT_EQ(status,Core::ERROR_NONE);
-
-    TEST_LOG("result_bool: %d", result_bool.Value());
-    EXPECT_TRUE(result_bool.Value());
-}
-
-TEST_F(UserSettingTest,SetPreferredCaptionsLanguagesSuccess)
-{
-    JSONRPC::LinkType<Core::JSON::IElement> jsonrpc(USERSETTING_CALLSIGN, USERSETTINGL2TEST_CALLSIGN);
-    StrictMock<AsyncHandlerMock_UserSetting> async_handler;
-    uint32_t status = Core::ERROR_GENERAL;
-    JsonObject params;
-    JsonObject result_json;
-    Core::JSON::String result_string;
-    string preferredLanguages = "en,es";
-    uint32_t signalled = UserSettings_StateInvalid;
-
-    TEST_LOG("Testing SetPreferredCaptionsLanguagesSuccess");
-
-    status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
-                                           _T("onpreferredcaptionslanguageschanged"),
-                                           [&async_handler](const JsonObject& parameters) {
-                                           std::string preferredLanguages = parameters["preferredLanguages"].String();
-                                           async_handler.OnPreferredCaptionsLanguagesChanged(preferredLanguages);
-                                       });
-
-    EXPECT_EQ(Core::ERROR_NONE, status);
-
-    EXPECT_CALL(async_handler, OnPreferredCaptionsLanguagesChanged(MatchRequestStatusString(preferredLanguages)))
-        .WillOnce(Invoke(this, &UserSettingTest::OnPreferredCaptionsLanguagesChanged));
-
-    params["value"] = "en,es";
-    status = InvokeServiceMethod("org.rdk.UserSettings", "setpreferredcaptionslanguages", params, result_json);
-    EXPECT_EQ(status,Core::ERROR_NONE);
-
-    signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_OnPreferredCaptionsLanguagesChanged);
-    EXPECT_TRUE(signalled & UserSettings_OnPreferredCaptionsLanguagesChanged);
-
-    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("onpreferredcaptionslanguageschanged"));
-
-    EXPECT_EQ(status,Core::ERROR_NONE);
-    if (status != Core::ERROR_NONE) {
-        TEST_LOG("Expected Core::ERROR_NONE (0) but got: %u", status);
-    }
-
-    status = InvokeServiceMethod("org.rdk.UserSettings", "getpreferredcaptionslanguages", result_string);
-    EXPECT_EQ(status,Core::ERROR_NONE);
-
-    EXPECT_EQ(result_string.Value(), preferredLanguages);
-}
-
-TEST_F(UserSettingTest,SetPreferredClosedCaptionServiceSuccess)
-{
-    JSONRPC::LinkType<Core::JSON::IElement> jsonrpc(USERSETTING_CALLSIGN, USERSETTINGL2TEST_CALLSIGN);
-    StrictMock<AsyncHandlerMock_UserSetting> async_handler;
-    uint32_t status = Core::ERROR_GENERAL;
-    JsonObject params;
-    JsonObject result_json;
-    Core::JSON::String result_string;
-    string expected_service = "CC3";
-    uint32_t signalled = UserSettings_StateInvalid;
-
-    TEST_LOG("Testing SetPreferredClosedCaptionServiceSuccess");
-
-    status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
-                                           _T("onpreferredclosedcaptionservicechanged"),
-                                           [&async_handler](const JsonObject& parameters) {
-                                               std::string preferredService = parameters["service"].String();
-                                           async_handler.OnPreferredClosedCaptionServiceChanged(preferredService);
-                                       });
-    EXPECT_EQ(Core::ERROR_NONE, status);
-
-    EXPECT_CALL(async_handler, OnPreferredClosedCaptionServiceChanged(MatchRequestStatusString(expected_service)))
-        .WillOnce(Invoke(this, &UserSettingTest::OnPreferredClosedCaptionServiceChanged));
-
-    params["value"] = "CC3";
-    status = InvokeServiceMethod("org.rdk.UserSettings", "setpreferredclosedcaptionservice", params, result_json);
-    EXPECT_EQ(status,Core::ERROR_NONE);
-
-    signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_OnPreferredClosedCaptionServiceChanged);
-    EXPECT_TRUE(signalled & UserSettings_OnPreferredClosedCaptionServiceChanged);
-
-    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("onpreferredclosedcaptionservicechanged"));
-
-    EXPECT_EQ(status,Core::ERROR_NONE);
-    if (status != Core::ERROR_NONE) {
-        TEST_LOG("Expected Core::ERROR_NONE (0) but got: %u", status);
-    }
-
-    status = InvokeServiceMethod("org.rdk.UserSettings", "getpreferredclosedcaptionservice", result_string);
-    EXPECT_EQ(status,Core::ERROR_NONE);
-
-    EXPECT_EQ(result_string.Value(), expected_service);
-}
-
-TEST_F(UserSettingTest,AudioDescriptionSuccessUsingComRpcConnection)
-{
-    uint32_t status = Core::ERROR_GENERAL;
     Core::Sink<NotificationHandler> notification;
+    bool defaultBooleanValue = true;
+    string defaultStrValue = "eng";
+
     if (CreateUserSettingInterfaceObjectUsingComRPCConnection() != Core::ERROR_NONE)
     {
         TEST_LOG("Invalid Client_UserSettings");
@@ -662,12 +598,694 @@ TEST_F(UserSettingTest,AudioDescriptionSuccessUsingComRpcConnection)
         ASSERT_TRUE(m_controller_usersettings!= nullptr);
         if (m_controller_usersettings)
         {
-            uint32_t signalled = UserSettings_StateInvalid;
             ASSERT_TRUE(m_usersettingsplugin!= nullptr);
             if (m_usersettingsplugin)
             {
                 m_usersettingsplugin->AddRef();
                 m_usersettingsplugin->Register(&notification);
+
+                /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
+                status = m_usersettingsplugin->GetAudioDescription(defaultBooleanValue);
+                EXPECT_EQ(defaultBooleanValue, false);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* defaultStrValue should get empty string and the return status is Core::ERROR_NONE */
+                status = m_usersettingsplugin->GetPreferredAudioLanguages(defaultStrValue);
+                EXPECT_EQ(defaultStrValue, "");
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* defaultStrValue should get empty string and the return status is Core::ERROR_NONE */
+                status = m_usersettingsplugin->GetPresentationLanguage(defaultStrValue);
+                EXPECT_EQ(defaultStrValue, "");
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
+                status = m_usersettingsplugin->GetCaptions(defaultBooleanValue);
+                EXPECT_EQ(defaultBooleanValue, false);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* defaultStrValue should get empty string and the return status is Core::ERROR_NONE */
+                status = m_usersettingsplugin->GetPreferredCaptionsLanguages(defaultStrValue);
+                EXPECT_EQ(defaultStrValue, "");
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* defaultStrValue should get "AUTO" and the return status is Core::ERROR_NONE */
+                status = m_usersettingsplugin->GetPreferredClosedCaptionService(defaultStrValue);
+                EXPECT_EQ(defaultStrValue, "AUTO");
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                 /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
+                 status = m_usersettingsplugin->GetPinControl(defaultBooleanValue);
+                 EXPECT_EQ(defaultBooleanValue, false);
+                 EXPECT_EQ(status,Core::ERROR_NONE);
+                 if (status != Core::ERROR_NONE)
+                 {
+                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                     TEST_LOG("Err: %s", errorMsg.c_str());
+                 }
+
+
+                 /* defaultStrValue should get "" and the return status is Core::ERROR_NONE */
+                 status = m_usersettingsplugin->GetViewingRestrictions(defaultStrValue);
+                 EXPECT_EQ(defaultStrValue, "");
+                 EXPECT_EQ(status,Core::ERROR_NONE);
+                 if (status != Core::ERROR_NONE)
+                 {
+                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                     TEST_LOG("Err: %s", errorMsg.c_str());
+                 }
+
+                 /* defaultStrValue should get "" and the return status is Core::ERROR_NONE */
+                 status = m_usersettingsplugin->GetViewingRestrictionsWindow(defaultStrValue);
+                 EXPECT_EQ(defaultStrValue, "");
+                 EXPECT_EQ(status,Core::ERROR_NONE);
+                 if (status != Core::ERROR_NONE)
+                 {
+                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                     TEST_LOG("Err: %s", errorMsg.c_str());
+                 }
+
+                 /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
+                 status = m_usersettingsplugin->GetLiveWatershed(defaultBooleanValue);
+                 EXPECT_EQ(defaultBooleanValue, false);
+                 EXPECT_EQ(status,Core::ERROR_NONE);
+                 if (status != Core::ERROR_NONE)
+                 {
+                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                     TEST_LOG("Err: %s", errorMsg.c_str());
+                 }
+
+                 /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
+                 status = m_usersettingsplugin->GetPlaybackWatershed(defaultBooleanValue);
+                 EXPECT_EQ(defaultBooleanValue, false);
+                 EXPECT_EQ(status,Core::ERROR_NONE);
+                 if (status != Core::ERROR_NONE)
+                 {
+                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                     TEST_LOG("Err: %s", errorMsg.c_str());
+                 }
+
+
+                 /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
+                 status = m_usersettingsplugin->GetBlockNotRatedContent(defaultBooleanValue);
+                 EXPECT_EQ(defaultBooleanValue, false);
+                 EXPECT_EQ(status,Core::ERROR_NONE);
+                 if (status != Core::ERROR_NONE)
+                 {
+                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                     TEST_LOG("Err: %s", errorMsg.c_str());
+                 }
+
+
+                 /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
+                 status = m_usersettingsplugin->GetPinOnPurchase(defaultBooleanValue);
+                 EXPECT_EQ(defaultBooleanValue, false);
+                 EXPECT_EQ(status,Core::ERROR_NONE);
+                 if (status != Core::ERROR_NONE)
+                 {
+                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                     TEST_LOG("Err: %s", errorMsg.c_str());
+                 }
+
+                 /* Setting Audio Description value as true.So UserSettings namespace has one entry in db.
+                 But we are trying to get PreferredAudioLanguages, which has no entry in db.
+                 So GetPreferredAudioLanguages should return the empty string and the return status
+                 from Persistant store is  Core::ERROR_UNKNOWN_KEY and return status from usersettings is Core::ERROR_NONE */
+                 status = m_usersettingsplugin->SetAudioDescription(defaultBooleanValue);
+                 EXPECT_EQ(status,Core::ERROR_NONE);
+                 if (status != Core::ERROR_NONE)
+                 {
+                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                     TEST_LOG("Err: %s", errorMsg.c_str());
+                 }
+
+                 signalled = notification.WaitForRequestStatus(JSON_TIMEOUT,UserSettings_onAudioDescriptionChanged);
+                 EXPECT_TRUE(signalled & UserSettings_onAudioDescriptionChanged);
+
+                 /* We are trying to get PreferredAudioLanguages, which has no entry in db.
+                 Persistant store returns status as Core::ERROR_UNKNOWN_KEY to UserSettings 
+                 GetPreferredAudioLanguages should get the empty string.*/
+                status = m_usersettingsplugin->GetPreferredAudioLanguages(defaultStrValue);
+                EXPECT_EQ(defaultStrValue, "");
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* We are trying to get PresentationLanguage, which has no entry in db.
+                Persistant store returns status as Core::ERROR_UNKNOWN_KEY to UserSettings 
+                GetPreferredAudioLanguages should get the empty string.*/
+                status = m_usersettingsplugin->GetPresentationLanguage(defaultStrValue);
+                EXPECT_EQ(defaultStrValue, "");
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* We are trying to get Captions, which has no entry in db.
+                Persistant store returns status as Core::ERROR_UNKNOWN_KEY to UserSettings 
+                GetPreferredAudioLanguages should get the empty string.*/
+                status = m_usersettingsplugin->GetCaptions(defaultBooleanValue);
+                EXPECT_EQ(defaultBooleanValue, false);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* We are trying to get PreferredCaptionsLanguages, which has no entry in db.
+                Persistant store returns status as Core::ERROR_UNKNOWN_KEY to UserSettings 
+                GetPreferredAudioLanguages should get the empty string.*/
+                status = m_usersettingsplugin->GetPreferredCaptionsLanguages(defaultStrValue);
+                EXPECT_EQ(defaultStrValue, "");
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* We are trying to get PreferredClosedCaptionService, which has no entry in db.
+                Persistant store returns status as Core::ERROR_UNKNOWN_KEY to UserSettings 
+                GetPreferredAudioLanguages should get the empty string.*/
+                status = m_usersettingsplugin->GetPreferredClosedCaptionService(defaultStrValue);
+                EXPECT_EQ(defaultStrValue, "AUTO");
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
+                status = m_usersettingsplugin->GetPinControl(defaultBooleanValue);
+                EXPECT_EQ(defaultBooleanValue, false);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* defaultStrValue should get "" and the return status is Core::ERROR_NONE */
+                status = m_usersettingsplugin->GetViewingRestrictions(defaultStrValue);
+                EXPECT_EQ(defaultStrValue, "");
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* defaultStrValue should get "" and the return status is Core::ERROR_NONE */
+                status = m_usersettingsplugin->GetViewingRestrictionsWindow(defaultStrValue);
+                EXPECT_EQ(defaultStrValue, "");
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
+                status = m_usersettingsplugin->GetLiveWatershed(defaultBooleanValue);
+                EXPECT_EQ(defaultBooleanValue, false);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
+                status = m_usersettingsplugin->GetPlaybackWatershed(defaultBooleanValue);
+                EXPECT_EQ(defaultBooleanValue, false);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
+                status = m_usersettingsplugin->GetBlockNotRatedContent(defaultBooleanValue);
+                EXPECT_EQ(defaultBooleanValue, false);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                /* defaultBooleanValue should get false and the return status is Core::ERROR_NONE */
+                status = m_usersettingsplugin->GetPinOnPurchase(defaultBooleanValue);
+                EXPECT_EQ(defaultBooleanValue, false);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                m_usersettingsplugin->Unregister(&notification);
+                m_usersettingsplugin->Release();
+            }
+            else
+            {
+                TEST_LOG("m_usersettingsplugin is NULL");
+            }
+            m_controller_usersettings->Release();
+        }
+        else
+        {
+            TEST_LOG("m_controller_usersettings is NULL");
+        }
+    }
+}
+
+TEST_F(UserSettingTest, SetAndGetMethodsUsingJsonRpcConnectionSuccessCase)
+{
+    JSONRPC::LinkType<Core::JSON::IElement> jsonrpc(USERSETTING_CALLSIGN, USERSETTINGL2TEST_CALLSIGN);
+    StrictMock<AsyncHandlerMock_UserSetting> async_handler;
+    uint32_t status = Core::ERROR_GENERAL;
+    uint32_t signalled = UserSettings_StateInvalid;
+
+    bool enabled = true;
+    string preferredLanguages = "en";
+    string presentationLanguage = "fra";
+    string preferredCaptionsLanguages = "en,es";
+    string preferredService = "CC3";
+    string viewingRestrictions = "ALWAYS";
+    Core::JSON::String result_string;
+    Core::JSON::Boolean result_bool;
+    JsonObject result_json;
+
+    TEST_LOG("Testing AudioDescriptionSuccess");
+    status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
+                                       _T("onAudioDescriptionChanged"),
+                                       [this, &async_handler](const JsonObject& parameters) {
+                                           bool enabled = parameters["enabled"].Boolean();
+                                           async_handler.onAudioDescriptionChanged(enabled);
+                                       });
+    EXPECT_EQ(Core::ERROR_NONE, status);
+
+    EXPECT_CALL(async_handler, onAudioDescriptionChanged(MatchRequestStatusBool(enabled)))
+    .WillOnce(Invoke(this, &UserSettingTest::onAudioDescriptionChanged));
+
+    JsonObject paramsAudioDes;
+    paramsAudioDes["enabled"] = true;
+    status = InvokeServiceMethod("org.rdk.UserSettings", "setAudioDescription", paramsAudioDes, result_json);
+    EXPECT_EQ(status,Core::ERROR_NONE);
+
+    signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_onAudioDescriptionChanged);
+    EXPECT_TRUE(signalled & UserSettings_onAudioDescriptionChanged);
+
+    /* Unregister for events. */
+    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("onAudioDescriptionChanged"));
+    EXPECT_EQ(status,Core::ERROR_NONE);
+
+    status = InvokeServiceMethod("org.rdk.UserSettings", "getAudioDescription", result_bool);
+    EXPECT_EQ(status, Core::ERROR_NONE);
+    EXPECT_TRUE(result_bool.Value());
+
+    TEST_LOG("Testing PreferredAudioLanguagesSuccess");
+    status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
+                                           _T("onPreferredAudioLanguagesChanged"),
+                                           [&async_handler](const JsonObject& parameters) {
+                                           string preferredLanguages = parameters["preferredLanguages"].String();
+                                           async_handler.onPreferredAudioLanguagesChanged(preferredLanguages);
+                                       });
+    EXPECT_EQ(Core::ERROR_NONE, status);
+
+    EXPECT_CALL(async_handler, onPreferredAudioLanguagesChanged(MatchRequestStatusString(preferredLanguages)))
+    .WillOnce(Invoke(this, &UserSettingTest::onPreferredAudioLanguagesChanged));
+
+    JsonObject paramsAudioLanguage;
+    paramsAudioLanguage["preferredLanguages"] = preferredLanguages;
+    status = InvokeServiceMethod("org.rdk.UserSettings", "setPreferredAudioLanguages", paramsAudioLanguage, result_json);
+    EXPECT_EQ(status,Core::ERROR_NONE);
+
+    signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_onPreferredAudioLanguagesChanged);
+    EXPECT_TRUE(signalled & UserSettings_onPreferredAudioLanguagesChanged);
+    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("onPreferredAudioLanguagesChanged"));
+
+    status = InvokeServiceMethod("org.rdk.UserSettings", "getPreferredAudioLanguages", result_string);
+    EXPECT_EQ(status,Core::ERROR_NONE);
+    EXPECT_EQ(result_string.Value(), preferredLanguages);
+
+    TEST_LOG("Testing PresentationLanguageSuccess");
+    status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
+                                           _T("onPresentationLanguageChanged"),
+                                           [&async_handler](const JsonObject& parameters) {
+                                           string presentationLanguage = parameters["presentationLanguage"].String();
+                                           async_handler.onPresentationLanguageChanged(presentationLanguage);
+                                       });
+    EXPECT_EQ(Core::ERROR_NONE, status);
+
+    EXPECT_CALL(async_handler, onPresentationLanguageChanged(MatchRequestStatusString(presentationLanguage)))
+    .WillOnce(Invoke(this, &UserSettingTest::onPresentationLanguageChanged));
+
+    JsonObject paramsPresLanguage;
+    paramsPresLanguage["presentationLanguage"] = presentationLanguage;
+    status = InvokeServiceMethod("org.rdk.UserSettings", "setPresentationLanguage", paramsPresLanguage, result_json);
+    EXPECT_EQ(status,Core::ERROR_NONE);
+
+    signalled = WaitForRequestStatus(JSON_TIMEOUT, UserSettings_onPresentationLanguageChanged);
+    EXPECT_TRUE(signalled & UserSettings_onPresentationLanguageChanged);
+    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("onPresentationLanguageChanged"));
+
+    status = InvokeServiceMethod("org.rdk.UserSettings", "getPresentationLanguage", result_string);
+    EXPECT_EQ(status,Core::ERROR_NONE);
+    EXPECT_EQ(result_string.Value(), presentationLanguage);
+
+    TEST_LOG("Testing SetCaptionsSuccess");
+    status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
+                                       _T("onCaptionsChanged"),
+                                       [this, &async_handler](const JsonObject& parameters) {
+                                           bool enabled = parameters["enabled"].Boolean();
+                                           async_handler.onCaptionsChanged(enabled);
+                                       });
+    EXPECT_EQ(Core::ERROR_NONE, status);
+
+    EXPECT_CALL(async_handler, onCaptionsChanged(MatchRequestStatusBool(enabled)))
+    .WillOnce(Invoke(this, &UserSettingTest::onCaptionsChanged));
+
+    JsonObject paramsCaptions;
+    paramsCaptions["enabled"] = true;
+    status = InvokeServiceMethod("org.rdk.UserSettings", "setCaptions", paramsCaptions, result_json);
+    EXPECT_EQ(status,Core::ERROR_NONE);
+
+    signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_onCaptionsChanged);
+    EXPECT_TRUE(signalled & UserSettings_onCaptionsChanged);
+    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("onCaptionsChanged"));
+
+    status = InvokeServiceMethod("org.rdk.UserSettings", "getCaptions", result_bool);
+    EXPECT_EQ(status,Core::ERROR_NONE);
+    EXPECT_TRUE(result_bool.Value());
+
+    TEST_LOG("Testing SetPreferredCaptionsLanguagesSuccess");
+    status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
+                                           _T("onPreferredCaptionsLanguagesChanged"),
+                                           [&async_handler](const JsonObject& parameters) {
+                                           string preferredCaptionsLanguages = parameters["preferredLanguages"].String();
+                                           async_handler.onPreferredCaptionsLanguagesChanged(preferredCaptionsLanguages);
+                                       });
+    EXPECT_EQ(Core::ERROR_NONE, status);
+
+    EXPECT_CALL(async_handler, onPreferredCaptionsLanguagesChanged(MatchRequestStatusString(preferredCaptionsLanguages)))
+    .WillOnce(Invoke(this, &UserSettingTest::onPreferredCaptionsLanguagesChanged));
+
+    JsonObject paramsPrefLang;
+    paramsPrefLang["preferredLanguages"] = preferredCaptionsLanguages;
+    status = InvokeServiceMethod("org.rdk.UserSettings", "setPreferredCaptionsLanguages", paramsPrefLang, result_json);
+    EXPECT_EQ(status,Core::ERROR_NONE);
+
+    signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_onPreferredCaptionsLanguagesChanged);
+    EXPECT_TRUE(signalled & UserSettings_onPreferredCaptionsLanguagesChanged);
+    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("OnPreferredCaptionsLanguagesChanged"));
+
+    status = InvokeServiceMethod("org.rdk.UserSettings", "getPreferredCaptionsLanguages", result_string);
+    EXPECT_EQ(status,Core::ERROR_NONE);
+    EXPECT_EQ(result_string.Value(), preferredCaptionsLanguages);
+
+    TEST_LOG("Testing SetPreferredClosedCaptionServiceSuccess");
+    status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
+                                           _T("onPreferredClosedCaptionServiceChanged"),
+                                           [&async_handler](const JsonObject& parameters) {
+                                           string preferredService = parameters["service"].String();
+                                           async_handler.onPreferredClosedCaptionServiceChanged(preferredService);
+                                       });
+    EXPECT_EQ(Core::ERROR_NONE, status);
+
+    EXPECT_CALL(async_handler, onPreferredClosedCaptionServiceChanged(MatchRequestStatusString(preferredService)))
+    .WillOnce(Invoke(this, &UserSettingTest::onPreferredClosedCaptionServiceChanged));
+
+    JsonObject paramspreferredService;
+    paramspreferredService["service"] = preferredService;
+    status = InvokeServiceMethod("org.rdk.UserSettings", "setPreferredClosedCaptionService", paramspreferredService, result_json);
+    EXPECT_EQ(status,Core::ERROR_NONE);
+
+    signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_onPreferredClosedCaptionServiceChanged);
+    EXPECT_TRUE(signalled & UserSettings_onPreferredClosedCaptionServiceChanged);
+    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("onPreferredClosedCaptionServiceChanged"));
+
+    status = InvokeServiceMethod("org.rdk.UserSettings", "getPreferredClosedCaptionService", result_string);
+    EXPECT_EQ(status,Core::ERROR_NONE);
+    EXPECT_EQ(result_string.Value(), preferredService);
+
+    TEST_LOG("Testing PinControl Success");
+    status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
+                                       _T("onPinControlChanged"),
+                                       [this, &async_handler](const JsonObject& parameters) {
+                                           bool enabled = parameters["enabled"].Boolean();
+                                           async_handler.onPinControlChanged(enabled);
+                                       });
+    EXPECT_EQ(Core::ERROR_NONE, status);
+
+    EXPECT_CALL(async_handler, onPinControlChanged(MatchRequestStatusBool(enabled)))
+    .WillOnce(Invoke(this, &UserSettingTest::onPinControlChanged));
+
+    JsonObject paramsPinControl;
+    paramsPinControl["enabled"] = true;
+    status = InvokeServiceMethod("org.rdk.UserSettings", "setPinControl", paramsPinControl, result_json);
+    EXPECT_EQ(status,Core::ERROR_NONE);
+
+    signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_onPinControlChanged);
+    EXPECT_TRUE(signalled & UserSettings_onPinControlChanged);
+
+    /* Unregister for events. */
+    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("onPinControlChanged"));
+    EXPECT_EQ(status,Core::ERROR_NONE);
+
+    status = InvokeServiceMethod("org.rdk.UserSettings", "getPinControl", result_bool);
+    EXPECT_EQ(status, Core::ERROR_NONE);
+    EXPECT_TRUE(result_bool.Value());
+
+    string viewRes = "{\"restrictions\": [{\"scheme\": \"US_TV\", \"restrict\": [\"TV-Y7/FV\"]}, {\"scheme\": \"MPAA\", \"restrict\": []}]}";
+    TEST_LOG("Testing SetViewingRestrictions Success");
+    status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
+                                           _T("onViewingRestrictionsChanged"),
+                                           [&async_handler](const JsonObject& parameters) {
+                                           string viewRes = parameters["viewingRestrictions"].String();
+                                           async_handler.onViewingRestrictionsChanged(viewRes);
+                                       });
+    EXPECT_EQ(Core::ERROR_NONE, status);
+
+    EXPECT_CALL(async_handler, onViewingRestrictionsChanged(MatchRequestStatusString(viewRes)))
+    .WillOnce(Invoke(this, &UserSettingTest::onViewingRestrictionsChanged));
+
+    JsonObject paramsViewRestrictions;
+    paramsViewRestrictions["viewingRestrictions"] = viewRes;
+    status = InvokeServiceMethod("org.rdk.UserSettings", "setViewingRestrictions", paramsViewRestrictions, result_json);
+    EXPECT_EQ(status,Core::ERROR_NONE);
+
+    signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_onViewingRestrictionsChanged);
+    EXPECT_TRUE(signalled & UserSettings_onViewingRestrictionsChanged);
+    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("onViewingRestrictionsChanged"));
+
+    status = InvokeServiceMethod("org.rdk.UserSettings", "getViewingRestrictions", result_string);
+    EXPECT_EQ(status,Core::ERROR_NONE);
+    EXPECT_EQ(result_string.Value(), viewRes);
+
+    string viewResWindow = "ALWAYS";
+    TEST_LOG("Testing SetViewingRestrictionsWindow Success");
+    status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
+                                           _T("onViewingRestrictionsWindowChanged"),
+                                           [&async_handler](const JsonObject& parameters) {
+                                           string viewResWindow = parameters["viewingRestrictionsWindow"].String();
+                                           async_handler.onViewingRestrictionsWindowChanged(viewResWindow);
+                                       });
+    EXPECT_EQ(Core::ERROR_NONE, status);
+
+    EXPECT_CALL(async_handler, onViewingRestrictionsWindowChanged(MatchRequestStatusString(viewResWindow)))
+    .WillOnce(Invoke(this, &UserSettingTest::onViewingRestrictionsWindowChanged));
+
+    JsonObject paramsViewResWindow;
+    paramsViewResWindow["viewingRestrictionsWindow"] = viewResWindow;
+    status = InvokeServiceMethod("org.rdk.UserSettings", "setViewingRestrictionsWindow", paramsViewResWindow, result_json);
+    EXPECT_EQ(status,Core::ERROR_NONE);
+
+    signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_onViewingRestrictionsWindowChanged);
+    EXPECT_TRUE(signalled & UserSettings_onViewingRestrictionsWindowChanged);
+    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("onViewingRestrictionsWindowChanged"));
+
+    status = InvokeServiceMethod("org.rdk.UserSettings", "getViewingRestrictionsWindow", result_string);
+    EXPECT_EQ(status,Core::ERROR_NONE);
+    EXPECT_EQ(result_string.Value(), viewResWindow);
+
+    TEST_LOG("Testing LiveWatershed Success");
+    status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
+                                       _T("onLiveWatershedChanged"),
+                                       [this, &async_handler](const JsonObject& parameters) {
+                                           bool enabled = parameters["enabled"].Boolean();
+                                           async_handler.onLiveWatershedChanged(enabled);
+                                       });
+    EXPECT_EQ(Core::ERROR_NONE, status);
+
+    EXPECT_CALL(async_handler, onLiveWatershedChanged(MatchRequestStatusBool(enabled)))
+    .WillOnce(Invoke(this, &UserSettingTest::onLiveWatershedChanged));
+
+    JsonObject paramsLiveWatershed;
+    paramsLiveWatershed["enabled"] = true;
+    status = InvokeServiceMethod("org.rdk.UserSettings", "setLiveWatershed", paramsLiveWatershed, result_json);
+    EXPECT_EQ(status,Core::ERROR_NONE);
+
+    signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_onLiveWatershedChanged);
+    EXPECT_TRUE(signalled & UserSettings_onLiveWatershedChanged);
+
+    /* Unregister for events. */
+    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("onLiveWatershedChanged"));
+    EXPECT_EQ(status,Core::ERROR_NONE);
+
+    status = InvokeServiceMethod("org.rdk.UserSettings", "getLiveWatershed", result_bool);
+    EXPECT_EQ(status, Core::ERROR_NONE);
+    EXPECT_TRUE(result_bool.Value());
+
+    TEST_LOG("Testing PlaybackWatershed Success");
+    status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
+                                       _T("onPlaybackWatershedChanged"),
+                                       [this, &async_handler](const JsonObject& parameters) {
+                                           bool enabled = parameters["enabled"].Boolean();
+                                           async_handler.onPlaybackWatershedChanged(enabled);
+                                       });
+    EXPECT_EQ(Core::ERROR_NONE, status);
+
+    EXPECT_CALL(async_handler, onPlaybackWatershedChanged(MatchRequestStatusBool(enabled)))
+    .WillOnce(Invoke(this, &UserSettingTest::onPlaybackWatershedChanged));
+
+    JsonObject paramsPlaybackWatershed;
+    paramsPlaybackWatershed["enabled"] = true;
+    status = InvokeServiceMethod("org.rdk.UserSettings", "setPlaybackWatershed", paramsPlaybackWatershed, result_json);
+    EXPECT_EQ(status,Core::ERROR_NONE);
+
+    signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_onPlaybackWatershedChanged);
+    EXPECT_TRUE(signalled & UserSettings_onPlaybackWatershedChanged);
+
+    /* Unregister for events. */
+    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("onPlaybackWatershedChanged"));
+    EXPECT_EQ(status,Core::ERROR_NONE);
+
+    status = InvokeServiceMethod("org.rdk.UserSettings", "getPlaybackWatershed", result_bool);
+    EXPECT_EQ(status, Core::ERROR_NONE);
+    EXPECT_TRUE(result_bool.Value());
+
+    TEST_LOG("Testing BlockNotRatedContent Success");
+    status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
+                                       _T("onBlockNotRatedContentChanged"),
+                                       [this, &async_handler](const JsonObject& parameters) {
+                                           bool enabled = parameters["enabled"].Boolean();
+                                           async_handler.onBlockNotRatedContentChanged(enabled);
+                                       });
+    EXPECT_EQ(Core::ERROR_NONE, status);
+
+    EXPECT_CALL(async_handler, onBlockNotRatedContentChanged(MatchRequestStatusBool(enabled)))
+    .WillOnce(Invoke(this, &UserSettingTest::onBlockNotRatedContentChanged));
+
+    JsonObject paramsBlockNotRatedContent;
+    paramsBlockNotRatedContent["enabled"] = true;
+    status = InvokeServiceMethod("org.rdk.UserSettings", "setBlockNotRatedContent", paramsBlockNotRatedContent, result_json);
+    EXPECT_EQ(status,Core::ERROR_NONE);
+
+    signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_onBlockNotRatedContentChanged);
+    EXPECT_TRUE(signalled & UserSettings_onBlockNotRatedContentChanged);
+
+    /* Unregister for events. */
+    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("onBlockNotRatedContentChanged"));
+    EXPECT_EQ(status,Core::ERROR_NONE);
+
+    status = InvokeServiceMethod("org.rdk.UserSettings", "getBlockNotRatedContent", result_bool);
+    EXPECT_EQ(status, Core::ERROR_NONE);
+    EXPECT_TRUE(result_bool.Value());
+
+    TEST_LOG("Testing PinOnPurchase Success");
+    status = jsonrpc.Subscribe<JsonObject>(JSON_TIMEOUT,
+                                       _T("onPinOnPurchaseChanged"),
+                                       [this, &async_handler](const JsonObject& parameters) {
+                                           bool enabled = parameters["enabled"].Boolean();
+                                           async_handler.onPinOnPurchaseChanged(enabled);
+                                       });
+    EXPECT_EQ(Core::ERROR_NONE, status);
+
+    EXPECT_CALL(async_handler, onPinOnPurchaseChanged(MatchRequestStatusBool(enabled)))
+    .WillOnce(Invoke(this, &UserSettingTest::onPinOnPurchaseChanged));
+
+    JsonObject paramsPinOnPurchase;
+    paramsPinOnPurchase["enabled"] = true;
+    status = InvokeServiceMethod("org.rdk.UserSettings", "setPinOnPurchase", paramsPinOnPurchase, result_json);
+    EXPECT_EQ(status,Core::ERROR_NONE);
+
+    signalled = WaitForRequestStatus(JSON_TIMEOUT,UserSettings_onPinOnPurchaseChanged);
+    EXPECT_TRUE(signalled & UserSettings_onPinOnPurchaseChanged);
+
+    /* Unregister for events. */
+    jsonrpc.Unsubscribe(JSON_TIMEOUT, _T("onPinOnPurchaseChanged"));
+    EXPECT_EQ(status,Core::ERROR_NONE);
+
+    status = InvokeServiceMethod("org.rdk.UserSettings", "getPinOnPurchase", result_bool);
+    EXPECT_EQ(status, Core::ERROR_NONE);
+    EXPECT_TRUE(result_bool.Value());
+
+}
+
+TEST_F(UserSettingTest,SetAndGetMethodsUsingComRpcConnectionSuccessCase)
+{
+    uint32_t status = Core::ERROR_GENERAL;
+    bool getBoolValue = false;
+    string getStringValue = "";
+    Core::Sink<NotificationHandler> notification;
+    uint32_t signalled = UserSettings_StateInvalid;
+
+    if (CreateUserSettingInterfaceObjectUsingComRPCConnection() != Core::ERROR_NONE)
+    {
+        TEST_LOG("Invalid Client_UserSettings");
+    }
+    else
+    {
+        ASSERT_TRUE(m_controller_usersettings!= nullptr);
+        if (m_controller_usersettings)
+        {
+            ASSERT_TRUE(m_usersettingsplugin!= nullptr);
+            if (m_usersettingsplugin)
+            {
+                m_usersettingsplugin->AddRef();
+                m_usersettingsplugin->Register(&notification);
+
+                TEST_LOG("Setting and Getting AudioDescription Values");
                 status = m_usersettingsplugin->SetAudioDescription(true);
                 EXPECT_EQ(status,Core::ERROR_NONE);
                 if (status != Core::ERROR_NONE)
@@ -675,56 +1293,11 @@ TEST_F(UserSettingTest,AudioDescriptionSuccessUsingComRpcConnection)
                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
                     TEST_LOG("Err: %s", errorMsg.c_str());
                 }
+                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT, UserSettings_onAudioDescriptionChanged);
+                EXPECT_TRUE(signalled & UserSettings_onAudioDescriptionChanged);
 
-                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT,UserSettings_OnAudioDescriptionChanged);
-                EXPECT_TRUE(signalled & UserSettings_OnAudioDescriptionChanged);
-
-                bool Enable = false;
-                status = m_usersettingsplugin->GetAudioDescription(Enable);
-                EXPECT_EQ(Enable, true);
-                EXPECT_EQ(status,Core::ERROR_NONE);
-                if (status != Core::ERROR_NONE)
-                {
-                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
-                    TEST_LOG("Err: %s", errorMsg.c_str());
-                }
-                m_usersettingsplugin->Unregister(&notification);
-                m_usersettingsplugin->Release();
-            }
-            else
-            {
-                TEST_LOG("m_usersettingsplugin is NULL");
-            }
-            m_controller_usersettings->Release();
-        }
-        else
-        {
-            TEST_LOG("m_controller_usersettings is NULL");
-        }
-    }
-}
-
-TEST_F(UserSettingTest,PreferredAudioLanguagesSuccessUsingComRpcConnection)
-{
-    uint32_t status = Core::ERROR_GENERAL;
-    Core::Sink<NotificationHandler> notification;
-    if (CreateUserSettingInterfaceObjectUsingComRPCConnection() != Core::ERROR_NONE)
-    {
-        TEST_LOG("Invalid Client_UserSettings");
-    }
-    else
-    {
-        ASSERT_TRUE(m_controller_usersettings!= nullptr);
-        if (m_controller_usersettings)
-        {
-            uint32_t signalled = UserSettings_StateInvalid;
-            ASSERT_TRUE(m_usersettingsplugin!= nullptr);
-            if (m_usersettingsplugin)
-            {
-                m_usersettingsplugin->AddRef();
-                m_usersettingsplugin->Register(&notification);
-                const string preferredLanguages = "eng";
-                status = m_usersettingsplugin->SetPreferredAudioLanguages(preferredLanguages);
+                status = m_usersettingsplugin->GetAudioDescription(getBoolValue);
+                EXPECT_EQ(getBoolValue, true);
                 EXPECT_EQ(status,Core::ERROR_NONE);
                 if (status != Core::ERROR_NONE)
                 {
@@ -732,56 +1305,19 @@ TEST_F(UserSettingTest,PreferredAudioLanguagesSuccessUsingComRpcConnection)
                     TEST_LOG("Err: %s", errorMsg.c_str());
                 }
 
-                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT,UserSettings_OnPreferredAudioLanguagesChanged);
-                EXPECT_TRUE(signalled & UserSettings_OnPreferredAudioLanguagesChanged);
-
-                string preferredLanguages1 = "";
-                status = m_usersettingsplugin->GetPreferredAudioLanguages(preferredLanguages1);
-                EXPECT_EQ(preferredLanguages1, preferredLanguages);
+                TEST_LOG("Setting and Getting PreferredAudioLanguages Values");
+                status = m_usersettingsplugin->SetPreferredAudioLanguages("eng");
                 EXPECT_EQ(status,Core::ERROR_NONE);
                 if (status != Core::ERROR_NONE)
                 {
                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
                     TEST_LOG("Err: %s", errorMsg.c_str());
                 }
-                m_usersettingsplugin->Unregister(&notification);
-                m_usersettingsplugin->Release();
-            }
-            else
-            {
-                TEST_LOG("m_usersettingsplugin is NULL");
-            }
-            m_controller_usersettings->Release();
-        }
-        else
-        {
-            TEST_LOG("m_controller_usersettings is NULL");
-        }
-    }
-}
+                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT,UserSettings_onPreferredAudioLanguagesChanged);
+                EXPECT_TRUE(signalled & UserSettings_onPreferredAudioLanguagesChanged);
 
-TEST_F(UserSettingTest,PresentationLanguageSuccessUsingComRpcConnection)
-{
-    uint32_t status = Core::ERROR_GENERAL;
-    Core::Sink<NotificationHandler> notification;
-
-    if (CreateUserSettingInterfaceObjectUsingComRPCConnection() != Core::ERROR_NONE)
-    {
-        TEST_LOG("Invalid mClient_UserSettings");
-    }
-    else
-    {
-        ASSERT_TRUE(m_controller_usersettings!= nullptr);
-        if (m_controller_usersettings)
-        {
-            uint32_t signalled = UserSettings_StateInvalid;
-            ASSERT_TRUE(m_usersettingsplugin!= nullptr);
-            if (m_usersettingsplugin)
-            {
-                m_usersettingsplugin->AddRef();
-                m_usersettingsplugin->Register(&notification);
-                const string presentationLanguage = "fra";
-                status = m_usersettingsplugin->SetPresentationLanguage(presentationLanguage);
+                status = m_usersettingsplugin->GetPreferredAudioLanguages(getStringValue);
+                EXPECT_EQ(getStringValue, "eng");
                 EXPECT_EQ(status,Core::ERROR_NONE);
                 if (status != Core::ERROR_NONE)
                 {
@@ -789,54 +1325,28 @@ TEST_F(UserSettingTest,PresentationLanguageSuccessUsingComRpcConnection)
                     TEST_LOG("Err: %s", errorMsg.c_str());
                 }
 
-                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT,UserSettings_OnPresentationLanguageChanged);
-                EXPECT_TRUE(signalled & UserSettings_OnPresentationLanguageChanged);
-
-                string presentationLanguage1 = "";
-                status = m_usersettingsplugin->GetPresentationLanguage(presentationLanguage1);
-                EXPECT_EQ(presentationLanguage1, presentationLanguage);
+                TEST_LOG("Setting and Getting PresentationLanguage Values");
+                status = m_usersettingsplugin->SetPresentationLanguage("fra");
                 EXPECT_EQ(status,Core::ERROR_NONE);
                 if (status != Core::ERROR_NONE)
                 {
                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
                     TEST_LOG("Err: %s", errorMsg.c_str());
                 }
-                m_usersettingsplugin->Unregister(&notification);
-                m_usersettingsplugin->Release();
-            }
-            else
-            {
-                TEST_LOG("m_usersettingsplugin is NULL");
-            }
-            m_controller_usersettings->Release();
-        }
-        else
-        {
-            TEST_LOG("m_controller_usersettings is NULL");
-        }
-    }
-}
+                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT,UserSettings_onPresentationLanguageChanged);
+                EXPECT_TRUE(signalled & UserSettings_onPresentationLanguageChanged);
 
-TEST_F(UserSettingTest,CaptionsSuccessUsingComRpcConnection)
-{
-    uint32_t status = Core::ERROR_GENERAL;
-    Core::Sink<NotificationHandler> notification;
+                status = m_usersettingsplugin->GetPresentationLanguage(getStringValue);
+                EXPECT_EQ(getStringValue, "fra");
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
 
-    if (CreateUserSettingInterfaceObjectUsingComRPCConnection() != Core::ERROR_NONE)
-    {
-        TEST_LOG("Invalid Client_UserSettings");
-    }
-    else
-    {
-        ASSERT_TRUE(m_controller_usersettings!= nullptr);
-        if (m_controller_usersettings)
-        {
-            uint32_t signalled = UserSettings_StateInvalid;
-            ASSERT_TRUE(m_usersettingsplugin!= nullptr);
-            if (m_usersettingsplugin)
-            {
-                m_usersettingsplugin->AddRef();
-                m_usersettingsplugin->Register(&notification);
+                TEST_LOG("Setting and Getting Captions Values");
+                getBoolValue = false;
                 status = m_usersettingsplugin->SetCaptions(true);
                 EXPECT_EQ(status,Core::ERROR_NONE);
                 if (status != Core::ERROR_NONE)
@@ -844,19 +1354,198 @@ TEST_F(UserSettingTest,CaptionsSuccessUsingComRpcConnection)
                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
                     TEST_LOG("Err: %s", errorMsg.c_str());
                 }
+                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT,UserSettings_onCaptionsChanged);
+                EXPECT_TRUE(signalled & UserSettings_onCaptionsChanged);
 
-                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT,UserSettings_OnCaptionsChanged);
-                EXPECT_TRUE(signalled & UserSettings_OnCaptionsChanged);
-
-                bool Enable = false;
-                status = m_usersettingsplugin->GetCaptions(Enable);
-                EXPECT_EQ(Enable, true);
+                status = m_usersettingsplugin->GetCaptions(getBoolValue);
+                EXPECT_EQ(getBoolValue, true);
                 EXPECT_EQ(status,Core::ERROR_NONE);
                 if (status != Core::ERROR_NONE)
                 {
                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
                     TEST_LOG("Err: %s", errorMsg.c_str());
                 }
+
+                TEST_LOG("Setting and Getting Captions Values");
+                status = m_usersettingsplugin->SetPreferredCaptionsLanguages("en,es");
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT,UserSettings_onPreferredCaptionsLanguagesChanged);
+                EXPECT_TRUE(signalled & UserSettings_onPreferredCaptionsLanguagesChanged);
+
+                status = m_usersettingsplugin->GetPreferredCaptionsLanguages(getStringValue);
+                EXPECT_EQ(getStringValue, "en,es");
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                TEST_LOG("Setting and Getting PreferredClosedCaptionService Values");
+                status = m_usersettingsplugin->SetPreferredClosedCaptionService("CC3");
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT,UserSettings_onPreferredClosedCaptionServiceChanged);
+                EXPECT_TRUE(signalled & UserSettings_onPreferredClosedCaptionServiceChanged);
+
+                status = m_usersettingsplugin->GetPreferredClosedCaptionService(getStringValue);
+                EXPECT_EQ(getStringValue, "CC3");
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                TEST_LOG("Setting and Getting PinControl Values");
+                status = m_usersettingsplugin->SetPinControl(true);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT, UserSettings_onPinControlChanged);
+                EXPECT_TRUE(signalled & UserSettings_onPinControlChanged);
+
+                status = m_usersettingsplugin->GetPinControl(getBoolValue);
+                EXPECT_EQ(getBoolValue, true);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+                string viewRes = "{\"restrictions\": [{\"scheme\": \"US_TV\", \"restrict\": [\"TV-Y7/FV\"]}, {\"scheme\": \"MPAA\", \"restrict\": []}]}";
+                TEST_LOG("Setting and Getting ViewingRestrictions Values");
+                status = m_usersettingsplugin->SetViewingRestrictions(viewRes);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT,UserSettings_onViewingRestrictionsChanged);
+                EXPECT_TRUE(signalled & UserSettings_onViewingRestrictionsChanged);
+
+                status = m_usersettingsplugin->GetViewingRestrictions(getStringValue);
+                EXPECT_EQ(getStringValue, viewRes);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                TEST_LOG("Setting and Getting ViewingRestrictionsWindow Values");
+                status = m_usersettingsplugin->SetViewingRestrictionsWindow("ALWAYS");
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT,UserSettings_onViewingRestrictionsWindowChanged);
+                EXPECT_TRUE(signalled & UserSettings_onViewingRestrictionsWindowChanged);
+
+                status = m_usersettingsplugin->GetViewingRestrictionsWindow(getStringValue);
+                EXPECT_EQ(getStringValue, "ALWAYS");
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                TEST_LOG("Setting and Getting LiveWatershed Values");
+                status = m_usersettingsplugin->SetLiveWatershed(true);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT, UserSettings_onLiveWatershedChanged);
+                EXPECT_TRUE(signalled & UserSettings_onLiveWatershedChanged);
+
+                status = m_usersettingsplugin->GetLiveWatershed(getBoolValue);
+                EXPECT_EQ(getBoolValue, true);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                TEST_LOG("Setting and Getting PlaybackWatershed Values");
+                status = m_usersettingsplugin->SetPlaybackWatershed(true);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT, UserSettings_onPlaybackWatershedChanged);
+                EXPECT_TRUE(signalled & UserSettings_onPlaybackWatershedChanged);
+
+                status = m_usersettingsplugin->GetPlaybackWatershed(getBoolValue);
+                EXPECT_EQ(getBoolValue, true);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                TEST_LOG("Setting and Getting BlockNotRatedContent Values");
+                status = m_usersettingsplugin->SetBlockNotRatedContent(true);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT, UserSettings_onBlockNotRatedContentChanged);
+                EXPECT_TRUE(signalled & UserSettings_onBlockNotRatedContentChanged);
+
+                status = m_usersettingsplugin->GetBlockNotRatedContent(getBoolValue);
+                EXPECT_EQ(getBoolValue, true);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
+                TEST_LOG("Setting and Getting PinOnPurchase Values");
+                status = m_usersettingsplugin->SetPinOnPurchase(true);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT, UserSettings_onPinOnPurchaseChanged);
+                EXPECT_TRUE(signalled & UserSettings_onPinOnPurchaseChanged);
+
+                status = m_usersettingsplugin->GetPinOnPurchase(getBoolValue);
+                EXPECT_EQ(getBoolValue, true);
+                EXPECT_EQ(status,Core::ERROR_NONE);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+
                 m_usersettingsplugin->Unregister(&notification);
                 m_usersettingsplugin->Release();
             }
@@ -873,67 +1562,13 @@ TEST_F(UserSettingTest,CaptionsSuccessUsingComRpcConnection)
     }
 }
 
-TEST_F(UserSettingTest,PreferredCaptionsLanguagesSuccessUsingComRpcConnection)
+TEST_F(UserSettingTest, NoDBFileInPersistentstoreErrorCase)
 {
     uint32_t status = Core::ERROR_GENERAL;
+    bool getBoolValue = false;
+    string getStringValue = "";
     Core::Sink<NotificationHandler> notification;
-
-    if (CreateUserSettingInterfaceObjectUsingComRPCConnection() != Core::ERROR_NONE)
-    {
-        TEST_LOG("Invalid mClient_UserSettings");
-    }
-    else
-    {
-        ASSERT_TRUE(m_controller_usersettings!= nullptr);
-        if (m_controller_usersettings)
-        {
-            const string preferredCaptionsLanguages = "eng";
-            uint32_t signalled = UserSettings_StateInvalid;
-            ASSERT_TRUE(m_usersettingsplugin!= nullptr);
-            if (m_usersettingsplugin)
-            {
-                m_usersettingsplugin->AddRef();
-                m_usersettingsplugin->Register(&notification);
-                status = m_usersettingsplugin->SetPreferredCaptionsLanguages(preferredCaptionsLanguages);
-                EXPECT_EQ(status,Core::ERROR_NONE);
-                if (status != Core::ERROR_NONE)
-                {
-                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
-                    TEST_LOG("Err: %s", errorMsg.c_str());
-                }
-
-                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT,UserSettings_OnPreferredCaptionsLanguagesChanged);
-                EXPECT_TRUE(signalled & UserSettings_OnPreferredCaptionsLanguagesChanged);
-
-                string preferredCaptionsLanguages1 = "";
-                status = m_usersettingsplugin->GetPreferredCaptionsLanguages(preferredCaptionsLanguages1);
-                EXPECT_EQ(preferredCaptionsLanguages1, preferredCaptionsLanguages);
-                EXPECT_EQ(status,Core::ERROR_NONE);
-                if (status != Core::ERROR_NONE)
-                {
-                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
-                    TEST_LOG("Err: %s", errorMsg.c_str());
-                }
-                m_usersettingsplugin->Unregister(&notification);
-                m_usersettingsplugin->Release();
-            }
-            else
-            {
-                TEST_LOG("m_usersettingsplugin is NULL");
-            }
-            m_controller_usersettings->Release();
-        }
-        else
-        {
-            TEST_LOG("m_controller_usersettings is NULL");
-        }
-    }
-}
-
-TEST_F(UserSettingTest,PreferredClosedCaptionServiceSuccessUsingComRpcConnection)
-{
-    uint32_t status = Core::ERROR_GENERAL;
-    Core::Sink<NotificationHandler> notification;
+    uint32_t signalled = UserSettings_StateInvalid;
 
     if (CreateUserSettingInterfaceObjectUsingComRPCConnection() != Core::ERROR_NONE)
     {
@@ -944,39 +1579,86 @@ TEST_F(UserSettingTest,PreferredClosedCaptionServiceSuccessUsingComRpcConnection
         ASSERT_TRUE(m_controller_usersettings!= nullptr);
         if (m_controller_usersettings)
         {
-            uint32_t signalled = UserSettings_StateInvalid;
             ASSERT_TRUE(m_usersettingsplugin!= nullptr);
             if (m_usersettingsplugin)
             {
                 m_usersettingsplugin->AddRef();
                 m_usersettingsplugin->Register(&notification);
-                const string preferredClosedCaptionService = "CC3";
-                status = m_usersettingsplugin->SetPreferredClosedCaptionService(preferredClosedCaptionService);
+
+                TEST_LOG("Setting and Getting AudioDescription Values");
+                status = m_usersettingsplugin->SetAudioDescription(true);
                 EXPECT_EQ(status,Core::ERROR_NONE);
                 if (status != Core::ERROR_NONE)
                 {
                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
                     TEST_LOG("Err: %s", errorMsg.c_str());
                 }
+                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT, UserSettings_onAudioDescriptionChanged);
+                EXPECT_TRUE(signalled & UserSettings_onAudioDescriptionChanged);
 
-                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT,UserSettings_OnPreferredClosedCaptionServiceChanged);
-                EXPECT_TRUE(signalled & UserSettings_OnPreferredClosedCaptionServiceChanged);
+                status = m_usersettingsplugin->GetAudioDescription(getBoolValue);
+                EXPECT_EQ(getBoolValue, true);
+                EXPECT_EQ(status, Core::ERROR_NONE);
 
-                string preferredClosedCaptionService1 = "";
-                status = m_usersettingsplugin->GetPreferredClosedCaptionService(preferredClosedCaptionService1);
-                EXPECT_EQ(preferredClosedCaptionService1, preferredClosedCaptionService);
+                TEST_LOG("Setting and Getting PinControl Values");
+                status = m_usersettingsplugin->SetPinControl(true);
                 EXPECT_EQ(status,Core::ERROR_NONE);
                 if (status != Core::ERROR_NONE)
                 {
                     std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
                     TEST_LOG("Err: %s", errorMsg.c_str());
                 }
+                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT, UserSettings_onPinControlChanged);
+                EXPECT_TRUE(signalled & UserSettings_onPinControlChanged);
+
+                status = m_usersettingsplugin->GetPinControl(getBoolValue);
+                EXPECT_EQ(getBoolValue, true);
+                EXPECT_EQ(status, Core::ERROR_NONE);
+
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+                int file_status = remove("/tmp/secure/persistent/rdkservicestore");
+                // Check if the file has been successfully removed
+                if (file_status != 0)
+                {
+                    TEST_LOG("Error deleting file[/tmp/secure/persistent/rdkservicestore]");
+                }
+                else
+                {
+                    TEST_LOG("File[/tmp/secure/persistent/rdkservicestore] successfully deleted");
+                }
+
+                TEST_LOG("Setting and Getting AudioDescription Values after DB file deletion");
+                status = m_usersettingsplugin->SetAudioDescription(false);
+                EXPECT_EQ(status, Core::ERROR_GENERAL);
+
+                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT, UserSettings_onAudioDescriptionChanged);
+                EXPECT_TRUE(signalled & UserSettings_onAudioDescriptionChanged);
+
+                status = m_usersettingsplugin->GetAudioDescription(getBoolValue);
+                EXPECT_EQ(getBoolValue, true);
+                EXPECT_EQ(status, Core::ERROR_NONE);
+
+                TEST_LOG("Setting and Getting setPinControl Values after DB file deletion");
+                status = m_usersettingsplugin->SetPinControl(false);
+                EXPECT_EQ(status, Core::ERROR_GENERAL);
+
+                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT, UserSettings_onPinControlChanged);
+                EXPECT_TRUE(signalled & UserSettings_onPinControlChanged);
+
+                status = m_usersettingsplugin->GetPinControl(getBoolValue);
+                EXPECT_EQ(getBoolValue, true);
+                EXPECT_EQ(status, Core::ERROR_NONE);
+
                 m_usersettingsplugin->Unregister(&notification);
                 m_usersettingsplugin->Release();
             }
             else
             {
-                TEST_LOG("UserSettingsPlugin is NULL");
+                TEST_LOG("m_usersettingsplugin is NULL");
             }
             m_controller_usersettings->Release();
         }
@@ -986,3 +1668,170 @@ TEST_F(UserSettingTest,PreferredClosedCaptionServiceSuccessUsingComRpcConnection
         }
     }
 }
+#if 0
+TEST_F(UserSettingTest, PersistentstoreIsDeactivatedErrorCase)
+{
+    uint32_t status = Core::ERROR_GENERAL;
+    bool getBoolValue = false;
+    string getStringValue = "";
+    Core::Sink<NotificationHandler> notification;
+    uint32_t signalled = UserSettings_StateInvalid;
+
+    status = DeactivateService("org.rdk.PersistentStore");
+    EXPECT_EQ(Core::ERROR_NONE, status);
+    sleep(5);
+
+    int file_status = remove("/tmp/secure/persistent/rdkservicestore");
+    // Check if the file has been successfully removed
+    if (file_status != 0)
+    {
+        TEST_LOG("Error deleting file[/tmp/secure/persistent/rdkservicestore]");
+    }
+    else
+    {
+        TEST_LOG("File[/tmp/secure/persistent/rdkservicestore] successfully deleted");
+    }
+
+    if (CreateUserSettingInterfaceObjectUsingComRPCConnection() != Core::ERROR_NONE)
+    {
+        TEST_LOG("Invalid Client_UserSettings");
+    }
+    else
+    {
+        ASSERT_TRUE(m_controller_usersettings!= nullptr);
+        if (m_controller_usersettings)
+        {
+            ASSERT_TRUE(m_usersettingsplugin!= nullptr);
+            if (m_usersettingsplugin)
+            {
+                m_usersettingsplugin->AddRef();
+                m_usersettingsplugin->Register(&notification);
+
+                TEST_LOG("Setting and Getting AudioDescription Values");
+                status = m_usersettingsplugin->setAudioDescription(true);
+                EXPECT_EQ(status,Core::ERROR_GENERAL);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT, UserSettings_onAudioDescriptionChanged);
+                EXPECT_FALSE(signalled & UserSettings_onAudioDescriptionChanged);
+
+                status = m_usersettingsplugin->getAudioDescription(getBoolValue);
+                EXPECT_EQ(getBoolValue, false);
+                EXPECT_EQ(status, Core::ERROR_NONE);
+
+                TEST_LOG("Setting and Getting PinControl Values");
+                status = m_usersettingsplugin->setPinControl(true);
+                EXPECT_EQ(status,Core::ERROR_GENERAL);
+                if (status != Core::ERROR_NONE)
+                {
+                    std::string errorMsg = "COM-RPC returned error " + std::to_string(status) + " (" + std::string(Core::ErrorToString(status)) + ")";
+                    TEST_LOG("Err: %s", errorMsg.c_str());
+                }
+                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT, UserSettings_onPinControlChanged);
+                EXPECT_FALSE(signalled & UserSettings_onPinControlChanged);
+
+                status = m_usersettingsplugin->getPinControl(getBoolValue);
+                EXPECT_EQ(getBoolValue, false);
+                EXPECT_EQ(status, Core::ERROR_NONE);
+
+                m_usersettingsplugin->Unregister(&notification);
+                m_usersettingsplugin->Release();
+            }
+            else
+            {
+                TEST_LOG("m_usersettingsplugin is NULL");
+            }
+            m_controller_usersettings->Release();
+        }
+        else
+        {
+            TEST_LOG("m_controller_usersettings is NULL");
+        }
+    }
+}
+#endif
+TEST_F(UserSettingTest, PersistentstoreIsNotActivatedWhileUserSettingsActivatingErrorCase)
+{
+    uint32_t status = Core::ERROR_GENERAL;
+    bool getBoolValue = false;
+    string getStringValue = "";
+    Core::Sink<NotificationHandler> notification;
+    uint32_t signalled = UserSettings_StateInvalid;
+
+    status = DeactivateService("org.rdk.UserSettings");
+    EXPECT_EQ(Core::ERROR_NONE, status);
+    status = DeactivateService("org.rdk.PersistentStore");
+    EXPECT_EQ(Core::ERROR_NONE, status);
+
+    int file_status = remove("/tmp/secure/persistent/rdkservicestore");
+    // Check if the file has been successfully removed
+    if (file_status != 0)
+    {
+        TEST_LOG("Error deleting file[/tmp/secure/persistent/rdkservicestore]");
+    }
+    else
+    {
+        TEST_LOG("File[/tmp/secure/persistent/rdkservicestore] successfully deleted");
+    }
+
+    sleep(5);
+    status = ActivateService("org.rdk.UserSettings");
+    EXPECT_EQ(Core::ERROR_NONE, status);
+
+    if (CreateUserSettingInterfaceObjectUsingComRPCConnection() != Core::ERROR_NONE)
+    {
+        TEST_LOG("Invalid Client_UserSettings");
+    }
+    else
+    {
+        ASSERT_TRUE(m_controller_usersettings!= nullptr);
+        if (m_controller_usersettings)
+        {
+            ASSERT_TRUE(m_usersettingsplugin!= nullptr);
+            if (m_usersettingsplugin)
+            {
+                m_usersettingsplugin->AddRef();
+                m_usersettingsplugin->Register(&notification);
+
+                TEST_LOG("Setting and Getting AudioDescription Values");
+                status = m_usersettingsplugin->SetAudioDescription(true);
+                EXPECT_EQ(status,Core::ERROR_GENERAL);
+
+                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT, UserSettings_onAudioDescriptionChanged);
+                EXPECT_FALSE(signalled & UserSettings_onAudioDescriptionChanged);
+
+                status = m_usersettingsplugin->GetAudioDescription(getBoolValue);
+                EXPECT_EQ(getBoolValue, false);
+                EXPECT_EQ(status, Core::ERROR_GENERAL);
+
+                TEST_LOG("Setting and Getting PinControl Values");
+                status = m_usersettingsplugin->SetPinControl(true);
+                EXPECT_EQ(status,Core::ERROR_GENERAL);
+
+                signalled = notification.WaitForRequestStatus(JSON_TIMEOUT, UserSettings_onPinControlChanged);
+                EXPECT_FALSE(signalled & UserSettings_onPinControlChanged);
+
+                status = m_usersettingsplugin->GetPinControl(getBoolValue);
+                EXPECT_EQ(getBoolValue, false);
+                EXPECT_EQ(status, Core::ERROR_GENERAL);
+
+                m_usersettingsplugin->Unregister(&notification);
+                m_usersettingsplugin->Release();
+            }
+            else
+            {
+                TEST_LOG("m_usersettingsplugin is NULL");
+            }
+            m_controller_usersettings->Release();
+        }
+        else
+        {
+            TEST_LOG("m_controller_usersettings is NULL");
+        }
+    }
+}
+
+

--- a/Tests/L2Tests/patches/RDKV-48604-User-Settings-Thunder-Plugin.patch
+++ b/Tests/L2Tests/patches/RDKV-48604-User-Settings-Thunder-Plugin.patch
@@ -1,18 +1,15 @@
-From 6382e8759eb966a7b4d2a1f1d0988edb35194aa3 Mon Sep 17 00:00:00 2001
-From: kprathyusha <kprathyusha@synamedia.com>
-Date: Wed, 26 Jun 2024 15:42:01 +0530
-Subject: [PATCH] Add ITextToSpeech.h
+commit 8afc4a92b878252780fae90496b9782600a41bd0
+Author: Nagalakshmi Dosakayala <nadosakayala@synamedia.com>
+Date:   Fri Sep 6 12:49:05 2024 +0530
 
----
- interfaces/IUserSettings.h | 146 +++++++++++++++++++++++++++++++++++++++++++++
- interfaces/Ids.h           |   5 +-
- 2 files changed, 150 insertions(+), 1 deletion(-)
- create mode 100755 interfaces/IUserSettings.h
+    RDK-48604: New UserSettings Thunder Plugin
 
-diff -uprN a/interfaces/IUserSettings.h b/interfaces/IUserSettings.h
---- a/interfaces/IUserSettings.h	1970-01-01 03:00:00.000000000 +0300
-+++ b/interfaces/IUserSettings.h	2024-06-27 18:41:13.733055666 +0300
-@@ -0,0 +1,178 @@
+diff --git a/interfaces/IUserSettings.h b/interfaces/IUserSettings.h
+new file mode 100755
+index 0000000..9353f6d
+--- /dev/null
++++ b/interfaces/IUserSettings.h
+@@ -0,0 +1,281 @@
 +/*
 + * If not stated otherwise in this file or this component's LICENSE file the
 + * following copyright and licenses apply:
@@ -38,67 +35,100 @@ diff -uprN a/interfaces/IUserSettings.h b/interfaces/IUserSettings.h
 +
 +namespace WPEFramework {
 +namespace Exchange {
-+ // @json
-+struct EXTERNAL IUserSettings : virtual public Core::IUnknown {
++  // @json @text:keep
++  struct EXTERNAL IUserSettings : virtual public Core::IUnknown {
 +  enum { ID = ID_USER_SETTINGS };
 +
 +  // @event
 +  struct EXTERNAL INotification : virtual public Core::IUnknown {
 +    enum { ID = ID_USER_SETTINGS_NOTIFICATION };
 +
-+    // @alt OnAudioDescriptionChanged
++    // @text onAudioDescriptionChanged
 +    // @brief The AudioDescription setting has changed.
 +    // @param enabled: Enabled/Disabled.
 +    virtual void OnAudioDescriptionChanged(const bool enabled) = 0;
 +
-+    // @alt OnPreferredAudioLanguagesChanged
++    // @text onPreferredAudioLanguagesChanged
 +    // @brief The preferredLanguages setting has changed.
 +    // @param preferredLanguages: PreferredLanguages.
 +    virtual void OnPreferredAudioLanguagesChanged(const string& preferredLanguages /* @text preferredLanguages */) = 0;
 +
-+    // @alt OnPresentationLanguageChanged
++    // @text onPresentationLanguageChanged
 +    // @brief The PresentationLanguages setting has changed.
-+    // @param presentationLanguages: PresentationLanguages.
-+    virtual void OnPresentationLanguageChanged(const string& presentationLanguages /* @text presentationLanguages */) = 0;
++    // @param presentationLanguage: PresentationLanguage.
++    virtual void OnPresentationLanguageChanged(const string& presentationLanguage /* @text presentationLanguage */) = 0;
 +
-+    // @alt OnCaptionsChanged
++    // @text onCaptionsChanged
 +    // @brief The Captions setting has changed.
 +    // @param enabled: Enabled/Disabled.
 +    virtual void OnCaptionsChanged(const bool enabled) = 0;
 +
-+    // @alt OnPreferredCaptionsLanguagesChanged
++    // @text onPreferredCaptionsLanguagesChanged
 +    // @brief The PreferredCaptionsLanguages setting has changed.
 +    // @param preferredLanguages: PreferredLanguages.
 +    virtual void OnPreferredCaptionsLanguagesChanged(const string& preferredLanguages /* @text preferredLanguages */) = 0;
 +
-+    // @alt OnPreferredClosedCaptionServiceChanged
++    // @text onPreferredClosedCaptionServiceChanged
 +    // @brief The PreferredClosedCaptionService setting has changed.
 +    // @param service: "CC[1-4]", "TEXT[1-4]", "SERVICE[1-64]".
 +    virtual void OnPreferredClosedCaptionServiceChanged(const string& service) = 0;
 +
-+    // @alt OnPrivacyModeChanged
++    // @text onPrivacyModeChanged
 +    // @brief The PrivacyMode setting has changed.
 +    // @param privacyMode: "SHARE", "DO_NOT_SHARE".
 +    virtual void OnPrivacyModeChanged(const string& privacyMode /* @text privacyMode */) = 0;
++
++    // @text onPinControlChanged
++    // @brief The PinControl setting has changed.
++    // @param enabled: Enabled/Disabled.
++    virtual void OnPinControlChanged(const bool enabled) = 0;
++
++    // @text onViewingRestrictionsChanged
++    // @brief The ViewingRestrictions setting has changed.
++    // @param viewingRestrictions:  Empty string
++    virtual void OnViewingRestrictionsChanged(const string& viewingRestrictions /* @text viewingRestrictions */) = 0;
++
++    // @text onViewingRestrictionsWindowChanged
++    // @brief The ViewingRestrictionsWindow setting has changed.
++    // @param viewingRestrictionsWindow: "ALWAYS"
++    virtual void OnViewingRestrictionsWindowChanged(const string& viewingRestrictionsWindow /* @text viewingRestrictionsWindow */) = 0;
++
++    // @text onLiveWatershedChanged
++    // @brief The LiveWatershed setting has changed.
++    // @param enabled: Enabled/Disabled.
++    virtual void OnLiveWatershedChanged(const bool enabled) = 0;
++
++    // @text onPlaybackWatershedChanged
++    // @brief The PlaybackWatershed setting has changed.
++    // @param enabled: Enabled/Disabled.
++    virtual void OnPlaybackWatershedChanged(const bool enabled) = 0;
++
++    // @text onBlockNotRatedContentChanged
++    // @brief The BlockNotRatedContent setting has changed.
++    // @param enabled: Enabled/Disabled.
++    virtual void OnBlockNotRatedContentChanged(const bool enabled) = 0;
++
++    // @text onPinOnPurchaseChanged
++    // @brief The PinOnPurchase setting has changed.
++    // @param enabled: Enabled/Disabled.
++    virtual void OnPinOnPurchaseChanged(const bool enabled) = 0;
++
 +  };
 +
 +  virtual uint32_t Register(Exchange::IUserSettings::INotification* notification /* @in */) = 0;
 +  virtual uint32_t Unregister(Exchange::IUserSettings::INotification* notification /* @in */) = 0;
 +
-+  // @property
-+  // @alt SetAudioDescription
++  // @text setAudioDescription
 +  // @brief Sets AudioDescription ON/OFF. Players should preferred Audio Descriptive tracks over normal audio track when enabled
 +  // @param enabled: Enabled/Disabled
 +  virtual uint32_t SetAudioDescription(const bool enabled /* @in */) = 0;
 +
-+  // @property
-+  // @alt GetAudioDescription
++  // @text getAudioDescription
 +  // @brief Gets the current AudioDescription setting
 +  // @param enabled: Enabled/Disabled
 +  virtual uint32_t GetAudioDescription(bool &enabled /* @out */) const = 0;
 +
-+  // @property
-+  // @alt SetPreferredAudioLanguages
++  // @text setPreferredAudioLanguages
 +  // @brief A prioritized list of ISO 639-2/B codes for the preferred audio languages,
 +  // expressed as a comma separated lists of languages of zero of more elements.
 +  // The players will pick the audio track that has the best match compared with
@@ -107,26 +137,22 @@ diff -uprN a/interfaces/IUserSettings.h b/interfaces/IUserSettings.h
 +  // @param preferredLanguages: PreferredLanguages
 +  virtual uint32_t SetPreferredAudioLanguages(const string& preferredLanguages  /* @in @text preferredLanguages */) = 0;
 +
-+  // @property
-+  // @alt GetPreferredAudioLanguages
++  // @text getPreferredAudioLanguages
 +  // @brief Gets the current PreferredAudioLanguages setting
 +  // @param preferredLanguages: PreferredLanguages
 +  virtual uint32_t GetPreferredAudioLanguages(string &preferredLanguages /* @out @text preferredLanguages */) const = 0;
 +
-+  // @property
-+  // @alt SetPresentationLanguage
-+  // @brief Sets the presentationLanguages in a full BCP 47 value, including script, region, variant
-+  // @param presentationLanguages: "en-US", "es-US", "en-CA", "fr-CA"
-+  virtual uint32_t SetPresentationLanguage(const string& presentationLanguages /* @in @text presentationLanguages */) = 0;
++  // @text setPresentationLanguage
++  // @brief Sets the presentationLanguage in a full BCP 47 value, including script, region, variant
++  // @param presentationLanguage: "en-US", "es-US", "en-CA", "fr-CA"
++  virtual uint32_t SetPresentationLanguage(const string& presentationLanguage /* @in @text presentationLanguage */) = 0;
 +
-+  // @property
-+  // @alt GetPresentationLanguage
-+  // @brief Gets the presentationLanguages
-+  // @param presentationLanguages: "en-US", "es-US", "en-CA", "fr-CA"
-+  virtual uint32_t GetPresentationLanguage(string &presentationLanguages /* @out @text presentationLanguages */) const = 0;
++  // @text getPresentationLanguage
++  // @brief Gets the presentationLanguage
++  // @param presentationLanguage: "en-US", "es-US", "en-CA", "fr-CA"
++  virtual uint32_t GetPresentationLanguage(string &presentationLanguage /* @out @text presentationLanguage */) const = 0;
 +
-+  // @property
-+  // @alt SetCaptions
++  // @text setCaptions
 +  // @brief brief Sets Captions ON/OFF.
 +  // @details A setting of ON indicates that Players should select a subtitle track for presentation
 +  // The Setting does not influence any running sessions. It is up to the player to enforce the setting.
@@ -137,62 +163,136 @@ diff -uprN a/interfaces/IUserSettings.h b/interfaces/IUserSettings.h
 +  // When media players start playback, they should also call the GetCaptions method to retrieve the current enabled state.
 +  // This holds true for media players that utilize TextTrack render sessions for text track decode-display and also for media
 +  // players or apps that decode-display internally 
-+  // @param enabled Sets the state
++  // @param enabled: Sets the state
 +  virtual uint32_t SetCaptions(const bool enabled  /* @in */) = 0;
 +
-+  // @property
-+  // @alt GetCaptions
++  // @text getCaptions
 +  // @brief Gets the Captions setting.
-+  // @param enabled Receives the state
++  // @param enabled: Receives the state
 +  virtual uint32_t GetCaptions(bool &enabled /* @out */) const = 0;
 +
-+  // @property
-+  // @alt SetPreferredCaptionsLanguages
++  // @text setPreferredCaptionsLanguages
 +  // @brief Set preferred languages for captions.
 +  // @details A prioritized list of ISO 639-2/B codes for the preferred Captions languages,
 +  // expressed as a comma separated lists of languages of zero of more elements.
 +  // The players will pick the subtitle track that has the best match compared with
 +  // this list. In the absence of a matching track, the player should by best
 +  // effort select the preferred subtitle track. 
-+  // @param preferredLanguages Is the list to set (e.g. "eng,fra")
++  // @param preferredLanguages: Is the list to set (e.g. "eng,fra")
 +  virtual uint32_t SetPreferredCaptionsLanguages(const string& preferredLanguages  /* @in @text preferredLanguages */) = 0;
 +
-+  // @property
-+  // @alt GetPreferredCaptionsLanguages
++  // @text getPreferredCaptionsLanguages
 +  // @brief Gets the current PreferredCaptionsLanguages setting.
-+  // @param preferredLanguages (e.g. "eng,fra")
++  // @param preferredLanguages: "eng,fra"
 +  virtual uint32_t GetPreferredCaptionsLanguages(string &preferredLanguages /* @out @text preferredLanguages */) const = 0;
 +
-+  // @property
-+  // @alt SetPreferredClosedCaptionService
++  // @text setPreferredClosedCaptionService
 +  // @brief Sets the PreferredClosedCaptionService.
 +  // @details The setting should be honored by the player. The behaviour of AUTO may be player specific.
 +  // Valid input for service is "CC[1-4]", "TEXT[1-4]", "SERVICE[1-64]" 
-+  // @param service Identifies the service to display e.g. "CC3".
++  // @param service: Identifies the service to display e.g. "CC3".
 +  virtual uint32_t SetPreferredClosedCaptionService(const string& service  /* @in */) = 0;
 +
-+  // @property
-+  // @alt GetPreferredClosedCaptionService
++  // @text getPreferredClosedCaptionService
 +  // @brief Gets the current PreferredClosedCaptionService setting.
-+  // @param service Identifies the service to display e.g. "CC3".
++  // @param service: Identifies the service to display e.g. "CC3".
 +  virtual uint32_t GetPreferredClosedCaptionService(string &service /* @out */) const = 0;
 +
-+  // @alt SetPrivacyMode
++  // @text setPrivacyMode
 +  // @brief Sets the PrivacyMode.
 +  // @details The setting should be honored by the Telemetry.
 +  // If privacyMode is "DO_NOT_SHARE", logs and crash report should not be uploaded.
 +  // @param privacyMode: "SHARE", "DO_NOT_SHARE"
 +  virtual uint32_t SetPrivacyMode(const string& privacyMode /* @in @text privacyMode*/) = 0;
 +
-+  // @alt GetPrivacyMode
++  // @text getPrivacyMode
 +  // @brief Gets the current PrivacyMode setting.
-+  // @param privacyMode e.g "SHARE"
++  // @param privacyMode: "SHARE"
 +  virtual uint32_t GetPrivacyMode(string &privacyMode /* @out @text privacyMode */) const = 0;
++
++  // @text setPinControl
++  // @brief Sets PinControl ON/OFF. Parental Control as a whole is enabled or disabled.
++  // @param enabled: Enabled/Disabled
++  virtual uint32_t SetPinControl(const bool enabled /* @in */) = 0;
++
++  // @text getPinControl
++  // @brief Gets the PinControl setting
++  // @param enabled: Enabled/Disabled
++  virtual uint32_t GetPinControl(bool &enabled /* @out */) const = 0;
++
++  // @text setViewingRestrictions
++  // @brief Sets the ViewingRestrictions.
++  // @details A JSON document that escribes the rating scheme(s) and ratings that are blocked.
++  // @param viewingRestrictions: A JSON document that describes the rating scheme(s) and ratings that are blocked.
++  virtual uint32_t SetViewingRestrictions(const string& viewingRestrictions /* @in @text viewingRestrictions */) = 0;
++
++  // @text getViewingRestrictions
++  // @brief Gets the current ViewingRestrictions.
++  // @param viewingRestrictions: A JSON document that escribes the rating scheme(s) and ratings that are blocked.
++  virtual uint32_t GetViewingRestrictions(string &viewingRestrictions /* @out @text viewingRestrictions */) const = 0;
++
++  // @text setViewingRestrictionsWindow
++  // @brief Sets the ViewingRestrictionsWindow.
++  // @details A project-specific representation of the time interval when viewing
++  // restrictions are to be applied, if applicable for the project
++  // @param viewingRestrictionsWindow: A project-specific representation of the time interval.Eg: "ALWAYS"
++  virtual uint32_t SetViewingRestrictionsWindow(const string &viewingRestrictionsWindow /* @in @text viewingRestrictionsWindow */) = 0;
++  
++  // @text getViewingRestrictionsWindow
++  // @brief Gets the current ViewingRestrictionsWindow.
++  // @param viewingRestrictionsWindow: A project-specific representation of the time interval.Eg: "ALWAYS"
++  virtual uint32_t GetViewingRestrictionsWindow(string &viewingRestrictionsWindow /* @out @text viewingRestrictionsWindow */) const = 0;
++
++  // @text setLiveWatershed
++  // @brief Sets LiveWatershed ON/OFF.Whether project-specific watershed rules
++  // should be applied for live content, if applicable for the project.
++  // @param enabled: Enabled/Disabled
++  virtual uint32_t SetLiveWatershed(const bool enabled /* @in */) = 0;
++
++  // @text getLiveWatershed
++  // @brief Gets the LiveWatershed setting
++  // @param enabled: Enabled/Disabled
++  virtual uint32_t GetLiveWatershed(bool &enabled /* @out */) const = 0;
++
++  // @text setPlaybackWatershed
++  // @brief Sets PlaybackWatershed ON/OFF. Whether project-specific watershed rules
++  // should be applied for non-live content, if applicable for the project.
++  // @param enabled: Enabled/Disabled
++  virtual uint32_t SetPlaybackWatershed(const bool enabled /* @in */) = 0;
++
++  // @text getPlaybackWatershed
++  // @brief Gets the PlaybackWatershed setting
++  // @param enabled: Enabled/Disabled
++  virtual uint32_t GetPlaybackWatershed(bool &enabled /* @out */) const = 0;
++
++  // @text setBlockNotRatedContent
++  // @brief Sets BlockNotRatedContent ON/OFF. Whether content that is not rated should be
++  // blocked, if applicable for the project.
++  // @param enabled: Enabled/Disabled
++  virtual uint32_t SetBlockNotRatedContent(const bool enabled /* @in */) = 0;
++
++  // @text getBlockNotRatedContent
++  // @brief Gets the BlockNotRatedContent setting
++  // @param enabled: Enabled/Disabled
++  virtual uint32_t GetBlockNotRatedContent(bool &enabled /* @out */) const = 0;
++
++  // @text setPinOnPurchase
++  // @brief Sets PinOnPurchase ON/OFF.Whether a PIN challenge should be made
++  // when a purchase is attempted.
++  // @param enabled: Enabled/Disabled
++  virtual uint32_t SetPinOnPurchase(const bool enabled /* @in */) = 0;
++
++  // @text getPinOnPurchase
++  // @brief Gets the PinOnPurchase setting
++  // @param enabled: Enabled/Disabled
++  virtual uint32_t GetPinOnPurchase(bool &enabled /* @out */) const = 0;
++
 +};
 +} // namespace Exchange
 +} // namespace WPEFramework
++
 diff --git a/interfaces/Ids.h b/interfaces/Ids.h
-index a37db24..a9f4556 100644
+index a37db24..293dd73 100644
 --- a/interfaces/Ids.h
 +++ b/interfaces/Ids.h
 @@ -354,7 +354,10 @@ namespace Exchange {
@@ -202,11 +302,8 @@ index a37db24..a9f4556 100644
 -        ID_TEXT_TO_SPEECH_NOTIFICATION               = ID_TEXT_TO_SPEECH + 1
 +        ID_TEXT_TO_SPEECH_NOTIFICATION               = ID_TEXT_TO_SPEECH + 1,
 +
-+        ID_USER_SETTINGS                             = RPC::IDS::ID_EXTERNAL_INTERFACE_OFFSET + 0x4D0,
++	ID_USER_SETTINGS                             = RPC::IDS::ID_EXTERNAL_INTERFACE_OFFSET + 0x4D0,
 +        ID_USER_SETTINGS_NOTIFICATION                = ID_USER_SETTINGS + 1
      };
  }
  }
--- 
-2.11.0
-

--- a/Tests/L2Tests/patches/Use_Legact_Alt_Based_On_ThunderTools_R4.4.3.patch
+++ b/Tests/L2Tests/patches/Use_Legact_Alt_Based_On_ThunderTools_R4.4.3.patch
@@ -1,0 +1,20 @@
+commit 810aae64cb31c907698e468b615797750094b847
+Author: Pesala Lakshmi Jwala Priya <plakshmijwalapriya@synamedia.com>
+Date:   Thu Aug 29 12:31:30 2024 +0530
+
+    Alt change
+
+diff --git a/Source/plugins/CMakeLists.txt b/Source/plugins/CMakeLists.txt
+index 4d362d54..cdb53cdc 100644
+--- a/Source/plugins/CMakeLists.txt
++++ b/Source/plugins/CMakeLists.txt
+@@ -29,7 +29,7 @@ ProxyStubGenerator(NAMESPACE "WPEFramework::PluginHost" INPUT "${CMAKE_CURRENT_S
+ ProxyStubGenerator(NAMESPACE "WPEFramework::PluginHost" INPUT "${CMAKE_CURRENT_SOURCE_DIR}/ISubSystem.h" OUTDIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
+ ProxyStubGenerator(NAMESPACE "WPEFramework::PluginHost" INPUT "${CMAKE_CURRENT_SOURCE_DIR}/IDispatcher.h" OUTDIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
+ 
+-JsonGenerator(CODE NAMESPACE WPEFramework::Exchange::Controller INPUT ${CMAKE_CURRENT_SOURCE_DIR}/IController.h OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/generated/jsonrpc" INCLUDE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/.." NO_INCLUDES)
++JsonGenerator(CODE NAMESPACE WPEFramework::Exchange::Controller INPUT ${CMAKE_CURRENT_SOURCE_DIR}/IController.h OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/generated/jsonrpc" INCLUDE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/.." NO_INCLUDES LEGACY_ALT)
+ 
+ add_library(${TARGET} SHARED
+         Channel.cpp
+

--- a/Tests/L2Tests/patches/Use_Legact_Alt_In_ThunderInterfaces_Based_On_ThunderTools_R4.4.3.patch
+++ b/Tests/L2Tests/patches/Use_Legact_Alt_In_ThunderInterfaces_Based_On_ThunderTools_R4.4.3.patch
@@ -1,0 +1,22 @@
+commit f6fd38dcb9f2f1eaf5617119580957228231191c
+Author: Pesala Lakshmi Jwala Priya <plakshmijwalapriya@synamedia.com>
+Date:   Thu Aug 29 12:17:41 2024 +0530
+
+    R4.4.3_change
+
+diff --git a/definitions/CMakeLists.txt b/definitions/CMakeLists.txt
+index adacc7b..53c5327 100644
+--- a/definitions/CMakeLists.txt
++++ b/definitions/CMakeLists.txt
+@@ -49,8 +49,8 @@ if(NOT GENERATOR_SEARCH_PATH)
+     set(GENERATOR_SEARCH_PATH ${CMAKE_SYSROOT}${CMAKE_INSTALL_PREFIX}/include/${NAMESPACE})
+ endif()
+ 
+-JsonGenerator(CODE INPUT ${JSON_FILE} OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/generated" INCLUDE_PATH ${GENERATOR_SEARCH_PATH} CPPIFDIR "${CMAKE_CURRENT_SOURCE_DIR}/../interfaces/")
+-JsonGenerator(CODE INPUT ${INTERFACE_FILE} OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/generated" INCLUDE_PATH ${GENERATOR_SEARCH_PATH})
++JsonGenerator(CODE INPUT ${JSON_FILE} OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/generated" INCLUDE_PATH ${GENERATOR_SEARCH_PATH} CPPIFDIR "${CMAKE_CURRENT_SOURCE_DIR}/../interfaces/" LEGACY_ALT)
++JsonGenerator(CODE INPUT ${INTERFACE_FILE} OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/generated" INCLUDE_PATH ${GENERATOR_SEARCH_PATH} LEGACY_ALT)
+ 
+ file(GLOB JSON_ENUM_SOURCES "${CMAKE_CURRENT_BINARY_DIR}/generated/JsonEnum*.cpp")
+ file(GLOB JSON_LINK_HEADERS "${CMAKE_CURRENT_BINARY_DIR}/generated/J*.h")
+

--- a/UserSettings/CHANGELOG.md
+++ b/UserSettings/CHANGELOG.md
@@ -16,6 +16,18 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.2.0] - 2024-09-17
+### Added
+- Added ParentalControl new properties in Usersetttings.
+
+## [1.1.2] - 2024-08-26
+### Fixed
+- Updated api documentation according to interface.
+
+## [1.1.1] - 2024-07-08
+### Fixed
+- UserSettings Plugin missing default values updated.
+
 ## [1.1.0] - 2024-06-02
 ### Added
 - Added GetPrivacyMode/GetPrivacyMode calls.

--- a/UserSettings/UserSettings.h
+++ b/UserSettings/UserSettings.h
@@ -80,10 +80,10 @@ namespace Plugin {
                     Exchange::JUserSettings::Event::OnPreferredAudioLanguagesChanged(_parent, preferredLanguages);
                 }
 
-                void OnPresentationLanguageChanged(const string& presentationLanguages) override
+                void OnPresentationLanguageChanged(const string& presentationLanguage) override
                 {
-                    LOGINFO("PresentationLanguageChanged: %s\n", presentationLanguages.c_str());
-                    Exchange::JUserSettings::Event::OnPresentationLanguageChanged(_parent, presentationLanguages);
+                    LOGINFO("PresentationLanguageChanged: %s\n", presentationLanguage.c_str());
+                    Exchange::JUserSettings::Event::OnPresentationLanguageChanged(_parent, presentationLanguage);
                 }
 
                 void OnCaptionsChanged(bool enabled) override
@@ -108,6 +108,48 @@ namespace Plugin {
                 {
                     LOGINFO("PrivacyModeChanged: %s\n", privacyMode.c_str());
                     Exchange::JUserSettings::Event::OnPrivacyModeChanged(_parent, privacyMode);
+                }
+
+                void OnPinControlChanged(const bool enabled) override
+                {
+                    LOGINFO("PinControlChanged: %d\n", enabled);
+                    Exchange::JUserSettings::Event::OnPinControlChanged(_parent, enabled);
+                }
+
+                void OnViewingRestrictionsChanged(const string& viewingRestrictions) override
+                {
+                    LOGINFO("ViewingRestrictionsChanged: %s\n", viewingRestrictions.c_str());
+                    Exchange::JUserSettings::Event::OnViewingRestrictionsChanged(_parent, viewingRestrictions);
+                }
+
+                void OnViewingRestrictionsWindowChanged(const string& viewingRestrictionsWindow) override
+                {
+                    LOGINFO("ViewingRestrictionsWindowChanged: %s\n", viewingRestrictionsWindow.c_str());
+                    Exchange::JUserSettings::Event::OnViewingRestrictionsWindowChanged(_parent, viewingRestrictionsWindow);
+                }
+
+                void OnLiveWatershedChanged(const bool enabled) override
+                {
+                    LOGINFO("LiveWatershedChanged: %d\n", enabled);
+                    Exchange::JUserSettings::Event::OnLiveWatershedChanged(_parent, enabled);
+                }
+
+                void OnPlaybackWatershedChanged(const bool enabled) override
+                {
+                    LOGINFO("PlaybackWatershedChanged: %d\n", enabled);
+                    Exchange::JUserSettings::Event::OnPlaybackWatershedChanged(_parent, enabled);
+                }
+
+                void OnBlockNotRatedContentChanged(const bool enabled) override
+                {
+                    LOGINFO("BlockNotRatedContentChanged: %d\n", enabled);
+                    Exchange::JUserSettings::Event::OnBlockNotRatedContentChanged(_parent, enabled);
+                }
+
+                void OnPinOnPurchaseChanged(const bool enabled) override
+                {
+                    LOGINFO("PinOnPurchaseChanged: %d\n", enabled);
+                    Exchange::JUserSettings::Event::OnPinOnPurchaseChanged(_parent, enabled);
                 }
 
             private:

--- a/UserSettings/UserSettings.json
+++ b/UserSettings/UserSettings.json
@@ -3,155 +3,402 @@
     "jsonrpc": "2.0",
     "info": {
         "title": "UserSettings API",
-        "class": "UserSettings",
+        "class": "org.rdk.UserSettings",
         "description": "The `UserSettings`, that is responsible for persisting and notifying listeners of any change of these settings.."
     },
     "common": {
         "$ref": "../common/common.json"
     },
+    "definitions": {
+        "preferredLanguages": {
+            "summary": "A prioritized list of ISO 639-2/B codes for the preferred audio languages",
+            "type": "string",
+            "example": "eng"
+        },
+        "preferredCaptionsLanguages": {
+            "summary": "A prioritized list of ISO 639-2/B codes for the preferred captions languages",
+            "type": "string",
+            "example": "eng"
+        },
+        "preferredClosedCaptionService": {
+            "summary": "A string for the preferred closed captions service.  Valid values are AUTO, CC[1-4], TEXT[1-4], SERVICE[1-64] where CC and TEXT is CTA-608 and SERVICE is CTA-708.  AUTO indicates that the choice is left to the player",
+            "type": "string",
+            "example": "CC3"
+        },
+        "presentationLanguage": {
+            "summary": "The preferred presentationLanguage in a full BCP 47 value, including script, * region, variant The language set and used by Immerse UI",
+            "type": "string",
+            "example": "en-US"
+        },
+        "viewingRestrictions": {
+            "summary": "A project-specific representation of the time interval when viewing.",
+            "type": "string",
+            "example": "ALWAYS"
+        },
+        "viewingRestrictionsWindow": {
+            "summary": "A project-specific representation of the time interval",
+            "type": "string",
+            "example": "ALWAYS"
+        }
+    },
     "methods": {
-        "SetAudioDescription": {
+        "setAudioDescription": {
             "summary": "Setting Audio Description.",
-            "params": {
-                "summary": "Audio Description Enabled: true/false",
-                "type": "boolean",
-                "example": true
+			"events": {
+                "OnAudioDescriptionChanged" : "Triggered when the audio description changes."
             },
-            "result": {
-                "summary": "Null string will display",
-                "type": "string",
-                "example": "null"
-            }
-        },
-        "SetPreferredAudioLanguages": {
-            "summary": "Setting Preferred Audio Languages.",
-            "params": {
-                "summary": "Preferred Audio Languages: eng, wel",
-                "type": "string",
-                "example": "eng"
-            },
-            "result": {
-                "summary": "Null string will display",
-                "type": "string",
-                "example": "null"
-            }
-        },
-        "SetPresentationLanguage": {
-            "summary": "Setting Presentation Languages.",
-            "params": {
-                "summary": "Presentation Languages: en-US, es-US",
-                "type": "string",
-                "example": "en-US"
-            },
-            "result": {
-                "summary": "Null string will display",
-                "type": "string",
-                "example": "null"
-            }
-        },
-        "SetCaptions": {
-            "summary": "Setting Captions.",
-            "params": {
-                "summary": "Captions Enabled: true/false",
-                "type": "boolean",
-                "example": true
-            },
-            "result": {
-                "summary": "Null string will display ",
-                "type": "string",
-                "example": "null"
-            }
-        },
-        "SetPreferredCaptionsLanguages": {
-            "summary": "Setting PreferredCaption Languages.",
-            "params": {
-                "summary": "PreferredCaption Languages: eng, fra",
-                "type": "string",
-                "example": "eng"
-            },
-            "result": {
-                "summary": "Null string will display",
-                "type": "string",
-                "example": "null"
-            }
-        },
-        "SetPreferredClosedCaptionService": {
-            "summary": "Setting Preferred Closed Caption Service.",
-            "params": {
-                "summary": "Preferred Closed Caption Service: CC3",
-                "type": "string",
-                "example": "CC3"
-            },
-            "result": {
-                "summary": "Null string will display",
-                "type": "string",
-                "example": "null"
-            }
-        },
-        "SetPrivacyMode": {
-            "summary": "Setting Privacy Mode.",          
             "params": {
                 "type": "object",
                 "properties": {
-                    "privacyMode": {
-                        "summary": "New Privacy Mode",
-                        "type": "string",
-                        "example": "DO_NOT_SHARE"
+                    "enabled": {
+                        "summary": "Audio Description Enabled: true/false",
+                        "type": "boolean",
+                        "example":true
                     }
                 }
             },
             "result": {
-                "summary": "Null string will display",
+                "summary": "On success null will be returned",
                 "type": "string",
                 "example": "null"
             }
         },
-        "GetAudioDescription":{
-            "summary": "Returns Audio Description.",
+        "setPreferredAudioLanguages": {
+            "summary": "Setting Preferred Audio Languages.",
+			"events": {
+                "onPreferredAudioLanguagesChanged" : "Triggered when the audio preferred Audio languages changes."
+            },
+            "params": {
+                "type": "object",
+                "properties": {
+                    "preferredLanguages": {
+                        "$ref": "#/definitions/preferredLanguages"
+                    }
+                }
+            },
             "result": {
-                "type": "boolean"
+                "summary": "On success null will be returned",
+                "type": "string",
+                "example": "null"
             }
         },
-        "GetPreferredAudioLanguages":{
-            "summary": "Returns Audio Description.",
+        "setPresentationLanguage": {
+            "summary": "Setting Presentation Languages.",
+			"events": {
+                "onPresentationLanguageChanged" : "Triggered when the presentation Language changes."
+            },
+            "params": {
+                "type": "object",
+                "properties": {
+                    "presentationLanguage": {
+                        "$ref": "#/definitions/presentationLanguage"
+                    }
+                }
+            },
             "result": {
-                "type": "string"
+                "summary": "On success null will be returned",
+                "type": "string",
+                "example": "null"
             }
         },
-        "GetPresentationLanguage":{
+        "setCaptions": {
+            "summary": "Setting Captions.",
+			"events": {
+                "onCaptionsChanged" : "Triggered when the captions changes."
+            },
+            "params": {
+                "type": "object",
+                "properties": {
+                    "enabled": {
+                        "summary": "Captions Enabled: true/false",
+                        "type": "boolean",
+                        "example": true
+                    }
+                }
+            },
+            "result": {
+                "summary": "On success null will be returned",
+                "type": "string",
+                "example": "null"
+            }
+        },
+        "setPreferredCaptionsLanguages": {
+            "summary": "Setting PreferredCaption Languages.",
+			"events": {
+                "onPreferredCaptionsLanguagesChanged" : "Triggered when the PreferredCaption Languages changes."
+            },
+            "params": {
+                "type": "object",
+                "properties": {
+                    "preferredLanguages": {
+                        "$ref": "#/definitions/preferredCaptionsLanguages"
+                    }
+                }
+            },
+            "result": {
+                "summary": "On success null will be returned",
+                "type": "string",
+                "example": "null"
+            }
+        },
+        "setPreferredClosedCaptionService": {
+            "summary": "Setting Preferred Closed Caption Service.",
+			"events": {
+                "onPreferredClosedCaptionServiceChanged" : "Triggered when the Preferred Closed Caption changes."
+            },
+            "params": {
+                "type": "object",
+                "properties": {
+                    "service": {
+                        "$ref": "#/definitions/preferredClosedCaptionService"
+                    }
+                }
+            },
+            "result": {
+                "summary": "On success null will be returned",
+                "type": "string",
+                "example": "null"
+            }
+        },
+	"setPinControl": {
+            "summary": "Setting PinControl.",
+			"events": {
+                "onPinControlChanged" : "Triggered when the pincontrol changes."
+            },
+            "params": {
+                "type": "object",
+                "properties": {
+                    "enabled": {
+                        "summary": "PinControl Enabled: true/false",
+                        "type": "boolean",
+                        "example":true
+                    }
+                }
+            },
+            "result": {
+                "summary": "On success null will be returned",
+                "type": "string",
+                "example": "null"
+            }
+        },
+	"setViewingRestrictions": {
+            "summary": "Setting ViewingRestrictions.",
+			"events": {
+                "OnViewingRestrictionsChanged" : "Triggered when the viewingRestrictions changes."
+            },
+            "params": {
+                "type": "object",
+                "properties": {
+                    "viewingRestrictions": {
+                        "$ref": "#/definitions/viewingRestrictions"
+                    }
+                }
+            },
+            "result": {
+                "summary": "On success null will be returned",
+                "type": "string",
+                "example": "null"
+            }
+        },
+        "setViewingRestrictionsWindow": {
+            "summary": "Setting viewingRestrictionsWindow.",
+			"events": {
+                "OnViewingRestrictionsWindowChanged" : "Triggered when the viewingRestrictionsWindow changes."
+            },
+            "params": {
+                "type": "object",
+                "properties": {
+                    "viewingRestrictionsWindow": {
+                        "$ref": "#/definitions/viewingRestrictionsWindow"
+                    }
+                }
+            },
+            "result": {
+                "summary": "On success null will be returned",
+                "type": "string",
+                "example": "null"
+            }
+        },
+	"setLiveWatershed": {
+            "summary": "Setting LiveWatershed.",
+			"events": {
+                "OnLiveWatershedChanged" : "Triggered when the liveWatershed changes."
+            },
+            "params": {
+                "type": "object",
+                "properties": {
+                    "enabled": {
+                        "summary": "LiveWatershed Enabled: true/false",
+                        "type": "boolean",
+                        "example":true
+                    }
+                }
+            },
+            "result": {
+                "summary": "On success null will be returned",
+                "type": "string",
+                "example": "null"
+            }
+        },
+	"setPlaybackWatershed": {
+            "summary": "Setting PlaybackWatershed.",
+			"events": {
+                "OnPlaybackWatershedChanged" : "Triggered when the playbackWatershed changes."
+            },
+            "params": {
+                "type": "object",
+                "properties": {
+                    "enabled": {
+                        "summary": "PlaybackWatershed Enabled: true/false",
+                        "type": "boolean",
+                        "example":true
+                    }
+                }
+            },
+            "result": {
+                "summary": "On success null will be returned",
+                "type": "string",
+                "example": "null"
+            }
+        },
+	"setBlockNotRatedContent": {
+            "summary": "Setting BlockNotRatedContent.",
+			"events": {
+                "OnBlockNotRatedContentChanged" : "Triggered when the blockNotRatedContent changes."
+            },
+            "params": {
+                "type": "object",
+                "properties": {
+                    "enabled": {
+                        "summary": "BlockNotRatedContent Enabled: true/false",
+                        "type": "boolean",
+                        "example":true
+                    }
+                }
+            },
+            "result": {
+                "summary": "On success null will be returned",
+                "type": "string",
+                "example": "null"
+            }
+        },
+	"setPinOnPurchase": {
+            "summary": "Setting setPinOnPurchase",
+			"events": {
+                "OnPinOnPurchaseChanged" : "Triggered when the pin on the purchase changes."
+            },
+            "params": {
+                "type": "object",
+                "properties": {
+                    "enabled": {
+                        "summary": "setPinOnPurchase Enabled: true/false",
+                        "type": "boolean",
+                        "example":true
+                    }
+                }
+            },
+            "result": {
+                "summary": "On success null will be returned",
+                "type": "string",
+                "example": "null"
+            }
+        },
+        "getAudioDescription":{
+            "summary": "Returns Audio Description.",
+            "result": {
+                "summary": "Audio Description Enabled: true/false",
+                "type": "boolean",
+                "example": true
+            }
+        },
+        "getPreferredAudioLanguages":{
+            "summary": "Returns Preferred Audio Languages.",
+            "result": {
+                "$ref": "#/definitions/preferredLanguages"
+            }
+        },
+        "getPresentationLanguage":{
             "summary": "Getting Presentation Languages.",
             "result": {
-                "type": "string"
+                "$ref": "#/definitions/presentationLanguage"
             }
         },
-        "GetCaptions":{
+        "getCaptions":{
             "summary": "Getting Captions Enabled.",
             "result": {
-                "type": "boolean"
+                "summary": "Captions Enabled: true/false",
+                "type": "boolean",
+                "example": true
             }
         },
-        "GetPreferredCaptionsLanguages":{
+        "getPreferredCaptionsLanguages":{
             "summary": "Getting Preferred Caption Languages.",
             "result": {
-                "type": "string"
+                "$ref": "#/definitions/preferredCaptionsLanguages"
             }
         },
-        "GetPreferredClosedCaptionService":{
+        "getPreferredClosedCaptionService":{
             "summary": "Getting Preferred ClosedCaption Service.",
             "result": {
-                "type": "string"
+                "$ref": "#/definitions/preferredClosedCaptionService"
             }
         },
-        "GetPrivacyMode":{
-            "summary": "Getting Privacy Mode",
+	"getPinControl":{
+            "summary": "Returns Pin Control.",
             "result": {
-                "type": "string"
+                "summary": "Pin Control Enabled: true/false",
+                "type": "boolean",
+                "example": true
+            }
+        },
+        "getViewingRestrictions":{
+            "summary": "Returns Get Viewing Restrictions.",
+            "result": {
+              "$ref": "#/definitions/viewingRestrictions"
+            }
+        },
+        "getViewingRestrictionsWindow":{
+            "summary": "Returns Get Viewing Restrictions Window.",
+            "result": {
+              "$ref": "#/definitions/viewingRestrictionsWindow"
+            }
+        },
+        "getLiveWatershed":{
+            "summary": "Returns Live Watershed.",
+            "result": {
+                "summary": "Live Watershed Enabled: true/false",
+                "type": "boolean",
+                "example": true
+            }
+        },
+        "getPlaybackWatershed":{
+            "summary": "Returns Playback Watershed.",
+            "result": {
+                "summary": "Playback Watershed Enabled: true/false",
+                "type": "boolean",
+                "example": true
+            }
+        },
+        "getBlockNotRatedContent":{
+            "summary": "Returns BlockNotRatedContent.",
+            "result": {
+                "summary": "BlockNotRatedContent Enabled: true/false",
+                "type": "boolean",
+                "example": true
+            }
+        },
+        "getPinOnPurchase":{
+            "summary": "Returns PinOnPurchase.",
+            "result": {
+                "summary": "PinOnPurchase Enabled: true/false",
+                "type": "boolean",
+                "example": true
             }
         }
     },
     "events": {
-        "OnAudioDescriptionChanged": {
-            "summary": "Triggered after the audio description changes (see `setaudiodescription`)",
+        "onAudioDescriptionChanged": {
+            "summary": "Triggered after the audio description changes (see `SetAudioDescription`)",
             "params": {
                 "type": "object",
                 "properties": {
@@ -166,8 +413,8 @@
                 ]
             }
         },
-        "OnPreferredAudioLanguagesChanged": {
-            "summary": "Triggered after the audio preferred Audio languages changes (see `setpreferredaudiolanguages`)",
+        "onPreferredAudioLanguagesChanged": {
+            "summary": "Triggered after the audio preferred Audio languages changes (see `SetPreferredAudioLanguages`)",
             "params": {
                 "type": "object",
                 "properties": {
@@ -182,24 +429,24 @@
                 ]
             }
         },
-        "OnPresentationLanguageChanged": {
-            "summary": "Triggered after the Presentation Language changes (see `setpresentationlanguages`)",
+        "onPresentationLanguageChanged": {
+            "summary": "Triggered after the Presentation Language changes (see `SetPresentationLanguage`)",
             "params": {
                 "type": "object",
                 "properties": {
-                    "presentationLanguages":{
+                    "presentationLanguage":{
                         "summary": "Receive Presentation Language changes",
                         "type": "string",
                         "example": "en-US"
                     }
                 },
                 "required": [
-                    "presentationLanguages"
+                    "presentationLanguage"
                 ]
             }
         },
-        "OnCaptionsChanged": {
-            "summary": "Triggered after the captions changes (see `setcaptionsenabled`)",
+        "onCaptionsChanged": {
+            "summary": "Triggered after the captions changes (see `SetCaptions`)",
             "params": {
                 "type": "object",
                 "properties": {
@@ -214,8 +461,8 @@
                 ]
             }
         },
-        "OnPreferredCaptionsLanguagesChanged": {
-            "summary": "Triggered after the PreferredCaption Languages changes (see `setpreferredcaptionlanguages`)",
+        "onPreferredCaptionsLanguagesChanged": {
+            "summary": "Triggered after the PreferredCaption Languages changes (see `SetPreferredCaptionsLanguages`)",
             "params": {
                 "type": "object",
                 "properties": {
@@ -230,13 +477,13 @@
                 ]
             }
         },
-        "OnPreferredClosedCaptionServiceChanged": {
-            "summary": "Triggered after the Preferred Closed Caption changes (see `setpreferredclosedcaptionservice`)",
+        "onPreferredClosedCaptionServiceChanged": {
+            "summary": "Triggered after the Preferred Closed Caption changes (see `SetPreferredClosedCaptionService`)",
             "params": {
                 "type": "object",
                 "properties": {
                     "service":{
-                        "summary": "Receive Preferred Closed Caption changes",
+                        "summary": "Receive Preferred Closed Caption Service changes",
                         "type": "string",
                         "example": "CC3"
                     }
@@ -246,19 +493,115 @@
                 ]
             }
         },
-        "OnPrivacyModeChanged": {
-            "summary": "Triggered after the Privacy Mode changes (see `SetPrivacyMode`)",
+	"onPinControlChanged": {
+            "summary": "Triggered after the pin control changes (see `setPinControl`)",
             "params": {
                 "type": "object",
                 "properties": {
-                    "privacyMode":{
-                        "summary": "Receive Privacy Mode changes",
-                        "type": "string",
-                        "example": "DO_NOT_SHARE"
+                    "enabled":{
+                        "summary": "Receive pin control changes enable or not",
+                        "type": "boolean",
+                        "example": true
                     }
                 },
                 "required": [
-                    "privacyMode"
+                    "enabled"
+                ]
+            }
+        },
+        "onViewingRestrictionsChanged": {
+            "summary": "Triggered after the viewingRestrictions changes (see `setViewingRestrictions`)",
+            "params": {
+                "type": "object",
+                "properties": {
+                    "enabled":{
+                        "summary": "Receive viewingRestrictions changes enable or not",
+                        "type": "boolean",
+                        "example": true
+                    }
+                },
+                "required": [
+                    "enabled"
+                ]
+            }
+        },
+        "onViewingRestrictionsWindowChanged": {
+            "summary": "Triggered after the viewingRestrictionsWindow changes (see `setViewingRestrictionsWindow`)",
+            "params": {
+                "type": "object",
+                "properties": {
+                    "enabled":{
+                        "summary": "Receive viewingRestrictionsWindow changes enable or not",
+                        "type": "boolean",
+                        "example": true
+                    }
+                },
+                "required": [
+                    "enabled"
+                ]
+            }
+        },
+        "onLiveWatershedChanged": {
+            "summary": "Triggered after the liveWatershed changes (see `setLiveWatershed`)",
+            "params": {
+                "type": "object",
+                "properties": {
+                    "enabled":{
+                        "summary": "Receives liveWatershed changes enable or not",
+                        "type": "boolean",
+                        "example": true
+                    }
+                },
+                "required": [
+                    "enabled"
+                ]
+            }
+        },
+        "onPlaybackWatershedChanged": {
+            "summary": "Triggered after the playbackWatershed changes (see `setPlaybackWatershed`)",
+            "params": {
+                "type": "object",
+                "properties": {
+                    "enabled":{
+                        "summary": "Receive playbackWatershed changes enable or not",
+                        "type": "boolean",
+                        "example": true
+                    }
+                },
+                "required": [
+                    "enabled"
+                ]
+            }
+        },
+        "onBlockNotRatedContentChanged": {
+            "summary": "Triggered after the blockNotRatedContent changes (see `setBlockNotRatedContent`)",
+            "params": {
+                "type": "object",
+                "properties": {
+                    "enabled":{
+                        "summary": "Receive blockNotRatedContent changes enable or not",
+                        "type": "boolean",
+                        "example": true
+                    }
+                },
+                "required": [
+                    "enabled"
+                ]
+            }
+        },
+        "onPinOnPurchaseChanged": {
+            "summary": "Triggered after the pinOnPurchase changes (see `setPinOnPurchase`)",
+            "params": {
+                "type": "object",
+                "properties": {
+                    "enabled":{
+                        "summary": "Receive pinOnPurchase changes enable or not",
+                        "type": "boolean",
+                        "example": true
+                    }
+                },
+                "required": [
+                    "enabled"
                 ]
             }
         }

--- a/UserSettings/UserSettingsImplementation.cpp
+++ b/UserSettings/UserSettingsImplementation.cpp
@@ -23,16 +23,6 @@
 #include <mutex>
 #include "tracing/Logging.h"
 
-#define USERSETTINGS_NAMESPACE "UserSettings"
-
-#define USERSETTINGS_AUDIO_DESCRIPTION_KEY                    "audioDescription"
-#define USERSETTINGS_PREFERRED_AUDIO_LANGUAGES_KEY            "preferredAudioLanguages"
-#define USERSETTINGS_PRESENTATION_LANGUAGE_KEY                "presentationLanguage"
-#define USERSETTINGS_CAPTIONS_KEY                             "captions"
-#define USERSETTINGS_PREFERRED_CAPTIONS_LANGUAGES_KEY         "preferredCaptionsLanguages"
-#define USERSETTINGS_PREFERRED_CLOSED_CAPTIONS_SERVICE_KEY    "preferredClosedCaptionsService"
-#define USERSETTINGS_PRIVACY_MODE_KEY                         "privacyMode"
-
 #ifdef HAS_RBUS
 #define RBUS_COMPONENT_NAME "UserSettingsThunderPlugin"
 #define RBUS_PRIVACY_MODE_EVENT_NAME "Device.X_RDKCENTRAL-COM_UserSettings.PrivacyModeChanged"
@@ -40,6 +30,20 @@
 
 namespace WPEFramework {
 namespace Plugin {
+
+const std::map<string, string> UserSettingsImplementation::usersettingsDefaultMap = {{USERSETTINGS_AUDIO_DESCRIPTION_KEY, "false"},
+                                                                 {USERSETTINGS_PREFERRED_AUDIO_LANGUAGES_KEY, ""},
+                                                                 {USERSETTINGS_PRESENTATION_LANGUAGE_KEY, ""},
+                                                                 {USERSETTINGS_CAPTIONS_KEY, "false"},
+                                                                 {USERSETTINGS_PREFERRED_CAPTIONS_LANGUAGES_KEY, ""},
+                                                                 {USERSETTINGS_PREFERRED_CLOSED_CAPTIONS_SERVICE_KEY, "AUTO"},
+                                                                 {USERSETTINGS_PIN_CONTROL_KEY, "false"},
+                                                                 {USERSETTINGS_VIEWING_RESTRICTIONS_KEY, ""},
+                                                                 {USERSETTINGS_VIEWING_RESTRICTIONS_WINDOW_KEY, ""},
+                                                                 {USERSETTINGS_LIVE_WATERSHED_KEY, "false"},
+                                                                 {USERSETTINGS_PLAYBACK_WATERSHED_KEY, "false"},
+                                                                 {USERSETTINGS_BLOCK_NOT_RATED_CONTENT_KEY, "false"},
+                                                                 {USERSETTINGS_PIN_ON_PURCHASE_KEY, "false"}};
 
 SERVICE_REGISTRATION(UserSettingsImplementation, 1, 0);
 
@@ -110,7 +114,7 @@ UserSettingsImplementation::~UserSettingsImplementation()
     if (_controller)
     {
         _controller->Release();
-	 _controller = nullptr;
+        _controller = nullptr;
     }
 
     LOGINFO("Disconnect from the COM-RPC socket\n");
@@ -222,7 +226,7 @@ void UserSettingsImplementation::Dispatch(Event event, const JsonValue params)
                  (*index)->OnAudioDescriptionChanged(params.Boolean());
                  ++index;
              }
-		break;
+         break;
 
          case PREFERRED_AUDIO_CHANGED:
              while (index != _userSettingNotification.end())
@@ -230,7 +234,7 @@ void UserSettingsImplementation::Dispatch(Event event, const JsonValue params)
                  (*index)->OnPreferredAudioLanguagesChanged(params.String());
                  ++index;
              }
-		break;
+         break;
 
          case PRESENTATION_LANGUAGE_CHANGED:
              while (index != _userSettingNotification.end())
@@ -238,7 +242,7 @@ void UserSettingsImplementation::Dispatch(Event event, const JsonValue params)
                  (*index)->OnPresentationLanguageChanged(params.String());
                  ++index;
              }
-		break;
+         break;
 
          case CAPTIONS_CHANGED:
              while (index != _userSettingNotification.end())
@@ -246,7 +250,7 @@ void UserSettingsImplementation::Dispatch(Event event, const JsonValue params)
                  (*index)->OnCaptionsChanged(params.Boolean());
                  ++index;
              }
-		break;
+         break;
 
          case PREFERRED_CAPTIONS_LANGUAGE_CHANGED:
              while (index != _userSettingNotification.end())
@@ -254,7 +258,7 @@ void UserSettingsImplementation::Dispatch(Event event, const JsonValue params)
                  (*index)->OnPreferredCaptionsLanguagesChanged(params.String());
                  ++index;
              }
-		break;
+         break;
 
          case PREFERRED_CLOSED_CAPTIONS_SERVICE_CHANGED:
              while (index != _userSettingNotification.end())
@@ -262,7 +266,7 @@ void UserSettingsImplementation::Dispatch(Event event, const JsonValue params)
                  (*index)->OnPreferredClosedCaptionServiceChanged(params.String());
                  ++index;
              }
-		break;
+         break;
 
          case PRIVACY_MODE_CHANGED:
              while (index != _userSettingNotification.end())
@@ -270,7 +274,63 @@ void UserSettingsImplementation::Dispatch(Event event, const JsonValue params)
                  (*index)->OnPrivacyModeChanged(params.String());
                  ++index;
              }
-		break;
+         break;
+
+         case PIN_CONTROL_CHANGED:
+              while (index != _userSettingNotification.end())
+              {
+                  (*index)->OnPinControlChanged(params.Boolean());
+                  ++index;
+              }
+         break;
+
+         case VIEWING_RESTRICTIONS_CHANGED:
+              while (index != _userSettingNotification.end())
+              {
+                  (*index)->OnViewingRestrictionsChanged(params.String());
+                  ++index;
+              }
+         break;
+
+         case VIEWING_RESTRICTIONS_WINDOW_CHANGED:
+              while (index != _userSettingNotification.end())
+              {
+                  (*index)->OnViewingRestrictionsWindowChanged(params.String());
+                  ++index;
+              }
+         break;
+
+         case LIVE_WATERSHED_CHANGED:
+              while (index != _userSettingNotification.end())
+              {
+                  (*index)->OnLiveWatershedChanged(params.Boolean());
+                  ++index;
+              }
+         break;
+
+         case PLAYBACK_WATERSHED_CHANGED:
+              while (index != _userSettingNotification.end())
+              {
+                  (*index)->OnPlaybackWatershedChanged(params.Boolean());
+                  ++index;
+              }
+         break;
+
+         case BLOCK_NOT_RATED_CONTENT_CHANGED:
+              while (index != _userSettingNotification.end())
+              {
+                  (*index)->OnBlockNotRatedContentChanged(params.Boolean());
+                  ++index;
+              }
+         break;
+
+         case PIN_ON_PURCHASE_CHANGED:
+              while (index != _userSettingNotification.end())
+              {
+                  (*index)->OnPinOnPurchaseChanged(params.Boolean());
+                  ++index;
+              }
+         break;
 
          default:
              break;
@@ -311,10 +371,83 @@ void UserSettingsImplementation::ValueChanged(const Exchange::IStore2::ScopeType
     {
         dispatchEvent(PRIVACY_MODE_CHANGED, JsonValue((string)value));
     }
+    else if((ns.compare(USERSETTINGS_NAMESPACE) == 0) && (key.compare(USERSETTINGS_PIN_CONTROL_KEY) == 0))
+    {
+        dispatchEvent(PIN_CONTROL_CHANGED, JsonValue((bool)(value.compare("true")==0)?true:false));
+    }
+    else if((ns.compare(USERSETTINGS_NAMESPACE) == 0) && (key.compare(USERSETTINGS_VIEWING_RESTRICTIONS_KEY) == 0))
+    {
+        dispatchEvent(VIEWING_RESTRICTIONS_CHANGED, JsonValue((string)value));
+    }
+    else if((ns.compare(USERSETTINGS_NAMESPACE) == 0) && (key.compare(USERSETTINGS_VIEWING_RESTRICTIONS_WINDOW_KEY) == 0))
+    {
+        dispatchEvent(VIEWING_RESTRICTIONS_WINDOW_CHANGED, JsonValue((string)value));
+    }
+    else if((ns.compare(USERSETTINGS_NAMESPACE) == 0) && (key.compare(USERSETTINGS_LIVE_WATERSHED_KEY) == 0))
+    {
+        dispatchEvent(LIVE_WATERSHED_CHANGED, JsonValue((bool)(value.compare("true")==0)?true:false));
+    }
+    else if((ns.compare(USERSETTINGS_NAMESPACE) == 0) && (key.compare(USERSETTINGS_PLAYBACK_WATERSHED_KEY) == 0))
+    {
+        dispatchEvent(PLAYBACK_WATERSHED_CHANGED, JsonValue((bool)(value.compare("true")==0)?true:false));
+    }
+    else if((ns.compare(USERSETTINGS_NAMESPACE) == 0) && (key.compare(USERSETTINGS_BLOCK_NOT_RATED_CONTENT_KEY) == 0))
+    {
+        dispatchEvent(BLOCK_NOT_RATED_CONTENT_CHANGED, JsonValue((bool)(value.compare("true")==0)?true:false));
+    }
+    else if((ns.compare(USERSETTINGS_NAMESPACE) == 0) && (key.compare(USERSETTINGS_PIN_ON_PURCHASE_KEY) == 0))
+    {
+        dispatchEvent(PIN_ON_PURCHASE_CHANGED, JsonValue((bool)(value.compare("true")==0)?true:false));
+    }
     else
     {
         LOGERR("Not supported");
     }
+}
+
+uint32_t UserSettingsImplementation::SetUserSettingsValue(const string& key, const string& value)
+{
+    uint32_t status = Core::ERROR_GENERAL;
+    _adminLock.Lock();
+
+    ASSERT (nullptr != _remotStoreObject);
+    if (nullptr != _remotStoreObject)
+    {
+        status = _remotStoreObject->SetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, key, value, 0);
+    }
+
+    _adminLock.Unlock();
+    return status;
+}
+
+uint32_t UserSettingsImplementation::GetUserSettingsValue(const string& key, string &value) const
+{
+    uint32_t status = Core::ERROR_GENERAL;
+    uint32_t ttl = 0;
+    _adminLock.Lock();
+
+    ASSERT (nullptr != _remotStoreObject);
+    if (nullptr != _remotStoreObject)
+    {
+        status = _remotStoreObject->GetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, key, value, ttl);
+
+        LOGINFO("Key[%s] value[%s] status[%d]", key.c_str(), value.c_str(), status);
+        if(Core::ERROR_UNKNOWN_KEY == status || Core::ERROR_NOT_EXIST == status)
+        {
+            if(usersettingsDefaultMap.find(key)!=usersettingsDefaultMap.end())
+            {
+                value = usersettingsDefaultMap.find(key)->second;
+                status = Core::ERROR_NONE;
+            }
+            else
+            {
+                LOGERR("Default value is not found in usersettingsDefaultMap for '%s' Key", key.c_str());
+            }
+        }
+    }
+    _adminLock.Unlock();
+
+    return status;
 }
 
 uint32_t UserSettingsImplementation::SetAudioDescription(const bool enabled)
@@ -322,18 +455,7 @@ uint32_t UserSettingsImplementation::SetAudioDescription(const bool enabled)
     uint32_t status = Core::ERROR_GENERAL;
 
     LOGINFO("enabled: %d", enabled);
-
-    _adminLock.Lock();
-
-    ASSERT (nullptr != _remotStoreObject);
-
-    if (nullptr != _remotStoreObject)
-    {
-        status = _remotStoreObject->SetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_AUDIO_DESCRIPTION_KEY, (enabled)?"true":"false", 0);
-    }
-
-    _adminLock.Unlock();
-
+    status = SetUserSettingsValue(USERSETTINGS_AUDIO_DESCRIPTION_KEY, (enabled)?"true":"false");
     return status;
 }
 
@@ -341,30 +463,19 @@ uint32_t UserSettingsImplementation::GetAudioDescription(bool &enabled) const
 {
     uint32_t status = Core::ERROR_GENERAL;
     std::string value = "";
-    uint32_t ttl = 0;
 
-    _adminLock.Lock();
-
-    ASSERT (nullptr != _remotStoreObject);
-
-    if (nullptr != _remotStoreObject)
+    status = GetUserSettingsValue(USERSETTINGS_AUDIO_DESCRIPTION_KEY, value);
+    if(Core::ERROR_NONE == status)
     {
-        status = _remotStoreObject->GetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_AUDIO_DESCRIPTION_KEY, value, ttl);
-
-        if(Core::ERROR_NONE == status)
+        if (0 == value.compare("true"))
         {
-            if (0 == value.compare("true"))
-            {
-                enabled = true;
-            }
-            else
-            {
-                enabled = false;
-            }
+            enabled = true;
+        }
+        else
+        {
+            enabled = false;
         }
     }
-
-    _adminLock.Unlock();
 
     return status;
 }
@@ -374,18 +485,7 @@ uint32_t UserSettingsImplementation::SetPreferredAudioLanguages(const string& pr
     uint32_t status = Core::ERROR_GENERAL;
 
     LOGINFO("preferredLanguages: %s", preferredLanguages.c_str());
-
-    _adminLock.Lock();
-
-    ASSERT (nullptr != _remotStoreObject);
-
-    if (nullptr != _remotStoreObject)
-    {
-        status = _remotStoreObject->SetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_PREFERRED_AUDIO_LANGUAGES_KEY, preferredLanguages, 0);
-    }
-
-    _adminLock.Unlock();
-
+    status = SetUserSettingsValue(USERSETTINGS_PREFERRED_AUDIO_LANGUAGES_KEY, preferredLanguages);
     return status;
 }
 
@@ -393,59 +493,26 @@ uint32_t UserSettingsImplementation::GetPreferredAudioLanguages(string &preferre
 {
     uint32_t status = Core::ERROR_GENERAL;
     std::string value = "";
-    uint32_t ttl = 0;
 
-    _adminLock.Lock();
-
-    ASSERT (nullptr != _remotStoreObject);
-
-    if (nullptr != _remotStoreObject)
-    {
-        status = _remotStoreObject->GetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_PREFERRED_AUDIO_LANGUAGES_KEY, preferredLanguages, ttl);
-    }
-
-    _adminLock.Unlock();
-
+    status = GetUserSettingsValue(USERSETTINGS_PREFERRED_AUDIO_LANGUAGES_KEY, preferredLanguages);
     return status;
 }
 
-uint32_t UserSettingsImplementation::SetPresentationLanguage(const string& presentationLanguages)
+uint32_t UserSettingsImplementation::SetPresentationLanguage(const string& presentationLanguage)
 {
     uint32_t status = Core::ERROR_GENERAL;
 
-    LOGINFO("presentationLanguages: %s", presentationLanguages.c_str());
-
-    _adminLock.Lock();
-
-    ASSERT (nullptr != _remotStoreObject);
-
-    if (nullptr != _remotStoreObject)
-    {
-        status = _remotStoreObject->SetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_PRESENTATION_LANGUAGE_KEY, presentationLanguages, 0);
-    }
-
-    _adminLock.Unlock();
-
+    LOGINFO("presentationLanguage: %s", presentationLanguage.c_str());
+    status = SetUserSettingsValue(USERSETTINGS_PRESENTATION_LANGUAGE_KEY, presentationLanguage);
     return status;
 }
 
-uint32_t UserSettingsImplementation::GetPresentationLanguage(string &presentationLanguages) const
+uint32_t UserSettingsImplementation::GetPresentationLanguage(string &presentationLanguage) const
 {
     uint32_t status = Core::ERROR_GENERAL;
     std::string value = "";
-    uint32_t ttl = 0;
 
-    _adminLock.Lock();
-
-    ASSERT (nullptr != _remotStoreObject);
-
-    if (nullptr != _remotStoreObject)
-    {
-        status = _remotStoreObject->GetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_PRESENTATION_LANGUAGE_KEY, presentationLanguages, ttl);
-    }
-
-    _adminLock.Unlock();
-
+    status = GetUserSettingsValue(USERSETTINGS_PRESENTATION_LANGUAGE_KEY, presentationLanguage);
     return status;
 }
 
@@ -454,18 +521,7 @@ uint32_t UserSettingsImplementation::SetCaptions(const bool enabled)
     uint32_t status = Core::ERROR_GENERAL;
 
     LOGINFO("enabled: %d", enabled);
-
-    _adminLock.Lock();
-
-    ASSERT (nullptr != _remotStoreObject);
-
-    if (nullptr != _remotStoreObject)
-    {
-        status = _remotStoreObject->SetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_CAPTIONS_KEY, (enabled)?"true":"false", 0);
-    }
-
-    _adminLock.Unlock();
-
+    status = SetUserSettingsValue(USERSETTINGS_CAPTIONS_KEY, (enabled)?"true":"false");
     return status;
 }
 
@@ -473,31 +529,20 @@ uint32_t UserSettingsImplementation::GetCaptions(bool &enabled) const
 {
     uint32_t status = Core::ERROR_GENERAL;
     std::string value = "";
-    uint32_t ttl = 0;
 
-    _adminLock.Lock();
+    status = GetUserSettingsValue(USERSETTINGS_CAPTIONS_KEY, value);
 
-    ASSERT (nullptr != _remotStoreObject);
-
-    if (nullptr != _remotStoreObject)
+    if(Core::ERROR_NONE == status)
     {
-        status = _remotStoreObject->GetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_CAPTIONS_KEY, value, ttl);
-
-        if(Core::ERROR_NONE == status)
+        if (0 == value.compare("true"))
         {
-            if (0 == value.compare("true"))
-            {
-                enabled = true;
-            }
-            else
-            {
-                enabled = false;
-            }
+            enabled = true;
+        }
+        else
+        {
+            enabled = false;
         }
     }
-
-    _adminLock.Unlock();
-
     return status;
 }
 
@@ -506,18 +551,7 @@ uint32_t UserSettingsImplementation::SetPreferredCaptionsLanguages(const string&
     uint32_t status = Core::ERROR_GENERAL;
 
     LOGINFO("preferredLanguages: %s", preferredLanguages.c_str());
-
-    _adminLock.Lock();
-
-    ASSERT (nullptr != _remotStoreObject);
-
-    if (nullptr != _remotStoreObject)
-    {
-        status = _remotStoreObject->SetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_PREFERRED_CAPTIONS_LANGUAGES_KEY, preferredLanguages, 0);
-    }
-
-    _adminLock.Unlock();
-
+    status = SetUserSettingsValue(USERSETTINGS_PREFERRED_CAPTIONS_LANGUAGES_KEY, preferredLanguages);
     return status;
 }
 
@@ -525,19 +559,8 @@ uint32_t UserSettingsImplementation::GetPreferredCaptionsLanguages(string &prefe
 {
     uint32_t status = Core::ERROR_GENERAL;
     std::string value = "";
-    uint32_t ttl = 0;
 
-    _adminLock.Lock();
-
-    ASSERT (nullptr != _remotStoreObject);
-
-    if (nullptr != _remotStoreObject)
-    {
-        status = _remotStoreObject->GetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_PREFERRED_CAPTIONS_LANGUAGES_KEY, preferredLanguages, ttl);
-    }
-
-    _adminLock.Unlock();
-
+    status = GetUserSettingsValue(USERSETTINGS_PREFERRED_CAPTIONS_LANGUAGES_KEY, preferredLanguages);
     return status;
 }
 
@@ -546,18 +569,7 @@ uint32_t UserSettingsImplementation::SetPreferredClosedCaptionService(const stri
     uint32_t status = Core::ERROR_GENERAL;
 
     LOGINFO("service: %s", service.c_str());
-
-    _adminLock.Lock();
-
-    ASSERT (nullptr != _remotStoreObject);
-
-    if (nullptr != _remotStoreObject)
-    {
-        status = _remotStoreObject->SetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_PREFERRED_CLOSED_CAPTIONS_SERVICE_KEY, service, 0);
-    }
-
-    _adminLock.Unlock();
-
+    status = SetUserSettingsValue(USERSETTINGS_PREFERRED_CLOSED_CAPTIONS_SERVICE_KEY, service);
     return status;
 }
 
@@ -565,19 +577,8 @@ uint32_t UserSettingsImplementation::GetPreferredClosedCaptionService(string &se
 {
     uint32_t status = Core::ERROR_GENERAL;
     std::string value = "";
-    uint32_t ttl = 0;
 
-    _adminLock.Lock();
-
-    ASSERT (nullptr != _remotStoreObject);
-
-    if (nullptr != _remotStoreObject)
-    {
-        status = _remotStoreObject->GetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_PREFERRED_CLOSED_CAPTIONS_SERVICE_KEY, service, ttl);
-    }
-
-    _adminLock.Unlock();
-
+    status = GetUserSettingsValue(USERSETTINGS_PREFERRED_CLOSED_CAPTIONS_SERVICE_KEY, service);
     return status;
 }
 
@@ -671,6 +672,197 @@ uint32_t UserSettingsImplementation::GetPrivacyMode(string &privacyMode) const
         privacyMode = "SHARE";
     }
 
+    return status;
+}
+
+uint32_t UserSettingsImplementation::SetPinControl(const bool enabled)
+{
+    uint32_t status = Core::ERROR_GENERAL;
+
+    LOGINFO("enabled: %d", enabled);
+    status = SetUserSettingsValue(USERSETTINGS_PIN_CONTROL_KEY, (enabled)?"true":"false");
+    return status;
+}
+
+uint32_t UserSettingsImplementation::GetPinControl(bool &enabled) const
+{
+    uint32_t status = Core::ERROR_GENERAL;
+    std::string value = "";
+
+    status = GetUserSettingsValue(USERSETTINGS_PIN_CONTROL_KEY, value);
+
+    if(Core::ERROR_NONE == status)
+    {
+        if (0 == value.compare("true"))
+        {
+            enabled = true;
+        }
+        else
+        {
+            enabled = false;
+        }
+    }
+    return status;
+
+}
+
+uint32_t UserSettingsImplementation::SetViewingRestrictions(const string& viewingRestrictions)
+{
+    uint32_t status = Core::ERROR_GENERAL;
+
+    LOGINFO("viewingRestrictions: %s", viewingRestrictions.c_str());
+    status = SetUserSettingsValue(USERSETTINGS_VIEWING_RESTRICTIONS_KEY, viewingRestrictions);
+    return status;
+
+}
+
+uint32_t UserSettingsImplementation::GetViewingRestrictions(string &viewingRestrictions) const
+{
+    uint32_t status = Core::ERROR_GENERAL;
+
+    status = GetUserSettingsValue(USERSETTINGS_VIEWING_RESTRICTIONS_KEY, viewingRestrictions);
+    return status;
+
+}
+
+uint32_t UserSettingsImplementation::SetViewingRestrictionsWindow(const string& viewingRestrictionsWindow)
+{
+    uint32_t status = Core::ERROR_GENERAL;
+
+    LOGINFO("viewingRestrictionsWindow: %s", viewingRestrictionsWindow.c_str());
+    status = SetUserSettingsValue(USERSETTINGS_VIEWING_RESTRICTIONS_WINDOW_KEY, viewingRestrictionsWindow);
+    return status;
+
+}
+
+uint32_t UserSettingsImplementation::GetViewingRestrictionsWindow(string &viewingRestrictionsWindow) const
+{
+    uint32_t status = Core::ERROR_GENERAL;
+
+    status = GetUserSettingsValue(USERSETTINGS_VIEWING_RESTRICTIONS_WINDOW_KEY, viewingRestrictionsWindow);
+    return status;
+}
+
+uint32_t UserSettingsImplementation::SetLiveWatershed(const bool enabled)
+{
+    uint32_t status = Core::ERROR_GENERAL;
+
+    LOGINFO("enabled: %d", enabled);
+    status = SetUserSettingsValue(USERSETTINGS_LIVE_WATERSHED_KEY, (enabled)?"true":"false");
+    return status;
+
+}
+
+uint32_t UserSettingsImplementation::GetLiveWatershed(bool &enabled) const
+{
+    uint32_t status = Core::ERROR_GENERAL;
+    std::string value = "";
+
+    status = GetUserSettingsValue(USERSETTINGS_LIVE_WATERSHED_KEY, value);
+
+    if(Core::ERROR_NONE == status)
+    {
+        if (0 == value.compare("true"))
+        {
+            enabled = true;
+        }
+        else
+        {
+            enabled = false;
+        }
+    }
+    return status;
+}
+
+uint32_t UserSettingsImplementation::SetPlaybackWatershed(const bool enabled)
+{
+    uint32_t status = Core::ERROR_GENERAL;
+
+    LOGINFO("enabled: %d", enabled);
+    status = SetUserSettingsValue(USERSETTINGS_PLAYBACK_WATERSHED_KEY, (enabled)?"true":"false");
+    return status;
+}
+
+uint32_t UserSettingsImplementation::GetPlaybackWatershed(bool &enabled) const
+{
+    uint32_t status = Core::ERROR_GENERAL;
+    std::string value = "";
+
+    status = GetUserSettingsValue(USERSETTINGS_PLAYBACK_WATERSHED_KEY, value);
+
+    if(Core::ERROR_NONE == status)
+    {
+        if (0 == value.compare("true"))
+        {
+            enabled = true;
+        }
+        else
+        {
+            enabled = false;
+        }
+    }
+    return status;
+}
+
+uint32_t UserSettingsImplementation::SetBlockNotRatedContent(const bool enabled)
+{
+    uint32_t status = Core::ERROR_GENERAL;
+
+    LOGINFO("enabled: %d", enabled);
+    status = SetUserSettingsValue(USERSETTINGS_BLOCK_NOT_RATED_CONTENT_KEY, (enabled)?"true":"false");
+    return status;
+}
+
+uint32_t UserSettingsImplementation::GetBlockNotRatedContent(bool &enabled) const
+{
+    uint32_t status = Core::ERROR_GENERAL;
+    std::string value = "";
+
+    status = GetUserSettingsValue(USERSETTINGS_BLOCK_NOT_RATED_CONTENT_KEY, value);
+
+    if(Core::ERROR_NONE == status)
+    {
+        if (0 == value.compare("true"))
+        {
+            enabled = true;
+        }
+        else
+        {
+            enabled = false;
+        }
+    }
+    return status;
+}
+
+uint32_t UserSettingsImplementation::SetPinOnPurchase(const bool enabled)
+{
+    uint32_t status = Core::ERROR_GENERAL;
+
+    LOGINFO("enabled: %d", enabled);
+    status = SetUserSettingsValue(USERSETTINGS_PIN_ON_PURCHASE_KEY, (enabled)?"true":"false");
+    return status;
+}
+
+uint32_t UserSettingsImplementation::GetPinOnPurchase(bool &enabled) const
+{
+    uint32_t status = Core::ERROR_GENERAL;
+    std::string value = "";
+
+    status = GetUserSettingsValue(USERSETTINGS_PIN_ON_PURCHASE_KEY, value);
+
+    if(Core::ERROR_NONE == status)
+    {
+        LOGINFO("getPinOnPurchase: %d", enabled);
+
+        if (0 == value.compare("true"))
+        {
+            enabled = true;
+        }
+        else
+        {
+            enabled = false;
+        }
+    }
     return status;
 }
 

--- a/UserSettings/UserSettingsImplementation.h
+++ b/UserSettings/UserSettingsImplementation.h
@@ -34,9 +34,30 @@
 #include "rbus.h"
 #endif
 
+#define USERSETTINGS_NAMESPACE "UserSettings"
+
+#define USERSETTINGS_AUDIO_DESCRIPTION_KEY                    "audioDescription"
+#define USERSETTINGS_PREFERRED_AUDIO_LANGUAGES_KEY            "preferredAudioLanguages"
+#define USERSETTINGS_PRESENTATION_LANGUAGE_KEY                "presentationLanguage"
+#define USERSETTINGS_CAPTIONS_KEY                             "captions"
+#define USERSETTINGS_PREFERRED_CAPTIONS_LANGUAGES_KEY         "preferredCaptionsLanguages"
+#define USERSETTINGS_PREFERRED_CLOSED_CAPTIONS_SERVICE_KEY    "preferredClosedCaptionsService"
+#define USERSETTINGS_PRIVACY_MODE_KEY                         "privacyMode"
+#define USERSETTINGS_PIN_CONTROL_KEY                          "pinControl"
+#define USERSETTINGS_VIEWING_RESTRICTIONS_KEY                 "viewingRestrictions"
+#define USERSETTINGS_VIEWING_RESTRICTIONS_WINDOW_KEY          "viewingRestrictionsWindow"
+#define USERSETTINGS_LIVE_WATERSHED_KEY                       "liveWaterShed"
+#define USERSETTINGS_PLAYBACK_WATERSHED_KEY                   "playbackWaterShed"
+#define USERSETTINGS_BLOCK_NOT_RATED_CONTENT_KEY              "blockNotRatedContent"
+#define USERSETTINGS_PIN_ON_PURCHASE_KEY                      "pinOnPurchase"
+
 namespace WPEFramework {
 namespace Plugin {
     class UserSettingsImplementation : public Exchange::IUserSettings{
+
+    public:
+        static const std::map<string, string> usersettingsDefaultMap;
+
     private:
         class Store2Notification : public Exchange::IStore2::INotification {
         private:
@@ -87,7 +108,14 @@ namespace Plugin {
                 CAPTIONS_CHANGED,
                 PREFERRED_CAPTIONS_LANGUAGE_CHANGED,
                 PREFERRED_CLOSED_CAPTIONS_SERVICE_CHANGED,
-                PRIVACY_MODE_CHANGED
+                PRIVACY_MODE_CHANGED,
+                PIN_CONTROL_CHANGED,
+                VIEWING_RESTRICTIONS_CHANGED,
+                VIEWING_RESTRICTIONS_WINDOW_CHANGED,
+                LIVE_WATERSHED_CHANGED,
+                PLAYBACK_WATERSHED_CHANGED,
+                BLOCK_NOT_RATED_CONTENT_CHANGED,
+                PIN_ON_PURCHASE_CHANGED
             };
 
         class EXTERNAL Job : public Core::IDispatch {
@@ -136,8 +164,8 @@ namespace Plugin {
         uint32_t GetAudioDescription(bool &enabled) const override;
         uint32_t SetPreferredAudioLanguages(const string& preferredLanguages) override;
         uint32_t GetPreferredAudioLanguages(string &preferredLanguages) const override;
-        uint32_t SetPresentationLanguage(const string& presentationLanguages) override;
-        uint32_t GetPresentationLanguage(string &presentationLanguages) const override;
+        uint32_t SetPresentationLanguage(const string& presentationLanguage) override;
+        uint32_t GetPresentationLanguage(string &presentationLanguage) const override;
         uint32_t SetCaptions(const bool enabled) override;
         uint32_t GetCaptions(bool &enabled) const override;
         uint32_t SetPreferredCaptionsLanguages(const string& preferredLanguages) override;
@@ -146,9 +174,27 @@ namespace Plugin {
         uint32_t GetPreferredClosedCaptionService(string &service) const override;
         uint32_t SetPrivacyMode(const string& privacyMode) override;
         uint32_t GetPrivacyMode(string &privacyMode) const override;
+        uint32_t SetPinControl(const bool enabled) override;
+        uint32_t GetPinControl(bool &enabled) const override;
+        uint32_t SetViewingRestrictions(const string& viewingRestrictions) override;
+        uint32_t GetViewingRestrictions(string &viewingRestrictions) const override;
+        uint32_t SetViewingRestrictionsWindow(const string& viewingRestrictionsWindow) override;
+        uint32_t GetViewingRestrictionsWindow(string &viewingRestrictionsWindow) const override;
+        uint32_t SetLiveWatershed(const bool enabled) override;
+        uint32_t GetLiveWatershed(bool &enabled) const override;
+        uint32_t SetPlaybackWatershed(const bool enabled) override;
+        uint32_t GetPlaybackWatershed(bool &enabled) const override;
+        uint32_t SetBlockNotRatedContent(const bool enabled) override;
+        uint32_t GetBlockNotRatedContent(bool &enabled) const override;
+        uint32_t SetPinOnPurchase(const bool enabled) override;
+        uint32_t GetPinOnPurchase(bool &enabled) const override;
 
         void registerEventHandlers();
         void ValueChanged(const Exchange::IStore2::ScopeType scope, const string& ns, const string& key, const string& value);
+
+    private:
+        uint32_t SetUserSettingsValue(const string& key, const string& value);
+        uint32_t GetUserSettingsValue(const string& key, string &value) const;
 
     private:
         mutable Core::CriticalSection _adminLock;

--- a/docs/api/UserSettingsPlugin.md
+++ b/docs/api/UserSettingsPlugin.md
@@ -1,353 +1,100 @@
 <!-- Generated automatically, DO NOT EDIT! -->
-<a name="UserSettings_Plugin"></a>
-# UserSettings Plugin
+<a name="head.UserSettings_API"></a>
+# UserSettings API
 
-**Version: [1.1.0](https://github.com/rdkcentral/rdkservices/blob/main/UserSettings/CHANGELOG.md)**
+**Version: [1.0.0]()**
 
 A org.rdk.UserSettings plugin for Thunder framework.
 
 ### Table of Contents
 
-- [Abbreviation, Acronyms and Terms](#Abbreviation,_Acronyms_and_Terms)
-- [Description](#Description)
-- [Configuration](#Configuration)
-- [Methods](#Methods)
-- [Notifications](#Notifications)
+- [Abbreviation, Acronyms and Terms](#head.Abbreviation,_Acronyms_and_Terms)
+- [Description](#head.Description)
+- [Configuration](#head.Configuration)
+- [Methods](#head.Methods)
+- [Notifications](#head.Notifications)
 
-<a name="Abbreviation,_Acronyms_and_Terms"></a>
+<a name="head.Abbreviation,_Acronyms_and_Terms"></a>
 # Abbreviation, Acronyms and Terms
 
 [[Refer to this link](userguide/aat.md)]
 
-<a name="Description"></a>
+<a name="head.Description"></a>
 # Description
 
-The `UserSettings` that is responsible for persisting and notifying listeners of any change of these settings.
+The `UserSettings`, that is responsible for persisting and notifying listeners of any change of these settings..
 
-The plugin is designed to be loaded and executed within the Thunder framework. For more information about the framework refer to [[Thunder](#Thunder)].
+The plugin is designed to be loaded and executed within the Thunder framework. For more information about the framework refer to [[Thunder](#ref.Thunder)].
 
-<a name="Configuration"></a>
+<a name="head.Configuration"></a>
 # Configuration
 
 The table below lists configuration options of the plugin.
 
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
-| callsign | string | Plugin instance name (default: *org.rdk.UserSettings*) |
 | classname | string | Class name: *org.rdk.UserSettings* |
-| locator | string | Library name: *libWPEFrameworkUserSettings.so* |
 | autostart | boolean | Determines if the plugin shall be started automatically along with the framework |
 
-<a name="Methods"></a>
+<a name="head.Methods"></a>
 # Methods
 
 The following methods are provided by the org.rdk.UserSettings plugin:
 
-UserSettings interface methods:
+org.rdk.UserSettings interface methods:
 
 | Method | Description |
 | :-------- | :-------- |
-| [SetAudioDescription](#SetAudioDescription) | Setting Audio Description |
-| [SetPreferredAudioLanguages](#SetPreferredAudioLanguages) | Setting Preferred Audio Languages |
-| [SetPresentationLanguage](#SetPresentationLanguage) | Setting Presentation Languages |
-| [SetCaptions](#SetCaptions) | Setting Captions |
-| [SetPreferredCaptionsLanguages](#SetPreferredCaptionsLanguages) | Setting PreferredCaption Languages |
-| [SetPreferredClosedCaptionService](#SetPreferredClosedCaptionService) | Setting Preferred Closed Caption Service |
-| [SetPrivacyMode](#SetPrivacyMode) | Setting Privacy Mode |
-| [GetAudioDescription](#GetAudioDescription) | Returns Audio Description |
-| [GetPreferredAudioLanguages](#GetPreferredAudioLanguages) | Returns Audio Description |
-| [GetPresentationLanguage](#GetPresentationLanguage) | Getting Presentation Languages |
-| [GetCaptions](#GetCaptions) | Getting Captions Enabled |
-| [GetPreferredCaptionsLanguages](#GetPreferredCaptionsLanguages) | Getting Preferred Caption Languages |
-| [GetPreferredClosedCaptionService](#GetPreferredClosedCaptionService) | Getting Preferred ClosedCaption Service |
-| [GetPrivacyMode](#GetPrivacyMode) | Getting Privacy Mode |
+| [setAudioDescription](#method.setAudioDescription) | Setting Audio Description |
+| [setPreferredAudioLanguages](#method.setPreferredAudioLanguages) | Setting Preferred Audio Languages |
+| [setPresentationLanguage](#method.setPresentationLanguage) | Setting Presentation Languages |
+| [setCaptions](#method.setCaptions) | Setting Captions |
+| [setPreferredCaptionsLanguages](#method.setPreferredCaptionsLanguages) | Setting PreferredCaption Languages |
+| [setPreferredClosedCaptionService](#method.setPreferredClosedCaptionService) | Setting Preferred Closed Caption Service |
+| [setPinControl](#method.setPinControl) | Setting PinControl |
+| [setViewingRestrictions](#method.setViewingRestrictions) | Setting ViewingRestrictions |
+| [setViewingRestrictionsWindow](#method.setViewingRestrictionsWindow) | Setting viewingRestrictionsWindow |
+| [setLiveWatershed](#method.setLiveWatershed) | Setting LiveWatershed |
+| [setPlaybackWatershed](#method.setPlaybackWatershed) | Setting PlaybackWatershed |
+| [setBlockNotRatedContent](#method.setBlockNotRatedContent) | Setting BlockNotRatedContent |
+| [setPinOnPurchase](#method.setPinOnPurchase) | Setting setPinOnPurchase |
+| [getAudioDescription](#method.getAudioDescription) | Returns Audio Description |
+| [getPreferredAudioLanguages](#method.getPreferredAudioLanguages) | Returns Preferred Audio Languages |
+| [getPresentationLanguage](#method.getPresentationLanguage) | Getting Presentation Languages |
+| [getCaptions](#method.getCaptions) | Getting Captions Enabled |
+| [getPreferredCaptionsLanguages](#method.getPreferredCaptionsLanguages) | Getting Preferred Caption Languages |
+| [getPreferredClosedCaptionService](#method.getPreferredClosedCaptionService) | Getting Preferred ClosedCaption Service |
+| [getPinControl](#method.getPinControl) | Returns Pin Control |
+| [getViewingRestrictions](#method.getViewingRestrictions) | Returns Get Viewing Restrictions |
+| [getViewingRestrictionsWindow](#method.getViewingRestrictionsWindow) | Returns Get Viewing Restrictions Window |
+| [getLiveWatershed](#method.getLiveWatershed) | Returns Live Watershed |
+| [getPlaybackWatershed](#method.getPlaybackWatershed) | Returns Playback Watershed |
+| [getBlockNotRatedContent](#method.getBlockNotRatedContent) | Returns BlockNotRatedContent |
+| [getPinOnPurchase](#method.getPinOnPurchase) | Returns PinOnPurchase |
 
 
-<a name="SetAudioDescription"></a>
-## *SetAudioDescription*
+<a name="method.setAudioDescription"></a>
+## *setAudioDescription [<sup>method</sup>](#head.Methods)*
 
 Setting Audio Description.
 
 ### Events
 
-No Events
-
-### Parameters
-
-| Name | Type | Description |
-| :-------- | :-------- | :-------- |
-| params | boolean | Audio Description Enabled: true/false |
-
-### Result
-
-| Name | Type | Description |
-| :-------- | :-------- | :-------- |
-| result | string | Null string will display |
-
-### Example
-
-#### Request
-
-```json
-{
-    "jsonrpc": "2.0",
-    "id": 42,
-    "method": "org.rdk.UserSettings.SetAudioDescription",
-    "params": true
-}
-```
-
-#### Response
-
-```json
-{
-    "jsonrpc": "2.0",
-    "id": 42,
-    "result": "null"
-}
-```
-
-<a name="SetPreferredAudioLanguages"></a>
-## *SetPreferredAudioLanguages*
-
-Setting Preferred Audio Languages.
-
-### Events
-
-No Events
-
-### Parameters
-
-| Name | Type | Description |
-| :-------- | :-------- | :-------- |
-| params | string | Preferred Audio Languages: eng, wel |
-
-### Result
-
-| Name | Type | Description |
-| :-------- | :-------- | :-------- |
-| result | string | Null string will display |
-
-### Example
-
-#### Request
-
-```json
-{
-    "jsonrpc": "2.0",
-    "id": 42,
-    "method": "org.rdk.UserSettings.SetPreferredAudioLanguages",
-    "params": "eng"
-}
-```
-
-#### Response
-
-```json
-{
-    "jsonrpc": "2.0",
-    "id": 42,
-    "result": "null"
-}
-```
-
-<a name="SetPresentationLanguage"></a>
-## *SetPresentationLanguage*
-
-Setting Presentation Languages.
-
-### Events
-
-No Events
-
-### Parameters
-
-| Name | Type | Description |
-| :-------- | :-------- | :-------- |
-| params | string | Presentation Languages: en-US, es-US |
-
-### Result
-
-| Name | Type | Description |
-| :-------- | :-------- | :-------- |
-| result | string | Null string will display |
-
-### Example
-
-#### Request
-
-```json
-{
-    "jsonrpc": "2.0",
-    "id": 42,
-    "method": "org.rdk.UserSettings.SetPresentationLanguage",
-    "params": "en-US"
-}
-```
-
-#### Response
-
-```json
-{
-    "jsonrpc": "2.0",
-    "id": 42,
-    "result": "null"
-}
-```
-
-<a name="SetCaptions"></a>
-## *SetCaptions*
-
-Setting Captions.
-
-### Events
-
-No Events
-
-### Parameters
-
-| Name | Type | Description |
-| :-------- | :-------- | :-------- |
-| params | boolean | Captions Enabled: true/false |
-
-### Result
-
-| Name | Type | Description |
-| :-------- | :-------- | :-------- |
-| result | string | Null string will display  |
-
-### Example
-
-#### Request
-
-```json
-{
-    "jsonrpc": "2.0",
-    "id": 42,
-    "method": "org.rdk.UserSettings.SetCaptions",
-    "params": true
-}
-```
-
-#### Response
-
-```json
-{
-    "jsonrpc": "2.0",
-    "id": 42,
-    "result": "null"
-}
-```
-
-<a name="SetPreferredCaptionsLanguages"></a>
-## *SetPreferredCaptionsLanguages*
-
-Setting PreferredCaption Languages.
-
-### Events
-
-No Events
-
-### Parameters
-
-| Name | Type | Description |
-| :-------- | :-------- | :-------- |
-| params | string | PreferredCaption Languages: eng, fra |
-
-### Result
-
-| Name | Type | Description |
-| :-------- | :-------- | :-------- |
-| result | string | Null string will display |
-
-### Example
-
-#### Request
-
-```json
-{
-    "jsonrpc": "2.0",
-    "id": 42,
-    "method": "org.rdk.UserSettings.SetPreferredCaptionsLanguages",
-    "params": "eng"
-}
-```
-
-#### Response
-
-```json
-{
-    "jsonrpc": "2.0",
-    "id": 42,
-    "result": "null"
-}
-```
-
-<a name="SetPreferredClosedCaptionService"></a>
-## *SetPreferredClosedCaptionService*
-
-Setting Preferred Closed Caption Service.
-
-### Events
-
-No Events
-
-### Parameters
-
-| Name | Type | Description |
-| :-------- | :-------- | :-------- |
-| params | string | Preferred Closed Caption Service: CC3 |
-
-### Result
-
-| Name | Type | Description |
-| :-------- | :-------- | :-------- |
-| result | string | Null string will display |
-
-### Example
-
-#### Request
-
-```json
-{
-    "jsonrpc": "2.0",
-    "id": 42,
-    "method": "org.rdk.UserSettings.SetPreferredClosedCaptionService",
-    "params": "CC3"
-}
-```
-
-#### Response
-
-```json
-{
-    "jsonrpc": "2.0",
-    "id": 42,
-    "result": "null"
-}
-```
-
-<a name="SetPrivacyMode"></a>
-## *SetPrivacyMode*
-
-Setting Privacy Mode.
-
-### Events
-
-No Events
-
+| Event | Description |
+| :-------- | :-------- |
+| [OnAudioDescriptionChanged](#event.OnAudioDescriptionChanged) | Triggered when the audio description changes. |
 ### Parameters
 
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
 | params | object |  |
-| params.privacyMode | string | New Privacy Mode |
+| params.enabled | boolean | Audio Description Enabled: true/false |
 
 ### Result
 
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
-| result | string | Null string will display |
+| result | string | On success null will be returned |
 
 ### Example
 
@@ -357,9 +104,9 @@ No Events
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.UserSettings.SetPrivacyMode",
+    "method": "org.rdk.UserSettings.setAudioDescription",
     "params": {
-        "privacyMode": "DO_NOT_SHARE"
+        "enabled": true
     }
 }
 ```
@@ -374,8 +121,584 @@ No Events
 }
 ```
 
-<a name="GetAudioDescription"></a>
-## *GetAudioDescription*
+<a name="method.setPreferredAudioLanguages"></a>
+## *setPreferredAudioLanguages [<sup>method</sup>](#head.Methods)*
+
+Setting Preferred Audio Languages.
+
+### Events
+
+| Event | Description |
+| :-------- | :-------- |
+| [onPreferredAudioLanguagesChanged](#event.onPreferredAudioLanguagesChanged) | Triggered when the audio preferred Audio languages changes. |
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.preferredLanguages | string | A prioritized list of ISO 639-2/B codes for the preferred audio languages |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | string | On success null will be returned |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.UserSettings.setPreferredAudioLanguages",
+    "params": {
+        "preferredLanguages": "eng"
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": "null"
+}
+```
+
+<a name="method.setPresentationLanguage"></a>
+## *setPresentationLanguage [<sup>method</sup>](#head.Methods)*
+
+Setting Presentation Languages.
+
+### Events
+
+| Event | Description |
+| :-------- | :-------- |
+| [onPresentationLanguageChanged](#event.onPresentationLanguageChanged) | Triggered when the presentation Language changes. |
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.presentationLanguage | string | The preferred presentationLanguage in a full BCP 47 value, including script, * region, variant The language set and used by Immerse UI |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | string | On success null will be returned |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.UserSettings.setPresentationLanguage",
+    "params": {
+        "presentationLanguage": "en-US"
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": "null"
+}
+```
+
+<a name="method.setCaptions"></a>
+## *setCaptions [<sup>method</sup>](#head.Methods)*
+
+Setting Captions.
+
+### Events
+
+| Event | Description |
+| :-------- | :-------- |
+| [onCaptionsChanged](#event.onCaptionsChanged) | Triggered when the captions changes. |
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.enabled | boolean | Captions Enabled: true/false |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | string | On success null will be returned |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.UserSettings.setCaptions",
+    "params": {
+        "enabled": true
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": "null"
+}
+```
+
+<a name="method.setPreferredCaptionsLanguages"></a>
+## *setPreferredCaptionsLanguages [<sup>method</sup>](#head.Methods)*
+
+Setting PreferredCaption Languages.
+
+### Events
+
+| Event | Description |
+| :-------- | :-------- |
+| [onPreferredCaptionsLanguagesChanged](#event.onPreferredCaptionsLanguagesChanged) | Triggered when the PreferredCaption Languages changes. |
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.preferredLanguages | string | A prioritized list of ISO 639-2/B codes for the preferred captions languages |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | string | On success null will be returned |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.UserSettings.setPreferredCaptionsLanguages",
+    "params": {
+        "preferredLanguages": "eng"
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": "null"
+}
+```
+
+<a name="method.setPreferredClosedCaptionService"></a>
+## *setPreferredClosedCaptionService [<sup>method</sup>](#head.Methods)*
+
+Setting Preferred Closed Caption Service.
+
+### Events
+
+| Event | Description |
+| :-------- | :-------- |
+| [onPreferredClosedCaptionServiceChanged](#event.onPreferredClosedCaptionServiceChanged) | Triggered when the Preferred Closed Caption changes. |
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.service | string | A string for the preferred closed captions service.  Valid values are AUTO, CC[1-4], TEXT[1-4], SERVICE[1-64] where CC and TEXT is CTA-608 and SERVICE is CTA-708.  AUTO indicates that the choice is left to the player |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | string | On success null will be returned |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.UserSettings.setPreferredClosedCaptionService",
+    "params": {
+        "service": "CC3"
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": "null"
+}
+```
+
+<a name="method.setPinControl"></a>
+## *setPinControl [<sup>method</sup>](#head.Methods)*
+
+Setting PinControl.
+
+### Events
+
+| Event | Description |
+| :-------- | :-------- |
+| [onPinControlChanged](#event.onPinControlChanged) | Triggered when the pincontrol changes. |
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.enabled | boolean | PinControl Enabled: true/false |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | string | On success null will be returned |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.UserSettings.setPinControl",
+    "params": {
+        "enabled": true
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": "null"
+}
+```
+
+<a name="method.setViewingRestrictions"></a>
+## *setViewingRestrictions [<sup>method</sup>](#head.Methods)*
+
+Setting ViewingRestrictions.
+
+### Events
+
+| Event | Description |
+| :-------- | :-------- |
+| [OnViewingRestrictionsChanged](#event.OnViewingRestrictionsChanged) | Triggered when the viewingRestrictions changes. |
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.viewingRestrictions | string | A project-specific representation of the time interval when viewing |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | string | On success null will be returned |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.UserSettings.setViewingRestrictions",
+    "params": {
+        "viewingRestrictions": "ALWAYS"
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": "null"
+}
+```
+
+<a name="method.setViewingRestrictionsWindow"></a>
+## *setViewingRestrictionsWindow [<sup>method</sup>](#head.Methods)*
+
+Setting viewingRestrictionsWindow.
+
+### Events
+
+| Event | Description |
+| :-------- | :-------- |
+| [OnViewingRestrictionsWindowChanged](#event.OnViewingRestrictionsWindowChanged) | Triggered when the viewingRestrictionsWindow changes. |
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.viewingRestrictionsWindow | string | A project-specific representation of the time interval |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | string | On success null will be returned |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.UserSettings.setViewingRestrictionsWindow",
+    "params": {
+        "viewingRestrictionsWindow": "ALWAYS"
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": "null"
+}
+```
+
+<a name="method.setLiveWatershed"></a>
+## *setLiveWatershed [<sup>method</sup>](#head.Methods)*
+
+Setting LiveWatershed.
+
+### Events
+
+| Event | Description |
+| :-------- | :-------- |
+| [OnLiveWatershedChanged](#event.OnLiveWatershedChanged) | Triggered when the liveWatershed changes. |
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.enabled | boolean | LiveWatershed Enabled: true/false |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | string | On success null will be returned |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.UserSettings.setLiveWatershed",
+    "params": {
+        "enabled": true
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": "null"
+}
+```
+
+<a name="method.setPlaybackWatershed"></a>
+## *setPlaybackWatershed [<sup>method</sup>](#head.Methods)*
+
+Setting PlaybackWatershed.
+
+### Events
+
+| Event | Description |
+| :-------- | :-------- |
+| [OnPlaybackWatershedChanged](#event.OnPlaybackWatershedChanged) | Triggered when the playbackWatershed changes. |
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.enabled | boolean | PlaybackWatershed Enabled: true/false |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | string | On success null will be returned |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.UserSettings.setPlaybackWatershed",
+    "params": {
+        "enabled": true
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": "null"
+}
+```
+
+<a name="method.setBlockNotRatedContent"></a>
+## *setBlockNotRatedContent [<sup>method</sup>](#head.Methods)*
+
+Setting BlockNotRatedContent.
+
+### Events
+
+| Event | Description |
+| :-------- | :-------- |
+| [OnBlockNotRatedContentChanged](#event.OnBlockNotRatedContentChanged) | Triggered when the blockNotRatedContent changes. |
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.enabled | boolean | BlockNotRatedContent Enabled: true/false |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | string | On success null will be returned |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.UserSettings.setBlockNotRatedContent",
+    "params": {
+        "enabled": true
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": "null"
+}
+```
+
+<a name="method.setPinOnPurchase"></a>
+## *setPinOnPurchase [<sup>method</sup>](#head.Methods)*
+
+Setting setPinOnPurchase.
+
+### Events
+
+| Event | Description |
+| :-------- | :-------- |
+| [OnPinOnPurchaseChanged](#event.OnPinOnPurchaseChanged) | Triggered when the pin on the purchase changes. |
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.enabled | boolean | setPinOnPurchase Enabled: true/false |
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | string | On success null will be returned |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.UserSettings.setPinOnPurchase",
+    "params": {
+        "enabled": true
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": "null"
+}
+```
+
+<a name="method.getAudioDescription"></a>
+## *getAudioDescription [<sup>method</sup>](#head.Methods)*
 
 Returns Audio Description.
 
@@ -391,7 +714,7 @@ This method takes no parameters.
 
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
-| result | boolean |  |
+| result | boolean | Audio Description Enabled: true/false |
 
 ### Example
 
@@ -401,7 +724,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.UserSettings.GetAudioDescription"
+    "method": "org.rdk.UserSettings.getAudioDescription"
 }
 ```
 
@@ -411,14 +734,14 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "result": false
+    "result": true
 }
 ```
 
-<a name="GetPreferredAudioLanguages"></a>
-## *GetPreferredAudioLanguages*
+<a name="method.getPreferredAudioLanguages"></a>
+## *getPreferredAudioLanguages [<sup>method</sup>](#head.Methods)*
 
-Returns Audio Description.
+Returns Preferred Audio Languages.
 
 ### Events
 
@@ -432,7 +755,7 @@ This method takes no parameters.
 
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
-| result | string |  |
+| result | string | A prioritized list of ISO 639-2/B codes for the preferred audio languages |
 
 ### Example
 
@@ -442,7 +765,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.UserSettings.GetPreferredAudioLanguages"
+    "method": "org.rdk.UserSettings.getPreferredAudioLanguages"
 }
 ```
 
@@ -452,12 +775,12 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "result": "..."
+    "result": "eng"
 }
 ```
 
-<a name="GetPresentationLanguage"></a>
-## *GetPresentationLanguage*
+<a name="method.getPresentationLanguage"></a>
+## *getPresentationLanguage [<sup>method</sup>](#head.Methods)*
 
 Getting Presentation Languages.
 
@@ -473,7 +796,7 @@ This method takes no parameters.
 
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
-| result | string |  |
+| result | string | The preferred presentationLanguage in a full BCP 47 value, including script, * region, variant The language set and used by Immerse UI |
 
 ### Example
 
@@ -483,7 +806,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.UserSettings.GetPresentationLanguage"
+    "method": "org.rdk.UserSettings.getPresentationLanguage"
 }
 ```
 
@@ -493,12 +816,12 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "result": "..."
+    "result": "en-US"
 }
 ```
 
-<a name="GetCaptions"></a>
-## *GetCaptions*
+<a name="method.getCaptions"></a>
+## *getCaptions [<sup>method</sup>](#head.Methods)*
 
 Getting Captions Enabled.
 
@@ -514,7 +837,7 @@ This method takes no parameters.
 
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
-| result | boolean |  |
+| result | boolean | Captions Enabled: true/false |
 
 ### Example
 
@@ -524,7 +847,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.UserSettings.GetCaptions"
+    "method": "org.rdk.UserSettings.getCaptions"
 }
 ```
 
@@ -534,12 +857,12 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "result": false
+    "result": true
 }
 ```
 
-<a name="GetPreferredCaptionsLanguages"></a>
-## *GetPreferredCaptionsLanguages*
+<a name="method.getPreferredCaptionsLanguages"></a>
+## *getPreferredCaptionsLanguages [<sup>method</sup>](#head.Methods)*
 
 Getting Preferred Caption Languages.
 
@@ -555,7 +878,7 @@ This method takes no parameters.
 
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
-| result | string |  |
+| result | string | A prioritized list of ISO 639-2/B codes for the preferred captions languages |
 
 ### Example
 
@@ -565,7 +888,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.UserSettings.GetPreferredCaptionsLanguages"
+    "method": "org.rdk.UserSettings.getPreferredCaptionsLanguages"
 }
 ```
 
@@ -575,12 +898,12 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "result": "..."
+    "result": "eng"
 }
 ```
 
-<a name="GetPreferredClosedCaptionService"></a>
-## *GetPreferredClosedCaptionService*
+<a name="method.getPreferredClosedCaptionService"></a>
+## *getPreferredClosedCaptionService [<sup>method</sup>](#head.Methods)*
 
 Getting Preferred ClosedCaption Service.
 
@@ -596,7 +919,7 @@ This method takes no parameters.
 
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
-| result | string |  |
+| result | string | A string for the preferred closed captions service.  Valid values are AUTO, CC[1-4], TEXT[1-4], SERVICE[1-64] where CC and TEXT is CTA-608 and SERVICE is CTA-708.  AUTO indicates that the choice is left to the player |
 
 ### Example
 
@@ -606,7 +929,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.UserSettings.GetPreferredClosedCaptionService"
+    "method": "org.rdk.UserSettings.getPreferredClosedCaptionService"
 }
 ```
 
@@ -616,14 +939,14 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "result": "..."
+    "result": "CC3"
 }
 ```
 
-<a name="GetPrivacyMode"></a>
-## *GetPrivacyMode*
+<a name="method.getPinControl"></a>
+## *getPinControl [<sup>method</sup>](#head.Methods)*
 
-Getting Privacy Mode.
+Returns Pin Control.
 
 ### Events
 
@@ -637,7 +960,7 @@ This method takes no parameters.
 
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
-| result | string |  |
+| result | boolean | Pin Control Enabled: true/false |
 
 ### Example
 
@@ -647,7 +970,7 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "method": "org.rdk.UserSettings.GetPrivacyMode"
+    "method": "org.rdk.UserSettings.getPinControl"
 }
 ```
 
@@ -657,34 +980,286 @@ This method takes no parameters.
 {
     "jsonrpc": "2.0",
     "id": 42,
-    "result": "..."
+    "result": true
 }
 ```
 
-<a name="Notifications"></a>
+<a name="method.getViewingRestrictions"></a>
+## *getViewingRestrictions [<sup>method</sup>](#head.Methods)*
+
+Returns Get Viewing Restrictions.
+
+### Events
+
+No Events
+
+### Parameters
+
+This method takes no parameters.
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | string | A project-specific representation of the time interval when viewing |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.UserSettings.getViewingRestrictions"
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": "ALWAYS"
+}
+```
+
+<a name="method.getViewingRestrictionsWindow"></a>
+## *getViewingRestrictionsWindow [<sup>method</sup>](#head.Methods)*
+
+Returns Get Viewing Restrictions Window.
+
+### Events
+
+No Events
+
+### Parameters
+
+This method takes no parameters.
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | string | A project-specific representation of the time interval |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.UserSettings.getViewingRestrictionsWindow"
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": "ALWAYS"
+}
+```
+
+<a name="method.getLiveWatershed"></a>
+## *getLiveWatershed [<sup>method</sup>](#head.Methods)*
+
+Returns Live Watershed.
+
+### Events
+
+No Events
+
+### Parameters
+
+This method takes no parameters.
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | boolean | Live Watershed Enabled: true/false |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.UserSettings.getLiveWatershed"
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": true
+}
+```
+
+<a name="method.getPlaybackWatershed"></a>
+## *getPlaybackWatershed [<sup>method</sup>](#head.Methods)*
+
+Returns Playback Watershed.
+
+### Events
+
+No Events
+
+### Parameters
+
+This method takes no parameters.
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | boolean | Playback Watershed Enabled: true/false |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.UserSettings.getPlaybackWatershed"
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": true
+}
+```
+
+<a name="method.getBlockNotRatedContent"></a>
+## *getBlockNotRatedContent [<sup>method</sup>](#head.Methods)*
+
+Returns BlockNotRatedContent.
+
+### Events
+
+No Events
+
+### Parameters
+
+This method takes no parameters.
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | boolean | BlockNotRatedContent Enabled: true/false |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.UserSettings.getBlockNotRatedContent"
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": true
+}
+```
+
+<a name="method.getPinOnPurchase"></a>
+## *getPinOnPurchase [<sup>method</sup>](#head.Methods)*
+
+Returns PinOnPurchase.
+
+### Events
+
+No Events
+
+### Parameters
+
+This method takes no parameters.
+
+### Result
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| result | boolean | PinOnPurchase Enabled: true/false |
+
+### Example
+
+#### Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "org.rdk.UserSettings.getPinOnPurchase"
+}
+```
+
+#### Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": true
+}
+```
+
+<a name="head.Notifications"></a>
 # Notifications
 
-Notifications are autonomous events, triggered by the internals of the implementation, and broadcasted via JSON-RPC to all registered observers. Refer to [[Thunder](#Thunder)] for information on how to register for a notification.
+Notifications are autonomous events, triggered by the internals of the implementation, and broadcasted via JSON-RPC to all registered observers. Refer to [[Thunder](#ref.Thunder)] for information on how to register for a notification.
 
 The following events are provided by the org.rdk.UserSettings plugin:
 
-UserSettings interface events:
+org.rdk.UserSettings interface events:
 
 | Event | Description |
 | :-------- | :-------- |
-| [OnAudioDescriptionChanged](#OnAudioDescriptionChanged) | Triggered after the audio description changes (see `setaudiodescription`) |
-| [OnPreferredAudioLanguagesChanged](#OnPreferredAudioLanguagesChanged) | Triggered after the audio preferred Audio languages changes (see `setpreferredaudiolanguages`) |
-| [OnPresentationLanguageChanged](#OnPresentationLanguageChanged) | Triggered after the Presentation Language changes (see `setpresentationlanguages`) |
-| [OnCaptionsChanged](#OnCaptionsChanged) | Triggered after the captions changes (see `setcaptionsenabled`) |
-| [OnPreferredCaptionsLanguagesChanged](#OnPreferredCaptionsLanguagesChanged) | Triggered after the PreferredCaption Languages changes (see `setpreferredcaptionlanguages`) |
-| [OnPreferredClosedCaptionServiceChanged](#OnPreferredClosedCaptionServiceChanged) | Triggered after the Preferred Closed Caption changes (see `setpreferredclosedcaptionservice`) |
-| [OnPrivacyModeChanged](#OnPrivacyModeChanged) | Triggered after the Privacy Mode changes (see `SetPrivacyMode`) |
+| [onAudioDescriptionChanged](#event.onAudioDescriptionChanged) | Triggered after the audio description changes (see `SetAudioDescription`) |
+| [onPreferredAudioLanguagesChanged](#event.onPreferredAudioLanguagesChanged) | Triggered after the audio preferred Audio languages changes (see `SetPreferredAudioLanguages`) |
+| [onPresentationLanguageChanged](#event.onPresentationLanguageChanged) | Triggered after the Presentation Language changes (see `SetPresentationLanguage`) |
+| [onCaptionsChanged](#event.onCaptionsChanged) | Triggered after the captions changes (see `SetCaptions`) |
+| [onPreferredCaptionsLanguagesChanged](#event.onPreferredCaptionsLanguagesChanged) | Triggered after the PreferredCaption Languages changes (see `SetPreferredCaptionsLanguages`) |
+| [onPreferredClosedCaptionServiceChanged](#event.onPreferredClosedCaptionServiceChanged) | Triggered after the Preferred Closed Caption changes (see `SetPreferredClosedCaptionService`) |
+| [onPinControlChanged](#event.onPinControlChanged) | Triggered after the pin control changes (see `setPinControl`) |
+| [onViewingRestrictionsChanged](#event.onViewingRestrictionsChanged) | Triggered after the viewingRestrictions changes (see `setViewingRestrictions`) |
+| [onViewingRestrictionsWindowChanged](#event.onViewingRestrictionsWindowChanged) | Triggered after the viewingRestrictionsWindow changes (see `setViewingRestrictionsWindow`) |
+| [onLiveWatershedChanged](#event.onLiveWatershedChanged) | Triggered after the liveWatershed changes (see `setLiveWatershed`) |
+| [onPlaybackWatershedChanged](#event.onPlaybackWatershedChanged) | Triggered after the playbackWatershed changes (see `setPlaybackWatershed`) |
+| [onBlockNotRatedContentChanged](#event.onBlockNotRatedContentChanged) | Triggered after the blockNotRatedContent changes (see `setBlockNotRatedContent`) |
+| [onPinOnPurchaseChanged](#event.onPinOnPurchaseChanged) | Triggered after the pinOnPurchase changes (see `setPinOnPurchase`) |
 
 
-<a name="OnAudioDescriptionChanged"></a>
-## *OnAudioDescriptionChanged*
+<a name="event.onAudioDescriptionChanged"></a>
+## *onAudioDescriptionChanged [<sup>event</sup>](#head.Notifications)*
 
-Triggered after the audio description changes (see `setaudiodescription`).
+Triggered after the audio description changes (see `SetAudioDescription`).
 
 ### Parameters
 
@@ -698,17 +1273,17 @@ Triggered after the audio description changes (see `setaudiodescription`).
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.OnAudioDescriptionChanged",
+    "method": "client.events.onAudioDescriptionChanged",
     "params": {
         "enabled": true
     }
 }
 ```
 
-<a name="OnPreferredAudioLanguagesChanged"></a>
-## *OnPreferredAudioLanguagesChanged*
+<a name="event.onPreferredAudioLanguagesChanged"></a>
+## *onPreferredAudioLanguagesChanged [<sup>event</sup>](#head.Notifications)*
 
-Triggered after the audio preferred Audio languages changes (see `setpreferredaudiolanguages`).
+Triggered after the audio preferred Audio languages changes (see `SetPreferredAudioLanguages`).
 
 ### Parameters
 
@@ -722,41 +1297,41 @@ Triggered after the audio preferred Audio languages changes (see `setpreferredau
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.OnPreferredAudioLanguagesChanged",
+    "method": "client.events.onPreferredAudioLanguagesChanged",
     "params": {
         "preferredLanguages": "eng"
     }
 }
 ```
 
-<a name="OnPresentationLanguageChanged"></a>
-## *OnPresentationLanguageChanged*
+<a name="event.onPresentationLanguageChanged"></a>
+## *onPresentationLanguageChanged [<sup>event</sup>](#head.Notifications)*
 
-Triggered after the Presentation Language changes (see `setpresentationlanguages`).
+Triggered after the Presentation Language changes (see `SetPresentationLanguage`).
 
 ### Parameters
 
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
 | params | object |  |
-| params.presentationLanguages | string | Receive Presentation Language changes |
+| params.presentationLanguage | string | Receive Presentation Language changes |
 
 ### Example
 
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.OnPresentationLanguageChanged",
+    "method": "client.events.onPresentationLanguageChanged",
     "params": {
-        "presentationLanguages": "en-US"
+        "presentationLanguage": "en-US"
     }
 }
 ```
 
-<a name="OnCaptionsChanged"></a>
-## *OnCaptionsChanged*
+<a name="event.onCaptionsChanged"></a>
+## *onCaptionsChanged [<sup>event</sup>](#head.Notifications)*
 
-Triggered after the captions changes (see `setcaptionsenabled`).
+Triggered after the captions changes (see `SetCaptions`).
 
 ### Parameters
 
@@ -770,17 +1345,17 @@ Triggered after the captions changes (see `setcaptionsenabled`).
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.OnCaptionsChanged",
+    "method": "client.events.onCaptionsChanged",
     "params": {
         "enabled": true
     }
 }
 ```
 
-<a name="OnPreferredCaptionsLanguagesChanged"></a>
-## *OnPreferredCaptionsLanguagesChanged*
+<a name="event.onPreferredCaptionsLanguagesChanged"></a>
+## *onPreferredCaptionsLanguagesChanged [<sup>event</sup>](#head.Notifications)*
 
-Triggered after the PreferredCaption Languages changes (see `setpreferredcaptionlanguages`).
+Triggered after the PreferredCaption Languages changes (see `SetPreferredCaptionsLanguages`).
 
 ### Parameters
 
@@ -794,57 +1369,201 @@ Triggered after the PreferredCaption Languages changes (see `setpreferredcaption
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.OnPreferredCaptionsLanguagesChanged",
+    "method": "client.events.onPreferredCaptionsLanguagesChanged",
     "params": {
         "preferredLanguages": "eng"
     }
 }
 ```
 
-<a name="OnPreferredClosedCaptionServiceChanged"></a>
-## *OnPreferredClosedCaptionServiceChanged*
+<a name="event.onPreferredClosedCaptionServiceChanged"></a>
+## *onPreferredClosedCaptionServiceChanged [<sup>event</sup>](#head.Notifications)*
 
-Triggered after the Preferred Closed Caption changes (see `setpreferredclosedcaptionservice`).
+Triggered after the Preferred Closed Caption changes (see `SetPreferredClosedCaptionService`).
 
 ### Parameters
 
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
 | params | object |  |
-| params.service | string | Receive Preferred Closed Caption changes |
+| params.service | string | Receive Preferred Closed Caption Service changes |
 
 ### Example
 
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.OnPreferredClosedCaptionServiceChanged",
+    "method": "client.events.onPreferredClosedCaptionServiceChanged",
     "params": {
         "service": "CC3"
     }
 }
 ```
 
-<a name="OnPrivacyModeChanged"></a>
-## *OnPrivacyModeChanged*
+<a name="event.onPinControlChanged"></a>
+## *onPinControlChanged [<sup>event</sup>](#head.Notifications)*
 
-Triggered after the Privacy Mode changes (see `SetPrivacyMode`).
+Triggered after the pin control changes (see `setPinControl`).
 
 ### Parameters
 
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
 | params | object |  |
-| params.privacyMode | string | Receive Privacy Mode changes |
+| params.enabled | boolean | Receive pin control changes enable or not |
 
 ### Example
 
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "client.events.OnPrivacyModeChanged",
+    "method": "client.events.onPinControlChanged",
     "params": {
-        "privacyMode": "DO_NOT_SHARE"
+        "enabled": true
+    }
+}
+```
+
+<a name="event.onViewingRestrictionsChanged"></a>
+## *onViewingRestrictionsChanged [<sup>event</sup>](#head.Notifications)*
+
+Triggered after the viewingRestrictions changes (see `setViewingRestrictions`).
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.enabled | boolean | Receive viewingRestrictions changes enable or not |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.onViewingRestrictionsChanged",
+    "params": {
+        "enabled": true
+    }
+}
+```
+
+<a name="event.onViewingRestrictionsWindowChanged"></a>
+## *onViewingRestrictionsWindowChanged [<sup>event</sup>](#head.Notifications)*
+
+Triggered after the viewingRestrictionsWindow changes (see `setViewingRestrictionsWindow`).
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.enabled | boolean | Receive viewingRestrictionsWindow changes enable or not |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.onViewingRestrictionsWindowChanged",
+    "params": {
+        "enabled": true
+    }
+}
+```
+
+<a name="event.onLiveWatershedChanged"></a>
+## *onLiveWatershedChanged [<sup>event</sup>](#head.Notifications)*
+
+Triggered after the liveWatershed changes (see `setLiveWatershed`).
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.enabled | boolean | Receives liveWatershed changes enable or not |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.onLiveWatershedChanged",
+    "params": {
+        "enabled": true
+    }
+}
+```
+
+<a name="event.onPlaybackWatershedChanged"></a>
+## *onPlaybackWatershedChanged [<sup>event</sup>](#head.Notifications)*
+
+Triggered after the playbackWatershed changes (see `setPlaybackWatershed`).
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.enabled | boolean | Receive playbackWatershed changes enable or not |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.onPlaybackWatershedChanged",
+    "params": {
+        "enabled": true
+    }
+}
+```
+
+<a name="event.onBlockNotRatedContentChanged"></a>
+## *onBlockNotRatedContentChanged [<sup>event</sup>](#head.Notifications)*
+
+Triggered after the blockNotRatedContent changes (see `setBlockNotRatedContent`).
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.enabled | boolean | Receive blockNotRatedContent changes enable or not |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.onBlockNotRatedContentChanged",
+    "params": {
+        "enabled": true
+    }
+}
+```
+
+<a name="event.onPinOnPurchaseChanged"></a>
+## *onPinOnPurchaseChanged [<sup>event</sup>](#head.Notifications)*
+
+Triggered after the pinOnPurchase changes (see `setPinOnPurchase`).
+
+### Parameters
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| params | object |  |
+| params.enabled | boolean | Receive pinOnPurchase changes enable or not |
+
+### Example
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "client.events.onPinOnPurchaseChanged",
+    "params": {
+        "enabled": true
     }
 }
 ```


### PR DESCRIPTION
Reason for change:

ParentalControl new properties are added in Usersetttings. (RDK-52180)
Add Unit Test for newly added properties (RDK-52181)
Updated documentation for new APIs added in User Settings (RDK-52122)

Test Procedure: Make full stack build and verify all the properties with get/set methods.
Run L2 tests and verify test cases.
Risks: High