### PR TITLE
RDKDEV-1102: Update documentation for Network plugin to align with NetworkManger documentation

### DIFF
--- a/docs/api/NetworkPlugin.md
+++ b/docs/api/NetworkPlugin.md
@@ -1,6 +1,6 @@
 <!-- Generated automatically, DO NOT EDIT! -->
 <a name="NetworkPlugin"></a>
-# NetworkPlugin $${\color{red}DEPRECATED}$$
+# Network Plugin $${\color{red}(DEPRECATED)}$$
 
 **Version: [1.3.11](https://github.com/rdkcentral/rdkservices/blob/main/Network/CHANGELOG.md)**
 

--- a/docs/api/NetworkPlugin.md
+++ b/docs/api/NetworkPlugin.md
@@ -1,8 +1,8 @@
 <!-- Generated automatically, DO NOT EDIT! -->
 <a name="NetworkPlugin"></a>
-# NetworkPlugin
+# NetworkPlugin $${\color{red}DEPRECATED}$$
 
-**Version: [1.3.11](https://github.com/rdkcentral/rdkservices/blob/main/Network/CHANGELOG.md) (DEPRECATED)**
+**Version: [1.3.11](https://github.com/rdkcentral/rdkservices/blob/main/Network/CHANGELOG.md)**
 
 A org.rdk.Network plugin for Thunder framework.
 

--- a/docs/api/NetworkPlugin.md
+++ b/docs/api/NetworkPlugin.md
@@ -2,7 +2,7 @@
 <a name="NetworkPlugin"></a>
 # NetworkPlugin
 
-**Version: [1.3.11](https://github.com/rdkcentral/rdkservices/blob/main/Network/CHANGELOG.md)**
+**Version: [1.3.11](https://github.com/rdkcentral/rdkservices/blob/main/Network/CHANGELOG.md) (DEPRECATED)**
 
 A org.rdk.Network plugin for Thunder framework.
 
@@ -815,7 +815,7 @@ No Events
 | :-------- | :-------- | :-------- |
 | params | object |  |
 | params.endpoint | string | The host name or IP address |
-| params.packets | integer | The number of packets to send. Default is 15 |
+| params.packets | integer | The number of packets to send. Default is 3 |
 | params?.guid | string | <sup>*(optional)*</sup> The globally unique identifier |
 
 ### Result
@@ -846,7 +846,7 @@ No Events
     "method": "org.rdk.Network.ping",
     "params": {
         "endpoint": "45.57.221.20",
-        "packets": 10,
+        "packets": 3,
         "guid": "..."
     }
 }
@@ -1303,7 +1303,7 @@ No Events
 | :-------- | :-------- | :-------- |
 | params | object |  |
 | params.endpoint | string | The host name or IP address |
-| params.packets | integer | The number of packets to send. Default is 15 |
+| params.packets | integer | The number of packets to send. Default is 5 |
 
 ### Result
 
@@ -1326,7 +1326,7 @@ No Events
     "method": "org.rdk.Network.trace",
     "params": {
         "endpoint": "45.57.221.20",
-        "packets": 10
+        "packets": 5
     }
 }
 ```

--- a/docs/api/NetworkPlugin.md
+++ b/docs/api/NetworkPlugin.md
@@ -6,6 +6,8 @@
 
 A org.rdk.Network plugin for Thunder framework.
 
+For newer APIs, please refer: https://github.com/rdkcentral/networkmanager/blob/main/docs/NetworkManagerPlugin.md
+
 ### Table of Contents
 
 - [Abbreviation, Acronyms and Terms](#Abbreviation,_Acronyms_and_Terms)

--- a/docs/api/WifiPlugin.md
+++ b/docs/api/WifiPlugin.md
@@ -2,7 +2,7 @@
 <a name="Wifi_Plugin"></a>
 # Wifi Plugin
 
-**Version: [1.0.9](https://github.com/rdkcentral/rdkservices/blob/main/WifiManager/CHANGELOG.md)**
+**Version: [1.0.9](https://github.com/rdkcentral/rdkservices/blob/main/WifiManager/CHANGELOG.md) (DEPRECATED)**
 
 A org.rdk.Wifi plugin for Thunder framework.
 

--- a/docs/api/WifiPlugin.md
+++ b/docs/api/WifiPlugin.md
@@ -6,6 +6,8 @@
 
 A org.rdk.Wifi plugin for Thunder framework.
 
+For newer APIs, please refer: https://github.com/rdkcentral/networkmanager/blob/main/docs/NetworkManagerPlugin.md
+
 ### Table of Contents
 
 - [Abbreviation, Acronyms and Terms](#Abbreviation,_Acronyms_and_Terms)

--- a/docs/api/WifiPlugin.md
+++ b/docs/api/WifiPlugin.md
@@ -1,8 +1,8 @@
 <!-- Generated automatically, DO NOT EDIT! -->
 <a name="Wifi_Plugin"></a>
-# Wifi Plugin
+# Wifi Plugin $${\color{red}(DEPRECATED)}$$
 
-**Version: [1.0.9](https://github.com/rdkcentral/rdkservices/blob/main/WifiManager/CHANGELOG.md) (DEPRECATED)**
+**Version: [1.0.9](https://github.com/rdkcentral/rdkservices/blob/main/WifiManager/CHANGELOG.md)**
 
 A org.rdk.Wifi plugin for Thunder framework.
 


### PR DESCRIPTION
Reason for change: Align Network plugin documention with NetworkManager documention update

Risks: Low

Test Procedure: Verify default packet sizes for ping and trace APIs in https://rdkcentral.github.io/rdkservices/#/api/NetworkPlugin is aligned with https://github.com/rdkcentral/networkmanager/blob/develop/docs/NetworkManagerPlugin.md

Signed-off-by: Jitha James <jitha_james@comcast.com>