### PR TITLE
DELIA-66652 : Fix L2 test crash

### DIFF
--- a/Tests/L2Tests/L2TestsPlugin/tests/Telemetry_L2Test.cpp
+++ b/Tests/L2Tests/L2TestsPlugin/tests/Telemetry_L2Test.cpp
@@ -95,6 +95,9 @@ Telemetry_L2test::~Telemetry_L2test()
     uint32_t status = Core::ERROR_GENERAL;
     m_event_signalled = TELEMETRYL2TEST_STATE_INVALID;
 
+    // Deactivate System plugin since it was activated by Telemetry plugin
+    DeactivateService("org.rdk.System");
+
     status = DeactivateService("org.rdk.Telemetry");
     EXPECT_EQ(Core::ERROR_NONE, status);
 }


### PR DESCRIPTION
Reason for change: L2 segmentation fault fix
Test Procedure: L2 workflow
Risks: Med
Priority: P1

(cherry picked from commit ff35a8e6d0b74c15f189c6c1cc9a0ddaa7f58743)