### PR TITLE
SERXIONE-6222

### DIFF
--- a/TextToSpeech/impl/TTSDownloader.cpp
+++ b/TextToSpeech/impl/TTSDownloader.cpp
@@ -146,8 +146,8 @@ void TTSDownloader::saveConfiguration(std::string path)
     TTSLOG_INFO("TTSDownloader saveconfiguration path %s\n", path.c_str());
     m_objectMutex.lock();
     m_config.saveFallbackPath(path);
-    m_config.updateConfigStore();
     m_defaultConfig.saveFallbackPath(path);
+    m_defaultConfig.updateConfigStore();
     m_objectMutex.unlock();
 }
 


### PR DESCRIPTION
Reason for change:TTSDownloader::saveConfiguration is
not updating the correct reference of ttsconfiguration
Test Procedure: as per SERXIONE-6222
Risks: Low
Priority: P1
Signed-off-by: Tony Paul <Tony_Paul@comcast.com>