### PR TITLE
DELIA-66507: CEC is not working intermittently

### DIFF
--- a/HdmiCecSource/HdmiCecSource.cpp
+++ b/HdmiCecSource/HdmiCecSource.cpp
@@ -769,7 +769,7 @@ namespace WPEFramework
                     break;
                     case IARM_BUS_CECMGR_EVENT_STATUS_UPDATED:
                     {
-                        IARM_Bus_CECMgr_Status_Updated_Param_t *evtData = new IARM_Bus_CECMgr_Status_Updated_Param_t;
+                        IARM_Bus_CECMgr_Status_Updated_Param_t *evtData = (IARM_Bus_CECMgr_Status_Updated_Param_t *)data;
                         if(evtData)
                         {
                             std::thread worker(threadCecStatusUpdateHandler,evtData->logicalAddress);


### PR DESCRIPTION
Reason for change: Add proper typecasting to get the LA from IARM CEC event

Test Procedure: build and verify
Risks: Medium
Priority: P1
Signed-off-by: Srigayathry Pugazhenthi<srigayathry.pugazhenthi@sky.uk>