### PR TITLE
RDKTV-34608: Fix for SIG-ILL crash due to missing unregister call for power event

### DIFF
--- a/Miracast/MiracastService/MiracastService.cpp
+++ b/Miracast/MiracastService/MiracastService.cpp
@@ -276,12 +276,11 @@ namespace WPEFramework
 			if (!m_isServiceInitialized)
 			{
 				MiracastError ret_code = MIRACAST_OK;
-
-				InitializeIARM();
 		
 				m_miracast_ctrler_obj = MiracastController::getInstance(ret_code, this,p2p_ctrl_iface);
 				if (nullptr != m_miracast_ctrler_obj)
 				{
+					InitializeIARM();
 					m_CurrentService = service;
 					getThunderPlugins();
 					// subscribe for event


### PR DESCRIPTION
RDKTV-34608: Fix for SIG-ILL crash due to missing unregister call for power event

Signed-off-by: yuvaramachandran_gurusamy <yuvaramachandran_gurusamy@comcast.com>