### PR TITLE
SERXIONE-6067: WPEFramework crash

### DIFF
--- a/DisplaySettings/CHANGELOG.md
+++ b/DisplaySettings/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [2.0.1] - 2024-12-03
+### Fixed
+- Fixed unhandled exception that was occasionally causing a crash if thread creation failed.
+
 ## [2.0.0] - 2024-10-15
 ### Removed
 - Get and Set Delay Offset support has been removed.

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -85,7 +85,7 @@ using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 2
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 0
+#define API_VERSION_NUMBER_PATCH 1
 
 static bool isCecEnabled = false;
 static bool isResCacheUpdated = false;
@@ -582,7 +582,11 @@ namespace WPEFramework {
             m_service = service;
             m_service->AddRef();
 
-	    m_sendMsgThread = std::thread(sendMsgThread);
+	    try {
+            m_sendMsgThread = std::thread(sendMsgThread);
+        } catch (const std::system_error& e) {
+            LOGERR("Failed to start m_sendMsgThread: %s", e.what());
+        }
 	    m_timer.connect(std::bind(&DisplaySettings::onTimer, this));
             m_AudioDeviceDetectTimer.connect(std::bind(&DisplaySettings::checkAudioDeviceDetectionTimer, this));
             m_ArcDetectionTimer.connect(std::bind(&DisplaySettings::checkArcDeviceConnected, this));
@@ -4755,7 +4759,12 @@ namespace WPEFramework {
 	            try
                     {
 		        LOGWARN("creating worker thread for initAudioPortsWorker ");
-		        std::thread audioPortInitThread = std::thread(initAudioPortsWorker);
+		        std::thread audioPortInitThread;
+                try {
+                    audioPortInitThread = std::thread(initAudioPortsWorker);
+                } catch (const std::system_error& e) {
+                    LOGERR("Failed to start initAudioPortsWorker: %s", e.what());
+                }
 			audioPortInitThread.detach();
                     }
                     catch(const std::system_error& e)

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -85,7 +85,7 @@ using namespace std;
 
 #define API_VERSION_NUMBER_MAJOR 2
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 1
+#define API_VERSION_NUMBER_PATCH 0
 
 static bool isCecEnabled = false;
 static bool isResCacheUpdated = false;
@@ -4759,12 +4759,7 @@ namespace WPEFramework {
 	            try
                     {
 		        LOGWARN("creating worker thread for initAudioPortsWorker ");
-		        std::thread audioPortInitThread;
-                try {
-                    audioPortInitThread = std::thread(initAudioPortsWorker);
-                } catch (const std::system_error& e) {
-                    LOGERR("Failed to start initAudioPortsWorker: %s", e.what());
-                }
+		        std::thread audioPortInitThread = std::thread(initAudioPortsWorker);
 			audioPortInitThread.detach();
                     }
                     catch(const std::system_error& e)


### PR DESCRIPTION
Reason for change: Add try catch in DisplaySettings for thread creation Test Procedure:
Risks: low
Priority: P1

Signed-off-by:Hayden Gfeller Hayden_Gfeller@comcast.com