### PR TITLE
DELIA-66507: CEC is not working intermittently, Unable to wake up the TV

### DIFF
--- a/HdmiCecSource/HdmiCecSource.cpp
+++ b/HdmiCecSource/HdmiCecSource.cpp
@@ -863,6 +863,8 @@ namespace WPEFramework
                     {
                         logicalAddress = logicalAddr;
                         logicalAddressDeviceType = logicalAddrDeviceType;
+                        if(smConnection)
+                            smConnection->setSource(logicalAddress); //update initiator LA
                     }
                 }
                 catch (const std::exception& e)


### PR DESCRIPTION
Reason for change: Update source initiator LA whenever we receice IARM_BUS_CECMGR_EVENT_STATUS_UPDATED  event

Test Procedure: build and verify
Risks: Medium
Priority: P1
Signed-off-by: Srigayathry Pugazhenthi<srigayathry.pugazhenthi@sky.uk>