### PR TITLE
RDKDEV-1107: Fix Realtek DRM screencapture implementation

### DIFF
--- a/ScreenCapture/Implementation/Realtek/Realtek.h
+++ b/ScreenCapture/Implementation/Realtek/Realtek.h
@@ -25,6 +25,7 @@ typedef struct DRMScreenCapture_s {
 	uint32_t height;
 	uint32_t pitch;
 	uint8_t bpp;
+	int dmabuf_fd;
 }DRMScreenCapture;
 
 DRMScreenCapture* DRMScreenCapture_Init();


### PR DESCRIPTION
Reason for change: Use DRM_IOCTL_PRIME_HANDLE_TO_FD to get fd and do mmap instead of using DRM_IOCTL_MODE_MAP_DUMB
Test Procedure: Ref to RDKDEV-1107, RTD131X-1370
Risks: Low
Priority: P0

Change-Id: Icf6955d5523e26c5ab417722f7b4358674d5fd3c