### PR TITLE
SERXIONE-6196: DeviceIdentification activation fail

### DIFF
--- a/DeviceIdentification/CMakeLists.txt
+++ b/DeviceIdentification/CMakeLists.txt
@@ -126,4 +126,6 @@ target_include_directories(${MODULE_NAME}
 install(TARGETS ${MODULE_NAME} 
     DESTINATION lib/${STORAGE_DIRECTORY}/plugins)
 
+target_include_directories(${MODULE_NAME} PRIVATE ../helpers)
+
 write_config(${PLUGIN_NAME})

--- a/DeviceIdentification/DeviceIdentification.cpp
+++ b/DeviceIdentification/DeviceIdentification.cpp
@@ -20,6 +20,18 @@
 #include "DeviceIdentification.h"
 #include "IdentityProvider.h"
 #include <interfaces/IConfiguration.h>
+#include "tracing/Logging.h"
+#include "UtilsJsonRpc.h"
+#include <com/com.h>
+#include <core/core.h>
+#include <plugins/plugins.h>
+#include <interfaces/Ids.h>
+#include "UtilsController.h"
+#ifdef USE_THUNDER_R4
+#include <interfaces/IDeviceInfo.h>
+#else
+#include <interfaces/IDeviceInfo2.h>
+#endif /* USE_THUNDER_R4 */
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
@@ -154,6 +166,7 @@ namespace Plugin {
     string DeviceIdentification::GetDeviceId() const
     {
         string result;
+        string serial;
 #ifndef DISABLE_DEVICEID_CONTROL
         ASSERT(_identifier != nullptr);
 
@@ -164,6 +177,25 @@ namespace Plugin {
 
             if (myBuffer[0] != 0) {
                 result = Core::SystemInfo::Instance().Id(myBuffer, ~0);
+            }
+            else
+            {
+                serial = RetrieveSerialNumberThroughCOMRPC();
+
+            if (!serial.empty()) {
+            uint8_t ret = serial.length();
+
+            if (ret > (sizeof(myBuffer) - 1))
+            {
+                ret = sizeof(myBuffer) - 1;
+            }
+            myBuffer[0] = ret;
+            ::memcpy(&(myBuffer[1]), serial.c_str(), ret);
+
+            if(myBuffer[0] != 0){
+                result = Core::SystemInfo::Instance().Id(myBuffer, ~0);
+            }
+            }
             }
         }
 #else
@@ -184,6 +216,35 @@ namespace Plugin {
 #endif
         return result;
     }
+
+        string DeviceIdentification::RetrieveSerialNumberThroughCOMRPC() const
+    {
+        std::string Number;
+        if (_service)
+        {
+            PluginHost::IShell::state state;
+
+        if ((Utils::getServiceState(_service, "DeviceInfo", state) == Core::ERROR_NONE) && (state != PluginHost::IShell::state::ACTIVATED))
+        {
+            Utils::activatePlugin(_service, "DeviceInfo");
+        }
+        if ((Utils::getServiceState(_service, "DeviceInfo", state) == Core::ERROR_NONE) && (state == PluginHost::IShell::state::ACTIVATED))
+        {
+            auto _remoteDeviceInfoObject = _service->QueryInterfaceByCallsign<Exchange::IDeviceInfo>("DeviceInfo");
+                if(_remoteDeviceInfoObject)
+                {
+                    _remoteDeviceInfoObject->SerialNumber(Number);
+                    _remoteDeviceInfoObject->Release();
+                }
+        }
+        else
+        {
+            LOGERR("Failed to create DeviceInfo object\n");
+        }
+        }
+        return Number;
+    }
+
 
     void DeviceIdentification::Info(JsonData::DeviceIdentification::DeviceidentificationData& deviceInfo) const
     {

--- a/DeviceIdentification/DeviceIdentification.h
+++ b/DeviceIdentification/DeviceIdentification.h
@@ -94,6 +94,7 @@ namespace Plugin {
         uint32_t get_deviceidentification(JsonData::DeviceIdentification::DeviceidentificationData& response) const;
 
         string GetDeviceId() const;
+        string RetrieveSerialNumberThroughCRPC() const;
         void Info(JsonData::DeviceIdentification::DeviceidentificationData&) const;
 
         void Deactivated(RPC::IRemoteConnection* connection);

--- a/DeviceIdentification/DeviceIdentification.h
+++ b/DeviceIdentification/DeviceIdentification.h
@@ -94,7 +94,7 @@ namespace Plugin {
         uint32_t get_deviceidentification(JsonData::DeviceIdentification::DeviceidentificationData& response) const;
 
         string GetDeviceId() const;
-        string RetrieveSerialNumberThroughCRPC() const;
+        string RetrieveSerialNumberThroughCOMRPC() const;
         void Info(JsonData::DeviceIdentification::DeviceidentificationData&) const;
 
         void Deactivated(RPC::IRemoteConnection* connection);


### PR DESCRIPTION
Reason for change: DeviceIdentification plugin activation fail Test Procedure: 
Check DeviceIdentification plugin activation. 
Risks: Low
Signed-off-by:AkshayKumar_Gampa AkshayKumar_Gampa@comcast.com