### PR TITLE
DELIA-65853: Atmos indication is not displayed with DDP

### DIFF
--- a/PlayerInfo/DeviceSettings/PlatformImplementation.cpp
+++ b/PlayerInfo/DeviceSettings/PlatformImplementation.cpp
@@ -393,6 +393,8 @@ public:
                 else if(soundmode == device::AudioStereoMode::kStereo) mode = STEREO;
                 else if(soundmode == device::AudioStereoMode::kMono) mode = MONO;
                 else if(soundmode == device::AudioStereoMode::kPassThru) mode = PASSTHRU;
+                else if(soundmode == device::AudioStereoMode::kDD) mode = DOLBYDIGITAL;
+                else if(soundmode == device::AudioStereoMode::kDDPlus) mode = DOLBYDIGITALPLUS;
                 else mode = UNKNOWN;
 
                 /* Auto mode applicable for HDMI Arc and SPDIF */


### PR DESCRIPTION
Reason for change: Add DD and DDP options in the soundmode API

Test Procedure: build and verify
Risks: Medium
Priority: P1
Signed-off-by: Srigayathry Pugazhenthisrigayathry.pugazhenthi@sky.uk