### PR TITLE
RDK-52196: [SECVULN] Unsafe Use of strncpy C Functions

### DIFF
--- a/AVOutput/AVOutputTVHelper.cpp
+++ b/AVOutput/AVOutputTVHelper.cpp
@@ -655,6 +655,7 @@ namespace Plugin {
             }
         }
         strncpy(rfc_caller_id,PQFileName.c_str(),PQFileName.size());
+        rfc_caller_id[sizeof(rfc_caller_id) - 1] = '\0';
         LOGINFO("%s : Default tvsettings file : %s\n",__FUNCTION__,rfc_caller_id);
     }
 
@@ -1417,6 +1418,7 @@ namespace Plugin {
         tr181ErrorCode_t err = getLocalParam(rfc_caller_id, tr181_param_name.c_str(), &param);
         if ( err == tr181Success ) {
             strncpy(picMode, param.value, strlen(param.value)+1);
+            picMode[strlen(param.value)] = '\0';
             LOGINFO("getLocalParam success, mode = %s\n", picMode);
             return 1;
         }

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -2264,6 +2264,7 @@ namespace WPEFramework {
             {
                 IARM_Bus_PWRMgr_StandbyVideoState_Param_t param;
                 strncpy(param.port, portname.c_str(), PWRMGR_MAX_VIDEO_PORT_NAME_LENGTH);
+                param.port[sizeof(param.port) - 1] = '\0';
                 if(IARM_RESULT_SUCCESS != IARM_Bus_Call(IARM_BUS_PWRMGR_NAME, IARM_BUS_PWRMGR_API_GetStandbyVideoState, &param, sizeof(param)))
                 {
                     LOGERR("Port: %s. enable:%d", param.port, param.isEnabled);
@@ -2287,6 +2288,7 @@ namespace WPEFramework {
             {
                 dsMgrStandbyVideoStateParam_t param;
                 strncpy(param.port, portname.c_str(), PWRMGR_MAX_VIDEO_PORT_NAME_LENGTH);
+                param.port[sizeof(param.port) - 1] = '\0';
                 if(IARM_RESULT_SUCCESS != IARM_Bus_Call(IARM_BUS_DSMGR_NAME, IARM_BUS_DSMGR_API_GetStandbyVideoState, &param, sizeof(param)))
                 {
                     LOGERR("Port: %s. enable:%d", param.port, param.isEnabled);

--- a/FrameRate/FrameRate.cpp
+++ b/FrameRate/FrameRate.cpp
@@ -461,7 +461,8 @@ namespace WPEFramework
                 switch (eventId) {
                     case IARM_BUS_DSMGR_EVENT_DISPLAY_FRAMRATE_PRECHANGE:
                         IARM_Bus_DSMgr_EventData_t *eventData = (IARM_Bus_DSMgr_EventData_t *)data;
-                        strcpy(dispFrameRate,eventData->data.DisplayFrameRateChange.framerate);
+                        strncpy(dispFrameRate,eventData->data.DisplayFrameRateChange.framerate, sizeof(dispFrameRate));
+                        dispFrameRate[sizeof(dispFrameRate) - 1] = '\0';
                         break;
                 }
             }
@@ -487,7 +488,8 @@ namespace WPEFramework
                 switch (eventId) {
                     case IARM_BUS_DSMGR_EVENT_DISPLAY_FRAMRATE_POSTCHANGE:
                         IARM_Bus_DSMgr_EventData_t *eventData = (IARM_Bus_DSMgr_EventData_t *)data;
-                        strcpy(dispFrameRate,eventData->data.DisplayFrameRateChange.framerate);
+                        strncpy(dispFrameRate,eventData->data.DisplayFrameRateChange.framerate, sizeof(dispFrameRate));
+                        dispFrameRate[sizeof(dispFrameRate) - 1] = '\0';
                         break;
                 }
             }

--- a/Miracast/MiracastPlayer/MiracastPlayer.cpp
+++ b/Miracast/MiracastPlayer/MiracastPlayer.cpp
@@ -187,9 +187,13 @@ namespace WPEFramework
 				sink_dev_ip = device_parameters["sink_dev_ip"].String();
 
 				strncpy( rtsp_hldr_msgq_data.source_dev_ip, source_dev_ip.c_str() , sizeof(rtsp_hldr_msgq_data.source_dev_ip));
+				rtsp_hldr_msgq_data.source_dev_ip[sizeof(rtsp_hldr_msgq_data.source_dev_ip) - 1] = '\0';
 				strncpy( rtsp_hldr_msgq_data.source_dev_mac, source_dev_mac.c_str() , sizeof(rtsp_hldr_msgq_data.source_dev_mac));
+				rtsp_hldr_msgq_data.source_dev_mac[sizeof(rtsp_hldr_msgq_data.source_dev_mac) - 1] = '\0';
 				strncpy( rtsp_hldr_msgq_data.source_dev_name, source_dev_name.c_str() , sizeof(rtsp_hldr_msgq_data.source_dev_name));
+				rtsp_hldr_msgq_data.source_dev_name[sizeof(rtsp_hldr_msgq_data.source_dev_name) - 1] = '\0';
 				strncpy( rtsp_hldr_msgq_data.sink_dev_ip, sink_dev_ip.c_str() , sizeof(rtsp_hldr_msgq_data.sink_dev_ip));
+				rtsp_hldr_msgq_data.sink_dev_ip[sizeof(rtsp_hldr_msgq_data.sink_dev_ip) - 1] = '\0';
 
 				rtsp_hldr_msgq_data.state = RTSP_START_RECEIVE_MSGS;
 				success = true;
@@ -692,8 +696,10 @@ namespace WPEFramework
 				}
 				else
 				{
-					strcpy( stMsgQ.src_dev_name, client_name.c_str());
-					strcpy( stMsgQ.src_dev_mac_addr, client_mac.c_str());
+					strncpy( stMsgQ.src_dev_name, client_name.c_str(), sizeof(stMsgQ.src_dev_name));
+					stMsgQ.src_dev_name[sizeof(stMsgQ.src_dev_name) - 1] = '\0';
+					strncpy( stMsgQ.src_dev_mac_addr, client_mac.c_str(), sizeof(stMsgQ.src_dev_mac_addr));
+					stMsgQ.src_dev_mac_addr[sizeof(stMsgQ.src_dev_mac_addr) - 1] = '\0';
 
 					MIRACASTLOG_INFO("Given 'NAME, MAC and state' are[%s-%s-%s]",
 							client_name.c_str(),

--- a/Miracast/MiracastService/MiracastController.cpp
+++ b/Miracast/MiracastService/MiracastController.cpp
@@ -464,6 +464,7 @@ void MiracastController::remove_P2PGroupInstance(void)
         if ( true == m_groupInfo->isGO )
         {
             strncpy( commandBuffer , "ps -ax | awk '/dnsmasq -p0 -i/ && !/grep/ {print $1}' | xargs kill -9" , sizeof(commandBuffer));
+            commandBuffer[sizeof(commandBuffer) - 1] = '\0';
             MIRACASTLOG_INFO("Terminate old dnsmasq instance: [%s]",commandBuffer);
             MiracastCommon::execute_SystemCommand(commandBuffer);
             memset( commandBuffer , 0x00 , sizeof(commandBuffer));
@@ -475,6 +476,7 @@ void MiracastController::remove_P2PGroupInstance(void)
         else
         {
             strncpy( commandBuffer , "ps -ax | awk '/p2p_udhcpc/ && !/grep/ {print $1}' | xargs kill -9" , sizeof(commandBuffer));
+            commandBuffer[sizeof(commandBuffer) - 1] = '\0';
             MIRACASTLOG_INFO("Terminate old udhcpc p2p instance : [%s]", commandBuffer);
             MiracastCommon::execute_SystemCommand(commandBuffer);
         }
@@ -518,7 +520,8 @@ void MiracastController::event_handler(P2P_EVENTS eventId, void *data, size_t le
     if (nullptr != m_controller_thread){
         controller_msgq_data.msg_type = P2P_MSG;
         controller_msgq_data.state = convertP2PtoSessionActions(eventId);
-        strcpy(controller_msgq_data.msg_buffer, event_buffer.c_str());
+        strncpy(controller_msgq_data.msg_buffer, event_buffer.c_str(), sizeof(controller_msgq_data.msg_buffer));
+        controller_msgq_data.msg_buffer[sizeof(controller_msgq_data.msg_buffer) - 1] = '\0';
 
         MIRACASTLOG_INFO("event_handler to Controller Action[%#08X] buffer:%s  ", controller_msgq_data.state, event_buffer.c_str());
         m_controller_thread->send_message(&controller_msgq_data, sizeof(controller_msgq_data));
@@ -1394,6 +1397,7 @@ void MiracastController::restart_session_discovery(std::string& mac_address)
     if ( !mac_address.empty())
     {
         strncpy(controller_msgq_data.source_dev_mac, mac_address.c_str(),sizeof(controller_msgq_data.source_dev_mac));
+        controller_msgq_data.source_dev_mac[sizeof(controller_msgq_data.source_dev_mac) - 1] = '\0';
     }
     controller_msgq_data.state = CONTROLLER_RESTART_DISCOVERING;
     send_thundermsg_to_controller_thread(controller_msgq_data);
@@ -1419,6 +1423,7 @@ void MiracastController::accept_client_connection(std::string is_accepted)
     {
         MIRACASTLOG_INFO("[MIRACAST_SERVICE_ACCEPT_CLIENT]");
         strncpy(controller_msgq_data.source_dev_mac, m_current_device_mac_addr.c_str(),sizeof(controller_msgq_data.source_dev_mac));
+        controller_msgq_data.source_dev_mac[sizeof(controller_msgq_data.source_dev_mac) - 1] = '\0';
         controller_msgq_data.state = CONTROLLER_CONNECT_REQ_FROM_THUNDER;
     }
     else
@@ -1448,9 +1453,13 @@ void MiracastController::switch_launch_request_context(std::string& source_dev_i
                             sink_dev_ip.c_str(),
                             source_dev_name.c_str());
         strncpy(controller_msgq_data.source_dev_ip, source_dev_ip.c_str(),sizeof(controller_msgq_data.source_dev_ip));
+        controller_msgq_data.source_dev_ip[sizeof(controller_msgq_data.source_dev_ip) - 1] = '\0';
         strncpy(controller_msgq_data.source_dev_mac, source_dev_mac.c_str(),sizeof(controller_msgq_data.source_dev_mac));
+        controller_msgq_data.source_dev_mac[sizeof(controller_msgq_data.source_dev_mac) - 1] = '\0';
         strncpy(controller_msgq_data.source_dev_name, source_dev_name.c_str(),sizeof(controller_msgq_data.source_dev_name));
+        controller_msgq_data.source_dev_name[sizeof(controller_msgq_data.source_dev_name) - 1] = '\0';
         strncpy(controller_msgq_data.sink_dev_ip, sink_dev_ip.c_str(),sizeof(controller_msgq_data.sink_dev_ip));
+        controller_msgq_data.sink_dev_ip[sizeof(controller_msgq_data.sink_dev_ip) - 1] = '\0';
         controller_msgq_data.state = CONTROLLER_SWITCH_LAUNCH_REQ_CTX;
         send_thundermsg_to_controller_thread(controller_msgq_data);
     }

--- a/Miracast/MiracastService/MiracastService.cpp
+++ b/Miracast/MiracastService/MiracastService.cpp
@@ -935,8 +935,10 @@ namespace WPEFramework
 				}
 				else
 				{
-					strcpy( stMsgQ.src_dev_name, client_name.c_str());
-					strcpy( stMsgQ.src_dev_mac_addr, client_mac.c_str());
+					strncpy( stMsgQ.src_dev_name, client_name.c_str(), sizeof(stMsgQ.src_dev_name));
+					stMsgQ.src_dev_name[sizeof(stMsgQ.src_dev_name) - 1] = '\0';
+					strncpy( stMsgQ.src_dev_mac_addr, client_mac.c_str(), sizeof(stMsgQ.src_dev_mac_addr));
+					stMsgQ.src_dev_mac_addr[sizeof(stMsgQ.src_dev_mac_addr) - 1] = '\0';
 
 					MIRACASTLOG_INFO("Given [NAME-MAC-state] are[%s-%s-%s]",
 							client_name.c_str(),
@@ -998,8 +1000,10 @@ namespace WPEFramework
 						}
 						else
 						{
-							strcpy( stMsgQ.src_dev_ip_addr, source_dev_ip.c_str());
-							strcpy( stMsgQ.sink_ip_addr, sink_dev_ip.c_str());
+							strncpy( stMsgQ.src_dev_ip_addr, source_dev_ip.c_str(), sizeof(stMsgQ.src_dev_ip_addr));
+							stMsgQ.src_dev_ip_addr[sizeof(stMsgQ.src_dev_ip_addr) - 1] = '\0';
+							strncpy( stMsgQ.sink_ip_addr, sink_dev_ip.c_str(), sizeof(stMsgQ.sink_ip_addr));
+							stMsgQ.sink_ip_addr[sizeof(stMsgQ.sink_ip_addr) - 1] = '\0';
 
 							MIRACASTLOG_INFO("Given [Src-Sink-IP] are [%s-%s]",
 									source_dev_ip.c_str(),
@@ -1049,6 +1053,7 @@ namespace WPEFramework
 				{
 					MIRACASTLOG_INFO("!!! NEED TO STOP ONGOING SESSION !!!");
 					strncpy(commandBuffer,"curl -H \"Authorization: Bearer `WPEFrameworkSecurityUtility | cut -d '\"' -f 4`\" --header \"Content-Type: application/json\" --request POST --data '{\"jsonrpc\":\"2.0\", \"id\":3,\"method\":\"org.rdk.MiracastPlayer.1.stopRequest\", \"params\":{\"reason\": \"NEW_CONNECTION\"}}' http://127.0.0.1:9998/jsonrpc",sizeof(commandBuffer));
+					commandBuffer[sizeof(commandBuffer) - 1] = '\0';
 					MIRACASTLOG_INFO("Stopping old Session by [%s]",commandBuffer);
 					MiracastCommon::execute_SystemCommand(commandBuffer);
 					sleep(1);

--- a/Network/Network.cpp
+++ b/Network/Network.cpp
@@ -859,10 +859,15 @@ typedef struct _IARM_BUS_NetSrvMgr_Iface_EventData_t {
                 iarmData.ipversion[sizeof(iarmData.ipversion) - 1] = '\0';
                 iarmData.autoconfig = autoconfig;
                 strncpy(iarmData.ipaddress, ipaddr.c_str(), 16);
+                iarmData.ipaddress[sizeof(iarmData.ipaddress) - 1] = '\0';
                 strncpy(iarmData.netmask, netmask.c_str(), 16);
+                iarmData.netmask[sizeof(iarmData.netmask) - 1] = '\0';
                 strncpy(iarmData.gateway, gateway.c_str(), 16);
+                iarmData.gateway[sizeof(iarmData.gateway) - 1] = '\0';
                 strncpy(iarmData.primarydns, primarydns.c_str(), 16);
+                iarmData.primarydns[sizeof(iarmData.primarydns) - 1] = '\0';
                 strncpy(iarmData.secondarydns, secondarydns.c_str(), 16);
+                iarmData.secondarydns[sizeof(iarmData.secondarydns) - 1] = '\0';
                 iarmData.isSupported = false;
 
                 if (!autoconfig)

--- a/NetworkManager/NetworkManagerRDKProxy.cpp
+++ b/NetworkManager/NetworkManagerRDKProxy.cpp
@@ -707,8 +707,10 @@ namespace WPEFramework
             //TODO: Fix netsrvmgr to accept eth0 & wlan0
             if ("wlan0" == interface)
                 strncpy(iarmData.setInterface, "WIFI", INTERFACE_SIZE);
+                iarmData.setInterface[sizeof(iarmData.setInterface) - 1] = '\0';
             else if ("eth0" == interface)
                 strncpy(iarmData.setInterface, "ETHERNET", INTERFACE_SIZE);
+                iarmData.setInterface[sizeof(iarmData.setInterface) - 1] = '\0';
             else
             {
                 rc = Core::ERROR_BAD_REQUEST;
@@ -737,8 +739,10 @@ namespace WPEFramework
             //TODO: Fix netsrvmgr to accept eth0 & wlan0
             if ("wlan0" == interface)
                 strncpy(iarmData.setInterface, "WIFI", INTERFACE_SIZE);
+                iarmData.setInterface[sizeof(iarmData.setInterface) - 1] = '\0';
             else if ("eth0" == interface)
                 strncpy(iarmData.setInterface, "ETHERNET", INTERFACE_SIZE);
+                iarmData.setInterface[sizeof(iarmData.setInterface) - 1] = '\0';
             else
             {
                 rc = Core::ERROR_BAD_REQUEST;
@@ -769,8 +773,10 @@ namespace WPEFramework
             //TODO: Fix netsrvmgr to accept eth0 & wlan0
             if ("wlan0" == interface)
                 strncpy(iarmData.setInterface, "WIFI", INTERFACE_SIZE);
+                iarmData.setInterface[sizeof(iarmData.setInterface) - 1] = '\0';
             else if ("eth0" == interface)
                 strncpy(iarmData.setInterface, "ETHERNET", INTERFACE_SIZE);
+                iarmData.setInterface[sizeof(iarmData.setInterface) - 1] = '\0';
             else
             {
                 rc = Core::ERROR_BAD_REQUEST;
@@ -829,10 +835,13 @@ namespace WPEFramework
             //TODO: Fix netsrvmgr to accept eth0 & wlan0
             if ("wlan0" == interface)
                 strncpy(iarmData.interface, "WIFI", INTERFACE_SIZE);
+                iarmData.interface[sizeof(iarmData.interface) - 1] = '\0';
             else if ("eth0" == interface)
                 strncpy(iarmData.interface, "ETHERNET", INTERFACE_SIZE);
+                iarmData.interface[sizeof(iarmData.interface) - 1] = '\0';
 
             strncpy(iarmData.ipversion, ipversion.c_str(), 16);
+            iarmData.ipversion[sizeof(iarmData.ipversion) - 1] = '\0';
             iarmData.isSupported = true;
             NMLOG_INFO("NetworkManagerImplementation::GetIPSettings - Before Calling IARM");
             if (IARM_RESULT_SUCCESS == IARM_Bus_Call (IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_NETSRVMGR_API_getIPSettings, (void *)&iarmData, sizeof(iarmData)))
@@ -908,8 +917,10 @@ const string CIDR_PREFIXES[CIDR_NETMASK_IP_LEN] = {
                 //TODO: Fix netsrvmgr to accept eth0 & wlan0
                 if ("wlan0" == interface)
                     strncpy(iarmData.interface, "WIFI", INTERFACE_SIZE);
+                    iarmData.interface[sizeof(iarmData.interface) - 1] = '\0';
                 else if ("eth0" == interface)
                     strncpy(iarmData.interface, "ETHERNET", INTERFACE_SIZE);
+                    iarmData.interface[sizeof(iarmData.interface) - 1] = '\0';
                 else
                 {
                     rc = Core::ERROR_BAD_REQUEST;
@@ -917,6 +928,7 @@ const string CIDR_PREFIXES[CIDR_NETMASK_IP_LEN] = {
                 }
                 /* IP version */
                 strncpy(iarmData.ipversion, ipversion.c_str(), 16);
+                iarmData.ipversion[sizeof(iarmData.ipversion) - 1] = '\0';
 
                 if (!address.m_autoConfig)
                 {
@@ -970,10 +982,15 @@ const string CIDR_PREFIXES[CIDR_NETMASK_IP_LEN] = {
                         if (Core::ERROR_NONE == rc)
                         {
                             strncpy(iarmData.ipaddress, address.m_ipAddress.c_str(), 16);
+                            iarmData.ipaddress[sizeof(iarmData.ipaddress) - 1] = '\0';
                             strncpy(iarmData.netmask, netmask.c_str(), 16);
+                            iarmData.netmask[sizeof(iarmData.netmask) - 1] = '\0';
                             strncpy(iarmData.gateway, address.m_gateway.c_str(), 16);
+                            iarmData.gateway[sizeof(iarmData.gateway) - 1] = '\0';
                             strncpy(iarmData.primarydns, address.m_primaryDns.c_str(), 16);
+                            iarmData.primarydns[sizeof(iarmData.primarydns) - 1] = '\0';
                             strncpy(iarmData.secondarydns, address.m_secondaryDns.c_str(), 16);
+                            iarmData.secondarydns[sizeof(iarmData.secondarydns) - 1] = '\0';
                         }
                     }
                 }
@@ -1083,7 +1100,9 @@ const string CIDR_PREFIXES[CIDR_NETMASK_IP_LEN] = {
             memset(&param, 0, sizeof(param));
 
             strncpy(param.data.connect.ssid, ssid.m_ssid.c_str(), SSID_SIZE - 1);
+            param.data.connect.ssid[sizeof(param.data.connect.ssid) - 1] = '\0';
             strncpy(param.data.connect.passphrase, ssid.m_passphrase.c_str(), PASSPHRASE_BUFF - 1);
+            param.data.connect.passphrase[sizeof(param.data.connect.passphrase) - 1] = '\0';
             param.data.connect.security_mode = (SsidSecurity) ssid.m_securityMode;
 
             IARM_Result_t retVal = IARM_Bus_Call(IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_WIFI_MGR_API_saveSSID, (void *)&param, sizeof(param));

--- a/StateObserver/StateObserver.cpp
+++ b/StateObserver/StateObserver.cpp
@@ -813,8 +813,8 @@ namespace WPEFramework {
 						{
 						systemStates.dac_init_timestamp.state = state;
 						systemStates.dac_init_timestamp.error = error;
-						strncpy(systemStates.dac_init_timestamp.payload,payload,strlen(payload));
-						systemStates.dac_init_timestamp.payload[strlen(payload)]='\0';
+						strncpy(systemStates.dac_init_timestamp.payload,payload,sizeof(systemStates.dac_init_timestamp.payload));
+						systemStates.dac_init_timestamp.payload[sizeof(systemStates.dac_init_timestamp.payload) - 1]='\0';
 						if(StateObserver::_instance)
 							StateObserver::_instance->setProp(params,SYSTEM_DAC_INIT_TIMESTAMP,state,error);
 						string payload_str(payload);
@@ -825,8 +825,8 @@ namespace WPEFramework {
 					case IARM_BUS_SYSMGR_SYSSTATE_CABLE_CARD_SERIAL_NO:
 						{
 						systemStates.card_serial_no.error =error;
-						strncpy(systemStates.card_serial_no.payload,payload,strlen(payload));
-						systemStates.card_serial_no.payload[strlen(payload)]='\0';
+						strncpy(systemStates.card_serial_no.payload,payload,sizeof(systemStates.card_serial_no.payload));
+						systemStates.card_serial_no.payload[sizeof(systemStates.card_serial_no.payload) - 1]='\0';
 						params["propertyName"]=SYSTEM_CARD_SERIAL_NO;
 						params["error"]=error;
 						string payload_str(payload);
@@ -837,8 +837,8 @@ namespace WPEFramework {
 					 case IARM_BUS_SYSMGR_SYSSTATE_STB_SERIAL_NO:
 						{
 						systemStates.stb_serial_no.error =error;
-						strncpy(systemStates.stb_serial_no.payload,payload,strlen(payload));
-						systemStates.stb_serial_no.payload[strlen(payload)]='\0';
+						strncpy(systemStates.stb_serial_no.payload,payload,sizeof(systemStates.stb_serial_no.payload));
+						systemStates.stb_serial_no.payload[sizeof(systemStates.stb_serial_no.payload) - 1]='\0';
 						params["propertyName"]=SYSTEM_STB_SERIAL_NO;
 						params["error"]=error;
 						string payload_str(payload);
@@ -973,8 +973,8 @@ namespace WPEFramework {
 					case IARM_BUS_SYSMGR_SYSSTATE_ECM_MAC:
 						{
 						systemStates.ecm_mac.error =error;
-						strncpy(systemStates.ecm_mac.payload,payload,strlen(payload));
-						systemStates.ecm_mac.payload[strlen(payload)]='\0';
+						strncpy(systemStates.ecm_mac.payload,payload,sizeof(systemStates.ecm_mac.payload));
+						systemStates.ecm_mac.payload[sizeof(systemStates.ecm_mac.payload) - 1]='\0';
 						params["propertyName"]=SYSTEM_ECM_MAC;
 						params["error"]=error;
 						string payload_str(payload);
@@ -986,8 +986,8 @@ namespace WPEFramework {
 						{
 						systemStates.ip_mode.state=state;
 						systemStates.ip_mode.error =error;
-						strncpy(systemStates.ip_mode.payload,payload,strlen(payload));
-						systemStates.ip_mode.payload[strlen(payload)]='\0';
+						strncpy(systemStates.ip_mode.payload,payload,sizeof(systemStates.ip_mode.payload));
+						systemStates.ip_mode.payload[sizeof(systemStates.ip_mode.payload) - 1]='\0';
 						if(StateObserver::_instance)
 							StateObserver::_instance->setProp(params,SYSTEM_IP_MODE,state,error);
 						string payload_str(payload);

--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -667,6 +667,7 @@ namespace WPEFramework {
 
             IARM_Bus_PWRMgr_RebootParam_t rebootParam;
             strncpy(rebootParam.requestor, "SystemServices", sizeof(rebootParam.requestor));
+            rebootParam.requestor[sizeof(rebootParam.requestor) - 1] = '\0';
             strncpy(rebootParam.reboot_reason_custom, customReason.c_str(), sizeof(rebootParam.reboot_reason_custom));
             rebootParam.reboot_reason_custom[sizeof(rebootParam.reboot_reason_custom) - 1] = '\0';
             strncpy(rebootParam.reboot_reason_other, otherReason.c_str(), sizeof(rebootParam.reboot_reason_other));
@@ -1355,7 +1356,8 @@ namespace WPEFramework {
                 if((strBLSplashScreenPath != "") && fileExists)
 		{
 			IARM_Bus_MFRLib_SetBLSplashScreen_Param_t mfrparam;
-			std::strcpy(mfrparam.path, strBLSplashScreenPath.c_str());
+			std::strncpy(mfrparam.path, strBLSplashScreenPath.c_str(), sizeof(mfrparam.path));
+            mfrparam.path[sizeof(mfrparam.path) - 1] = '\0';
 			IARM_Result_t result = IARM_Bus_Call(IARM_BUS_MFRLIB_NAME, IARM_BUS_MFRLIB_API_SetBlSplashScreen, (void *)&mfrparam, sizeof(mfrparam));
 			if (result != IARM_RESULT_SUCCESS){
 				LOGERR("Update failed. path: %s, fileExists %s, IARM result %d ",strBLSplashScreenPath.c_str(),fileExists ? "true" : "false",result);

--- a/Warehouse/Warehouse.cpp
+++ b/Warehouse/Warehouse.cpp
@@ -331,7 +331,8 @@ namespace WPEFramework
                 return false;
             }
 
-            strcpy(runScriptParam.script_path, script.c_str());
+            strncpy(runScriptParam.script_path, script.c_str(), sizeof(runScriptParam.script_path));
+            runScriptParam.script_path[sizeof(runScriptParam.script_path) - 1] = '\0';
             IARM_Bus_Call(IARM_BUS_SYSMGR_NAME, IARM_BUS_SYSMGR_API_RunScript, &runScriptParam, sizeof(runScriptParam));
             bool ok = runScriptParam.return_value == 0;
 

--- a/WifiManager/impl/WifiManagerState.cpp
+++ b/WifiManager/impl/WifiManagerState.cpp
@@ -114,6 +114,7 @@ uint32_t WifiManagerState::setEnabled(const JsonObject &parameters, JsonObject &
     memset(&param, 0, sizeof(param));
 
     strncpy(param.setInterface, "WIFI", INTERFACE_SIZE - 1);
+    param.setInterface[sizeof(param.setInterface) - 1] = '\0';
     param.isInterfaceEnabled = parameters["enable"].Boolean();
     bool persist_t = false;
     getDefaultBoolParameter("persist", persist_t, false);

--- a/WifiManager/impl/WifiManagerWPS.cpp
+++ b/WifiManager/impl/WifiManagerWPS.cpp
@@ -142,7 +142,9 @@ namespace WPEFramework
             memset(&param, 0, sizeof(param));
 
             strncpy(param.data.connect.ssid, parameters["ssid"].String().c_str(), SSID_SIZE - 1);
+            param.data.connect.ssid[sizeof(param.data.connect.ssid) - 1] = '\0';
             strncpy(param.data.connect.passphrase, parameters["passphrase"].String().c_str(), PASSPHRASE_BUFF - 1);
+            param.data.connect.passphrase[sizeof(param.data.connect.passphrase) - 1] = '\0';
             param.data.connect.security_mode = static_cast<SsidSecurity>(parameters["securityMode"].Number());
 
             IARM_Result_t retVal = IARM_Bus_Call(IARM_BUS_NM_SRV_MGR_NAME, IARM_BUS_WIFI_MGR_API_saveSSID, (void *)&param, sizeof(param));

--- a/XCast/XCast.cpp
+++ b/XCast/XCast.cpp
@@ -797,6 +797,7 @@ void XCast::updateDynamicAppCache(JsonArray applications)
                     memset ((void*)pDynamicAppConfig, '0', sizeof(DynamicAppConfig));
                     memset (pDynamicAppConfig->appName, '\0', sizeof(pDynamicAppConfig->appName));
                     strncpy (pDynamicAppConfig->appName, itrName.c_str(), sizeof(pDynamicAppConfig->appName) - 1);
+                    pDynamicAppConfig->appName[sizeof(pDynamicAppConfig->appName) - 1] = '\0';
                     memset (pDynamicAppConfig->prefixes, '\0', sizeof(pDynamicAppConfig->prefixes));
                     memset (pDynamicAppConfig->cors, '\0', sizeof(pDynamicAppConfig->cors));
                     memset (pDynamicAppConfig->query, '\0', sizeof(pDynamicAppConfig->query));
@@ -815,6 +816,7 @@ void XCast::updateDynamicAppCache(JsonArray applications)
                     LOGINFO("%s, size:%d", itrPrefix.c_str(), (int)strlen (itrPrefix.c_str()));
                     for (DynamicAppConfig* pDynamicAppConfig : appConfigListTemp) {
                         strncpy (pDynamicAppConfig->prefixes, itrPrefix.c_str(), sizeof(pDynamicAppConfig->prefixes) - 1);
+                        pDynamicAppConfig->prefixes[sizeof(pDynamicAppConfig->prefixes) - 1] = '\0';
                     }
                 }
             }
@@ -830,6 +832,7 @@ void XCast::updateDynamicAppCache(JsonArray applications)
                     LOGINFO("%s, size:%d", itrCor.c_str(), (int)strlen (itrCor.c_str()));
                     for (DynamicAppConfig* pDynamicAppConfig : appConfigListTemp) {
                         strncpy (pDynamicAppConfig->cors, itrCor.c_str(), sizeof(pDynamicAppConfig->cors) - 1);
+                        pDynamicAppConfig->cors[sizeof(pDynamicAppConfig->cors) - 1] = '\0';
                     }
                 }
             }
@@ -882,9 +885,11 @@ void XCast::updateDynamicAppCache(JsonArray applications)
                 for (DynamicAppConfig* pDynamicAppConfig : appConfigListTemp) {
                     if (jLaunchParam.HasLabel("query")) {
                         strncpy (pDynamicAppConfig->query, jQuery.c_str(), sizeof(pDynamicAppConfig->query) - 1);
+                        pDynamicAppConfig->query[sizeof(pDynamicAppConfig->query) - 1] = '\0';
                     }
                     if (jLaunchParam.HasLabel("payload")) {
                         strncpy (pDynamicAppConfig->payload, jPayload.c_str(), sizeof(pDynamicAppConfig->payload) - 1);
+                        pDynamicAppConfig->payload[sizeof(pDynamicAppConfig->payload) - 1] = '\0';
                     }
                 }
 
@@ -1085,29 +1090,36 @@ void XCast::getUrlFromAppLaunchParams (const char *app_name, const char *payload
             int has_query = query_string && strlen(query_string);
             int has_payload = 0;
             if (has_query) {
-                strcat(url, query_string);
+                snprintf(url + strlen(url), url_len, "%s", query_string);
                 url_len -= strlen(query_string);
             }
             if(payload && strlen(payload)) {
-                if (has_query) url_len -=1;  //for &
                 const char payload_key[] = "dialpayload=";
-                url_len -= sizeof(payload_key) - 1;
-                url_len -= strlen(payload);
                 if(url_len >= 0){
-                    if (has_query) strcat(url, "&");
-                    strcat(url, payload_key);
-                    strcat(url, payload);
-                    has_payload = 1;
+                    if (has_query) {
+                        snprintf(url + strlen(url), url_len, "%s", "&");
+                        url_len -= 1;
+                    }
+                    if(url_len >= 0) {
+                        snprintf(url + strlen(url), url_len, "%s%s", payload_key, payload);
+                        url_len -= strlen(payload_key) + strlen(payload);
+                        has_payload = 1;
+                    }
                 }
                 else {
-                    LOGINFO("there is no enough room for payload\r\n");
+                    LOGINFO("there is not enough room for payload\r\n");
                 }
             }
-
-        if(additional_data_url != NULL){
-                if (has_query || has_payload) strcat(url, "&");
-                strcat(url, "additionalDataUrl=");
-            strcat(url, additional_data_url);
+            
+            if(additional_data_url != NULL){
+                if ((has_query || has_payload) && url_len >= 0) {
+                    snprintf(url + strlen(url), url_len, "%s", "&");
+                    url_len -= 1;
+                }
+                if (url_len >= 0) {
+                    snprintf(url + strlen(url), url_len, "additionalDataUrl=%s", additional_data_url);
+                    url_len -= strlen(additional_data_url) + 18;
+                }
             }
             LOGINFO(" url is [%s]\r\n", url);
     }


### PR DESCRIPTION
Reason for change: Resolve security vulnerabilities in rdkservices
Test Procedure: See ticket
Risks: Low
Priority: P1