### PR TITLE
RDKTV-34010: Maintenance Status stuck at MAINTENANCE_STARTED

### DIFF
--- a/MaintenanceManager/CHANGELOG.md
+++ b/MaintenanceManager/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.0.38] - 2024-11-26
+### Added
+- MaintenanceManager is stuck at MAINTENANCE_STARTED in non-WAI case, when SUPPRESSED_MAINTENANCE is enabled with no Skip Firmware
+
 ## [1.0.37] - 2024-11-06
 ### Remove
 - Decouple DCM from Unsolicited Maintenance and remove DCM references in MaintenanceManager

--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -394,6 +394,12 @@ namespace WPEFramework {
                     tasks.push_back(task_names_foreground[0].c_str());
                     tasks.push_back(task_names_foreground[2].c_str());
 		}
+		else
+		{
+		    tasks.push_back(task_names_foreground[0].c_str());
+		    tasks.push_back(task_names_foreground[1].c_str());
+		    tasks.push_back(task_names_foreground[2].c_str());
+		}
 	    }
 #else
             tasks.push_back(task_names_foreground[0].c_str());


### PR DESCRIPTION
**MAINTENANCE_STARTED** when activationStatus is true and skipFirmwareCheck is false when **SUPPRESS_MAINTENANCE** is enabled in Non-WhoAmI device