### PR TITLE
SERXIONE-6196: DeviceIdentification activation fail

### DIFF
--- a/DeviceIdentification/CMakeLists.txt
+++ b/DeviceIdentification/CMakeLists.txt
@@ -126,4 +126,5 @@ target_include_directories(${MODULE_NAME}
 install(TARGETS ${MODULE_NAME} 
     DESTINATION lib/${STORAGE_DIRECTORY}/plugins)
 
+target_include_directories(${MODULE_NAME} PRIVATE ../helpers)
 write_config(${PLUGIN_NAME})

--- a/DeviceIdentification/DeviceIdentification.h
+++ b/DeviceIdentification/DeviceIdentification.h
@@ -94,6 +94,7 @@ namespace Plugin {
         uint32_t get_deviceidentification(JsonData::DeviceIdentification::DeviceidentificationData& response) const;
 
         string GetDeviceId() const;
+        string RetrieveSerialNumberThroughCOMRPC() const;
         void Info(JsonData::DeviceIdentification::DeviceidentificationData&) const;
 
         void Deactivated(RPC::IRemoteConnection* connection);


### PR DESCRIPTION
Reason for change: DeviceIdentification plugin activation fail Test Procedure: Check DeviceIdentification plugin activation. Risks: Low
Signed-off-by:AkshayKumar_Gampa <AkshayKumar_Gampa@comcast.com>