### PR TITLE
SERXIONE-6515 : Integrity check

### DIFF
--- a/PersistentStore/l0test/ServiceMock.h
+++ b/PersistentStore/l0test/ServiceMock.h
@@ -3,8 +3,7 @@
 #include "../Module.h"
 #include <gmock/gmock.h>
 
-class ServiceMock : public WPEFramework::PluginHost::IShell,
-                    public WPEFramework::PluginHost::IShell::ICOMLink {
+class ServiceMock : public WPEFramework::PluginHost::IShell {
 public:
     ~ServiceMock() override = default;
     MOCK_METHOD(string, Versions, (), (const, override));
@@ -47,15 +46,8 @@ public:
     MOCK_METHOD(WPEFramework::Core::hresult, Resumed, (const bool), (override));
     MOCK_METHOD(WPEFramework::Core::hresult, Metadata, (string&), (const, override));
     MOCK_METHOD(WPEFramework::Core::hresult, Hibernate, (const uint32_t), (override));
-    MOCK_METHOD(void, Register, (WPEFramework::RPC::IRemoteConnection::INotification*), (override));
-    MOCK_METHOD(void, Unregister, (const WPEFramework::RPC::IRemoteConnection::INotification*), (override));
-    MOCK_METHOD(void, Register, (IShell::ICOMLink::INotification*), (override));
-    MOCK_METHOD(void, Unregister, (const IShell::ICOMLink::INotification*), (override));
-    MOCK_METHOD(WPEFramework::RPC::IRemoteConnection*, RemoteConnection, (const uint32_t), (override));
-    MOCK_METHOD(void*, Instantiate, (const WPEFramework::RPC::Object&, const uint32_t, uint32_t&), (override));
     MOCK_METHOD(WPEFramework::RPC::IStringIterator*, GetLibrarySearchPaths, (const string&), (const, override));
     BEGIN_INTERFACE_MAP(ServiceMock)
     INTERFACE_ENTRY(IShell)
-    INTERFACE_ENTRY(IShell::ICOMLink)
     END_INTERFACE_MAP
 };

--- a/PersistentStore/l1test/ServiceMock.h
+++ b/PersistentStore/l1test/ServiceMock.h
@@ -3,8 +3,7 @@
 #include "../Module.h"
 #include <gmock/gmock.h>
 
-class ServiceMock : public WPEFramework::PluginHost::IShell,
-                    public WPEFramework::PluginHost::IShell::ICOMLink {
+class ServiceMock : public WPEFramework::PluginHost::IShell {
 public:
     ~ServiceMock() override = default;
     MOCK_METHOD(string, Versions, (), (const, override));
@@ -47,15 +46,8 @@ public:
     MOCK_METHOD(WPEFramework::Core::hresult, Resumed, (const bool), (override));
     MOCK_METHOD(WPEFramework::Core::hresult, Metadata, (string&), (const, override));
     MOCK_METHOD(WPEFramework::Core::hresult, Hibernate, (const uint32_t), (override));
-    MOCK_METHOD(void, Register, (WPEFramework::RPC::IRemoteConnection::INotification*), (override));
-    MOCK_METHOD(void, Unregister, (const WPEFramework::RPC::IRemoteConnection::INotification*), (override));
-    MOCK_METHOD(void, Register, (IShell::ICOMLink::INotification*), (override));
-    MOCK_METHOD(void, Unregister, (const IShell::ICOMLink::INotification*), (override));
-    MOCK_METHOD(WPEFramework::RPC::IRemoteConnection*, RemoteConnection, (const uint32_t), (override));
-    MOCK_METHOD(void*, Instantiate, (const WPEFramework::RPC::Object&, const uint32_t, uint32_t&), (override));
     MOCK_METHOD(WPEFramework::RPC::IStringIterator*, GetLibrarySearchPaths, (const string&), (const, override));
     BEGIN_INTERFACE_MAP(ServiceMock)
     INTERFACE_ENTRY(IShell)
-    INTERFACE_ENTRY(IShell::ICOMLink)
     END_INTERFACE_MAP
 };

--- a/PersistentStore/sqlite/l1test/Store2Test.cpp
+++ b/PersistentStore/sqlite/l1test/Store2Test.cpp
@@ -16,27 +16,20 @@ using ::testing::NiceMock;
 using ::testing::NotNull;
 using ::testing::Test;
 using ::WPEFramework::Exchange::IStore2;
-using ::WPEFramework::Exchange::IStoreCache;
 using ::WPEFramework::Exchange::IStoreInspector;
 using ::WPEFramework::Exchange::IStoreLimit;
 using ::WPEFramework::Plugin::Sqlite::Store2;
 using ::WPEFramework::RPC::IStringIterator;
 
 const auto kPath = "/tmp/persistentstore/sqlite/l1test/store2test";
+const auto kPathCorrupt = "/tmp/persistentstore/sqlite/l1test/corrupt";
 const auto kMaxSize = 100;
-const auto kMaxValue = 10;
+const auto kMaxValue = 5;
 const auto kLimit = 50;
-const auto kValue = "value_1";
-const auto kKey = "key_1";
-const auto kAppId = "app_id_1";
-const auto kTtl = 2;
+const auto kValue = "value";
+const auto kKey = "key";
+const auto kAppId = "app";
 const auto kNoTtl = 0;
-const auto kEmpty = "";
-const auto kOversize = "this is too large";
-const auto kUnknown = "unknown";
-const auto kLimit20 = 20;
-const auto kLimit30 = 30;
-const auto kLimit40 = 40;
 
 class AStore2 : public Test {
 protected:
@@ -45,7 +38,8 @@ protected:
     AStore2()
         : workerPool(WPEFramework::Core::ProxyType<WorkerPoolImplementation>::Create(
               WPEFramework::Core::Thread::DefaultStackSize()))
-        , store2(WPEFramework::Core::ProxyType<Store2>::Create(kPath, kMaxSize, kMaxValue, kLimit))
+        , store2(WPEFramework::Core::ProxyType<Store2>::Create(
+              kPath, kMaxSize, kMaxValue, kLimit))
     {
         WPEFramework::Core::IWorkerPool::Assign(&(*workerPool));
     }
@@ -57,142 +51,200 @@ protected:
 
 TEST_F(AStore2, DoesNotSetValueWhenNamespaceEmpty)
 {
-    EXPECT_THAT(store2->SetValue(IStore2::ScopeType::DEVICE, kEmpty, kKey, kValue, kNoTtl), Eq(WPEFramework::Core::ERROR_INVALID_INPUT_LENGTH));
+    EXPECT_THAT(store2->SetValue(
+                    IStore2::ScopeType::DEVICE, "", kKey, kValue, kNoTtl),
+        Eq(WPEFramework::Core::ERROR_INVALID_INPUT_LENGTH));
 }
 
 TEST_F(AStore2, DoesNotSetValueWhenKeyEmpty)
 {
-    EXPECT_THAT(store2->SetValue(IStore2::ScopeType::DEVICE, kAppId, kEmpty, kValue, kNoTtl), Eq(WPEFramework::Core::ERROR_INVALID_INPUT_LENGTH));
+    EXPECT_THAT(store2->SetValue(
+                    IStore2::ScopeType::DEVICE, kAppId, "", kValue, kNoTtl),
+        Eq(WPEFramework::Core::ERROR_INVALID_INPUT_LENGTH));
 }
 
-TEST_F(AStore2, DoesNotSetValueWhenNamespaceOversize)
+TEST_F(AStore2, DoesNotSetValueWhenNamespaceTooLarge)
 {
-    EXPECT_THAT(store2->SetValue(IStore2::ScopeType::DEVICE, kOversize, kKey, kValue, kNoTtl), Eq(WPEFramework::Core::ERROR_INVALID_INPUT_LENGTH));
+    EXPECT_THAT(store2->SetValue(
+                    IStore2::ScopeType::DEVICE, "this is too large",
+                    kKey, kValue, kNoTtl),
+        Eq(WPEFramework::Core::ERROR_INVALID_INPUT_LENGTH));
 }
 
-TEST_F(AStore2, DoesNotSetValueWhenKeyOversize)
+TEST_F(AStore2, DoesNotSetValueWhenKeyTooLarge)
 {
-    EXPECT_THAT(store2->SetValue(IStore2::ScopeType::DEVICE, kAppId, kOversize, kValue, kNoTtl), Eq(WPEFramework::Core::ERROR_INVALID_INPUT_LENGTH));
+    EXPECT_THAT(store2->SetValue(
+                    IStore2::ScopeType::DEVICE, kAppId, "this is too large",
+                    kValue, kNoTtl),
+        Eq(WPEFramework::Core::ERROR_INVALID_INPUT_LENGTH));
 }
 
-TEST_F(AStore2, DoesNotSetValueWhenValueOversize)
+TEST_F(AStore2, DoesNotSetValueWhenValueTooLarge)
 {
-    EXPECT_THAT(store2->SetValue(IStore2::ScopeType::DEVICE, kAppId, kKey, kOversize, kNoTtl), Eq(WPEFramework::Core::ERROR_INVALID_INPUT_LENGTH));
+    EXPECT_THAT(store2->SetValue(
+                    IStore2::ScopeType::DEVICE, kAppId, kKey,
+                    "this is too large", kNoTtl),
+        Eq(WPEFramework::Core::ERROR_INVALID_INPUT_LENGTH));
 }
 
-TEST_F(AStore2, DoesNotGetValueWhenNamespaceUnknown)
+TEST_F(AStore2, DoesNotGetValueWhenNamespaceDoesNotExist)
 {
     string value;
     uint32_t ttl;
-    EXPECT_THAT(store2->GetValue(IStore2::ScopeType::DEVICE, kUnknown, kKey, value, ttl), Eq(WPEFramework::Core::ERROR_NOT_EXIST));
+    EXPECT_THAT(store2->GetValue(
+                    IStore2::ScopeType::DEVICE, "none", kKey, value, ttl),
+        Eq(WPEFramework::Core::ERROR_NOT_EXIST));
 }
 
-TEST_F(AStore2, DeletesKeyWhenNamespaceUnknown)
+TEST_F(AStore2, DeletesKeyWhenNamespaceDoesNotExist)
 {
-    EXPECT_THAT(store2->DeleteKey(IStore2::ScopeType::DEVICE, kUnknown, kKey), Eq(WPEFramework::Core::ERROR_NONE));
+    EXPECT_THAT(store2->DeleteKey(IStore2::ScopeType::DEVICE, "none", kKey),
+        Eq(WPEFramework::Core::ERROR_NONE));
 }
 
-TEST_F(AStore2, DeletesNamespaceWhenNamespaceUnknown)
+TEST_F(AStore2, DeletesNamespaceWhenNamespaceDoesNotExist)
 {
-    EXPECT_THAT(store2->DeleteNamespace(IStore2::ScopeType::DEVICE, kUnknown), Eq(WPEFramework::Core::ERROR_NONE));
+    EXPECT_THAT(store2->DeleteNamespace(IStore2::ScopeType::DEVICE, "none"),
+        Eq(WPEFramework::Core::ERROR_NONE));
 }
 
 TEST_F(AStore2, SetsValueWhenValueEmpty)
 {
-    ASSERT_THAT(store2->SetValue(IStore2::ScopeType::DEVICE, kAppId, kKey, kEmpty, kNoTtl), Eq(WPEFramework::Core::ERROR_NONE));
+    ASSERT_THAT(store2->SetValue(
+                    IStore2::ScopeType::DEVICE, kAppId, kKey, "", kNoTtl),
+        Eq(WPEFramework::Core::ERROR_NONE));
     string value;
     uint32_t ttl;
-    ASSERT_THAT(store2->GetValue(IStore2::ScopeType::DEVICE, kAppId, kKey, value, ttl), Eq(WPEFramework::Core::ERROR_NONE));
-    EXPECT_THAT(value, Eq(kEmpty));
-    EXPECT_THAT(ttl, Eq(kNoTtl));
+    ASSERT_THAT(store2->GetValue(
+                    IStore2::ScopeType::DEVICE, kAppId, kKey, value, ttl),
+        Eq(WPEFramework::Core::ERROR_NONE));
+    EXPECT_THAT(value, Eq(""));
 }
 
-TEST_F(AStore2, GetsValueWhenTtlNotExpired)
+TEST_F(AStore2, GetsValueWhenTtl2Seconds)
 {
-    ASSERT_THAT(store2->SetValue(IStore2::ScopeType::DEVICE, kAppId, kKey, kValue, kTtl), Eq(WPEFramework::Core::ERROR_NONE));
+    ASSERT_THAT(store2->SetValue(
+                    IStore2::ScopeType::DEVICE, kAppId, kKey, kValue, 2 /*ttl*/),
+        Eq(WPEFramework::Core::ERROR_NONE));
     string value;
     uint32_t ttl;
-    ASSERT_THAT(store2->GetValue(IStore2::ScopeType::DEVICE, kAppId, kKey, value, ttl), Eq(WPEFramework::Core::ERROR_NONE));
+    ASSERT_THAT(store2->GetValue(
+                    IStore2::ScopeType::DEVICE, kAppId, kKey, value, ttl),
+        Eq(WPEFramework::Core::ERROR_NONE));
     EXPECT_THAT(value, Eq(kValue));
-    EXPECT_THAT(ttl, Le(kTtl));
-    EXPECT_THAT(ttl, Gt(kNoTtl));
+    EXPECT_THAT(ttl, Le(2));
+    EXPECT_THAT(ttl, Gt(0));
 }
 
-TEST_F(AStore2, DoesNotGetValueWhenTtlExpired)
+TEST_F(AStore2, DoesNotGetValueWhenTtl2SecondsExpired)
 {
-    ASSERT_THAT(store2->SetValue(IStore2::ScopeType::DEVICE, kAppId, kKey, kValue, kTtl), Eq(WPEFramework::Core::ERROR_NONE));
+    ASSERT_THAT(store2->SetValue(
+                    IStore2::ScopeType::DEVICE, kAppId, kKey, kValue, 2),
+        Eq(WPEFramework::Core::ERROR_NONE));
     WPEFramework::Core::Event lock(false, true);
-    lock.Lock(kTtl * WPEFramework::Core::Time::MilliSecondsPerSecond);
+    lock.Lock(2 * WPEFramework::Core::Time::MilliSecondsPerSecond);
     string value;
     uint32_t ttl;
-    EXPECT_THAT(store2->GetValue(IStore2::ScopeType::DEVICE, kAppId, kKey, value, ttl), Eq(WPEFramework::Core::ERROR_UNKNOWN_KEY));
+    EXPECT_THAT(store2->GetValue(
+                    IStore2::ScopeType::DEVICE, kAppId, kKey, value, ttl),
+        Eq(WPEFramework::Core::ERROR_UNKNOWN_KEY));
 }
 
-TEST_F(AStore2, ValueChangedWhenSetValue)
+TEST_F(AStore2, SendsValueChangedEventWhenSetValue)
 {
-    class Store2Notification : public NiceMock<Store2NotificationMock> {
-    public:
-        Store2Notification()
-        {
-            EXPECT_CALL(*this, ValueChanged(_, _, _, _))
-                .WillRepeatedly(Invoke(
-                    [](const IStore2::ScopeType scope, const string& ns, const string& key, const string& value) {
-                        EXPECT_THAT(scope, Eq(IStore2::ScopeType::DEVICE));
-                        EXPECT_THAT(ns, Eq(kAppId));
-                        EXPECT_THAT(key, Eq(kKey));
-                        EXPECT_THAT(value, Eq(kValue));
-                        return WPEFramework::Core::ERROR_NONE;
-                    }));
-        }
-    };
-    WPEFramework::Core::Sink<Store2Notification> sink;
+    IStore2::ScopeType eventScope;
+    string eventNamespace;
+    string eventKey;
+    string eventValue;
+    WPEFramework::Core::Event lock(false, true);
+    WPEFramework::Core::Sink<NiceMock<Store2NotificationMock>> sink;
+    EXPECT_CALL(sink, ValueChanged(_, _, _, _))
+        .WillRepeatedly(Invoke(
+            [&](const IStore2::ScopeType scope, const string& ns,
+                const string& key, const string& value) {
+                eventScope = scope;
+                eventNamespace = ns;
+                eventKey = key;
+                eventValue = value;
+                lock.SetEvent();
+                return WPEFramework::Core::ERROR_NONE;
+            }));
     store2->Register(&sink);
-    EXPECT_THAT(store2->SetValue(IStore2::ScopeType::DEVICE, kAppId, kKey, kValue, kNoTtl), Eq(WPEFramework::Core::ERROR_NONE));
+    EXPECT_THAT(store2->SetValue(
+                    IStore2::ScopeType::DEVICE, kAppId, kKey, kValue, kNoTtl),
+        Eq(WPEFramework::Core::ERROR_NONE));
+    lock.Lock(2 * WPEFramework::Core::Time::MilliSecondsPerSecond);
+    EXPECT_THAT(eventScope, Eq(IStore2::ScopeType::DEVICE));
+    EXPECT_THAT(eventNamespace, Eq(kAppId));
+    EXPECT_THAT(eventKey, Eq(kKey));
+    EXPECT_THAT(eventValue, Eq(kValue));
     store2->Unregister(&sink);
 }
 
-TEST_F(AStore2, DoesNotGetValueWhenKeyUnknown)
+TEST_F(AStore2, DoesNotGetValueWhenKeyDoesNotExist)
 {
-    ASSERT_THAT(store2->SetValue(IStore2::ScopeType::DEVICE, kAppId, kKey, kValue, kNoTtl), Eq(WPEFramework::Core::ERROR_NONE));
+    ASSERT_THAT(store2->SetValue(
+                    IStore2::ScopeType::DEVICE, kAppId, kKey, kValue, kNoTtl),
+        Eq(WPEFramework::Core::ERROR_NONE));
     string value;
     uint32_t ttl;
-    EXPECT_THAT(store2->GetValue(IStore2::ScopeType::DEVICE, kAppId, kUnknown, value, ttl), Eq(WPEFramework::Core::ERROR_UNKNOWN_KEY));
+    EXPECT_THAT(store2->GetValue(
+                    IStore2::ScopeType::DEVICE, kAppId, "none", value, ttl),
+        Eq(WPEFramework::Core::ERROR_UNKNOWN_KEY));
 }
 
-TEST_F(AStore2, DeletesKeyWhenKeyUnknown)
+TEST_F(AStore2, DeletesKeyWhenKeyDoesNotExist)
 {
-    ASSERT_THAT(store2->SetValue(IStore2::ScopeType::DEVICE, kAppId, kKey, kValue, kNoTtl), Eq(WPEFramework::Core::ERROR_NONE));
-    EXPECT_THAT(store2->DeleteKey(IStore2::ScopeType::DEVICE, kAppId, kUnknown), Eq(WPEFramework::Core::ERROR_NONE));
+    ASSERT_THAT(store2->SetValue(
+                    IStore2::ScopeType::DEVICE, kAppId, kKey, kValue, kNoTtl),
+        Eq(WPEFramework::Core::ERROR_NONE));
+    EXPECT_THAT(store2->DeleteKey(
+                    IStore2::ScopeType::DEVICE, kAppId, "none"),
+        Eq(WPEFramework::Core::ERROR_NONE));
 }
 
-TEST_F(AStore2, DeletesKey)
+TEST_F(AStore2, DoesNotGetValueWhenDeletedKey)
 {
-    ASSERT_THAT(store2->SetValue(IStore2::ScopeType::DEVICE, kAppId, kKey, kValue, kNoTtl), Eq(WPEFramework::Core::ERROR_NONE));
-    ASSERT_THAT(store2->DeleteKey(IStore2::ScopeType::DEVICE, kAppId, kKey), Eq(WPEFramework::Core::ERROR_NONE));
+    ASSERT_THAT(store2->SetValue(
+                    IStore2::ScopeType::DEVICE, kAppId, kKey, kValue, kNoTtl),
+        Eq(WPEFramework::Core::ERROR_NONE));
+    ASSERT_THAT(store2->DeleteKey(
+                    IStore2::ScopeType::DEVICE, kAppId, kKey),
+        Eq(WPEFramework::Core::ERROR_NONE));
     string value;
     uint32_t ttl;
-    EXPECT_THAT(store2->GetValue(IStore2::ScopeType::DEVICE, kAppId, kKey, value, ttl), Eq(WPEFramework::Core::ERROR_UNKNOWN_KEY));
+    EXPECT_THAT(store2->GetValue(
+                    IStore2::ScopeType::DEVICE, kAppId, kKey, value, ttl),
+        Eq(WPEFramework::Core::ERROR_UNKNOWN_KEY));
 }
 
-TEST_F(AStore2, DeletesNamespace)
+TEST_F(AStore2, DoesNotGetValueWhenDeletedNamespace)
 {
-    ASSERT_THAT(store2->SetValue(IStore2::ScopeType::DEVICE, kAppId, kKey, kValue, kNoTtl), Eq(WPEFramework::Core::ERROR_NONE));
-    ASSERT_THAT(store2->DeleteNamespace(IStore2::ScopeType::DEVICE, kAppId), Eq(WPEFramework::Core::ERROR_NONE));
+    ASSERT_THAT(store2->SetValue(
+                    IStore2::ScopeType::DEVICE, kAppId, kKey, kValue, kNoTtl),
+        Eq(WPEFramework::Core::ERROR_NONE));
+    ASSERT_THAT(store2->DeleteNamespace(IStore2::ScopeType::DEVICE, kAppId),
+        Eq(WPEFramework::Core::ERROR_NONE));
     string value;
     uint32_t ttl;
-    EXPECT_THAT(store2->GetValue(IStore2::ScopeType::DEVICE, kAppId, kKey, value, ttl), Eq(WPEFramework::Core::ERROR_NOT_EXIST));
+    EXPECT_THAT(store2->GetValue(
+                    IStore2::ScopeType::DEVICE, kAppId, kKey, value, ttl),
+        Eq(WPEFramework::Core::ERROR_NOT_EXIST));
 }
 
-TEST_F(AStore2, DoesNotSetValueWhenReachedMaxSize)
+TEST(Store2, DoesNotSetValueWhenReachedMaxSize)
 {
-    ASSERT_THAT(store2->DeleteNamespace(IStore2::ScopeType::DEVICE, kAppId), Eq(WPEFramework::Core::ERROR_NONE));
-    ASSERT_THAT(store2->SetValue(IStore2::ScopeType::DEVICE, "8InMXXU4hM", "YWKN74ODMf", "N0ed2C2h4n", kNoTtl), Eq(WPEFramework::Core::ERROR_NONE));
-    ASSERT_THAT(store2->SetValue(IStore2::ScopeType::DEVICE, "XhrICnuerw", "jPKODBDk5K", "d3BarkA5xF", kNoTtl), Eq(WPEFramework::Core::ERROR_NONE));
-    ASSERT_THAT(store2->SetValue(IStore2::ScopeType::DEVICE, "WNeBknDDI2", "GC96ZN6Fuq", "IBF2E1MLQh", kNoTtl), Eq(WPEFramework::Core::ERROR_NONE));
-    EXPECT_THAT(store2->SetValue(IStore2::ScopeType::DEVICE, kAppId, kKey, kValue, kNoTtl), Eq(WPEFramework::Core::ERROR_INVALID_INPUT_LENGTH));
-    EXPECT_THAT(store2->DeleteNamespace(IStore2::ScopeType::DEVICE, "8InMXXU4hM"), Eq(WPEFramework::Core::ERROR_NONE));
-    EXPECT_THAT(store2->DeleteNamespace(IStore2::ScopeType::DEVICE, "XhrICnuerw"), Eq(WPEFramework::Core::ERROR_NONE));
-    EXPECT_THAT(store2->DeleteNamespace(IStore2::ScopeType::DEVICE, "WNeBknDDI2"), Eq(WPEFramework::Core::ERROR_NONE));
+    auto workerPool = WPEFramework::Core::ProxyType<WorkerPoolImplementation>::Create(
+        WPEFramework::Core::Thread::DefaultStackSize());
+    auto store2 = WPEFramework::Core::ProxyType<Store2>::Create(
+        kPath, 10 /*max size*/, kMaxValue, kLimit);
+    WPEFramework::Core::IWorkerPool::Assign(&(*workerPool));
+    ASSERT_THAT(store2->DeleteNamespace(IStore2::ScopeType::DEVICE, kAppId),
+        Eq(WPEFramework::Core::ERROR_NONE));
+    EXPECT_THAT(store2->SetValue(
+                    IStore2::ScopeType::DEVICE, kAppId, kKey, kValue, kNoTtl),
+        Eq(WPEFramework::Core::ERROR_INVALID_INPUT_LENGTH));
+    WPEFramework::Core::IWorkerPool::Assign(nullptr);
 }
 
 TEST_F(AStore2, FlushesCache)
@@ -200,10 +252,12 @@ TEST_F(AStore2, FlushesCache)
     EXPECT_THAT(store2->FlushCache(), Eq(WPEFramework::Core::ERROR_NONE));
 }
 
-TEST_F(AStore2, GetsKeysWhenNamespaceUnknown)
+TEST_F(AStore2, GetsKeysWhenNamespaceDoesNotExist)
 {
     IStringIterator* it;
-    ASSERT_THAT(store2->GetKeys(IStoreInspector::ScopeType::DEVICE, kUnknown, it), Eq(WPEFramework::Core::ERROR_NONE));
+    ASSERT_THAT(store2->GetKeys(
+                    IStoreInspector::ScopeType::DEVICE, "none", it),
+        Eq(WPEFramework::Core::ERROR_NONE));
     ASSERT_THAT(it, NotNull());
     string element;
     EXPECT_THAT(it->Next(element), IsFalse());
@@ -212,9 +266,13 @@ TEST_F(AStore2, GetsKeysWhenNamespaceUnknown)
 
 TEST_F(AStore2, GetsKeys)
 {
-    ASSERT_THAT(store2->SetValue(IStore2::ScopeType::DEVICE, kAppId, kKey, kValue, kNoTtl), Eq(WPEFramework::Core::ERROR_NONE));
+    ASSERT_THAT(store2->SetValue(
+                    IStore2::ScopeType::DEVICE, kAppId, kKey, kValue, kNoTtl),
+        Eq(WPEFramework::Core::ERROR_NONE));
     IStringIterator* it;
-    ASSERT_THAT(store2->GetKeys(IStoreInspector::ScopeType::DEVICE, kAppId, it), Eq(WPEFramework::Core::ERROR_NONE));
+    ASSERT_THAT(store2->GetKeys(
+                    IStoreInspector::ScopeType::DEVICE, kAppId, it),
+        Eq(WPEFramework::Core::ERROR_NONE));
     ASSERT_THAT(it, NotNull());
     string element;
     ASSERT_THAT(it->Next(element), IsTrue());
@@ -225,9 +283,13 @@ TEST_F(AStore2, GetsKeys)
 
 TEST_F(AStore2, GetsNamespaces)
 {
-    ASSERT_THAT(store2->SetValue(IStore2::ScopeType::DEVICE, kAppId, kKey, kValue, kNoTtl), Eq(WPEFramework::Core::ERROR_NONE));
+    ASSERT_THAT(store2->SetValue(
+                    IStore2::ScopeType::DEVICE, kAppId, kKey, kValue, kNoTtl),
+        Eq(WPEFramework::Core::ERROR_NONE));
     IStringIterator* it;
-    ASSERT_THAT(store2->GetNamespaces(IStoreInspector::ScopeType::DEVICE, it), Eq(WPEFramework::Core::ERROR_NONE));
+    ASSERT_THAT(store2->GetNamespaces(
+                    IStoreInspector::ScopeType::DEVICE, it),
+        Eq(WPEFramework::Core::ERROR_NONE));
     ASSERT_THAT(it, NotNull());
     string element;
     ASSERT_THAT(it->Next(element), IsTrue());
@@ -238,9 +300,13 @@ TEST_F(AStore2, GetsNamespaces)
 
 TEST_F(AStore2, GetsStorageSizes)
 {
-    ASSERT_THAT(store2->SetValue(IStore2::ScopeType::DEVICE, kAppId, kKey, kValue, kNoTtl), Eq(WPEFramework::Core::ERROR_NONE));
+    ASSERT_THAT(store2->SetValue(
+                    IStore2::ScopeType::DEVICE, kAppId, kKey, kValue, kNoTtl),
+        Eq(WPEFramework::Core::ERROR_NONE));
     IStoreInspector::INamespaceSizeIterator* it;
-    ASSERT_THAT(store2->GetStorageSizes(IStoreInspector::ScopeType::DEVICE, it), Eq(WPEFramework::Core::ERROR_NONE));
+    ASSERT_THAT(store2->GetStorageSizes(
+                    IStoreInspector::ScopeType::DEVICE, it),
+        Eq(WPEFramework::Core::ERROR_NONE));
     ASSERT_THAT(it, NotNull());
     IStoreInspector::NamespaceSize element;
     ASSERT_THAT(it->Next(element), IsTrue());
@@ -250,67 +316,135 @@ TEST_F(AStore2, GetsStorageSizes)
     it->Release();
 }
 
-TEST_F(AStore2, DoesNotGetNamespaceStorageLimitWhenNamespaceUnknown)
+TEST_F(AStore2, DoesNotGetNamespaceStorageLimitWhenNamespaceDoesNotExist)
 {
     uint32_t value;
-    EXPECT_THAT(store2->GetNamespaceStorageLimit(IStoreLimit::ScopeType::DEVICE, kUnknown, value), Eq(WPEFramework::Core::ERROR_NOT_EXIST));
+    EXPECT_THAT(store2->GetNamespaceStorageLimit(
+                    IStoreLimit::ScopeType::DEVICE, "none", value),
+        Eq(WPEFramework::Core::ERROR_NOT_EXIST));
 }
 
 TEST_F(AStore2, DoesNotSetNamespaceStorageLimitWhenNamespaceEmpty)
 {
-    EXPECT_THAT(store2->SetNamespaceStorageLimit(IStoreLimit::ScopeType::DEVICE, kEmpty, kLimit20), Eq(WPEFramework::Core::ERROR_INVALID_INPUT_LENGTH));
+    EXPECT_THAT(store2->SetNamespaceStorageLimit(
+                    IStoreLimit::ScopeType::DEVICE, "", 10 /*limit*/),
+        Eq(WPEFramework::Core::ERROR_INVALID_INPUT_LENGTH));
 }
 
-TEST_F(AStore2, DoesNotSetNamespaceStorageLimitWhenNamespaceOversize)
+TEST_F(AStore2, DoesNotSetNamespaceStorageLimitWhenNamespaceTooLarge)
 {
-    EXPECT_THAT(store2->SetNamespaceStorageLimit(IStoreLimit::ScopeType::DEVICE, kOversize, kLimit20), Eq(WPEFramework::Core::ERROR_INVALID_INPUT_LENGTH));
+    EXPECT_THAT(store2->SetNamespaceStorageLimit(
+                    IStoreLimit::ScopeType::DEVICE, "this is too large", 10 /*limit*/),
+        Eq(WPEFramework::Core::ERROR_INVALID_INPUT_LENGTH));
 }
 
 TEST_F(AStore2, SetsNamespaceStorageLimit)
 {
-    ASSERT_THAT(store2->SetNamespaceStorageLimit(IStoreLimit::ScopeType::DEVICE, kAppId, kLimit20), Eq(WPEFramework::Core::ERROR_NONE));
+    ASSERT_THAT(store2->SetNamespaceStorageLimit(
+                    IStoreLimit::ScopeType::DEVICE, kAppId, 10 /*limit*/),
+        Eq(WPEFramework::Core::ERROR_NONE));
     uint32_t value;
-    ASSERT_THAT(store2->GetNamespaceStorageLimit(IStoreLimit::ScopeType::DEVICE, kAppId, value), Eq(WPEFramework::Core::ERROR_NONE));
-    EXPECT_THAT(value, Eq(kLimit20));
+    ASSERT_THAT(store2->GetNamespaceStorageLimit(
+                    IStoreLimit::ScopeType::DEVICE, kAppId, value),
+        Eq(WPEFramework::Core::ERROR_NONE));
+    EXPECT_THAT(value, Eq(10));
 }
 
-TEST_F(AStore2, SetsNamespaceStorageLimitWhenAlreadySet)
+TEST_F(AStore2, UpdatesNamespaceStorageLimit)
 {
-    ASSERT_THAT(store2->SetNamespaceStorageLimit(IStoreLimit::ScopeType::DEVICE, kAppId, kLimit30), Eq(WPEFramework::Core::ERROR_NONE));
+    ASSERT_THAT(store2->SetNamespaceStorageLimit(
+                    IStoreLimit::ScopeType::DEVICE, kAppId, 10 /*limit*/),
+        Eq(WPEFramework::Core::ERROR_NONE));
+    ASSERT_THAT(store2->SetNamespaceStorageLimit(
+                    IStoreLimit::ScopeType::DEVICE, kAppId, 20 /*limit*/),
+        Eq(WPEFramework::Core::ERROR_NONE));
     uint32_t value;
-    ASSERT_THAT(store2->GetNamespaceStorageLimit(IStoreLimit::ScopeType::DEVICE, kAppId, value), Eq(WPEFramework::Core::ERROR_NONE));
-    EXPECT_THAT(value, Eq(kLimit30));
-    ASSERT_THAT(store2->SetNamespaceStorageLimit(IStoreLimit::ScopeType::DEVICE, kAppId, kLimit40), Eq(WPEFramework::Core::ERROR_NONE));
-    ASSERT_THAT(store2->GetNamespaceStorageLimit(IStoreLimit::ScopeType::DEVICE, kAppId, value), Eq(WPEFramework::Core::ERROR_NONE));
-    EXPECT_THAT(value, Eq(kLimit40));
+    ASSERT_THAT(store2->GetNamespaceStorageLimit(
+                    IStoreLimit::ScopeType::DEVICE, kAppId, value),
+        Eq(WPEFramework::Core::ERROR_NONE));
+    EXPECT_THAT(value, Eq(20));
 }
 
-TEST_F(AStore2, DoesNotSetNamespaceStorageLimitWhenReachedMaxSize)
+TEST(Store2, DoesNotSetValueWhenReachedDefaultLimit)
 {
-    ASSERT_THAT(store2->DeleteNamespace(IStore2::ScopeType::DEVICE, kAppId), Eq(WPEFramework::Core::ERROR_NONE));
-    ASSERT_THAT(store2->SetValue(IStore2::ScopeType::DEVICE, "8InMXXU4hM", "YWKN74ODMf", "N0ed2C2h4n", kNoTtl), Eq(WPEFramework::Core::ERROR_NONE));
-    ASSERT_THAT(store2->SetValue(IStore2::ScopeType::DEVICE, "XhrICnuerw", "jPKODBDk5K", "d3BarkA5xF", kNoTtl), Eq(WPEFramework::Core::ERROR_NONE));
-    ASSERT_THAT(store2->SetValue(IStore2::ScopeType::DEVICE, "WNeBknDDI2", "GC96ZN6Fuq", "IBF2E1MLQh", kNoTtl), Eq(WPEFramework::Core::ERROR_NONE));
-    ASSERT_THAT(store2->SetValue(IStore2::ScopeType::DEVICE, "V92", "R1R", "rHk", kNoTtl), Eq(WPEFramework::Core::ERROR_NONE));
-    EXPECT_THAT(store2->SetNamespaceStorageLimit(IStoreLimit::ScopeType::DEVICE, kAppId, kLimit), Eq(WPEFramework::Core::ERROR_INVALID_INPUT_LENGTH));
-    EXPECT_THAT(store2->DeleteNamespace(IStore2::ScopeType::DEVICE, "8InMXXU4hM"), Eq(WPEFramework::Core::ERROR_NONE));
-    EXPECT_THAT(store2->DeleteNamespace(IStore2::ScopeType::DEVICE, "XhrICnuerw"), Eq(WPEFramework::Core::ERROR_NONE));
-    EXPECT_THAT(store2->DeleteNamespace(IStore2::ScopeType::DEVICE, "WNeBknDDI2"), Eq(WPEFramework::Core::ERROR_NONE));
-    EXPECT_THAT(store2->DeleteNamespace(IStore2::ScopeType::DEVICE, "V92"), Eq(WPEFramework::Core::ERROR_NONE));
+    auto workerPool = WPEFramework::Core::ProxyType<WorkerPoolImplementation>::Create(
+        WPEFramework::Core::Thread::DefaultStackSize());
+    auto store2 = WPEFramework::Core::ProxyType<Store2>::Create(
+        kPath, kMaxSize, kMaxValue, 5 /*limit*/);
+    WPEFramework::Core::IWorkerPool::Assign(&(*workerPool));
+    ASSERT_THAT(store2->DeleteNamespace(IStore2::ScopeType::DEVICE, kAppId),
+        Eq(WPEFramework::Core::ERROR_NONE));
+    EXPECT_THAT(store2->SetValue(
+                    IStore2::ScopeType::DEVICE, kAppId, kKey, kValue, kNoTtl),
+        Eq(WPEFramework::Core::ERROR_INVALID_INPUT_LENGTH));
+    WPEFramework::Core::IWorkerPool::Assign(nullptr);
 }
 
-TEST_F(AStore2, EnforcesSetValueToFailWhenReachedDefaultLimit)
+TEST_F(AStore2, DoesNotSetValueWhenReachedLimit)
 {
-    ASSERT_THAT(store2->DeleteNamespace(IStore2::ScopeType::DEVICE, kAppId), Eq(WPEFramework::Core::ERROR_NONE));
-    ASSERT_THAT(store2->SetValue(IStore2::ScopeType::DEVICE, kAppId, "YWKN74ODMf", "N0ed2C2h4n", kNoTtl), Eq(WPEFramework::Core::ERROR_NONE));
-    ASSERT_THAT(store2->SetValue(IStore2::ScopeType::DEVICE, kAppId, "jPKODBDk5K", "d3BarkA5xF", kNoTtl), Eq(WPEFramework::Core::ERROR_NONE));
-    ASSERT_THAT(store2->SetValue(IStore2::ScopeType::DEVICE, kAppId, kKey, kValue, kNoTtl), Eq(WPEFramework::Core::ERROR_INVALID_INPUT_LENGTH));
+    ASSERT_THAT(store2->DeleteNamespace(IStore2::ScopeType::DEVICE, kAppId),
+        Eq(WPEFramework::Core::ERROR_NONE));
+    ASSERT_THAT(store2->SetNamespaceStorageLimit(
+                    IStoreLimit::ScopeType::DEVICE, kAppId, 5 /*limit*/),
+        Eq(WPEFramework::Core::ERROR_NONE));
+    EXPECT_THAT(store2->SetValue(
+                    IStore2::ScopeType::DEVICE, kAppId, kKey, kValue, kNoTtl),
+        Eq(WPEFramework::Core::ERROR_INVALID_INPUT_LENGTH));
 }
 
-TEST_F(AStore2, EnforcesSetValueToFailWhenReachedLimit)
+TEST_F(AStore2, SetsValueWhenDoesNotReachLimit)
 {
-    ASSERT_THAT(store2->DeleteNamespace(IStore2::ScopeType::DEVICE, kAppId), Eq(WPEFramework::Core::ERROR_NONE));
-    EXPECT_THAT(store2->SetNamespaceStorageLimit(IStoreLimit::ScopeType::DEVICE, kAppId, kLimit20), Eq(WPEFramework::Core::ERROR_NONE));
-    ASSERT_THAT(store2->SetValue(IStore2::ScopeType::DEVICE, kAppId, "YWKN74ODMf", "N0ed2C2h4n", kNoTtl), Eq(WPEFramework::Core::ERROR_NONE));
-    ASSERT_THAT(store2->SetValue(IStore2::ScopeType::DEVICE, kAppId, kKey, kValue, kNoTtl), Eq(WPEFramework::Core::ERROR_INVALID_INPUT_LENGTH));
+    ASSERT_THAT(store2->DeleteNamespace(IStore2::ScopeType::DEVICE, kAppId),
+        Eq(WPEFramework::Core::ERROR_NONE));
+    ASSERT_THAT(store2->SetNamespaceStorageLimit(
+                    IStoreLimit::ScopeType::DEVICE, kAppId, 5 /*limit*/),
+        Eq(WPEFramework::Core::ERROR_NONE));
+    EXPECT_THAT(store2->SetValue(
+                    IStore2::ScopeType::DEVICE, kAppId, kKey, "", kNoTtl),
+        Eq(WPEFramework::Core::ERROR_NONE));
+}
+
+TEST(Store2, SetsValueWhenFileIsNotDatabase)
+{
+    {
+        WPEFramework::Core::File file(kPathCorrupt);
+        file.Destroy();
+        WPEFramework::Core::Directory(file.PathName().c_str()).CreatePath();
+        ASSERT_THAT(file.Create(), IsTrue());
+        uint8_t buffer[1024];
+        ASSERT_THAT(file.Write(buffer, 1024), Eq(1024));
+    }
+    auto workerPool = WPEFramework::Core::ProxyType<WorkerPoolImplementation>::Create(
+        WPEFramework::Core::Thread::DefaultStackSize());
+    auto store2 = WPEFramework::Core::ProxyType<Store2>::Create(
+        kPathCorrupt, kMaxSize, kMaxValue, kLimit);
+    WPEFramework::Core::IWorkerPool::Assign(&(*workerPool));
+    EXPECT_THAT(store2->SetValue(
+                    IStore2::ScopeType::DEVICE, kAppId, kKey, kValue, kNoTtl),
+        Eq(WPEFramework::Core::ERROR_NONE));
+    WPEFramework::Core::IWorkerPool::Assign(nullptr);
+}
+
+TEST(Store2, SetsValueWhenFileCorrupt)
+{
+    {
+        WPEFramework::Core::ProxyType<Store2>::Create(
+            kPathCorrupt, kMaxSize, kMaxValue, kLimit);
+    }
+    {
+        WPEFramework::Core::File file(kPathCorrupt);
+        ASSERT_THAT(file.Open(false /*readOnly*/), IsTrue());
+        ASSERT_THAT(file.Position(false /*relative*/, 8192), IsTrue());
+        uint8_t buffer[1024];
+        ASSERT_THAT(file.Write(buffer, 1024), Eq(1024));
+    }
+    auto workerPool = WPEFramework::Core::ProxyType<WorkerPoolImplementation>::Create(
+        WPEFramework::Core::Thread::DefaultStackSize());
+    auto store2 = WPEFramework::Core::ProxyType<Store2>::Create(
+        kPathCorrupt, kMaxSize, kMaxValue, kLimit);
+    WPEFramework::Core::IWorkerPool::Assign(&(*workerPool));
+    EXPECT_THAT(store2->SetValue(
+                    IStore2::ScopeType::DEVICE, kAppId, kKey, kValue, kNoTtl),
+        Eq(WPEFramework::Core::ERROR_NONE));
+    WPEFramework::Core::IWorkerPool::Assign(nullptr);
 }


### PR DESCRIPTION
Reason for change: Delete file if not a database, or corrupted. Fix namespace limits when namespace has no items.
Test Procedure: None
Risks: None
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>