### PR TITLE
SERXIONE-6620: CEC is not working intermittently

### DIFF
--- a/HdmiCecSource/CHANGELOG.md
+++ b/HdmiCecSource/CHANGELOG.md
@@ -17,6 +17,10 @@ All notable changes to this RDK Service will be documented in this file.
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
 
+## [1.1.3] - 2024-11-25
+### Changed
+- Fixed getting and updating latest LA data from IARM CEC event
+
 ## [1.1.2] - 2024-09-04
 ### Changed
 - Fixed CEC crash by passing invalid parameters to the HdmiCecSource plugin API

--- a/HdmiCecSource/HdmiCecSource.cpp
+++ b/HdmiCecSource/HdmiCecSource.cpp
@@ -774,7 +774,7 @@ namespace WPEFramework
                     break;
                     case IARM_BUS_CECMGR_EVENT_STATUS_UPDATED:
                     {
-                        IARM_Bus_CECMgr_Status_Updated_Param_t *evtData = new IARM_Bus_CECMgr_Status_Updated_Param_t;
+                        IARM_Bus_CECMgr_Status_Updated_Param_t *evtData = (IARM_Bus_CECMgr_Status_Updated_Param_t *)data;
                         if(evtData)
                         {
                             std::thread worker(threadCecStatusUpdateHandler,evtData->logicalAddress);
@@ -863,6 +863,8 @@ namespace WPEFramework
                     {
                         logicalAddress = logicalAddr;
                         logicalAddressDeviceType = logicalAddrDeviceType;
+                        if(smConnection)
+                            smConnection->setSource(logicalAddress); //update initiator LA
                     }
                 }
                 catch (const std::exception& e)


### PR DESCRIPTION
Reason for change:  Add proper typecasting to get the LA and update 
source initiator LA whenever we receive IARM_BUS_CECMGR_EVENT_STATUS_UPDATED event

Test Procedure: build and verify
Risks: Medium
Priority: P1
Signed-off-by: Srigayathry Pugazhenthi <srigayathry.pugazhenthi@sky.uk>