### PR TITLE
RDK-54100: [testRunner] Use "visible" activity state to hide parent view

### DIFF
--- a/WebKitBrowser/Testing/testrunner.cpp
+++ b/WebKitBrowser/Testing/testrunner.cpp
@@ -158,9 +158,11 @@ void TestRunnerImpl::setParentVisibility(bool visible) {
     auto* backend = webkit_web_view_backend_get_wpe_backend(webkit_web_view_get_backend(m_parentView));
     assert(backend);
     if (visible) {
+        // Setting the activity state to "visible" alone doesn’t bring the view back to the screen
         wpe_view_backend_add_activity_state(backend, wpe_view_activity_state_in_window);
+        wpe_view_backend_add_activity_state(backend, wpe_view_activity_state_visible);
     } else {
-        wpe_view_backend_remove_activity_state(backend, wpe_view_activity_state_in_window);
+        wpe_view_backend_remove_activity_state(backend, wpe_view_activity_state_visible);
     }
 }
 


### PR DESCRIPTION
Reason for change: Parent view is susspended during TC execution and is not able to handle timeouts
Test Procedure: Run testRunner
Priority: P1
Risks: None