### PR TITLE
DELIA-66581: Remove the ASSERT() which is caused by RDKShell

### DIFF
--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -2143,7 +2143,6 @@ namespace WPEFramework {
                 }
             });
 
-            service->Register(mClientsMonitor);
             char* thunderAccessValue = getenv("THUNDER_ACCESS_VALUE");
             if (NULL != thunderAccessValue)
             {


### PR DESCRIPTION
Reason for change: To avoid unwanted crash in Thunder
Test Procedure: None
Risks: P1
Signed-off-by: Ezhilarasi_Velumani@comcast.com