### PR TITLE
RDK-52708 - Add Unit Tests for RDKServices (Thunder Plugins) - Phase 10

### DIFF
--- a/.github/workflows/L1-tests.yml
+++ b/.github/workflows/L1-tests.yml
@@ -211,6 +211,7 @@ jobs:
           pkg.h
           secure_wrapper.h
           wpa_ctrl.h
+          btmgr.h
           &&
           cp -r /usr/include/gstreamer-1.0/gst /usr/include/glib-2.0/* /usr/lib/x86_64-linux-gnu/glib-2.0/include/* /usr/local/include/trower-base64/base64.h .
 
@@ -294,6 +295,7 @@ jobs:
           -DPLUGIN_TEXTTOSPEECH=ON
           -DPLUGIN_SYSTEMAUDIOPLAYER=ON
           -DPLUGIN_MIRACAST=ON
+          -DPLUGIN_BLUETOOTH=ON
           -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
           &&
           cmake --build build/rdkservices -j8

--- a/Bluetooth/CMakeLists.txt
+++ b/Bluetooth/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${MODULE_NAME} PROPERTIES
         CXX_STANDARD 11
         CXX_STANDARD_REQUIRED YES)
 
+set_source_files_properties(Bluetooth.cpp PROPERTIES COMPILE_FLAGS "-fexceptions")
+
 list(APPEND CMAKE_MODULE_PATH
         "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")
 

--- a/Tests/L1Tests/CMakeLists.txt
+++ b/Tests/L1Tests/CMakeLists.txt
@@ -45,6 +45,7 @@ add_executable(${PROJECT_NAME}
         ../mocks/rdkshell.cpp
 	../mocks/opkgMock.cpp
 	../mocks/WpaCtrl.cpp
+	../mocks/BluetoothMocks.cpp
         )
 
 set_source_files_properties(
@@ -102,6 +103,7 @@ include_directories(../../LocationSync
         ../../Miracast/MiracastService/P2P
 	../../Miracast/MiracastPlayer
         ../../Miracast/MiracastPlayer/RTSP
+	../../Bluetooth
         )
 link_directories(../../LocationSync
         ../../SecurityAgent
@@ -141,6 +143,7 @@ link_directories(../../LocationSync
         ../../TextToSpeech
         ../../SystemAudioPlayer
 	../../Miracast
+	../../Bluetooth
         )
 
 target_link_libraries(${PROJECT_NAME}
@@ -184,6 +187,7 @@ target_link_libraries(${PROJECT_NAME}
         ${NAMESPACE}SystemAudioPlayer
 	${NAMESPACE}MiracastService
 	${NAMESPACE}MiracastPlayer
+	${NAMESPACE}Bluetooth
         )
 
 target_include_directories(${PROJECT_NAME}

--- a/Tests/L1Tests/tests/test_Bluetooth.cpp
+++ b/Tests/L1Tests/tests/test_Bluetooth.cpp
@@ -1,0 +1,2413 @@
+#include <gtest/gtest.h>
+#include "Bluetooth.h"
+#include "BluetoothMocks.h"
+#include "FactoriesImplementation.h"
+#include <vector>
+#include "IarmBusMock.h"
+#include "ServiceMock.h"
+
+// Declare the mock instance globally for C function overrides
+MockBluetoothManager* mockBluetoothManagerInstance = nullptr;
+
+using namespace WPEFramework;
+
+using ::testing::NiceMock;
+
+class BluetoothTest : public ::testing::Test {
+protected:
+    Core::ProxyType<Plugin::Bluetooth> bluetooth;
+    Core::JSONRPC::Handler& handler;
+    Core::JSONRPC::Connection connection;
+    string response;
+    static IarmBusImplMock   *p_iarmBusImplMock;
+
+    BluetoothTest()
+        : bluetooth(Core::ProxyType<Plugin::Bluetooth>::Create())
+        , handler(*bluetooth)
+        , connection(1, 0)
+    {
+    }
+
+    static void SetUpTestCase() {
+        std::cout << "Setup once before start test" << std::endl;
+
+	if(mockBluetoothManagerInstance == nullptr) {
+            p_iarmBusImplMock  = new NiceMock <IarmBusImplMock>;
+            IarmBus::setImpl(p_iarmBusImplMock);
+	}
+
+	if(mockBluetoothManagerInstance == nullptr) {
+	    mockBluetoothManagerInstance = new MockBluetoothManager();
+	}
+    }
+
+    static void TearDownTestCase() {
+        // Called once after all test cases have run
+        std::cout << "Tearing down after all tests are run." << std::endl;
+        // Clean up tasks such as releasing resources or resetting state
+	if (p_iarmBusImplMock != nullptr) {
+	    delete p_iarmBusImplMock;
+	    p_iarmBusImplMock = nullptr;
+	}
+
+	if(mockBluetoothManagerInstance != nullptr) {
+	    delete mockBluetoothManagerInstance;
+	    mockBluetoothManagerInstance = nullptr;
+	}
+    }
+
+    void SetUp() override {
+    }
+
+    void TearDown() override {
+    }
+
+    virtual ~BluetoothTest() = default;
+};
+
+IarmBusImplMock* BluetoothTest::p_iarmBusImplMock = nullptr;
+
+// Test Case: Check registered JSONRPC methods
+TEST_F(BluetoothTest, RegisteredMethods) {	
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("startScan")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("stopScan")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("getApiVersionNumber")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("isDiscoverable")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("getDiscoveredDevices")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("getPairedDevices")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("getConnectedDevices")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("connect")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("disconnect")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("setAudioStream")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("pair")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("unpair")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("enable")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("disable")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("setDiscoverable")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("getName")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("setName")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("sendAudioPlaybackCommand")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("respondToEvent")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("getDeviceInfo")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("getAudioInfo")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("getDeviceVolumeMuteInfo")));
+    EXPECT_EQ(Core::ERROR_NONE, handler.Exists(_T("setDeviceVolumeMuteInfo")));
+}
+
+TEST_F(BluetoothTest, GetApiVersionNumber_Response) {
+    // API_VERSION_NUMBER_MAJOR is not defined in header file. So, this test case will be failed if API_VERSION_NUMBER_MAJOR is changed in future.
+    const int expectedVersion = 1;
+
+    // Call the method
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getApiVersionNumber"), _T("{}"), response));
+
+    // Verify the response contains the expected version
+    EXPECT_EQ(response, "{\"version\":" + std::to_string(expectedVersion) + ",\"success\":true}");
+}
+
+// Test Case: StartScanWrapper when adapters are available and scan starts successfully
+TEST_F(BluetoothTest, StartScanWrapper_SuccessWithAdapters) {
+    // Mock the behavior of the Bluetooth Manager when there is one available adapter
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetNumberOfAdapters(::testing::_))
+        .Times(1)
+        .WillOnce(::testing::DoAll(::testing::SetArgPointee<0>(1), ::testing::Return(BTRMGR_RESULT_SUCCESS)));
+
+    // Mock the behavior to simulate that the scan starts successfully
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_StartDeviceDiscovery(::testing::Eq(0), ::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Return(BTRMGR_RESULT_SUCCESS));
+
+    // Invoke the startScan method and check the response
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("startScan"), _T("{\"timeout\":30}"), response));
+    EXPECT_EQ(response, "{\"status\":\"AVAILABLE\",\"success\":true}");
+}
+
+// Test Case: StartScanWrapper when no adapters are available
+TEST_F(BluetoothTest, StartScanWrapper_NoAdapters) {
+    // Mock the behavior when there are no adapters available
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetNumberOfAdapters(::testing::_))
+        .Times(1)
+        .WillOnce(::testing::DoAll(::testing::SetArgPointee<0>(0), ::testing::Return(BTRMGR_RESULT_SUCCESS)));
+
+    // Invoke the startScan method and check the response
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("startScan"), _T("{\"timeout\":30}"), response));
+    EXPECT_EQ(response, "{\"status\":\"NO_BLUETOOTH_HARDWARE\",\"success\":true}");
+}
+
+// Test Case: StartScanWrapper when getting the number of adapters fails
+TEST_F(BluetoothTest, StartScanWrapper_GetAdaptersFailed) {
+    // Mock the behavior when fetching the number of adapters fails
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetNumberOfAdapters(::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Return(BTRMGR_RESULT_GENERIC_FAILURE));
+
+    // Invoke the startScan method and check the response
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("startScan"), _T("{\"timeout\":30}"), response));
+    EXPECT_EQ(response, "{\"status\":\"NO_BLUETOOTH_HARDWARE\",\"success\":true}");
+}
+
+TEST_F(BluetoothTest, StartScanWrapper_InvalidTimeout) {
+    // Mock expectations
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetNumberOfAdapters(::testing::_))
+        .Times(1)
+        .WillOnce(::testing::DoAll(::testing::SetArgPointee<0>(1), ::testing::Return(BTRMGR_RESULT_SUCCESS)));
+
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_StartDeviceDiscovery(::testing::_, ::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Return(BTRMGR_RESULT_SUCCESS));
+
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_StopDeviceDiscovery(::testing::_, ::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Return(BTRMGR_RESULT_SUCCESS));
+
+    // Invoke the startScan method with an invalid timeout
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("startScan"), _T("{\"timeout\":-1}"), response));
+
+    // Check the response
+    EXPECT_EQ(response, "{\"status\":\"AVAILABLE\",\"success\":true}");
+}
+
+TEST_F(BluetoothTest, StartScanWrapper_DiscoveryFailed) {
+    // Mock the behavior when there is one available adapter
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetNumberOfAdapters(::testing::_))
+        .Times(1)
+        .WillOnce(::testing::DoAll(::testing::SetArgPointee<0>(1), ::testing::Return(BTRMGR_RESULT_SUCCESS)));
+
+    // Mock the behavior when starting the discovery fails
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_StartDeviceDiscovery(::testing::Eq(0), ::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Return(BTRMGR_RESULT_GENERIC_FAILURE));
+
+    // Expectation based on the current behavior of startScanWrapper
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("startScan"), _T("{\"timeout\":30}"), response));
+
+    // Verify the response matches the actual implementation
+    EXPECT_EQ(response, "{\"status\":\"AVAILABLE\",\"success\":true}");
+}
+
+TEST_F(BluetoothTest, StartScanWrapper_ProfileParsingWithReset) {
+    // Mock the behavior when there is one available adapter
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetNumberOfAdapters(::testing::_))
+        .Times(6)
+        .WillRepeatedly(::testing::DoAll(::testing::SetArgPointee<0>(1), ::testing::Return(BTRMGR_RESULT_SUCCESS)));
+
+    // Mock the behavior for starting device discovery
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_StartDeviceDiscovery(::testing::Eq(0), ::testing::_))
+        .Times(6)
+        .WillRepeatedly(::testing::Return(BTRMGR_RESULT_SUCCESS));
+
+    // Mock the behavior for stopping device discovery
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_StopDeviceDiscovery(::testing::_, ::testing::_))
+        .Times(6)
+        .WillRepeatedly(::testing::Return(BTRMGR_RESULT_SUCCESS));
+
+    // Test AUDIO_AND_HID profile
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("startScan"),
+        _T("{\"timeout\":-1, \"profile\":\"LOUDSPEAKER, KEYBOARD\"}"), response));
+    EXPECT_EQ(response, "{\"status\":\"AVAILABLE\",\"success\":true}");
+
+    // Test AUDIO_OUTPUT profile
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("startScan"),
+        _T("{\"timeout\":-1, \"profile\":\"HEADPHONES\"}"), response));
+    EXPECT_EQ(response, "{\"status\":\"AVAILABLE\",\"success\":true}");
+
+    // Test AUDIO_INPUT profile
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("startScan"),
+        _T("{\"timeout\":-1, \"profile\":\"SMARTPHONE\"}"), response));
+    EXPECT_EQ(response, "{\"status\":\"AVAILABLE\",\"success\":true}");
+
+    // Test HID profile
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("startScan"),
+        _T("{\"timeout\":-1, \"profile\":\"KEYBOARD\"}"), response));
+    EXPECT_EQ(response, "{\"status\":\"AVAILABLE\",\"success\":true}");
+
+    // Test LE profile
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("startScan"),
+        _T("{\"timeout\":-1, \"profile\":\"LE TILE\"}"), response));
+    EXPECT_EQ(response, "{\"status\":\"AVAILABLE\",\"success\":true}");
+
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("startScan"),
+        _T("{\"timeout\":-1, \"profile\":\"DEFAULT\"}"), response));
+    EXPECT_EQ(response, "{\"status\":\"AVAILABLE\",\"success\":true}");
+}
+
+TEST_F(BluetoothTest, StartScanWrapper_DiscoveryInProgress) {
+    // Mock the behavior when there is one available adapter
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetNumberOfAdapters(::testing::_))
+        .Times(1) // Only called during the first invocation
+        .WillOnce(::testing::DoAll(::testing::SetArgPointee<0>(1), ::testing::Return(BTRMGR_RESULT_SUCCESS)));
+
+    // Mock the behavior for starting device discovery (only called once initially)
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_StartDeviceDiscovery(::testing::Eq(0), ::testing::_))
+        .Times(1) // Should only be called once
+        .WillOnce(::testing::Return(BTRMGR_RESULT_SUCCESS));
+
+    // First call: Start discovery successfully
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("startScan"),
+        _T("{\"timeout\":30, \"profile\":\"LOUDSPEAKER\"}"), response));
+    EXPECT_EQ(response, "{\"status\":\"AVAILABLE\",\"success\":true}");
+
+    // Second call: Attempt to start discovery while already running
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("startScan"),
+        _T("{\"timeout\":30, \"profile\":\"HEADPHONES\"}"), response));
+    EXPECT_EQ(response, "{\"status\":\"AVAILABLE\",\"success\":true}");
+}
+
+TEST_F(BluetoothTest, StartScanWrapper_MissingParameters) {
+    // No mocks are needed since the parameters are missing, and the logic fails early.
+
+    // Invoke the method without specifying required parameters
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("startScan"), _T("{}"), response));
+
+    // Verify that the response indicates failure
+    EXPECT_EQ(response.empty(), true);    
+}
+
+// Test Case: Adapters Available, Adapter is Discoverable
+TEST_F(BluetoothTest, IsDiscoverableWrapper_Success) {
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetNumberOfAdapters(::testing::_))
+        .Times(1)
+        .WillOnce(::testing::DoAll(::testing::SetArgPointee<0>(1), ::testing::Return(BTRMGR_RESULT_SUCCESS)));
+
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_IsAdapterDiscoverable(::testing::Eq(0), ::testing::_))
+        .Times(1)
+        .WillOnce(::testing::DoAll(::testing::SetArgPointee<1>(true), ::testing::Return(BTRMGR_RESULT_SUCCESS)));
+
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("isDiscoverable"), _T("{}"), response));
+    EXPECT_EQ(response, "{\"discoverable\":true,\"success\":true}");
+}
+
+// Test Case: Adapter Not Discoverable
+TEST_F(BluetoothTest, IsDiscoverableWrapper_NotDiscoverable) {
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetNumberOfAdapters(::testing::_))
+        .Times(1)
+        .WillOnce(::testing::DoAll(::testing::SetArgPointee<0>(1), ::testing::Return(BTRMGR_RESULT_SUCCESS)));
+
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_IsAdapterDiscoverable(::testing::Eq(0), ::testing::_))
+        .Times(1)
+        .WillOnce(::testing::DoAll(::testing::SetArgPointee<1>(false), ::testing::Return(BTRMGR_RESULT_SUCCESS)));
+
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("isDiscoverable"), _T("{}"), response));
+    EXPECT_EQ(response, "{\"discoverable\":false,\"success\":true}");
+}
+
+TEST_F(BluetoothTest, IsDiscoverableWrapper_DiscoverableCheckFails) {
+    // Mock the behavior for fetching adapters
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetNumberOfAdapters(::testing::_))
+        .Times(1)
+        .WillOnce(::testing::DoAll(::testing::SetArgPointee<0>(1), ::testing::Return(BTRMGR_RESULT_SUCCESS)));
+
+    // Mock the behavior when checking discoverable status fails
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_IsAdapterDiscoverable(::testing::Eq(0), ::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Return(BTRMGR_RESULT_GENERIC_FAILURE));
+
+    // Call the method
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("isDiscoverable"), _T("{}"), response));
+
+    // Verify the response matches the actual implementation
+    EXPECT_EQ(response, "{\"discoverable\":false,\"success\":true}");
+}
+
+TEST_F(BluetoothTest, IsDiscoverableWrapper_NoAdapters) {
+    // Mock the behavior when no adapters are available
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetNumberOfAdapters(::testing::_))
+        .Times(1)
+        .WillOnce(::testing::DoAll(::testing::SetArgPointee<0>(0), ::testing::Return(BTRMGR_RESULT_SUCCESS)));
+
+    // Call the method
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("isDiscoverable"), _T("{}"), response));
+
+    // Verify the response matches the actual implementation
+    EXPECT_EQ(response, "{\"discoverable\":false,\"success\":true}");
+}
+
+TEST_F(BluetoothTest, IsDiscoverableWrapper_GetAdaptersFails) {
+    // Mock the behavior when fetching adapters fails
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetNumberOfAdapters(::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Return(BTRMGR_RESULT_GENERIC_FAILURE));
+
+    // Call the method
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("isDiscoverable"), _T("{}"), response));
+
+    // Verify the response matches the actual implementation
+    EXPECT_EQ(response, "{\"discoverable\":false,\"success\":true}");
+}
+
+// Test Case: StopScanWrapper Success - Discovery Is Running
+TEST_F(BluetoothTest, StopScanWrapper_Success_DiscoveryRunning) {
+    // Simulate discovery running
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetNumberOfAdapters(::testing::_))
+        .Times(1)
+        .WillOnce(::testing::DoAll(::testing::SetArgPointee<0>(1), ::testing::Return(BTRMGR_RESULT_SUCCESS)));
+
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_StartDeviceDiscovery(::testing::Eq(0), ::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Return(BTRMGR_RESULT_SUCCESS));
+
+    // Start discovery to set m_discoveryRunning to true
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("startScan"), _T("{\"timeout\":30}"), response));
+    EXPECT_EQ(response, "{\"status\":\"AVAILABLE\",\"success\":true}");
+
+    // Mock successful stop
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_StopDeviceDiscovery(::testing::Eq(0), ::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Return(BTRMGR_RESULT_SUCCESS));
+
+    // Stop discovery
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("stopScan"), _T("{}"), response));
+    EXPECT_EQ(response, "{\"success\":true}");
+}
+
+// Test Case: StopScanWrapper Failure - StopDeviceDiscovery Fails
+TEST_F(BluetoothTest, StopScanWrapper_Failure_StopDeviceDiscoveryFails) {
+    // Simulate discovery running
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetNumberOfAdapters(::testing::_))
+        .Times(1)
+        .WillOnce(::testing::DoAll(::testing::SetArgPointee<0>(1), ::testing::Return(BTRMGR_RESULT_SUCCESS)));
+
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_StartDeviceDiscovery(::testing::Eq(0), ::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Return(BTRMGR_RESULT_SUCCESS));
+
+    // Start discovery to set m_discoveryRunning to true
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("startScan"), _T("{\"timeout\":30}"), response));
+    EXPECT_EQ(response, "{\"status\":\"AVAILABLE\",\"success\":true}");
+
+    // Mock failure in stopping discovery
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_StopDeviceDiscovery(::testing::Eq(0), ::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Return(BTRMGR_RESULT_GENERIC_FAILURE));
+
+    // Attempt to stop discovery
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("stopScan"), _T("{}"), response));
+
+    // Verify the response matches the actual implementation
+    EXPECT_EQ(response, "{\"success\":true}");
+}
+
+TEST_F(BluetoothTest, GetDiscoveredDevicesWrapper_Success_DevicesDiscovered) {
+    // Mock discovered devices
+    BTRMGR_DiscoveredDevicesList_t mockDevices = {};
+    mockDevices.m_numOfDevices = 2;
+
+    // Fill device 1
+    mockDevices.m_deviceProperty[0].m_deviceHandle = 1001;
+    strcpy(mockDevices.m_deviceProperty[0].m_name, "Device1");
+    mockDevices.m_deviceProperty[0].m_deviceType = BTRMGR_DEVICE_TYPE_HID;
+    mockDevices.m_deviceProperty[0].m_isConnected = true;
+    mockDevices.m_deviceProperty[0].m_isPairedDevice = false;
+    mockDevices.m_deviceProperty[0].m_ui32DevClassBtSpec = 259;
+    mockDevices.m_deviceProperty[0].m_ui16DevAppearanceBleSpec = 1023;
+
+    // Fill device 2
+    mockDevices.m_deviceProperty[1].m_deviceHandle = 1002;
+    strcpy(mockDevices.m_deviceProperty[1].m_name, "Device2");
+    mockDevices.m_deviceProperty[1].m_deviceType = BTRMGR_DEVICE_TYPE_HEADPHONES;
+    mockDevices.m_deviceProperty[1].m_isConnected = false;
+    mockDevices.m_deviceProperty[1].m_isPairedDevice = true;
+    mockDevices.m_deviceProperty[1].m_ui32DevClassBtSpec = 512;
+    mockDevices.m_deviceProperty[1].m_ui16DevAppearanceBleSpec = 2047;
+
+    // Mock BTRMGR_GetDiscoveredDevices
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetDiscoveredDevices(::testing::Eq(0), ::testing::_))
+        .Times(1)
+        .WillOnce(::testing::DoAll(::testing::SetArgPointee<1>(mockDevices), ::testing::Return(BTRMGR_RESULT_SUCCESS)));
+
+    // Mock BTRMGR_GetDeviceTypeAsString
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetDeviceTypeAsString(::testing::_))
+        .Times(2)
+        .WillRepeatedly(::testing::Invoke([](BTRMGR_DeviceType_t deviceType) -> const char* {
+            switch (deviceType) {
+                case BTRMGR_DEVICE_TYPE_HID:
+                    return "HUMAN INTERFACE DEVICE";
+                case BTRMGR_DEVICE_TYPE_HEADPHONES:
+                    return "HEADPHONES";
+                default:
+                    return "UNKNOWN";
+            }
+        }));
+
+    // Call the method
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getDiscoveredDevices"), _T("{}"), response));
+
+    // Verify the response
+    EXPECT_EQ(response, R"({"discoveredDevices":[{"deviceID":"1001","name":"Device1","deviceType":"HUMAN INTERFACE DEVICE","connected":true,"paired":false,"rawDeviceType":"259","rawBleDeviceType":"1023"},{"deviceID":"1002","name":"Device2","deviceType":"HEADPHONES","connected":false,"paired":true,"rawDeviceType":"512","rawBleDeviceType":"2047"}],"success":true})");
+}
+
+TEST_F(BluetoothTest, GetDiscoveredDevicesWrapper_Success_NoDevicesDiscovered) {
+    // Mock no discovered devices
+    BTRMGR_DiscoveredDevicesList_t mockDevices = {};
+    mockDevices.m_numOfDevices = 0;
+
+    // Mock BTRMGR_GetDiscoveredDevices
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetDiscoveredDevices(::testing::Eq(0), ::testing::_))
+        .Times(1)
+        .WillOnce(::testing::DoAll(::testing::SetArgPointee<1>(mockDevices), ::testing::Return(BTRMGR_RESULT_SUCCESS)));
+
+    // Call the method
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getDiscoveredDevices"), _T("{}"), response));
+
+    // Verify the response
+    EXPECT_EQ(response, R"({"discoveredDevices":[],"success":true})");
+}
+
+TEST_F(BluetoothTest, GetDiscoveredDevicesWrapper_Failure) {
+    // Mock BTRMGR_GetDiscoveredDevices failure
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetDiscoveredDevices(::testing::Eq(0), ::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Return(BTRMGR_RESULT_GENERIC_FAILURE));
+
+    // Call the method
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getDiscoveredDevices"), _T("{}"), response));
+
+    // Verify the response
+    EXPECT_EQ(response, R"({"discoveredDevices":[],"success":true})");
+}
+
+TEST_F(BluetoothTest, GetPairedDevicesWrapper_Success) {
+    // Mock paired devices
+    BTRMGR_PairedDevicesList_t mockDevices = {};
+    mockDevices.m_numOfDevices = 2;
+
+    // Fill device 1
+    mockDevices.m_deviceProperty[0].m_deviceHandle = 1001;
+    strcpy(mockDevices.m_deviceProperty[0].m_name, "Device1");
+    mockDevices.m_deviceProperty[0].m_deviceType = BTRMGR_DEVICE_TYPE_HID;
+    mockDevices.m_deviceProperty[0].m_isConnected = true;
+    mockDevices.m_deviceProperty[0].m_ui32DevClassBtSpec = 259;
+    mockDevices.m_deviceProperty[0].m_ui16DevAppearanceBleSpec = 1023;
+
+    // Fill device 2 (headphones device)
+    mockDevices.m_deviceProperty[1].m_deviceHandle = 1002;
+    strcpy(mockDevices.m_deviceProperty[1].m_name, "Device2");
+    mockDevices.m_deviceProperty[1].m_deviceType = BTRMGR_DEVICE_TYPE_HEADPHONES;  // Updated device type to HEADPHONES
+    mockDevices.m_deviceProperty[1].m_isConnected = false;
+    mockDevices.m_deviceProperty[1].m_ui32DevClassBtSpec = 512;
+    mockDevices.m_deviceProperty[1].m_ui16DevAppearanceBleSpec = 2047;
+
+    // Mock BTRMGR_GetPairedDevices
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetPairedDevices(::testing::Eq(0), ::testing::_))
+        .Times(1)
+        .WillOnce(::testing::DoAll(::testing::SetArgPointee<1>(mockDevices), ::testing::Return(BTRMGR_RESULT_SUCCESS)));
+
+    // Mock BTRMGR_GetDeviceTypeAsString for paired devices
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetDeviceTypeAsString(::testing::_))
+        .Times(2)
+        .WillRepeatedly(::testing::Invoke([](BTRMGR_DeviceType_t deviceType) -> const char* {
+            switch (deviceType) {
+                case BTRMGR_DEVICE_TYPE_HID:
+                    return "HUMAN INTERFACE DEVICE";
+                case BTRMGR_DEVICE_TYPE_HEADPHONES:
+                    return "HEADPHONES";
+                default:
+                    return "UNKNOWN";
+            }
+        }));
+
+    // Call the method
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getPairedDevices"), _T("{}"), response));
+
+    // Verify the response
+    EXPECT_EQ(response, R"({"pairedDevices":[{"deviceID":"1001","name":"Device1","deviceType":"HUMAN INTERFACE DEVICE","connected":true,"rawDeviceType":"259","rawBleDeviceType":"1023"},{"deviceID":"1002","name":"Device2","deviceType":"HEADPHONES","connected":false,"rawDeviceType":"512","rawBleDeviceType":"2047"}],"success":true})");
+}
+
+// Test Case: GetPairedDevicesWrapper when no paired devices are available
+TEST_F(BluetoothTest, GetPairedDevicesWrapper_NoPairedDevices) {
+    // Mock no paired devices
+    BTRMGR_PairedDevicesList_t mockDevices = {};
+    mockDevices.m_numOfDevices = 0;
+
+    // Mock BTRMGR_GetPairedDevices
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetPairedDevices(::testing::Eq(0), ::testing::_))
+        .Times(1)
+        .WillOnce(::testing::DoAll(::testing::SetArgPointee<1>(mockDevices), ::testing::Return(BTRMGR_RESULT_SUCCESS)));
+
+    // Call the method
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getPairedDevices"), _T("{}"), response));
+
+    // Verify the response
+    EXPECT_EQ(response, R"({"pairedDevices":[],"success":true})");
+}
+
+// Test Case: GetPairedDevicesWrapper when getting paired devices fails
+TEST_F(BluetoothTest, GetPairedDevicesWrapper_GetDevicesFailed) {
+    // Mock the failure of BTRMGR_GetPairedDevices
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetPairedDevices(::testing::Eq(0), ::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Return(BTRMGR_RESULT_GENERIC_FAILURE));
+
+    // Call the method
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getPairedDevices"), _T("{}"), response));
+
+    // Verify the response (the current implementation returns success with empty pairedDevices)
+    EXPECT_EQ(response, R"({"pairedDevices":[],"success":true})");
+}
+
+// Test Case: getConnectedDevicesWrapper when devices are connected successfully
+TEST_F(BluetoothTest, GetConnectedDevicesWrapper_Success) {
+    // Mock connected devices list
+    BTRMGR_ConnectedDevicesList_t mockDevices = {};
+    mockDevices.m_numOfDevices = 2;
+
+    // Fill device 1 (connected)
+    mockDevices.m_deviceProperty[0].m_deviceHandle = 1001;
+    strcpy(mockDevices.m_deviceProperty[0].m_name, "Device1");
+    mockDevices.m_deviceProperty[0].m_deviceType = BTRMGR_DEVICE_TYPE_HID;
+    mockDevices.m_deviceProperty[0].m_powerStatus = BTRMGR_DEVICE_POWER_ACTIVE;
+    mockDevices.m_deviceProperty[0].m_ui32DevClassBtSpec = 259;
+    mockDevices.m_deviceProperty[0].m_ui16DevAppearanceBleSpec = 1023;
+
+    // Fill device 2 (connected)
+    mockDevices.m_deviceProperty[1].m_deviceHandle = 1002;
+    strcpy(mockDevices.m_deviceProperty[1].m_name, "Device2");
+    mockDevices.m_deviceProperty[1].m_deviceType = BTRMGR_DEVICE_TYPE_HEADPHONES;
+    mockDevices.m_deviceProperty[1].m_powerStatus = BTRMGR_DEVICE_POWER_ACTIVE;
+    mockDevices.m_deviceProperty[1].m_ui32DevClassBtSpec = 512;
+    mockDevices.m_deviceProperty[1].m_ui16DevAppearanceBleSpec = 2047;
+
+    // Mock BTRMGR_GetConnectedDevices success
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetConnectedDevices(::testing::Eq(0), ::testing::_))
+        .Times(1)
+        .WillOnce(::testing::DoAll(::testing::SetArgPointee<1>(mockDevices), ::testing::Return(BTRMGR_RESULT_SUCCESS)));
+
+    // Mock BTRMGR_GetDeviceTypeAsString
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetDeviceTypeAsString(::testing::_))
+        .Times(2)
+        .WillRepeatedly(::testing::Invoke([](BTRMGR_DeviceType_t deviceType) -> const char* {
+            switch (deviceType) {
+                case BTRMGR_DEVICE_TYPE_HID:
+                    return "HUMAN INTERFACE DEVICE";
+                case BTRMGR_DEVICE_TYPE_HEADPHONES:
+                    return "HEADPHONES";
+                default:
+                    return "UNKNOWN";
+            }
+        }));
+
+    // Call the method and verify response
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getConnectedDevices"), _T("{}"), response));
+    EXPECT_EQ(response, R"({"connectedDevices":[{"deviceID":"1001","name":"Device1","deviceType":"HUMAN INTERFACE DEVICE","activeState":"1","rawDeviceType":"259","rawBleDeviceType":"1023"},{"deviceID":"1002","name":"Device2","deviceType":"HEADPHONES","activeState":"1","rawDeviceType":"512","rawBleDeviceType":"2047"}],"success":true})");
+}
+
+// Test Case: getConnectedDevicesWrapper when no devices are connected
+TEST_F(BluetoothTest, GetConnectedDevicesWrapper_NoDevices) {
+    // Mock empty connected devices list
+    BTRMGR_ConnectedDevicesList_t mockDevices = {};
+    mockDevices.m_numOfDevices = 0;
+
+    // Mock BTRMGR_GetConnectedDevices success
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetConnectedDevices(::testing::Eq(0), ::testing::_))
+        .Times(1)
+        .WillOnce(::testing::DoAll(::testing::SetArgPointee<1>(mockDevices), ::testing::Return(BTRMGR_RESULT_SUCCESS)));
+
+    // Call the method and verify response
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getConnectedDevices"), _T("{}"), response));
+    EXPECT_EQ(response, R"({"connectedDevices":[],"success":true})");
+}
+
+// Test Case: getConnectedDevicesWrapper when getting the connected devices fails
+TEST_F(BluetoothTest, GetConnectedDevicesWrapper_Failure) {
+    // Mock failure scenario for getting connected devices
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetConnectedDevices(::testing::Eq(0), ::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Return(BTRMGR_RESULT_GENERIC_FAILURE));  // Simulating failure
+
+    // Call the method and verify response
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getConnectedDevices"), _T("{}"), response));
+    EXPECT_EQ(response, "{\"connectedDevices\":[],\"success\":true}");  // Adjusted to match actual behavior
+}
+
+TEST_F(BluetoothTest, connectWrapper_Connect_AllDevices) {
+    // Define a list of device types and their corresponding deviceIDs
+    struct Device {
+        long long int deviceID;
+        string deviceType;
+    };
+
+    std::vector<Device> devices = {
+        {1001, "LE TILE"},
+        {1003, "JOYSTICK"},
+        {1004, "TABLET"},
+	{1005, "UNKNOWN DEVICE"}
+    };
+
+    // Loop through the device types and test connection for each
+    for (const auto& device : devices) {
+        string enable = "CONNECT";  // Hardcoded in connectWrapper
+        long long int deviceID = device.deviceID;
+        string deviceType = device.deviceType;
+
+        // Prepare the JSON parameters for the test
+        JsonObject params;
+        params["deviceID"] = std::to_string(deviceID);  // deviceID as string
+        params["enable"] = enable;
+        params["deviceType"] = deviceType;
+
+        // Convert JsonObject to string
+        string paramsStr;
+        params.ToString(paramsStr);
+
+	// Mock the behavior for different device types
+        if (deviceType == "LE TILE" || deviceType == "JOYSTICK") {
+            // Mock for LE TILE and JOYSTICK device types (Connect)
+            EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_ConnectToDevice(::testing::Eq(0), ::testing::Eq(deviceID), ::testing::_))
+                .Times(1)
+                .WillOnce(::testing::Return(BTRMGR_RESULT_SUCCESS));
+        } else if (deviceType == "TABLET") {
+            // Mock for TABLET (Audio streaming)
+            EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_StartAudioStreamingIn(::testing::Eq(0), ::testing::Eq(deviceID), BTRMGR_DEVICE_OP_TYPE_AUDIO_INPUT))
+                .Times(1)
+                .WillOnce(::testing::Return(BTRMGR_RESULT_SUCCESS));
+        } else if(deviceType == "UNKNOWN DEVICE" ) {
+	        EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_StartAudioStreamingOut(::testing::Eq(0), ::testing::Eq(deviceID), ::testing::_))
+		.Times(1)
+		.WillOnce(::testing::Return(BTRMGR_RESULT_SUCCESS));
+	}
+
+        // Invoke the connect method and check the response
+        EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("connect"), paramsStr, response));
+        EXPECT_EQ(response, "{\"success\":true}");
+    }
+}
+
+TEST_F(BluetoothTest, connectWrapper_Connect_DefaultDeviceType_Smartphone) {
+    // Device without specifying deviceType (defaults to SMARTPHONE)
+    long long int deviceID = 1001;  // Example deviceID
+    string enable = "CONNECT";  // Hardcoded in connectWrapper
+    string deviceType = "SMARTPHONE";  // This will be set by default
+
+    // Prepare the JSON parameters for the test (without deviceType)
+    JsonObject params;
+    params["deviceID"] = std::to_string(deviceID);  // deviceID as string
+    params["enable"] = enable;
+
+    // Convert JsonObject to string
+    string paramsStr;
+    params.ToString(paramsStr);
+
+    // Mock the behavior based on the default deviceType "SMARTPHONE"
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_StartAudioStreamingOut(::testing::Eq(0), ::testing::Eq(deviceID), ::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Return(BTRMGR_RESULT_SUCCESS));
+
+    // Invoke the connect method and check the response
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("connect"), paramsStr, response));
+    EXPECT_EQ(response, "{\"success\":true}");
+}
+
+TEST_F(BluetoothTest, connectWrapper_Failure) {
+    // Device without specifying deviceType (defaults to SMARTPHONE)
+    long long int deviceID = 1001;  // Example deviceID
+    string enable = "CONNECT";  // Hardcoded in connectWrapper
+    string deviceType = "SMARTPHONE";  // This will be set by default
+
+    // Prepare the JSON parameters for the test (without deviceType)
+    JsonObject params;
+    params["deviceID"] = std::to_string(deviceID);  // deviceID as string
+    params["enable"] = enable;
+
+    // Convert JsonObject to string
+    string paramsStr;
+    params.ToString(paramsStr);
+
+    // Mock the behavior based on the default deviceType "SMARTPHONE"
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_StartAudioStreamingOut(::testing::Eq(0), ::testing::Eq(deviceID), ::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Return(BTRMGR_RESULT_GENERIC_FAILURE));
+
+    // Invoke the connect method and check the response
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("connect"), paramsStr, response));
+    EXPECT_EQ(response.empty(), true);
+}
+
+TEST_F(BluetoothTest, connectWrapper_MissingParameters) {
+    // Prepare the JSON parameters with missing "deviceID"
+    JsonObject params;
+    // deviceID is omitted to simulate the missing parameter case
+
+    // Convert JsonObject to string
+    string paramsStr;
+    params.ToString(paramsStr);
+
+    // Invoke the connect method with missing parameters
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("connect"), paramsStr, response));
+
+    // Verify that the response is empty
+    EXPECT_EQ(response.empty(), true);
+}
+
+TEST_F(BluetoothTest, disconnectWrapper_Disconnect_AllDevices) {
+    // Define a list of device types and their corresponding deviceIDs
+    struct Device {
+        long long int deviceID;
+        string deviceType;
+    };
+
+    std::vector<Device> devices = {
+        {1001, "LE TILE"},
+        {1003, "JOYSTICK"},
+        {1004, "TABLET"},
+        {1005, "UNKNOWN DEVICE"}
+    };
+
+    // Loop through the device types and test disconnection for each
+    for (const auto& device : devices) {
+        string enable = "DISCONNECT";  // Hardcoded in disconnectWrapper
+        long long int deviceID = device.deviceID;
+        string deviceType = device.deviceType;
+
+        // Prepare the JSON parameters for the test
+        JsonObject params;
+        params["deviceID"] = std::to_string(deviceID);  // deviceID as string
+        params["enable"] = enable;
+        params["deviceType"] = deviceType;
+
+        // Convert JsonObject to string
+        string paramsStr;
+        params.ToString(paramsStr);
+
+        // Mock the behavior for different device types
+        if (deviceType == "LE TILE" || deviceType == "JOYSTICK") {
+            // Mock for LE TILE and JOYSTICK device types (Disconnect)
+            EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_DisconnectFromDevice(::testing::Eq(0), ::testing::Eq(deviceID)))
+                .Times(1)
+                .WillOnce(::testing::Return(BTRMGR_RESULT_SUCCESS));
+        } else if (deviceType == "TABLET") {
+            // Mock for TABLET (Stop Audio streaming)
+            EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_StopAudioStreamingIn(::testing::Eq(0), ::testing::Eq(deviceID)))
+                .Times(1)
+                .WillOnce(::testing::Return(BTRMGR_RESULT_SUCCESS));
+        } else if (deviceType == "UNKNOWN DEVICE") {
+            // Mock for UNKNOWN DEVICE (Stop Audio streaming)
+            EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_StopAudioStreamingOut(::testing::Eq(0), ::testing::Eq(deviceID)))
+                .Times(1)
+                .WillOnce(::testing::Return(BTRMGR_RESULT_SUCCESS));
+        }
+
+        // Invoke the disconnect method and check the response
+        EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("disconnect"), paramsStr, response));
+        EXPECT_EQ(response, "{\"success\":true}");
+    }
+}
+
+TEST_F(BluetoothTest, disconnectWrapper_DefaultDeviceType_Smartphone) {
+    // Device without specifying deviceType (defaults to SMARTPHONE)
+    long long int deviceID = 1004;  // Example deviceID
+    string enable = "DISCONNECT";  // Hardcoded in disconnectWrapper
+    string deviceType = "SMARTPHONE";  // This will be set by default
+
+    // Prepare the JSON parameters for the test (without deviceType)
+    JsonObject params;
+    params["deviceID"] = std::to_string(deviceID);  // deviceID as string
+    params["enable"] = enable;
+
+    // Convert JsonObject to string
+    string paramsStr;
+    params.ToString(paramsStr);
+
+    // Mock the behavior based on the default deviceType "SMARTPHONE"
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_StopAudioStreamingOut(::testing::Eq(0), ::testing::Eq(deviceID)))
+        .Times(1)
+        .WillOnce(::testing::Return(BTRMGR_RESULT_SUCCESS));
+
+    // Invoke the disconnect method and check the response
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("disconnect"), paramsStr, response));
+    EXPECT_EQ(response, "{\"success\":true}");
+}
+
+TEST_F(BluetoothTest, disconnectWrapper_MissingParameters) {
+    // Prepare the JSON parameters for the test with missing deviceID
+    JsonObject params;
+
+    // Convert JsonObject to string
+    string paramsStr;
+    params.ToString(paramsStr);
+
+    // Invoke the disconnect method and check the response
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("disconnect"), paramsStr, response));
+    EXPECT_EQ(response.empty(), true);  // Response should be empty since deviceID is missing
+}
+
+TEST_F(BluetoothTest, setAudioStreamWrapper_ValidParams) {
+    // Define the two possible audio stream names
+    string primaryStream = "PRIMARY";
+    string auxiliaryStream = "AUXILIARY";
+
+    long long int deviceID = 1001;  // Example deviceID
+    string enable = "CONNECT";  // Hardcoded in setAudioStreamWrapper
+    unsigned char adapterIdx = 0;  // Example adapter index
+
+    // Prepare the JSON parameters for "PRIMARY"
+    JsonObject paramsPrimary;
+    paramsPrimary["deviceID"] = std::to_string(deviceID);  // deviceID as string
+    paramsPrimary["audioStreamName"] = primaryStream;  // Primary stream
+
+    // Convert JsonObject to string for "PRIMARY"
+    string paramsStrPrimary;
+    paramsPrimary.ToString(paramsStrPrimary);
+
+    // Mock the behavior for "PRIMARY"
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_SetAudioStreamingOutType(adapterIdx, BTRMGR_STREAM_PRIMARY))
+        .Times(1)
+        .WillOnce(::testing::Return(BTRMGR_RESULT_SUCCESS));
+
+    // Invoke the method for "PRIMARY" and check the response
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("setAudioStream"), paramsStrPrimary, response));
+    EXPECT_EQ(response, "{\"success\":true}");
+
+    // Prepare the JSON parameters for "AUXILIARY"
+    JsonObject paramsAuxiliary;
+    paramsAuxiliary["deviceID"] = std::to_string(deviceID);  // deviceID as string
+    paramsAuxiliary["audioStreamName"] = auxiliaryStream;  // Auxiliary stream
+
+    // Convert JsonObject to string for "AUXILIARY"
+    string paramsStrAuxiliary;
+    paramsAuxiliary.ToString(paramsStrAuxiliary);
+
+    // Mock the behavior for "AUXILIARY"
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_SetAudioStreamingOutType(adapterIdx, BTRMGR_STREAM_AUXILIARY))
+        .Times(1)
+        .WillOnce(::testing::Return(BTRMGR_RESULT_SUCCESS));
+
+    // Invoke the method for "AUXILIARY" and check the response
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("setAudioStream"), paramsStrAuxiliary, response));
+    EXPECT_EQ(response, "{\"success\":true}");
+}
+
+TEST_F(BluetoothTest, setAudioStreamWrapper_SetAudioStreamingOutType_Failure) {
+    long long int deviceID = 1001;  // Example deviceID
+    string validStreamName = "PRIMARY";  // Valid stream name for testing
+    unsigned char adapterIdx = 0;  // Example adapter index
+
+    // Prepare the JSON parameters for the test with valid audioStreamName
+    JsonObject params;
+    params["deviceID"] = std::to_string(deviceID);  // deviceID as string
+    params["audioStreamName"] = validStreamName;  // Valid stream name
+
+    // Convert JsonObject to string
+    string paramsStr;
+    params.ToString(paramsStr);
+
+    // Mock the behavior for BTRMGR_SetAudioStreamingOutType to return failure
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_SetAudioStreamingOutType(adapterIdx, BTRMGR_STREAM_PRIMARY))
+        .Times(1)
+        .WillOnce(::testing::Return(BTRMGR_RESULT_GENERIC_FAILURE));  // Simulate failure
+
+    // Invoke the setAudioStream method and check the response
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("setAudioStream"), paramsStr, response));
+    EXPECT_EQ(response.empty(), true);  // Response should be empty since there was a failure
+}
+
+TEST_F(BluetoothTest, setAudioStreamWrapper_MissingParameters) {
+    // Test case for missing parameters
+
+    // Prepare the JSON parameters with missing "deviceID"
+    JsonObject params;
+    // Missing both deviceID and audioStreamName to simulate the missing parameter case
+
+    string paramsStr;
+    params.ToString(paramsStr);
+
+    // Invoke the method and check the response
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("setAudioStream"), paramsStr, response));
+
+    // Verify that the response is empty
+    EXPECT_EQ(response.empty(), true);
+}
+
+TEST_F(BluetoothTest, pairWrapper_Success) {
+    // Test case for success scenario
+    long long int deviceID = 1001;  // Device ID
+
+    // Prepare the JSON parameters for the test
+    JsonObject params;
+    params["deviceID"] = std::to_string(deviceID);  // deviceID as string
+
+    // Convert JsonObject to string
+    string paramsStr;
+    params.ToString(paramsStr);
+
+    // Mock the behavior of BTRMGR_PairDevice for the deviceID
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_PairDevice(::testing::Eq(0), ::testing::Eq(deviceID)))
+        .Times(1)
+        .WillOnce(::testing::Return(BTRMGR_RESULT_SUCCESS));
+
+    // Invoke the pair method and check the response
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("pair"), paramsStr, response));
+    EXPECT_EQ(response, "{\"success\":true}");
+}
+
+TEST_F(BluetoothTest, pairWrapper_MissingParameters) {
+    // Prepare the JSON parameters with missing "deviceID"
+    JsonObject params;
+    // deviceID is omitted to simulate the missing parameter case
+
+    // Convert JsonObject to string
+    string paramsStr;
+    params.ToString(paramsStr);
+
+    // Invoke the pair method with missing parameters
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("pair"), paramsStr, response));
+
+    // Verify that the response is empty
+    EXPECT_EQ(response.empty(), true);
+}
+
+TEST_F(BluetoothTest, pairWrapper_Failure) {
+    // Prepare a device ID for testing failure
+    long long int deviceID = 1001; // Example deviceID for failure case
+
+    // Prepare the JSON parameters for the test
+    JsonObject params;
+    params["deviceID"] = std::to_string(deviceID);  // deviceID as string
+
+    // Convert JsonObject to string
+    string paramsStr;
+    params.ToString(paramsStr);
+
+    // Mock the behavior of BTRMGR_PairDevice to simulate failure
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_PairDevice(::testing::Eq(0), ::testing::Eq(deviceID)))
+        .Times(1)
+        .WillOnce(::testing::Return(BTRMGR_RESULT_GENERIC_FAILURE));
+
+    // Invoke the pair method and check the response for failure
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("pair"), paramsStr, response));
+
+    // Verify the failure response
+    EXPECT_EQ(response.empty(), true);
+}
+
+// Test case for successful unpairing
+TEST_F(BluetoothTest, unpairWrapper_Success) {
+    long long int deviceID = 1001;
+
+    // Prepare the JSON parameters for the test
+    JsonObject params;
+    params["deviceID"] = std::to_string(deviceID);  // deviceID as string
+
+    // Convert JsonObject to string
+    string paramsStr;
+    params.ToString(paramsStr);
+
+    // Mock the behavior for unpairing (BTRMGR_UnpairDevice)
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_UnpairDevice(::testing::Eq(0), ::testing::Eq(deviceID)))
+        .Times(1)
+        .WillOnce(::testing::Return(BTRMGR_RESULT_SUCCESS));
+
+    // Invoke the unpair method and check the response
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("unpair"), paramsStr, response));
+    EXPECT_EQ(response, "{\"success\":true}");
+}
+
+// Test case for unpairing with failure in BTRMGR_UnpairDevice
+TEST_F(BluetoothTest, unpairWrapper_Failure) {
+    long long int deviceID = 1001;
+
+    // Prepare the JSON parameters for the test
+    JsonObject params;
+    params["deviceID"] = std::to_string(deviceID);  // deviceID as string
+
+    // Convert JsonObject to string
+    string paramsStr;
+    params.ToString(paramsStr);
+
+    // Mock the behavior for unpairing (BTRMGR_UnpairDevice) with failure
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_UnpairDevice(::testing::Eq(0), ::testing::Eq(deviceID)))
+        .Times(1)
+        .WillOnce(::testing::Return(BTRMGR_RESULT_GENERIC_FAILURE));  // Simulating failure
+
+    // Invoke the unpair method and check the response
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("unpair"), paramsStr, response));  // Expecting failure response
+    EXPECT_EQ(response.empty(), true);  // Response should be empty on failure
+}
+
+// Test case for missing parameters (deviceID)
+TEST_F(BluetoothTest, unpairWrapper_MissingParameters) {
+    // Prepare the JSON parameters with missing "deviceID"
+    JsonObject params;
+    // deviceID is omitted to simulate the missing parameter case
+
+    // Convert JsonObject to string
+    string paramsStr;
+    params.ToString(paramsStr);
+
+    // Invoke the unpair method with missing parameters
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("unpair"), paramsStr, response));
+
+    // Verify that the response is empty
+    EXPECT_EQ(response.empty(), true);
+}
+
+// Test case for successful enableWrapper invocation
+TEST_F(BluetoothTest, enableWrapper_Success) {
+    // Mock the behavior for BTRMGR_SetAdapterPowerStatus (success)
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_SetAdapterPowerStatus(::testing::Eq(0), ::testing::Eq(true)))
+        .Times(1)
+        .WillOnce(::testing::Return(BTRMGR_RESULT_SUCCESS));  // Success case
+
+    // Invoke the enableWrapper method and check the response
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("enable"), "", response));
+    EXPECT_EQ(response, "{\"success\":true}");  // Expected success response
+}
+
+// Test case for enableWrapper failure due to BTRMGR_SetAdapterPowerStatus failure
+TEST_F(BluetoothTest, enableWrapper_Failure) {
+    // Mock the behavior for BTRMGR_SetAdapterPowerStatus (failure)
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_SetAdapterPowerStatus(::testing::Eq(0), ::testing::Eq(true)))
+        .Times(1)
+        .WillOnce(::testing::Return(BTRMGR_RESULT_GENERIC_FAILURE));  // Failure case
+
+    // Invoke the enableWrapper method and check the response
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("enable"), "", response));  // Expect failure response
+    EXPECT_EQ(response.empty(), true);  // Response should be empty on failure
+}
+
+// Test case for successful disableWrapper invocation
+TEST_F(BluetoothTest, disableWrapper_Success) {
+    // Mock the behavior for BTRMGR_SetAdapterPowerStatus (success)
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_SetAdapterPowerStatus(::testing::Eq(0), ::testing::Eq(false)))
+        .Times(1)
+        .WillOnce(::testing::Return(BTRMGR_RESULT_SUCCESS));  // Success case
+
+    // Invoke the disableWrapper method and check the response
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("disable"), "", response));
+    EXPECT_EQ(response, "{\"success\":true}");  // Expected success response
+}
+
+// Test case for disableWrapper failure due to BTRMGR_SetAdapterPowerStatus failure
+TEST_F(BluetoothTest, disableWrapper_Failure) {
+    // Mock the behavior for BTRMGR_SetAdapterPowerStatus (failure)
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_SetAdapterPowerStatus(::testing::Eq(0), ::testing::Eq(false)))
+        .Times(1)
+        .WillOnce(::testing::Return(BTRMGR_RESULT_GENERIC_FAILURE));  // Failure case
+
+    // Invoke the disableWrapper method and check the response
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("disable"), "", response));  // Expect failure response
+    EXPECT_EQ(response.empty(), true);  // Response should be empty on failure
+}
+
+TEST_F(BluetoothTest, setDiscoverableWrapper_Success) {
+    // Prepare the JSON parameters
+    int timeout = 30;  // timeout value
+    bool discoverable = true;  // discoverable flag
+
+    JsonObject params;
+    params["timeout"] = timeout;  // timeout value
+    params["discoverable"] = discoverable;  // discoverable flag
+
+    // Convert JsonObject to string
+    string paramsStr;
+    params.ToString(paramsStr);
+
+    // Mock the behavior of BTRMGR_SetAdapterDiscoverable for success
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_SetAdapterDiscoverable(::testing::Eq(0), ::testing::Eq(discoverable), ::testing::Eq(timeout)))
+        .Times(1)
+        .WillOnce(::testing::Return(BTRMGR_RESULT_SUCCESS));
+
+    // Invoke the setDiscoverableWrapper method and check the response
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("setDiscoverable"), paramsStr, response));
+    EXPECT_EQ(response, "{\"success\":true}");
+
+    // Now test for discoverable = false
+    discoverable = false;  // discoverable flag set to false
+
+    // Update JSON parameters for discoverable = false
+    params["discoverable"] = discoverable;
+
+    // Convert JsonObject to string again
+    params.ToString(paramsStr);
+
+    // Mock the behavior of BTRMGR_SetAdapterDiscoverable for success with discoverable = false
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_SetAdapterDiscoverable(::testing::Eq(0), ::testing::Eq(discoverable), ::testing::Eq(timeout)))
+        .Times(1)
+        .WillOnce(::testing::Return(BTRMGR_RESULT_SUCCESS));
+
+    // Invoke the setDiscoverableWrapper method and check the response
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("setDiscoverable"), paramsStr, response));
+    EXPECT_EQ(response, "{\"success\":true}");
+}
+
+TEST_F(BluetoothTest, setDiscoverableWrapper_DefaultTimeout) {
+    // Prepare the JSON parameters with default timeout value
+    bool discoverable = true;  // discoverable flag
+
+    JsonObject params;
+    params["discoverable"] = discoverable;  // discoverable flag
+
+    // Convert JsonObject to string
+    string paramsStr;
+    params.ToString(paramsStr);
+
+    // Mock the behavior of BTRMGR_SetAdapterDiscoverable for success
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_SetAdapterDiscoverable(::testing::Eq(0), ::testing::Eq(discoverable), ::testing::Eq(-1)))
+        .Times(1)
+        .WillOnce(::testing::Return(BTRMGR_RESULT_SUCCESS));
+
+    // Invoke the setDiscoverableWrapper method and check the response
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("setDiscoverable"), paramsStr, response));
+    EXPECT_EQ(response, "{\"success\":true}");
+}
+
+TEST_F(BluetoothTest, setDiscoverableWrapper_Failure) {
+    // Prepare the JSON parameters for failure scenario
+    int timeout = 30;  // timeout value
+    bool discoverable = true;  // discoverable flag
+
+    JsonObject params;
+    params["timeout"] = timeout;  // timeout value
+    params["discoverable"] = discoverable;  // discoverable flag
+
+    // Convert JsonObject to string
+    string paramsStr;
+    params.ToString(paramsStr);
+
+    // Mock the behavior of BTRMGR_SetAdapterDiscoverable for failure
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_SetAdapterDiscoverable(::testing::Eq(0), ::testing::Eq(discoverable), ::testing::Eq(timeout)))
+        .Times(1)
+        .WillOnce(::testing::Return(BTRMGR_RESULT_GENERIC_FAILURE));
+
+    // Invoke the setDiscoverableWrapper method and check the response for failure
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("setDiscoverable"), paramsStr, response));
+    EXPECT_EQ(response.empty(), true);  // Response should be empty on failure
+}
+
+TEST_F(BluetoothTest, setDiscoverableWrapper_MissingParameters) {
+    // Prepare the JSON parameters with missing "discoverable" parameter
+    JsonObject params;
+
+    // Convert JsonObject to string (missing "discoverable" field)
+    string paramsStr;
+    params.ToString(paramsStr);
+
+    // Invoke the setDiscoverable method with missing parameters and check the response
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("setDiscoverable"), paramsStr, response));
+
+    // Check that the response is empty as no discoverable parameter is provided
+    EXPECT_EQ(response.empty(), true);
+}
+
+TEST_F(BluetoothTest, getNameWrapper_Success) {
+    // Define the expected adapter name
+    const char* expectedAdapterName = "Adapter1";
+
+    // Set the mock behavior for this test case with EXPECT_CALL
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetAdapterName(::testing::Eq(0), ::testing::_))
+        .Times(1)  // Ensure the mock is called exactly once
+        .WillOnce([&](unsigned char aui8AdapterIdx, char* pNameOfAdapter) {
+            // Set the adapter name for this test
+            strcpy(pNameOfAdapter, expectedAdapterName);  // This is the name we want to test
+            return BTRMGR_RESULT_SUCCESS;
+        });
+
+    // Prepare the parameters (no need to pass anything for this test case)
+    JsonObject params;
+    string paramsStr;
+    params.ToString(paramsStr);
+
+    // Invoke the getName method and check the response
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getName"), paramsStr, response));
+
+    // Check that the response contains the expected adapter name
+    EXPECT_EQ(response, "{\"name\":\"Adapter1\",\"success\":true}");
+}
+
+TEST_F(BluetoothTest, getNameWrapper_Failure) {
+    // Set the mock behavior to simulate BTRMGR_GetAdapterName failure
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetAdapterName(::testing::Eq(0), ::testing::_))
+        .Times(1)  // Ensure the mock is called exactly once
+        .WillOnce(::testing::Return(BTRMGR_RESULT_GENERIC_FAILURE));  // Simulate failure
+
+    // Prepare the parameters (no need to pass anything for this test case)
+    JsonObject params;
+    string paramsStr;
+    params.ToString(paramsStr);
+
+    // Invoke the getName method and check the response
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("getName"), paramsStr, response));
+
+    // Check that the response is empty since the method failed
+    EXPECT_EQ(response.empty(), true);
+}
+
+TEST_F(BluetoothTest, setNameWrapper_Success) {
+    // Define the expected adapter name
+    const char* expectedAdapterName = "NewAdapterName";
+
+    // Set the mock behavior for BTRMGR_SetAdapterName
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_SetAdapterName(::testing::Eq(0), ::testing::_))
+        .Times(1)  // Ensure the mock is called exactly once
+        .WillOnce(::testing::Return(BTRMGR_RESULT_SUCCESS));  // Simulate success
+
+    // Prepare the JSON parameters with the "name" field
+    JsonObject params;
+    params["name"] = expectedAdapterName;
+
+    string paramsStr;
+    params.ToString(paramsStr);  // Convert to string for the handler
+
+    // Invoke the setName method and check the response
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("setName"), paramsStr, response));
+
+    // Check that the response contains the expected success status
+    EXPECT_EQ(response, "{\"success\":true}");
+}
+
+TEST_F(BluetoothTest, setNameWrapper_Failure) {
+    // Set up the mock behavior for BTRMGR_SetAdapterName to return failure
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_SetAdapterName(::testing::Eq(0), ::testing::_))
+        .Times(1)  // Ensure the mock is called exactly once
+        .WillOnce(::testing::Return(BTRMGR_RESULT_GENERIC_FAILURE));  // Simulate failure
+
+    // Prepare the JSON parameters with the "name" field
+    JsonObject params;
+    params["name"] = "NewAdapterName";
+
+    string paramsStr;
+    params.ToString(paramsStr);
+
+    // Invoke the setName method and check the response
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("setName"), paramsStr, response));
+
+    //EXPECT_EQ(response.empty(), true);
+    EXPECT_EQ(response.empty(), true);
+}
+
+TEST_F(BluetoothTest, setNameWrapper_MissingParameters) {
+    // Prepare the JSON parameters with the "name" field missing
+    JsonObject params;
+    // "name" field is omitted to simulate missing parameter
+
+    string paramsStr;
+    params.ToString(paramsStr);  // Convert to string for the handler
+
+    // Invoke the setName method with missing parameters
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("setName"), paramsStr, response));
+
+    // Check that the response is empty because of missing parameters
+    EXPECT_EQ(response.empty(), false);
+}
+
+TEST_F(BluetoothTest, sendAudioPlaybackCommandWrapper_AllCommands) {
+    // Define the device ID
+    long long int deviceID = 1001;
+
+    std::vector<string> commands = {
+        {"PAUSE"},
+        {"RESUME"},
+        {"STOP"},
+        {"SKIP_NEXT"},
+        {"SKIP_PREV"},
+        {"AUDIO_MUTE"},
+        {"AUDIO_UNMUTE"},
+        {"VOLUME_UP"},
+        {"VOLUME_DOWN"}
+    };
+
+    std::map<std::string, BTRMGR_MediaControlCommand_t> commandMap = {
+        {"PAUSE", BTRMGR_MEDIA_CTRL_PAUSE},
+        {"RESUME", BTRMGR_MEDIA_CTRL_PLAY},  // Maps RESUME to PLAY
+        {"STOP", BTRMGR_MEDIA_CTRL_STOP},
+        {"SKIP_NEXT", BTRMGR_MEDIA_CTRL_NEXT},
+        {"SKIP_PREV", BTRMGR_MEDIA_CTRL_PREVIOUS},
+        {"AUDIO_MUTE", BTRMGR_MEDIA_CTRL_MUTE},
+        {"AUDIO_UNMUTE", BTRMGR_MEDIA_CTRL_UNMUTE},
+        {"VOLUME_UP", BTRMGR_MEDIA_CTRL_VOLUMEUP},
+        {"VOLUME_DOWN", BTRMGR_MEDIA_CTRL_VOLUMEDOWN}
+    };
+
+    // Loop through the commands and test each one
+    for (const auto& command : commands) {
+        // Prepare the JSON parameters
+        JsonObject params;
+        params["deviceID"] = std::to_string(deviceID);
+        params["command"] = command;
+
+        // Convert JsonObject to string
+        string paramsStr;
+        params.ToString(paramsStr);
+
+	BTRMGR_MediaControlCommand_t mediaCtrlCmd = commandMap[command];
+
+        // Mock the call to BTRMGR_MediaControl with the corresponding command
+        EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_MediaControl(::testing::Eq(0), ::testing::Eq(deviceID), ::testing::Eq(mediaCtrlCmd)))
+            .Times(1)
+            .WillOnce(::testing::Return(BTRMGR_RESULT_SUCCESS));
+
+        // Invoke the method and check the response
+        EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("sendAudioPlaybackCommand"), paramsStr, response));
+        EXPECT_EQ(response, "{\"success\":true}");  // Expect success response
+    }
+}
+
+TEST_F(BluetoothTest, sendAudioPlaybackCommandWrapper_PLAY) {
+    // Define the device ID and command
+    long long int deviceID = 1001;
+    std::string command = "PLAY";  // The command to be tested
+
+    // Prepare the JSON parameters for the PLAY command
+    JsonObject params;
+    params["deviceID"] = std::to_string(deviceID);
+    params["command"] = command;
+
+    // Convert JsonObject to string
+    std::string paramsStr;
+    params.ToString(paramsStr);
+
+    // Expect the call to BTRMGR_StartAudioStreamingIn for the PLAY command
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_StartAudioStreamingIn(::testing::Eq(0), ::testing::Eq(deviceID), ::testing::Eq(BTRMGR_DEVICE_OP_TYPE_AUDIO_INPUT)))
+        .Times(1)
+        .WillOnce(::testing::Return(BTRMGR_RESULT_SUCCESS));
+
+    // Invoke the method and check the response
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("sendAudioPlaybackCommand"), paramsStr, response));
+    EXPECT_EQ(response, "{\"success\":true}");  // Expect success response
+}
+
+TEST_F(BluetoothTest, sendAudioPlaybackCommandWrapper_RESTART_Failure) {
+    // Define the device ID and command
+    long long int deviceID = 1001;
+    std::string command = "RESTART";  // The command to be tested
+
+    // Prepare the JSON parameters for the RESTART command
+    JsonObject params;
+    params["deviceID"] = std::to_string(deviceID);
+    params["command"] = command;
+
+    // Convert JsonObject to string
+    std::string paramsStr;
+    params.ToString(paramsStr);
+
+    // Invoke the method and check the response
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("sendAudioPlaybackCommand"), paramsStr, response));  // Expect error response for failure
+    EXPECT_EQ(response.empty(), true);  // Expect the response to be empty since the command failed
+}
+
+TEST_F(BluetoothTest, sendAudioPlaybackCommandWrapper_MediaControl_Failure) {
+    // Define the device ID and command
+    long long int deviceID = 1001;
+    std::string command = "PAUSE";  // The command to be tested (can be any supported command like PAUSE)
+
+    // Prepare the JSON parameters for the PAUSE command
+    JsonObject params;
+    params["deviceID"] = std::to_string(deviceID);
+    params["command"] = command;
+
+    // Convert JsonObject to string
+    std::string paramsStr;
+    params.ToString(paramsStr);
+
+    // Expect the call to BTRMGR_MediaControl and simulate a failure for the command
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_MediaControl(::testing::Eq(0), ::testing::Eq(deviceID), ::testing::Eq(BTRMGR_MEDIA_CTRL_PAUSE)))
+        .Times(1)
+        .WillOnce(::testing::Return(BTRMGR_RESULT_GENERIC_FAILURE));  // Simulate failure
+
+    // Invoke the method and check the response
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("sendAudioPlaybackCommand"), paramsStr, response));  // Expect error response for failure
+    EXPECT_EQ(response.empty(), true);  // Expect the response to be empty since the command failed
+}
+
+TEST_F(BluetoothTest, sendAudioPlaybackCommandWrapper_MissingBothParameters) {
+    // Prepare the JSON parameters with both "deviceID" and "command" missing
+    JsonObject params;
+    // No parameters at all
+
+    // Convert JsonObject to string
+    std::string paramsStr;
+    params.ToString(paramsStr);
+
+    // Invoke the method with missing parameters and check the response
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("sendAudioPlaybackCommand"), paramsStr, response));
+    EXPECT_EQ(response.empty(), true);
+}
+
+TEST_F(BluetoothTest, setEventResponseWrapper_Success) {
+    // Define the structure to hold event type and response value
+    struct EventScenario {
+        std::string eventType;
+        std::string responseValue;
+    };
+
+    // Prepare the test data for a successful scenario
+    JsonObject params;
+    params["deviceID"] = "1001";  // Example device ID
+    string paramsStr;
+
+    // List of event type and response value pairs
+    std::vector<EventScenario> scenarios = {
+        {"onPairingRequest", "ACCEPTED"},
+        {"onPairingRequest", "REJECTED"},
+        {"onConnectionRequest", "ACCEPTED"},
+        {"onConnectionRequest", "REJECTED"},
+        {"onPlaybackRequest", "ACCEPTED"},
+        {"onPlaybackRequest", "REJECTED"}
+    };
+
+    // Iterate through each scenario
+    for (const auto& scenario : scenarios) {
+        // Update the parameters for the current scenario
+        params["eventType"] = scenario.eventType;
+        params["responseValue"] = scenario.responseValue;
+        params.ToString(paramsStr);
+
+        // Define expected behavior of BTRMGR_SetEventResponse
+        EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_SetEventResponse(::testing::Eq(0), ::testing::_))
+            .Times(1)
+            .WillOnce([&](unsigned char deviceID, BTRMGR_EventResponse_t* eventResp) {
+                // Check the values passed to the mock function
+                if (scenario.eventType == "onPairingRequest") {
+                    EXPECT_EQ(eventResp->m_eventType, BTRMGR_EVENT_RECEIVED_EXTERNAL_PAIR_REQUEST);
+                } else if (scenario.eventType == "onConnectionRequest") {
+                    EXPECT_EQ(eventResp->m_eventType, BTRMGR_EVENT_RECEIVED_EXTERNAL_CONNECT_REQUEST);
+                } else if (scenario.eventType == "onPlaybackRequest") {
+                    EXPECT_EQ(eventResp->m_eventType, BTRMGR_EVENT_RECEIVED_EXTERNAL_PLAYBACK_REQUEST);
+                }
+
+                // Set the expected response value based on ACCEPTED/REJECTED
+                eventResp->m_eventResp = (scenario.responseValue == "ACCEPTED") ? 1 : 0;
+
+                return BTRMGR_RESULT_SUCCESS;  // Mock successful return
+            });
+
+        EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("respondToEvent"), paramsStr, response));
+
+        // Check that the response is as expected
+        EXPECT_EQ(response, "{\"success\":true}");
+    }
+}
+
+TEST_F(BluetoothTest, setEventResponseWrapper_UnknownEvent) {
+    // Prepare the test data for an "Unknown" event type
+    JsonObject params;
+    params["deviceID"] = "1001";  // Example device ID
+    params["eventType"] = "unknown";  // Unknown event type
+    params["responseValue"] = "ACCEPTED";  // Response value for the event
+    string paramsStr;
+    params.ToString(paramsStr);
+
+    // Define expected behavior of BTRMGR_SetEventResponse for an unknown event type
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_SetEventResponse(::testing::Eq(0), ::testing::_))
+        .Times(1)
+        .WillOnce([&](unsigned char deviceID, BTRMGR_EventResponse_t* eventResp) {
+            // Verify that eventType is unknown
+            EXPECT_EQ(eventResp->m_eventType, BTRMGR_EVENT_MAX); // The expected type for unknown events
+
+            // Set the expected response value to 0 (assuming unknown event type results in no action)
+            eventResp->m_eventResp = 0;
+
+            return BTRMGR_RESULT_SUCCESS;  // Mock successful return
+        });
+
+    // Invoke the method with the unknown event type
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("respondToEvent"), paramsStr, response));
+
+    // Verify that the response is as expected
+    EXPECT_EQ(response, "{\"success\":true}");
+}
+
+TEST_F(BluetoothTest, setEventResponseWrapper_SetEventResponseFailure) {
+    // Prepare the test data for a failure scenario
+    JsonObject params;
+    params["deviceID"] = "1001";  // Example device ID
+    params["eventType"] = "onPairingRequest";  // Valid event type
+    params["responseValue"] = "ACCEPTED";  // Response value for the event
+    string paramsStr;
+    params.ToString(paramsStr);
+
+    // Define expected behavior of BTRMGR_SetEventResponse for a failure scenario
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_SetEventResponse(::testing::Eq(0), ::testing::_))
+        .Times(1)
+        .WillOnce([&](unsigned char deviceID, BTRMGR_EventResponse_t* eventResp) {
+            // Simulate failure of the BTRMGR_SetEventResponse function
+            return BTRMGR_RESULT_GENERIC_FAILURE;  // Return failure
+        });
+
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("respondToEvent"), paramsStr, response));
+
+    EXPECT_EQ(response.empty(), true);
+}
+
+TEST_F(BluetoothTest, setEventResponseWrapper_MissingParameters) {
+    // Prepare the test data for a missing parameters scenario
+    JsonObject params;
+    // Missing "eventType" and "responseValue", only deviceID is provided
+    params["deviceID"] = "1001";  // Example device ID
+    string paramsStr;
+    params.ToString(paramsStr);
+
+    // Define the expected behavior when parameters are missing
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_SetEventResponse(::testing::Eq(0), ::testing::_))
+        .Times(0);  // Ensure that BTRMGR_SetEventResponse is not called
+
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("respondToEvent"), paramsStr, response));
+
+    EXPECT_EQ(response.empty(), true);
+}
+
+TEST_F(BluetoothTest, getDeviceInfoWrapper_Success) {
+    JsonObject params;
+    params["deviceID"] = "1001";  // Example device ID
+    string paramsStr;
+    params.ToString(paramsStr);
+
+    // Define expected behavior of BTRMGR_GetDeviceProperties
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetDeviceProperties(::testing::Eq(0), ::testing::_ , ::testing::_))
+        .Times(1)
+        .WillOnce([&](unsigned char aui8AdapterIdx, BTRMgrDeviceHandle deviceHandle, BTRMGR_DevicesProperty_t* deviceProperty) {
+            // Populate deviceProperty structure with mock data
+            deviceProperty->m_deviceHandle = 1001;
+            deviceProperty->m_deviceType = BTRMGR_DEVICE_TYPE_SMARTPHONE;
+            strcpy(deviceProperty->m_name, "Test Device");
+            strcpy(deviceProperty->m_deviceAddress, "00:11:22:33:44:55");
+            deviceProperty->m_rssi = -40;
+            deviceProperty->m_signalLevel = BTRMGR_RSSI_GOOD;
+            deviceProperty->m_vendorID = 1234;
+            deviceProperty->m_isPaired = 1;
+            deviceProperty->m_isConnected = 1;
+            deviceProperty->m_isLowEnergyDevice = 0;
+            deviceProperty->m_batteryLevel = 80;
+            strcpy(deviceProperty->m_modalias, "TestModAlias");
+            strcpy(deviceProperty->m_firmwareRevision, "1.0.0");
+            deviceProperty->m_serviceInfo.m_numOfService = 2;
+            deviceProperty->m_serviceInfo.m_profileInfo[0].m_profile[0] = 'A';
+            deviceProperty->m_serviceInfo.m_profileInfo[1].m_profile[0] = 'B';
+            return BTRMGR_RESULT_SUCCESS;  // Mock successful return
+        });
+
+    // Mock the call to BTRMGR_GetDeviceTypeAsString for valid device types
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetDeviceTypeAsString(::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Invoke([](BTRMGR_DeviceType_t deviceType) -> const char* {
+            switch (deviceType) {
+                case BTRMGR_DEVICE_TYPE_SMARTPHONE:
+                    return "SMARTPHONE";
+                case BTRMGR_DEVICE_TYPE_HEADPHONES:
+                    return "HEADPHONES";
+                default:
+                    return "UNKNOWN";
+            }
+        }));
+
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getDeviceInfo"), paramsStr, response));
+
+    std::string expectedResponse = "{\"deviceInfo\":{\"deviceID\":\"1001\",\"name\":\"Test Device\",\"deviceType\":\"SMARTPHONE\","
+                                  "\"manufacturer\":\"1234\",\"MAC\":\"00:11:22:33:44:55\",\"signalStrength\":\"3\","
+                                  "\"rssi\":\"-40\",\"batteryLevel\":\"80\",\"modalias\":\"TestModAlias\","
+                                  "\"firmwareRevision\":\"1.0.0\",\"supportedProfile\":\"A;B\"},\"success\":true}";
+
+    EXPECT_EQ(response, expectedResponse);
+}
+
+TEST_F(BluetoothTest, getDeviceInfoWrapper_Failure) {
+    // Prepare the test data for a failure scenario
+    JsonObject params;
+    params["deviceID"] = "1001";  // Example device ID that will be used in the test
+    string paramsStr;
+    params.ToString(paramsStr);
+
+    // Mock the failure of BTRMGR_GetDeviceProperties
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetDeviceProperties(::testing::Eq(0), ::testing::_ , ::testing::_))
+        .Times(1)
+        .WillOnce([](unsigned char aui8AdapterIdx, BTRMgrDeviceHandle deviceHandle, BTRMGR_DevicesProperty_t* deviceProperty) {
+            // Simulate failure by returning an error code
+            return BTRMGR_RESULT_GENERIC_FAILURE;
+        });
+
+    // Invoke the method under test with the test parameters
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getDeviceInfo"), paramsStr, response));
+    EXPECT_EQ(response, "{\"deviceInfo\":{},\"success\":true}");
+}
+
+TEST_F(BluetoothTest, getDeviceInfoWrapper_MissingParameter) {
+    // Prepare the test data for a missing parameter scenario
+    JsonObject params;
+    // Missing "deviceID" parameter in this case.
+    // params["deviceID"] = "1001";  // Comment out to simulate missing parameter.
+
+    string paramsStr;
+    params.ToString(paramsStr);
+
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("getDeviceInfo"), paramsStr, response));
+    EXPECT_EQ(response.empty(), true);
+}
+
+TEST_F(BluetoothTest, getMediaTrackInfoWrapper_Success) {
+    // Prepare the test data for a successful scenario
+    JsonObject params;
+    params["deviceID"] = "1001";  // Example device ID (BTRMgrDeviceHandle)
+    string paramsStr;
+    params.ToString(paramsStr);
+
+    // Mock the behavior of BTRMGR_GetMediaTrackInfo
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetMediaTrackInfo(::testing::Eq(0), ::testing::Eq(1001), ::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Invoke([](unsigned char aui8AdapterIdx, BTRMgrDeviceHandle deviceID, BTRMGR_MediaTrackInfo_t* trackInfo) {
+            // Populate the track info with test data
+            strcpy(trackInfo->pcAlbum, "Test Album");
+            strcpy(trackInfo->pcGenre, "Rock");
+            strcpy(trackInfo->pcTitle, "Test Track");
+            strcpy(trackInfo->pcArtist, "Test Artist");
+            trackInfo->ui32TrackNumber = 1;
+            trackInfo->ui32Duration = 300;  // Duration in seconds
+            trackInfo->ui32NumberOfTracks = 10;
+            return BTRMGR_RESULT_SUCCESS;  // Return success
+        }));
+
+    // Invoke the method under test (getMediaTrackInfoWrapper)
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getAudioInfo"), paramsStr, response));
+    EXPECT_EQ(response, "{\"trackInfo\":{\"album\":\"Test Album\",\"genre\":\"Rock\",\"title\":\"Test Track\",\"artist\":\"Test Artist\",\"ui32Duration\":\"300\",\"ui32TrackNumber\":\"1\",\"ui32NumberOfTracks\":\"10\"},\"success\":true}");
+}
+
+TEST_F(BluetoothTest, getMediaTrackInfoWrapper_Failure) {
+    // Prepare the test data for the failure scenario
+    JsonObject params;
+    params["deviceID"] = "1001";  // Example device ID
+    string paramsStr;
+    params.ToString(paramsStr);
+
+    // Define expected behavior of BTRMGR_GetMediaTrackInfo to simulate failure
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetMediaTrackInfo(::testing::Eq(0), ::testing::Eq(1001), ::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Return(BTRMGR_RESULT_GENERIC_FAILURE)); // Simulate failure in the mock
+
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getAudioInfo"), paramsStr, response));
+    EXPECT_EQ(response, "{\"trackInfo\":{},\"success\":true}");
+}
+
+TEST_F(BluetoothTest, getMediaTrackInfoWrapper_MissingParameters) {
+    // Prepare the test data for the missing parameter scenario
+    JsonObject params;  // Device ID is intentionally missing in this case
+    string paramsStr;
+    params.ToString(paramsStr);
+
+    // Define expected behavior in case the parameters are missing
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetMediaTrackInfo(::testing::_, ::testing::_, ::testing::_))
+        .Times(0);  // The mock should not be called if parameters are missing
+
+    // Invoke the method with missing parameters (deviceID)
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("getAudioInfo"), paramsStr, response));
+
+    EXPECT_EQ(response.empty(), true);
+}
+
+TEST_F(BluetoothTest, getDeviceVolumeMuteInfoWrapper_Success) {
+    // List of device types to test
+    std::vector<std::string> deviceTypes = {
+        "LOUDSPEAKER", "HIFI AUDIO DEVICE", "TABLET", "JOYSTICK", "LE", "DEFAULT"
+    };
+
+    // Prepare the test data for a successful scenario, including deviceType
+    JsonObject params;
+    params["deviceID"] = "1001";  // Example device ID
+    string paramsStr;
+
+    // Iterate through each device type for testing
+    for (const auto& deviceType : deviceTypes) {
+        params["deviceType"] = deviceType;  // Set the device type
+        params.ToString(paramsStr);  // Convert params to string
+
+        // Mock expected behavior of BTRMGR_GetDeviceVolumeMute to return successful data
+        EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetDeviceVolumeMute(::testing::Eq(0), ::testing::Eq(1001), 
+				::testing::_, ::testing::_, ::testing::_))
+            .Times(1)
+            .WillOnce(::testing::Invoke([](unsigned char adapterIdx, BTRMgrDeviceHandle deviceHandle, 
+					    BTRMGR_DeviceOperationType_t deviceOpType, unsigned char* pui8Volume, unsigned char* pui8Mute) {
+                // Simulate successful return of volume and mute status
+                *pui8Volume = 75;  // Set volume level
+                *pui8Mute = 0;  // Set mute status to false (not muted)
+                return BTRMGR_RESULT_SUCCESS;  // Return success
+            }));
+
+        // Invoke the method
+        EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getDeviceVolumeMuteInfo"), paramsStr, response));
+
+        // Verify the response to ensure it contains the expected values
+        EXPECT_EQ(response, "{\"volumeinfo\":{\"volume\":\"75\",\"mute\":false},\"success\":true}");
+    }
+}
+
+TEST_F(BluetoothTest, getDeviceVolumeMuteInfoWrapper_Failure) {
+    // Prepare the test data for the failure scenario
+    JsonObject params;
+    params["deviceID"] = "1001";  // Example device ID
+    params["deviceType"] = "SMARTPHONE";  // Device type for the test
+    string paramsStr;
+    params.ToString(paramsStr);
+
+    // Define expected behavior of BTRMGR_GetDeviceVolumeMute to simulate failure
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetDeviceVolumeMute(::testing::Eq(0), ::testing::Eq(1001), ::testing::_, ::testing::_, ::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Return(BTRMGR_RESULT_GENERIC_FAILURE));  // Simulate failure in the mock
+
+    // Combine method invocation and validation in one line
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("getDeviceVolumeMuteInfo"), paramsStr, response));
+}
+
+TEST_F(BluetoothTest, getDeviceVolumeMuteInfoWrapper_MissingParameters) {
+    // Prepare the test data for the failure scenario with missing parameters
+    JsonObject params;
+    // We are intentionally omitting the deviceID and deviceType to simulate the missing parameters scenario
+    string paramsStr;
+    params.ToString(paramsStr);
+
+    // Invoke the method under test with missing parameters
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("getDeviceVolumeMuteInfo"), paramsStr, response));
+    EXPECT_EQ(response.empty(), true);
+}
+
+TEST_F(BluetoothTest, setDeviceVolumeMuteProperties_Success) {
+    // Prepare the test data for a successful scenario
+    JsonObject params;
+    params["deviceID"] = "1001";  // Example device ID
+    params["deviceType"] = "SMARTPHONE";  // Example device type
+    params["volume"] = "75";  // Example volume level
+    params["mute"] = "false";  // Example mute status (not muted)
+
+    string paramsStr;
+    params.ToString(paramsStr);
+
+    // Mock the BTRMGR_SetDeviceVolumeMute function to simulate success
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_SetDeviceVolumeMute(
+            ::testing::_,                      // Allow any adapter index
+            ::testing::_,                      // Allow any device ID
+            ::testing::_,                      // Allow any device operation type
+            ::testing::_,                      // Allow any volume value
+            ::testing::_                       // Allow any mute value
+        ))
+        .Times(1)
+        .WillOnce(::testing::Return(BTRMGR_RESULT_SUCCESS));  // Simulate success
+
+    // Invoke the method under test
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("setDeviceVolumeMuteInfo"), paramsStr, response));
+
+    // Verify the response is as expected for success
+    EXPECT_EQ(response, "{\"success\":true}");
+}
+
+TEST_F(BluetoothTest, setDeviceVolumeMuteProperties_Failure) {
+    // Prepare the test data for a failure scenario
+    JsonObject params;
+    params["deviceID"] = "1001";  // Example device ID
+    params["deviceType"] = "SMARTPHONE";  // Example device type
+    params["volume"] = "75";  // Example volume level
+    params["mute"] = "false";  // Example mute status (not muted)
+
+    string paramsStr;
+    params.ToString(paramsStr);
+
+    // Mock the BTRMGR_SetDeviceVolumeMute function to simulate failure
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_SetDeviceVolumeMute(
+            ::testing::_,                      // Allow any adapter index
+            ::testing::_,                      // Allow any device ID
+            ::testing::_,                      // Allow any device operation type
+            ::testing::_,                      // Allow any volume value
+            ::testing::_                       // Allow any mute value
+        ))
+        .Times(1)
+        .WillOnce(::testing::Return(BTRMGR_RESULT_GENERIC_FAILURE)); // Simulate failure
+
+    // Invoke the method under test
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("setDeviceVolumeMuteInfo"), paramsStr, response));
+    EXPECT_EQ(response.empty(), true);
+}
+
+TEST_F(BluetoothTest, setDeviceVolumeMuteProperties_MissingParameters) {
+    // Prepare the test data for a failure scenario with missing parameters
+    JsonObject params;
+    params["deviceID"] = "1001";  // Example device ID
+    // Missing deviceType and volume
+    string paramsStr;
+    params.ToString(paramsStr);
+
+    // Invoke the method under test with missing parameters
+    EXPECT_EQ(Core::ERROR_GENERAL, handler.Invoke(connection, _T("setDeviceVolumeMuteInfo"), paramsStr, response));
+    EXPECT_EQ(response.empty(), true);
+}
+
+TEST_F(BluetoothTest, EventCallbackTest) {
+    ASSERT_NE(mockBluetoothManagerInstance->evBluetoothHandler, nullptr);
+
+    {
+	BTRMGR_EventMessage_t eventMsg;
+        eventMsg.m_eventType = BTRMGR_EVENT_DEVICE_DISCOVERY_COMPLETE;
+        // Perform assertions on the result or any other necessary verifications
+        ASSERT_EQ(BTRMGR_RESULT_SUCCESS,mockBluetoothManagerInstance->evBluetoothHandler(eventMsg));
+    }
+
+    // Test for BTRMGR_EVENT_DEVICE_PAIRING_COMPLETE
+    {
+        BTRMGR_EventMessage_t eventMsg;
+        eventMsg.m_eventType = BTRMGR_EVENT_DEVICE_PAIRING_COMPLETE;
+        strncpy(eventMsg.m_discoveredDevice.m_name, "Device Name", sizeof(eventMsg.m_discoveredDevice.m_name) - 1);
+        eventMsg.m_discoveredDevice.m_name[sizeof(eventMsg.m_discoveredDevice.m_name) - 1] = '\0';
+        eventMsg.m_discoveredDevice.m_deviceHandle = 123;
+        eventMsg.m_discoveredDevice.m_deviceType = BTRMGR_DEVICE_TYPE_HID;
+        eventMsg.m_discoveredDevice.m_ui32DevClassBtSpec = 456;
+        eventMsg.m_discoveredDevice.m_ui16DevAppearanceBleSpec = 789;
+        eventMsg.m_discoveredDevice.m_isLastConnectedDevice = true;
+        eventMsg.m_discoveredDevice.m_isPairedDevice = true;
+        eventMsg.m_discoveredDevice.m_isConnected = false;
+
+	EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetDeviceTypeAsString(::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Invoke([](BTRMGR_DeviceType_t deviceType) -> const char* {
+            switch (deviceType) {
+                case BTRMGR_DEVICE_TYPE_HID:
+                    return "HUMAN INTERFACE DEVICE";
+                default:
+                    return "UNKNOWN";
+            }
+        }));
+
+	// Perform assertions on the result or any other necessary verifications
+	ASSERT_EQ(BTRMGR_RESULT_SUCCESS, mockBluetoothManagerInstance->evBluetoothHandler(eventMsg));
+    }
+
+    // Test for BTRMGR_EVENT_DEVICE_UNPAIRING_COMPLETE
+    {
+        BTRMGR_EventMessage_t eventMsg;
+        eventMsg.m_eventType = BTRMGR_EVENT_DEVICE_UNPAIRING_COMPLETE;
+        strncpy(eventMsg.m_discoveredDevice.m_name, "Device Name", sizeof(eventMsg.m_discoveredDevice.m_name) - 1);
+        eventMsg.m_discoveredDevice.m_name[sizeof(eventMsg.m_discoveredDevice.m_name) - 1] = '\0';
+        eventMsg.m_discoveredDevice.m_deviceHandle = 123;
+        eventMsg.m_discoveredDevice.m_deviceType = BTRMGR_DEVICE_TYPE_HID;
+        eventMsg.m_discoveredDevice.m_ui32DevClassBtSpec = 456;
+        eventMsg.m_discoveredDevice.m_ui16DevAppearanceBleSpec = 789;
+        eventMsg.m_discoveredDevice.m_isLastConnectedDevice = true;
+        eventMsg.m_discoveredDevice.m_isPairedDevice = true;
+        eventMsg.m_discoveredDevice.m_isConnected = false;
+
+        EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetDeviceTypeAsString(::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Invoke([](BTRMGR_DeviceType_t deviceType) -> const char* {
+            switch (deviceType) {
+                case BTRMGR_DEVICE_TYPE_HID:
+                    return "HUMAN INTERFACE DEVICE";
+                default:
+                    return "UNKNOWN";
+            }
+        }));
+
+        // Perform assertions on the result or any other necessary verifications
+        ASSERT_EQ(BTRMGR_RESULT_SUCCESS, mockBluetoothManagerInstance->evBluetoothHandler(eventMsg));
+    }
+
+    // Test for BTRMGR_EVENT_DEVICE_DISCONNECT_COMPLETE
+    {
+        BTRMGR_EventMessage_t eventMsg;
+        eventMsg.m_eventType = BTRMGR_EVENT_DEVICE_DISCONNECT_COMPLETE;
+        strncpy(eventMsg.m_discoveredDevice.m_name, "Device Name", sizeof(eventMsg.m_discoveredDevice.m_name) - 1);
+        eventMsg.m_discoveredDevice.m_name[sizeof(eventMsg.m_discoveredDevice.m_name) - 1] = '\0';
+        eventMsg.m_discoveredDevice.m_deviceHandle = 123;
+        eventMsg.m_discoveredDevice.m_deviceType = BTRMGR_DEVICE_TYPE_HID;
+        eventMsg.m_discoveredDevice.m_ui32DevClassBtSpec = 456;
+        eventMsg.m_discoveredDevice.m_ui16DevAppearanceBleSpec = 789;
+        eventMsg.m_discoveredDevice.m_isLastConnectedDevice = true;
+        eventMsg.m_discoveredDevice.m_isPairedDevice = true;
+        eventMsg.m_discoveredDevice.m_isConnected = false;
+
+        EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetDeviceTypeAsString(::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Invoke([](BTRMGR_DeviceType_t deviceType) -> const char* {
+            switch (deviceType) {
+                case BTRMGR_DEVICE_TYPE_HID:
+                    return "HUMAN INTERFACE DEVICE";
+                default:
+                    return "UNKNOWN";
+            }
+        }));
+
+        // Perform assertions on the result or any other necessary verifications
+        ASSERT_EQ(BTRMGR_RESULT_SUCCESS, mockBluetoothManagerInstance->evBluetoothHandler(eventMsg));
+    }
+
+    // Test for BTRMGR_EVENT_DEVICE_DISCOVERY_STARTED
+    {
+        BTRMGR_EventMessage_t eventMsg;
+        eventMsg.m_eventType = BTRMGR_EVENT_DEVICE_DISCOVERY_STARTED;
+        // Perform assertions on the result or any other necessary verifications
+        ASSERT_EQ(BTRMGR_RESULT_SUCCESS,mockBluetoothManagerInstance->evBluetoothHandler(eventMsg));
+    }
+
+    // Test for BTRMGR_EVENT_RECEIVED_EXTERNAL_PAIR_REQUEST
+    {
+	BTRMGR_EventMessage_t eventMsg;
+        eventMsg.m_eventType = BTRMGR_EVENT_RECEIVED_EXTERNAL_PAIR_REQUEST;
+        strncpy(eventMsg.m_externalDevice.m_name, "Device Name", sizeof(eventMsg.m_externalDevice.m_name) - 1);
+        eventMsg.m_externalDevice.m_name[sizeof(eventMsg.m_externalDevice.m_name) - 1] = '\0';
+        eventMsg.m_externalDevice.m_deviceHandle = 123;
+        eventMsg.m_externalDevice.m_deviceType = BTRMGR_DEVICE_TYPE_HID;
+        eventMsg.m_externalDevice.m_vendorID = 456;
+        strncpy(eventMsg.m_externalDevice.m_deviceAddress, "00:11:22:33:44:55", sizeof(eventMsg.m_externalDevice.m_deviceAddress) - 1);
+        eventMsg.m_externalDevice.m_deviceAddress[sizeof(eventMsg.m_externalDevice.m_deviceAddress) - 1] = '\0';
+
+        eventMsg.m_externalDevice.m_serviceInfo.m_numOfService = 2;
+        strncpy(eventMsg.m_externalDevice.m_serviceInfo.m_profileInfo[0].m_profile, "Profile1", sizeof(eventMsg.m_externalDevice.m_serviceInfo.m_profileInfo[0].m_profile) - 1);
+        eventMsg.m_externalDevice.m_serviceInfo.m_profileInfo[0].m_profile[sizeof(eventMsg.m_externalDevice.m_serviceInfo.m_profileInfo[0].m_profile) - 1] = '\0';
+        strncpy(eventMsg.m_externalDevice.m_serviceInfo.m_profileInfo[1].m_profile, "Profile2", sizeof(eventMsg.m_externalDevice.m_serviceInfo.m_profileInfo[1].m_profile) - 1);
+        eventMsg.m_externalDevice.m_serviceInfo.m_profileInfo[1].m_profile[sizeof(eventMsg.m_externalDevice.m_serviceInfo.m_profileInfo[1].m_profile) - 1] = '\0';
+
+        eventMsg.m_externalDevice.m_externalDevicePIN = 1234;
+
+        EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetDeviceTypeAsString(::testing::_))
+            .Times(1)
+            .WillOnce(::testing::Invoke([](BTRMGR_DeviceType_t deviceType) -> const char* {
+                switch (deviceType) {
+                    case BTRMGR_DEVICE_TYPE_HID:
+                        return "HUMAN INTERFACE DEVICE";
+                    default:
+                        return "UNKNOWN";
+            }
+        }));
+
+        // Perform assertions on the result or any other necessary verifications
+        ASSERT_EQ(BTRMGR_RESULT_SUCCESS, mockBluetoothManagerInstance->evBluetoothHandler(eventMsg));
+    }
+
+    {
+	BTRMGR_EventMessage_t eventMsg;
+	eventMsg.m_eventType = BTRMGR_EVENT_DEVICE_PAIRING_FAILED;
+	strncpy(eventMsg.m_discoveredDevice.m_name, "Device Name", sizeof(eventMsg.m_discoveredDevice.m_name) - 1);
+	eventMsg.m_discoveredDevice.m_name[sizeof(eventMsg.m_discoveredDevice.m_name) - 1] = '\0';
+	eventMsg.m_discoveredDevice.m_deviceHandle = 123;
+	eventMsg.m_discoveredDevice.m_deviceType = BTRMGR_DEVICE_TYPE_HID;
+	eventMsg.m_discoveredDevice.m_ui32DevClassBtSpec = 456;
+	eventMsg.m_discoveredDevice.m_ui16DevAppearanceBleSpec = 789;
+	eventMsg.m_discoveredDevice.m_isLastConnectedDevice = true;
+	eventMsg.m_discoveredDevice.m_isPairedDevice = true;
+	eventMsg.m_discoveredDevice.m_isConnected = false;
+
+	EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetDeviceTypeAsString(::testing::_))
+	    .Times(1)
+            .WillOnce(::testing::Invoke([](BTRMGR_DeviceType_t deviceType) -> const char* {
+                switch (deviceType) {
+                    case BTRMGR_DEVICE_TYPE_HID:
+                        return "HUMAN INTERFACE DEVICE";
+                    default:
+                        return "UNKNOWN";
+            }
+        }));
+
+	// Perform assertions on the result or any other necessary verifications
+	ASSERT_EQ(BTRMGR_RESULT_SUCCESS, mockBluetoothManagerInstance->evBluetoothHandler(eventMsg));
+    }
+
+    {
+        BTRMGR_EventMessage_t eventMsg;
+        eventMsg.m_eventType = BTRMGR_EVENT_DEVICE_UNPAIRING_FAILED;
+        strncpy(eventMsg.m_discoveredDevice.m_name, "Device Name", sizeof(eventMsg.m_discoveredDevice.m_name) - 1);
+        eventMsg.m_discoveredDevice.m_name[sizeof(eventMsg.m_discoveredDevice.m_name) - 1] = '\0';
+        eventMsg.m_discoveredDevice.m_deviceHandle = 123;
+        eventMsg.m_discoveredDevice.m_deviceType = BTRMGR_DEVICE_TYPE_HID;
+        eventMsg.m_discoveredDevice.m_ui32DevClassBtSpec = 456;
+        eventMsg.m_discoveredDevice.m_ui16DevAppearanceBleSpec = 789;
+        eventMsg.m_discoveredDevice.m_isLastConnectedDevice = true;
+        eventMsg.m_discoveredDevice.m_isPairedDevice = true;
+        eventMsg.m_discoveredDevice.m_isConnected = false;
+
+        EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetDeviceTypeAsString(::testing::_))
+            .Times(1)
+            .WillOnce(::testing::Invoke([](BTRMGR_DeviceType_t deviceType) -> const char* {
+                switch (deviceType) {
+                    case BTRMGR_DEVICE_TYPE_HID:
+                        return "HUMAN INTERFACE DEVICE";
+                    default:
+                        return "UNKNOWN";
+            }
+        }));
+
+        // Perform assertions on the result or any other necessary verifications
+        ASSERT_EQ(BTRMGR_RESULT_SUCCESS, mockBluetoothManagerInstance->evBluetoothHandler(eventMsg));
+    }
+
+    {
+        BTRMGR_EventMessage_t eventMsg;
+        eventMsg.m_eventType = BTRMGR_EVENT_DEVICE_CONNECTION_FAILED;
+        strncpy(eventMsg.m_discoveredDevice.m_name, "Device Name", sizeof(eventMsg.m_discoveredDevice.m_name) - 1);
+        eventMsg.m_discoveredDevice.m_name[sizeof(eventMsg.m_discoveredDevice.m_name) - 1] = '\0';
+        eventMsg.m_discoveredDevice.m_deviceHandle = 123;
+        eventMsg.m_discoveredDevice.m_deviceType = BTRMGR_DEVICE_TYPE_HID;
+        eventMsg.m_discoveredDevice.m_ui32DevClassBtSpec = 456;
+        eventMsg.m_discoveredDevice.m_ui16DevAppearanceBleSpec = 789;
+        eventMsg.m_discoveredDevice.m_isLastConnectedDevice = true;
+        eventMsg.m_discoveredDevice.m_isPairedDevice = true;
+        eventMsg.m_discoveredDevice.m_isConnected = false;
+
+        EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetDeviceTypeAsString(::testing::_))
+            .Times(1)
+            .WillOnce(::testing::Invoke([](BTRMGR_DeviceType_t deviceType) -> const char* {
+                switch (deviceType) {
+                    case BTRMGR_DEVICE_TYPE_HID:
+                        return "HUMAN INTERFACE DEVICE";
+                    default:
+                        return "UNKNOWN";
+            }
+        }));
+
+        // Perform assertions on the result or any other necessary verifications
+        ASSERT_EQ(BTRMGR_RESULT_SUCCESS, mockBluetoothManagerInstance->evBluetoothHandler(eventMsg));
+    }
+
+    {
+	BTRMGR_EventMessage_t eventMsg;
+	eventMsg.m_eventType = BTRMGR_EVENT_RECEIVED_EXTERNAL_PLAYBACK_REQUEST;
+	strncpy(eventMsg.m_externalDevice.m_name, "Device Name", sizeof(eventMsg.m_externalDevice.m_name) - 1);
+	eventMsg.m_externalDevice.m_name[sizeof(eventMsg.m_externalDevice.m_name) - 1] = '\0';
+	eventMsg.m_externalDevice.m_deviceHandle = 123;
+	eventMsg.m_externalDevice.m_deviceType = BTRMGR_DEVICE_TYPE_HID;
+	eventMsg.m_externalDevice.m_vendorID = 456;
+	strncpy(eventMsg.m_externalDevice.m_deviceAddress, "00:11:22:33:44:55", sizeof(eventMsg.m_externalDevice.m_deviceAddress) - 1);
+	eventMsg.m_externalDevice.m_deviceAddress[sizeof(eventMsg.m_externalDevice.m_deviceAddress) - 1] = '\0';
+
+	eventMsg.m_externalDevice.m_serviceInfo.m_numOfService = 2;
+	strncpy(eventMsg.m_externalDevice.m_serviceInfo.m_profileInfo[0].m_profile, "Profile1", sizeof(eventMsg.m_externalDevice.m_serviceInfo.m_profileInfo[0].m_profile) - 1);
+	eventMsg.m_externalDevice.m_serviceInfo.m_profileInfo[0].m_profile[sizeof(eventMsg.m_externalDevice.m_serviceInfo.m_profileInfo[0].m_profile) - 1] = '\0';
+	strncpy(eventMsg.m_externalDevice.m_serviceInfo.m_profileInfo[1].m_profile, "Profile2", sizeof(eventMsg.m_externalDevice.m_serviceInfo.m_profileInfo[1].m_profile) - 1);
+	eventMsg.m_externalDevice.m_serviceInfo.m_profileInfo[1].m_profile[sizeof(eventMsg.m_externalDevice.m_serviceInfo.m_profileInfo[1].m_profile) - 1] = '\0';
+
+	EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetDeviceTypeAsString(::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Invoke([](BTRMGR_DeviceType_t deviceType) -> const char* {
+            switch (deviceType) {
+                case BTRMGR_DEVICE_TYPE_HID:
+                    return "HUMAN INTERFACE DEVICE";
+                default:
+                    return "UNKNOWN";
+        }
+        }));
+        // Perform assertions on the result or any other necessary verifications
+        ASSERT_EQ(BTRMGR_RESULT_SUCCESS, mockBluetoothManagerInstance->evBluetoothHandler(eventMsg));
+    }
+
+    {
+        BTRMGR_EventMessage_t eventMsg;
+        eventMsg.m_eventType = BTRMGR_EVENT_RECEIVED_EXTERNAL_CONNECT_REQUEST;
+        strncpy(eventMsg.m_externalDevice.m_name, "Device Name", sizeof(eventMsg.m_externalDevice.m_name) - 1);
+        eventMsg.m_externalDevice.m_name[sizeof(eventMsg.m_externalDevice.m_name) - 1] = '\0';
+        eventMsg.m_externalDevice.m_deviceHandle = 123;
+        eventMsg.m_externalDevice.m_deviceType = BTRMGR_DEVICE_TYPE_HID;
+        eventMsg.m_externalDevice.m_vendorID = 456;
+        strncpy(eventMsg.m_externalDevice.m_deviceAddress, "00:11:22:33:44:55", sizeof(eventMsg.m_externalDevice.m_deviceAddress) - 1);
+        eventMsg.m_externalDevice.m_deviceAddress[sizeof(eventMsg.m_externalDevice.m_deviceAddress) - 1] = '\0';
+
+        eventMsg.m_externalDevice.m_serviceInfo.m_numOfService = 2;
+        strncpy(eventMsg.m_externalDevice.m_serviceInfo.m_profileInfo[0].m_profile, "Profile1", sizeof(eventMsg.m_externalDevice.m_serviceInfo.m_profileInfo[0].m_profile) - 1);
+        eventMsg.m_externalDevice.m_serviceInfo.m_profileInfo[0].m_profile[sizeof(eventMsg.m_externalDevice.m_serviceInfo.m_profileInfo[0].m_profile) - 1] = '\0';
+        strncpy(eventMsg.m_externalDevice.m_serviceInfo.m_profileInfo[1].m_profile, "Profile2", sizeof(eventMsg.m_externalDevice.m_serviceInfo.m_profileInfo[1].m_profile) - 1);
+        eventMsg.m_externalDevice.m_serviceInfo.m_profileInfo[1].m_profile[sizeof(eventMsg.m_externalDevice.m_serviceInfo.m_profileInfo[1].m_profile) - 1] = '\0';
+
+        EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetDeviceTypeAsString(::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Invoke([](BTRMGR_DeviceType_t deviceType) -> const char* {
+            switch (deviceType) {
+                case BTRMGR_DEVICE_TYPE_HID:
+                    return "HUMAN INTERFACE DEVICE";
+                default:
+                    return "UNKNOWN";
+        }
+        }));
+        // Perform assertions on the result or any other necessary verifications
+        ASSERT_EQ(BTRMGR_RESULT_SUCCESS, mockBluetoothManagerInstance->evBluetoothHandler(eventMsg));
+    }
+
+    {
+        BTRMGR_EventMessage_t eventMsg;
+        eventMsg.m_eventType = BTRMGR_EVENT_MEDIA_TRACK_STARTED;
+        eventMsg.m_mediaInfo.m_deviceHandle = 123;
+        eventMsg.m_mediaInfo.m_mediaPositionInfo.m_mediaPosition = 10;
+        eventMsg.m_mediaInfo.m_mediaPositionInfo.m_mediaDuration = 60;
+
+        // Perform assertions on the result or any other necessary verifications
+        ASSERT_EQ(BTRMGR_RESULT_SUCCESS, mockBluetoothManagerInstance->evBluetoothHandler(eventMsg));
+    }
+
+    {
+	BTRMGR_EventMessage_t eventMsg;
+	eventMsg.m_eventType = BTRMGR_EVENT_MEDIA_TRACK_PAUSED;
+	eventMsg.m_mediaInfo.m_deviceHandle = 123;
+	eventMsg.m_mediaInfo.m_mediaPositionInfo.m_mediaPosition = 20;
+	eventMsg.m_mediaInfo.m_mediaPositionInfo.m_mediaDuration = 60;
+	ASSERT_EQ(BTRMGR_RESULT_SUCCESS, mockBluetoothManagerInstance->evBluetoothHandler(eventMsg));
+    }
+
+    {
+	BTRMGR_EventMessage_t eventMsg;
+	eventMsg.m_eventType = BTRMGR_EVENT_MEDIA_TRACK_STOPPED;
+	eventMsg.m_mediaInfo.m_deviceHandle = 123;
+	eventMsg.m_mediaInfo.m_mediaPositionInfo.m_mediaPosition = 30;
+	eventMsg.m_mediaInfo.m_mediaPositionInfo.m_mediaDuration = 60;
+
+	ASSERT_EQ(BTRMGR_RESULT_SUCCESS, mockBluetoothManagerInstance->evBluetoothHandler(eventMsg));
+    }
+
+    {
+	BTRMGR_EventMessage_t eventMsg;
+	eventMsg.m_eventType = BTRMGR_EVENT_MEDIA_PLAYBACK_ENDED;
+	eventMsg.m_mediaInfo.m_deviceHandle = 123;
+
+	ASSERT_EQ(BTRMGR_RESULT_SUCCESS, mockBluetoothManagerInstance->evBluetoothHandler(eventMsg));
+    }
+
+    {
+        BTRMGR_EventMessage_t eventMsg;
+        eventMsg.m_eventType = BTRMGR_EVENT_MEDIA_TRACK_PLAYING;
+        eventMsg.m_mediaInfo.m_deviceHandle = 123;
+        eventMsg.m_mediaInfo.m_mediaPositionInfo.m_mediaPosition = 10;
+        eventMsg.m_mediaInfo.m_mediaPositionInfo.m_mediaDuration = 60;
+
+        ASSERT_EQ(BTRMGR_RESULT_SUCCESS, mockBluetoothManagerInstance->evBluetoothHandler(eventMsg));
+    }
+
+    {
+        BTRMGR_EventMessage_t eventMsg;
+        eventMsg.m_eventType = BTRMGR_EVENT_MEDIA_TRACK_POSITION;
+        eventMsg.m_mediaInfo.m_deviceHandle = 123;
+        eventMsg.m_mediaInfo.m_mediaPositionInfo.m_mediaPosition = 20;
+        eventMsg.m_mediaInfo.m_mediaPositionInfo.m_mediaDuration = 60;
+
+        ASSERT_EQ(BTRMGR_RESULT_SUCCESS, mockBluetoothManagerInstance->evBluetoothHandler(eventMsg));
+    }
+
+    {
+	BTRMGR_EventMessage_t eventMsg;
+	eventMsg.m_eventType = BTRMGR_EVENT_MEDIA_TRACK_CHANGED;
+	eventMsg.m_mediaInfo.m_deviceHandle = 123;
+	strncpy(eventMsg.m_mediaInfo.m_mediaTrackInfo.pcAlbum, "Album", sizeof(eventMsg.m_mediaInfo.m_mediaTrackInfo.pcAlbum) - 1);
+	eventMsg.m_mediaInfo.m_mediaTrackInfo.pcAlbum[sizeof(eventMsg.m_mediaInfo.m_mediaTrackInfo.pcAlbum) - 1] = '\0';
+	strncpy(eventMsg.m_mediaInfo.m_mediaTrackInfo.pcGenre, "Genre", sizeof(eventMsg.m_mediaInfo.m_mediaTrackInfo.pcGenre) - 1);
+	eventMsg.m_mediaInfo.m_mediaTrackInfo.pcGenre[sizeof(eventMsg.m_mediaInfo.m_mediaTrackInfo.pcGenre) - 1] = '\0';
+	strncpy(eventMsg.m_mediaInfo.m_mediaTrackInfo.pcTitle, "Title", sizeof(eventMsg.m_mediaInfo.m_mediaTrackInfo.pcTitle) - 1);
+	eventMsg.m_mediaInfo.m_mediaTrackInfo.pcTitle[sizeof(eventMsg.m_mediaInfo.m_mediaTrackInfo.pcTitle) - 1] = '\0';
+	strncpy(eventMsg.m_mediaInfo.m_mediaTrackInfo.pcArtist, "Artist", sizeof(eventMsg.m_mediaInfo.m_mediaTrackInfo.pcArtist) - 1);
+	eventMsg.m_mediaInfo.m_mediaTrackInfo.pcArtist[sizeof(eventMsg.m_mediaInfo.m_mediaTrackInfo.pcArtist) - 1] = '\0';
+	eventMsg.m_mediaInfo.m_mediaTrackInfo.ui32Duration = 180;
+	eventMsg.m_mediaInfo.m_mediaTrackInfo.ui32TrackNumber = 3;
+	eventMsg.m_mediaInfo.m_mediaTrackInfo.ui32NumberOfTracks = 10;
+
+	ASSERT_EQ(BTRMGR_RESULT_SUCCESS, mockBluetoothManagerInstance->evBluetoothHandler(eventMsg));
+    }
+
+    {
+	BTRMGR_EventMessage_t eventMsg;
+	eventMsg.m_eventType = BTRMGR_EVENT_DEVICE_FOUND;
+	eventMsg.m_pairedDevice.m_deviceHandle = 123;
+	strncpy(eventMsg.m_pairedDevice.m_name, "Device Name", sizeof(eventMsg.m_pairedDevice.m_name) - 1);
+	eventMsg.m_pairedDevice.m_name[sizeof(eventMsg.m_pairedDevice.m_name) - 1] = '\0';
+	eventMsg.m_pairedDevice.m_deviceType = BTRMGR_DEVICE_TYPE_HID;
+	eventMsg.m_pairedDevice.m_ui32DevClassBtSpec = 456;
+	eventMsg.m_pairedDevice.m_ui16DevAppearanceBleSpec = 789;
+	eventMsg.m_pairedDevice.m_isLastConnectedDevice = true;
+
+	EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetDeviceTypeAsString(::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Invoke([](BTRMGR_DeviceType_t deviceType) -> const char* {
+            switch (deviceType) {
+                case BTRMGR_DEVICE_TYPE_HID:
+                    return "HUMAN INTERFACE DEVICE";
+                default:
+                    return "UNKNOWN";
+        }
+        }));
+
+	ASSERT_EQ(BTRMGR_RESULT_SUCCESS, mockBluetoothManagerInstance->evBluetoothHandler(eventMsg));
+    }
+
+    {
+        BTRMGR_EventMessage_t eventMsg;
+	eventMsg.m_eventType = BTRMGR_EVENT_DEVICE_OUT_OF_RANGE;
+	eventMsg.m_pairedDevice.m_deviceHandle = 123;
+	strncpy(eventMsg.m_pairedDevice.m_name, "Device Name", sizeof(eventMsg.m_pairedDevice.m_name) - 1);
+	eventMsg.m_pairedDevice.m_name[sizeof(eventMsg.m_pairedDevice.m_name) - 1] = '\0';
+	eventMsg.m_pairedDevice.m_deviceType = BTRMGR_DEVICE_TYPE_HID;
+	eventMsg.m_pairedDevice.m_ui32DevClassBtSpec = 456;
+	eventMsg.m_pairedDevice.m_ui16DevAppearanceBleSpec = 789;
+	eventMsg.m_pairedDevice.m_isLastConnectedDevice = true;
+
+	EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetDeviceTypeAsString(::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Invoke([](BTRMGR_DeviceType_t deviceType) -> const char* {
+            switch (deviceType) {
+                case BTRMGR_DEVICE_TYPE_HID:
+                    return "HUMAN INTERFACE DEVICE";
+                default:
+                    return "UNKNOWN";
+        }
+        }));
+
+	ASSERT_EQ(BTRMGR_RESULT_SUCCESS, mockBluetoothManagerInstance->evBluetoothHandler(eventMsg));
+    }
+
+    {
+	BTRMGR_EventMessage_t eventMsg;
+	eventMsg.m_eventType = BTRMGR_EVENT_DEVICE_DISCOVERY_UPDATE;
+	eventMsg.m_discoveredDevice.m_deviceHandle = 123;
+	eventMsg.m_discoveredDevice.m_isDiscovered = true;
+	strncpy(eventMsg.m_discoveredDevice.m_name, "Device Name", sizeof(eventMsg.m_discoveredDevice.m_name) - 1);
+	eventMsg.m_discoveredDevice.m_name[sizeof(eventMsg.m_discoveredDevice.m_name) - 1] = '\0';
+	eventMsg.m_discoveredDevice.m_deviceType = BTRMGR_DEVICE_TYPE_HID;
+	eventMsg.m_discoveredDevice.m_ui32DevClassBtSpec = 456;
+	eventMsg.m_discoveredDevice.m_ui16DevAppearanceBleSpec = 789;
+	eventMsg.m_discoveredDevice.m_isLastConnectedDevice = true;
+	eventMsg.m_discoveredDevice.m_isPairedDevice = true;
+
+	EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetDeviceTypeAsString(::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Invoke([](BTRMGR_DeviceType_t deviceType) -> const char* {
+            switch (deviceType) {
+                case BTRMGR_DEVICE_TYPE_HID:
+                    return "HUMAN INTERFACE DEVICE";
+                default:
+                    return "UNKNOWN";
+        }
+        }));
+
+        ASSERT_EQ(BTRMGR_RESULT_SUCCESS, mockBluetoothManagerInstance->evBluetoothHandler(eventMsg));
+    }
+
+    // Test for BTRMGR_EVENT_DEVICE_MEDIA_STATUS
+    {
+        BTRMGR_EventMessage_t eventMsg;
+	eventMsg.m_eventType = BTRMGR_EVENT_DEVICE_MEDIA_STATUS;
+	eventMsg.m_mediaInfo.m_deviceHandle = 123;
+	strncpy(eventMsg.m_mediaInfo.m_name, "Device Name", sizeof(eventMsg.m_mediaInfo.m_name) - 1);
+	eventMsg.m_mediaInfo.m_name[sizeof(eventMsg.m_mediaInfo.m_name) - 1] = '\0';
+	eventMsg.m_mediaInfo.m_deviceType = BTRMGR_DEVICE_TYPE_HID;
+	eventMsg.m_mediaInfo.m_mediaDevStatus.m_ui8mediaDevVolume = 50;
+	eventMsg.m_mediaInfo.m_mediaDevStatus.m_ui8mediaDevMute = false;
+	eventMsg.m_mediaInfo.m_mediaDevStatus.m_enmediaCtrlCmd = BTRMGR_MEDIA_CTRL_VOLUMEUP;
+
+	EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetDeviceTypeAsString(::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Invoke([](BTRMGR_DeviceType_t deviceType) -> const char* {
+            switch (deviceType) {
+                case BTRMGR_DEVICE_TYPE_HID:
+                    return "HUMAN INTERFACE DEVICE";
+                default:
+                    return "UNKNOWN";
+        }
+        }));
+
+	ASSERT_EQ(BTRMGR_RESULT_SUCCESS, mockBluetoothManagerInstance->evBluetoothHandler(eventMsg));
+
+	EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetDeviceTypeAsString(::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Invoke([](BTRMGR_DeviceType_t deviceType) -> const char* {
+            switch (deviceType) {
+                case BTRMGR_DEVICE_TYPE_HID:
+                    return "HUMAN INTERFACE DEVICE";
+                default:
+                    return "UNKNOWN";
+        }
+        }));
+
+	eventMsg.m_mediaInfo.m_mediaDevStatus.m_enmediaCtrlCmd = BTRMGR_MEDIA_CTRL_VOLUMEDOWN;
+	ASSERT_EQ(BTRMGR_RESULT_SUCCESS, mockBluetoothManagerInstance->evBluetoothHandler(eventMsg));
+
+	EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetDeviceTypeAsString(::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Invoke([](BTRMGR_DeviceType_t deviceType) -> const char* {
+            switch (deviceType) {
+                case BTRMGR_DEVICE_TYPE_HID:
+                    return "HUMAN INTERFACE DEVICE";
+                default:
+                    return "UNKNOWN";
+        }
+        }));
+
+        eventMsg.m_mediaInfo.m_mediaDevStatus.m_enmediaCtrlCmd = BTRMGR_MEDIA_CTRL_MUTE;
+        ASSERT_EQ(BTRMGR_RESULT_SUCCESS, mockBluetoothManagerInstance->evBluetoothHandler(eventMsg));
+
+	EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetDeviceTypeAsString(::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Invoke([](BTRMGR_DeviceType_t deviceType) -> const char* {
+            switch (deviceType) {
+                case BTRMGR_DEVICE_TYPE_HID:
+                    return "HUMAN INTERFACE DEVICE";
+                default:
+                    return "UNKNOWN";
+        }
+        }));
+
+        eventMsg.m_mediaInfo.m_mediaDevStatus.m_enmediaCtrlCmd = BTRMGR_MEDIA_CTRL_UNMUTE;
+        ASSERT_EQ(BTRMGR_RESULT_SUCCESS, mockBluetoothManagerInstance->evBluetoothHandler(eventMsg));
+
+	EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_GetDeviceTypeAsString(::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Invoke([](BTRMGR_DeviceType_t deviceType) -> const char* {
+            switch (deviceType) {
+                case BTRMGR_DEVICE_TYPE_HID:
+                    return "HUMAN INTERFACE DEVICE";
+                default:
+                    return "UNKNOWN";
+        }
+        }));
+
+        eventMsg.m_mediaInfo.m_mediaDevStatus.m_enmediaCtrlCmd = BTRMGR_MEDIA_CTRL_UNKNOWN;
+        ASSERT_EQ(BTRMGR_RESULT_SUCCESS, mockBluetoothManagerInstance->evBluetoothHandler(eventMsg));
+    }
+
+    // Test for not implemented events
+    {
+        BTRMGR_EventMessage_t eventMsg;
+        eventMsg.m_eventType = BTRMGR_EVENT_MAX;
+        ASSERT_EQ(BTRMGR_RESULT_SUCCESS, mockBluetoothManagerInstance->evBluetoothHandler(eventMsg));
+
+        eventMsg.m_eventType = BTRMGR_EVENT_DEVICE_OP_READY;
+        ASSERT_EQ(BTRMGR_RESULT_SUCCESS, mockBluetoothManagerInstance->evBluetoothHandler(eventMsg));
+
+        eventMsg.m_eventType = BTRMGR_EVENT_DEVICE_OP_INFORMATION;
+        ASSERT_EQ(BTRMGR_RESULT_SUCCESS, mockBluetoothManagerInstance->evBluetoothHandler(eventMsg));
+
+        eventMsg.m_eventType = BTRMGR_EVENT_MEDIA_PLAYER_NAME;
+        ASSERT_EQ(BTRMGR_RESULT_SUCCESS, mockBluetoothManagerInstance->evBluetoothHandler(eventMsg));
+
+        eventMsg.m_eventType = BTRMGR_EVENT_MEDIA_PLAYER_VOLUME;
+        ASSERT_EQ(BTRMGR_RESULT_SUCCESS, mockBluetoothManagerInstance->evBluetoothHandler(eventMsg));
+
+        eventMsg.m_eventType = BTRMGR_EVENT_MEDIA_PLAYER_EQUALIZER_OFF;
+        ASSERT_EQ(BTRMGR_RESULT_SUCCESS, mockBluetoothManagerInstance->evBluetoothHandler(eventMsg));
+
+        eventMsg.m_eventType = BTRMGR_EVENT_MEDIA_PLAYER_EQUALIZER_ON;
+        ASSERT_EQ(BTRMGR_RESULT_SUCCESS, mockBluetoothManagerInstance->evBluetoothHandler(eventMsg));
+
+        eventMsg.m_eventType = BTRMGR_EVENT_MEDIA_PLAYER_SHUFFLE_OFF;
+        ASSERT_EQ(BTRMGR_RESULT_SUCCESS, mockBluetoothManagerInstance->evBluetoothHandler(eventMsg));
+
+        eventMsg.m_eventType = BTRMGR_EVENT_MEDIA_PLAYER_SHUFFLE_ALLTRACKS;
+        ASSERT_EQ(BTRMGR_RESULT_SUCCESS, mockBluetoothManagerInstance->evBluetoothHandler(eventMsg));
+
+        eventMsg.m_eventType = BTRMGR_EVENT_MEDIA_PLAYER_SHUFFLE_GROUP;
+        ASSERT_EQ(BTRMGR_RESULT_SUCCESS, mockBluetoothManagerInstance->evBluetoothHandler(eventMsg));
+
+        eventMsg.m_eventType = BTRMGR_EVENT_MEDIA_PLAYER_REPEAT_OFF;
+        ASSERT_EQ(BTRMGR_RESULT_SUCCESS, mockBluetoothManagerInstance->evBluetoothHandler(eventMsg));
+
+        eventMsg.m_eventType = BTRMGR_EVENT_MEDIA_PLAYER_REPEAT_SINGLETRACK;
+        ASSERT_EQ(BTRMGR_RESULT_SUCCESS, mockBluetoothManagerInstance->evBluetoothHandler(eventMsg));
+
+        eventMsg.m_eventType = BTRMGR_EVENT_MEDIA_PLAYER_REPEAT_ALLTRACKS;
+        ASSERT_EQ(BTRMGR_RESULT_SUCCESS, mockBluetoothManagerInstance->evBluetoothHandler(eventMsg));
+
+        eventMsg.m_eventType = BTRMGR_EVENT_MEDIA_PLAYER_REPEAT_GROUP;
+        ASSERT_EQ(BTRMGR_RESULT_SUCCESS, mockBluetoothManagerInstance->evBluetoothHandler(eventMsg));
+
+        eventMsg.m_eventType = BTRMGR_EVENT_MEDIA_ALBUM_INFO;
+        ASSERT_EQ(BTRMGR_RESULT_SUCCESS, mockBluetoothManagerInstance->evBluetoothHandler(eventMsg));
+
+        eventMsg.m_eventType = BTRMGR_EVENT_MEDIA_ARTIST_INFO;
+        ASSERT_EQ(BTRMGR_RESULT_SUCCESS, mockBluetoothManagerInstance->evBluetoothHandler(eventMsg));
+
+        eventMsg.m_eventType = BTRMGR_EVENT_MEDIA_GENRE_INFO;
+        ASSERT_EQ(BTRMGR_RESULT_SUCCESS, mockBluetoothManagerInstance->evBluetoothHandler(eventMsg));
+
+        eventMsg.m_eventType = BTRMGR_EVENT_MEDIA_COMPILATION_INFO;
+        ASSERT_EQ(BTRMGR_RESULT_SUCCESS, mockBluetoothManagerInstance->evBluetoothHandler(eventMsg));
+
+        eventMsg.m_eventType = BTRMGR_EVENT_MEDIA_PLAYLIST_INFO;
+        ASSERT_EQ(BTRMGR_RESULT_SUCCESS, mockBluetoothManagerInstance->evBluetoothHandler(eventMsg));
+
+        eventMsg.m_eventType = BTRMGR_EVENT_MEDIA_TRACKLIST_INFO;
+        ASSERT_EQ(BTRMGR_RESULT_SUCCESS, mockBluetoothManagerInstance->evBluetoothHandler(eventMsg));
+    }
+}

--- a/Tests/mocks/BluetoothMgr.h
+++ b/Tests/mocks/BluetoothMgr.h
@@ -1,0 +1,1325 @@
+/*
+ * If not stated otherwise in this file or this component's Licenses.txt file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2016 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+#ifndef __BTR_MGR_H__
+#define __BTR_MGR_H__
+/**
+ * @file btmgr.h
+ *
+ * @defgroup BTR_MGR Bluetooth Manager
+ *
+ * Bluetooth Manager (An RDK component) interfaces with BlueZ through the D-Bus API,
+ * so there is no direct linking of the BlueZ library with Bluetooth Manager.
+ * Bluetooth manager provides an interface to port any Bluetooth stack on RDK
+ * The Bluetooth manager daemon manages Bluetooth services in RDK.
+ * It uses IARM Bus to facilitate communication between the application and Bluetooth driver
+ * through Bluetooth Manager component.
+ * @ingroup  Bluetooth
+ *
+ * @defgroup BTR_MGR_API Bluetooth Manager Data Types and API(s)
+ * This file provides the data types and API(s) used by the bluetooth manager.
+ * @ingroup  BTR_MGR
+ *
+ */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+/**
+ * @addtogroup BTR_MGR_API
+ * @{
+ */
+#define BTRMGR_MAX_STR_LEN                  256
+#define BTRMGR_NAME_LEN_MAX                 64
+#define BTRMGR_STR_LEN                      32
+#define BTRMGR_DEVICE_COUNT_MAX             32
+#define BTRMGR_DISCOVERED_DEVICE_COUNT_MAX  128
+#define BTRMGR_LE_DEVICE_COUNT_MAX          BTRMGR_DEVICE_COUNT_MAX / 3
+#define BTRMGR_ADAPTER_COUNT_MAX            16
+#define BTRMGR_MAX_DEVICE_PROFILE           32
+#define BTRMGR_LE_FLAG_LIST_SIZE            10
+#define BTRMGR_MEDIA_ELEMENT_COUNT_MAX      64
+#define BTRMGR_DEVICE_MAC_LEN               6
+#define BTRMGR_MAX_DEV_OP_DATA_LEN          BTRMGR_MAX_STR_LEN * 3
+#define BTRMGR_SERVICE_DATA_LEN_MAX         32
+#define BTRMGR_UUID_STR_LEN_MAX             64
+#define BTRMGR_SERIAL_NUM_LEN               12
+#define BTRMGR_DEVICE_INFORMATION_UUID      "0x180a"
+#define BTRMGR_RDKDIAGNOSTICS_UUID          "0xFDB9"
+#define BTRMGR_COLUMBO_UUID                 "64d9f574-7756-4ebc-9ebe-ed5f7f2871ab"
+#define BTRMGR_XBOX_ELITE_PRODUCT_ID         0x0B05
+#define BTRMGR_XBOX_ELITE_VENDOR_ID          0x045E
+#define BTRMGR_SONY_PS_VENDOR_ID             0x054c
+#define BTRMGR_SONY_PS_PRODUCT_ID_1          0x05c4
+#define BTRMGR_SONY_PS_PRODUCT_ID_2          0x09cc
+#define BTRMGR_XBOX_GAMESIR_PRODUCT_ID       0x0402
+#define BTRMGR_XBOX_GAMESIR_VENDOR_ID        0x1949
+#define BTRMGR_NINTENDO_GAMESIR_PRODUCT_ID   0x2009
+#define BTRMGR_NINTENDO_GAMESIR_VENDOR_ID    0x057E
+#define BTRMGR_HID_GAMEPAD_LE_APPEARANCE     0x3C4
+#define BTRMGR_XBOX_ELITE_DEFAULT_FIRMWARE   0x0407
+#define BTRMGR_SYSTEM_ID_UUID               "0x2a23"
+#define BTRMGR_MODEL_NUMBER_UUID            "0x2a24"
+#define BTRMGR_SERIAL_NUMBER_UUID           "0x2a25"
+#define BTRMGR_FIRMWARE_REVISION_UUID       "0x2a26"
+#define BTRMGR_HARDWARE_REVISION_UUID       "0x2a27"
+#define BTRMGR_SOFTWARE_REVISION_UUID       "0x2a28"
+#define BTRMGR_MANUFACTURER_NAME_UUID       "0x2a29"
+#define BTRMGR_DEVICE_STATUS_UUID               "1f113f2c-cc01-4f03-9c5c-4b273ed631bb"
+#define BTRMGR_FWDOWNLOAD_STATUS_UUID           "915f96a6-3788-4271-a7ea-6820e98896b8"
+#define BTRMGR_WEBPA_STATUS_UUID                "9d5d3aae-51e3-4767-a055-59febd71de9d"
+#define BTRMGR_WIFIRADIO1_STATUS_UUID           "59a99d5a-3d2f-4265-af13-316c7c76b1f0"
+#define BTRMGR_WIFIRADIO2_STATUS_UUID           "9d6cf473-4fa6-4868-bf2b-c310f38df0c8"
+#define BTRMGR_RF_STATUS_UUID                   "91b9497e-634c-408a-9f77-8375b1461b8b"
+#define BTRMGR_COLUMBO_START                    "7c3fea2e-c082-4e17-b78b-1e69ca3889b9"
+#define BTRMGR_COLUMBO_STOP                     "5a7e479b-9fac-4d73-b5b0-906669946720"
+#define BTRMGR_COLUMBO_STATUS                   "26f05ee1-cefa-460d-8985-98c0dc078d6c"
+#define BTRMGR_COLUMBO_REPORT                   "c1e62616-b4de-4f72-86ca-9d9469041b6d"
+#define BTRMGR_DEVICE_MAC                       "device_mac"
+#define BTRMGR_WIFI_CONNECT_DUMMY_UUID          "4ffab12b-e545-1baf-1dc6-bd3fd749716a"
+#define BTRMGR_WIFI_SSID_DUMMY_UUID             "22d68435-f7af-1156-b2e2-c7d17211b026"
+#define BTRMGR_WIFI_PWD_DUMMY_UUID              "6bfebfe7-294d-2f4e-a4b3-b04f2a66f2f0"
+#define BTRMGR_WIFI_SEC_MODE_DUMMY_UUID         "112f9c72-82c1-93a3-d4fc-3dba3441b2c8"
+#define BTRMGR_LEONBRDG_SERVICE_UUID_SETUP      "8DF5AD72-9BBC-4167-BCD9-E8EB9E4D671B"
+#define BTRMGR_LEONBRDG_UUID_QR_CODE            "12984C43-3B43-4952-A387-715DCF9795C6"
+#define BTRMGR_LEONBRDG_UUID_PROVISION_STATUS   "79DEFBC1-EB45-448D-9F2A-1ECC3A47A242"
+#define BTRMGR_LEONBRDG_UUID_PUBLIC_KEY         "CB9FEE4D-C6ED-48C1-AB46-C3F2DA38EEDD"
+#define BTRMGR_LEONBRDG_UUID_WIFI_CONFIG        "B87A896B-4052-4CAB-A7E7-A71594D9C353"
+#define BTRMGR_LEONBRDG_UUID_SSID_LIST          "AAF92F88-7F35-48F1-9C3E-1FE5C3978B7A"
+#define BTRMGR_DEBUG_DIRECTORY "/tmp/btrMgr_DebugArtifacts"
+typedef unsigned long long int BTRMgrDeviceHandle;
+typedef unsigned long long int BTRMgrMediaElementHandle;
+/**
+ * @brief Represents the status of the operation.
+ */
+typedef enum _BTRMGR_Result_t {
+    BTRMGR_RESULT_SUCCESS = 0,
+    BTRMGR_RESULT_GENERIC_FAILURE = -1,
+    BTRMGR_RESULT_INVALID_INPUT = -2,
+    BTRMGR_RESULT_INIT_FAILED = -3
+} BTRMGR_Result_t;
+/**
+ * @brief Represents the event status.
+ */
+typedef enum _BTRMGR_Events_t {
+    BTRMGR_EVENT_DEVICE_OUT_OF_RANGE = 100,
+    BTRMGR_EVENT_DEVICE_DISCOVERY_UPDATE,
+    BTRMGR_EVENT_DEVICE_DISCOVERY_COMPLETE,
+    BTRMGR_EVENT_DEVICE_PAIRING_COMPLETE,
+    BTRMGR_EVENT_DEVICE_UNPAIRING_COMPLETE,
+    BTRMGR_EVENT_DEVICE_CONNECTION_COMPLETE,
+    BTRMGR_EVENT_DEVICE_DISCONNECT_COMPLETE,
+    BTRMGR_EVENT_DEVICE_PAIRING_FAILED,
+    BTRMGR_EVENT_DEVICE_UNPAIRING_FAILED,
+    BTRMGR_EVENT_DEVICE_CONNECTION_FAILED,
+    BTRMGR_EVENT_DEVICE_DISCONNECT_FAILED,
+    BTRMGR_EVENT_RECEIVED_EXTERNAL_PAIR_REQUEST,
+    BTRMGR_EVENT_RECEIVED_EXTERNAL_CONNECT_REQUEST,
+    BTRMGR_EVENT_RECEIVED_EXTERNAL_PLAYBACK_REQUEST,
+    BTRMGR_EVENT_DEVICE_FOUND,
+    BTRMGR_EVENT_MEDIA_TRACK_STARTED,
+    BTRMGR_EVENT_MEDIA_TRACK_PLAYING,
+    BTRMGR_EVENT_MEDIA_TRACK_PAUSED,
+    BTRMGR_EVENT_MEDIA_TRACK_STOPPED,
+    BTRMGR_EVENT_MEDIA_TRACK_POSITION,
+    BTRMGR_EVENT_MEDIA_TRACK_CHANGED,
+    BTRMGR_EVENT_MEDIA_PLAYBACK_ENDED,
+    BTRMGR_EVENT_DEVICE_DISCOVERY_STARTED,
+    BTRMGR_EVENT_DEVICE_OP_READY,
+    BTRMGR_EVENT_DEVICE_OP_INFORMATION,
+    BTRMGR_EVENT_MEDIA_PLAYER_NAME,
+    BTRMGR_EVENT_MEDIA_PLAYER_VOLUME,
+    BTRMGR_EVENT_MEDIA_PLAYER_DELAY,
+    BTRMGR_EVENT_MEDIA_PLAYER_EQUALIZER_OFF,
+    BTRMGR_EVENT_MEDIA_PLAYER_EQUALIZER_ON,
+    BTRMGR_EVENT_MEDIA_PLAYER_SHUFFLE_OFF,
+    BTRMGR_EVENT_MEDIA_PLAYER_SHUFFLE_ALLTRACKS,
+    BTRMGR_EVENT_MEDIA_PLAYER_SHUFFLE_GROUP,
+    BTRMGR_EVENT_MEDIA_PLAYER_REPEAT_OFF,
+    BTRMGR_EVENT_MEDIA_PLAYER_REPEAT_SINGLETRACK,
+    BTRMGR_EVENT_MEDIA_PLAYER_REPEAT_ALLTRACKS,
+    BTRMGR_EVENT_MEDIA_PLAYER_REPEAT_GROUP,
+    BTRMGR_EVENT_MEDIA_ALBUM_INFO,
+    BTRMGR_EVENT_MEDIA_ARTIST_INFO,
+    BTRMGR_EVENT_MEDIA_GENRE_INFO,
+    BTRMGR_EVENT_MEDIA_COMPILATION_INFO,
+    BTRMGR_EVENT_MEDIA_PLAYLIST_INFO,
+    BTRMGR_EVENT_MEDIA_TRACKLIST_INFO,
+    BTRMGR_EVENT_MEDIA_TRACK_INFO,
+    BTRMGR_EVENT_MEDIA_PLAYER_MUTE,
+    BTRMGR_EVENT_MEDIA_PLAYER_UNMUTE,
+    BTRMGR_EVENT_DEVICE_MEDIA_STATUS,
+    BTRMGR_EVENT_BATTERY_INFO,
+    BTRMGR_EVENT_MAX
+} BTRMGR_Events_t;
+/**
+ * @brief Represents the bluetooth device types.
+ */
+typedef enum _BTRMGR_DeviceType_t {
+    BTRMGR_DEVICE_TYPE_UNKNOWN,
+    BTRMGR_DEVICE_TYPE_WEARABLE_HEADSET,
+    BTRMGR_DEVICE_TYPE_HANDSFREE,
+    BTRMGR_DEVICE_TYPE_RESERVED,
+    BTRMGR_DEVICE_TYPE_MICROPHONE,
+    BTRMGR_DEVICE_TYPE_LOUDSPEAKER,
+    BTRMGR_DEVICE_TYPE_HEADPHONES,
+    BTRMGR_DEVICE_TYPE_PORTABLE_AUDIO,
+    BTRMGR_DEVICE_TYPE_CAR_AUDIO,
+    BTRMGR_DEVICE_TYPE_STB,
+    BTRMGR_DEVICE_TYPE_HIFI_AUDIO_DEVICE,
+    BTRMGR_DEVICE_TYPE_VCR,
+    BTRMGR_DEVICE_TYPE_VIDEO_CAMERA,
+    BTRMGR_DEVICE_TYPE_CAMCODER,
+    BTRMGR_DEVICE_TYPE_VIDEO_MONITOR,
+    BTRMGR_DEVICE_TYPE_TV,
+    BTRMGR_DEVICE_TYPE_VIDEO_CONFERENCE,
+    BTRMGR_DEVICE_TYPE_SMARTPHONE,
+    BTRMGR_DEVICE_TYPE_TABLET,
+    // LE
+    BTRMGR_DEVICE_TYPE_TILE,
+    BTRMGR_DEVICE_TYPE_XBB,
+    BTRMGR_DEVICE_TYPE_HID,
+    BTRMGR_DEVICE_TYPE_HID_GAMEPAD,
+    BTRMGR_DEVICE_TYPE_END
+} BTRMGR_DeviceType_t;
+/**
+ * @brief Represents the stream output types.
+ */
+typedef enum _BTRMGR_StreamOut_Type_t {
+    BTRMGR_STREAM_PRIMARY = 0,
+    BTRMGR_STREAM_AUXILIARY
+} BTRMGR_StreamOut_Type_t;
+/**
+ * @brief Represents the operation type for bluetooth device.
+ */
+typedef enum _BTRMGR_DeviceOperationType_t {
+    BTRMGR_DEVICE_OP_TYPE_AUDIO_OUTPUT  = 1 << 0,
+    BTRMGR_DEVICE_OP_TYPE_AUDIO_INPUT   = 1 << 1,
+    BTRMGR_DEVICE_OP_TYPE_LE            = 1 << 2,
+    BTRMGR_DEVICE_OP_TYPE_HID           = 1 << 3,
+    BTRMGR_DEVICE_OP_TYPE_UNKNOWN       = 1 << 4,
+    BTRMGR_DEVICE_OP_TYPE_AUDIO_AND_HID = (1 << 0) | (1 << 3) //combined type for scanning
+} BTRMGR_DeviceOperationType_t;
+/**
+ * @brief Represents the bluetooth power states.
+ */
+typedef enum _BTRMGR_DevicePower_t {
+    BTRMGR_DEVICE_POWER_ACTIVE = 1,
+    BTRMGR_DEVICE_POWER_LOW,
+    BTRMGR_DEVICE_POWER_STANDBY
+} BTRMGR_DevicePower_t;
+/**
+ * @brief Represents the bluetooth signal strength
+ */
+typedef enum _BTRMGR_RSSIValue_type_t {
+    BTRMGR_RSSI_NONE = 0,      //!< No signal (0 bar)
+    BTRMGR_RSSI_POOR,          //!< Poor (1 bar)
+    BTRMGR_RSSI_FAIR,          //!< Fair (2 bars)
+    BTRMGR_RSSI_GOOD,          //!< Good (3 bars)
+    BTRMGR_RSSI_EXCELLENT      //!< Excellent (4 bars)
+} BTRMGR_RSSIValue_t;
+/**
+ * @brief Represents the bluetooth Discovery Status
+ */
+typedef enum _BTRMGR_DiscoveryStatus_t {
+    BTRMGR_DISCOVERY_STATUS_OFF,
+    BTRMGR_DISCOVERY_STATUS_IN_PROGRESS,
+} BTRMGR_DiscoveryStatus_t;
+/**
+ * @brief Represents the commands to control the media files.
+ */
+typedef enum _BTRMGR_MediaControlCommand_t {
+    BTRMGR_MEDIA_CTRL_PLAY,
+    BTRMGR_MEDIA_CTRL_PAUSE,
+    BTRMGR_MEDIA_CTRL_STOP,
+    BTRMGR_MEDIA_CTRL_NEXT,
+    BTRMGR_MEDIA_CTRL_PREVIOUS,
+    BTRMGR_MEDIA_CTRL_FASTFORWARD,
+    BTRMGR_MEDIA_CTRL_REWIND,
+    BTRMGR_MEDIA_CTRL_VOLUMEUP,
+    BTRMGR_MEDIA_CTRL_VOLUMEDOWN,
+    BTRMGR_MEDIA_CTRL_EQUALIZER_OFF,
+    BTRMGR_MEDIA_CTRL_EQUALIZER_ON,
+    BTRMGR_MEDIA_CTRL_SHUFFLE_OFF,
+    BTRMGR_MEDIA_CTRL_SHUFFLE_ALLTRACKS,
+    BTRMGR_MEDIA_CTRL_SHUFFLE_GROUP,
+    BTRMGR_MEDIA_CTRL_REPEAT_OFF,
+    BTRMGR_MEDIA_CTRL_REPEAT_SINGLETRACK,
+    BTRMGR_MEDIA_CTRL_REPEAT_ALLTRACKS,
+    BTRMGR_MEDIA_CTRL_REPEAT_GROUP,
+    BTRMGR_MEDIA_CTRL_SCAN_OFF,
+    BTRMGR_MEDIA_CTRL_SCAN_ALLTRACKS,
+    BTRMGR_MEDIA_CTRL_SCAN_GROUP,
+    BTRMGR_MEDIA_CTRL_MUTE,
+    BTRMGR_MEDIA_CTRL_UNMUTE,
+    BTRMGR_MEDIA_CTRL_UNKNOWN
+} BTRMGR_MediaControlCommand_t;
+/**
+ * @brief Represents LE properties.
+ */
+typedef enum _BTRMGR_LeProperty_t {  // looking for a better enum name
+    BTRMGR_LE_PROP_UUID,
+    BTRMGR_LE_PROP_PRIMARY,
+    BTRMGR_LE_PROP_DEVICE,
+    BTRMGR_LE_PROP_SERVICE,
+    BTRMGR_LE_PROP_VALUE,
+    BTRMGR_LE_PROP_NOTIFY,
+    BTRMGR_LE_PROP_FLAGS,
+    BTRMGR_LE_PROP_CHAR,
+    BTRMGR_LE_PROP_DESC
+} BTRMGR_LeProperty_t;
+/**
+ * @brief Represents the Low energy operations.
+ */
+typedef enum _BTRMGR_LeOp_t {
+    BTRMGR_LE_OP_READY,
+    BTRMGR_LE_OP_READ_VALUE,
+    BTRMGR_LE_OP_WRITE_VALUE,
+    BTRMGR_LE_OP_START_NOTIFY,
+    BTRMGR_LE_OP_STOP_NOTIFY,
+    BTRMGR_LE_OP_UNKNOWN
+} BTRMGR_LeOp_t;
+/**
+ * @brief Represents Gatt Characteristic Flags.
+ */
+typedef enum _BTRMGR_GattCharFlags_t {
+    BTRMGR_GATT_CHAR_FLAG_READ                         = 1 << 0,
+    BTRMGR_GATT_CHAR_FLAG_WRITE                        = 1 << 1,
+    BTRMGR_GATT_CHAR_FLAG_ENCRYPT_READ                 = 1 << 2,
+    BTRMGR_GATT_CHAR_FLAG_ENCRYPT_WRITE                = 1 << 3,
+    BTRMGR_GATT_CHAR_FLAG_ENCRYPT_AUTHENTICATED_READ   = 1 << 4,
+    BTRMGR_GATT_CHAR_FLAG_ENCRYPT_AUTHENTICATED_WRITE  = 1 << 5,
+    BTRMGR_GATT_CHAR_FLAG_SECURE_READ                  = 1 << 6,
+    BTRMGR_GATT_CHAR_FLAG_SECURE_WRITE                 = 1 << 7,
+    BTRMGR_GATT_CHAR_FLAG_NOTIFY                       = 1 << 8,
+    BTRMGR_GATT_CHAR_FLAG_INDICATE                     = 1 << 9,
+    BTRMGR_GATT_CHAR_FLAG_BROADCAST                    = 1 << 10,
+    BTRMGR_GATT_CHAR_FLAG_WRITE_WITHOUT_RESPONSE       = 1 << 11,
+    BTRMGR_GATT_CHAR_FLAG_AUTHENTICATED_SIGNED_WRITES  = 1 << 12,
+    BTRMGR_GATT_CHAR_FLAG_RELIABLE_WRITE               = 1 << 13,
+    BTRMGR_GATT_CHAR_FLAG_WRITABLE_AUXILIARIES         = 1 << 14
+} BTRMGR_GattCharFlags_t;
+typedef enum _BTRMGR_ScanFilter_t {
+    BTRMGR_DISCOVERY_FILTER_UUID,
+    BTRMGR_DISCOVERY_FILTER_RSSI,
+    BTRMGR_DISCOVERY_FILTER_PATH_LOSS,
+    BTRMGR_DISCOVERY_FILTER_SCAN_TYPE
+} BTRMGR_ScanFilter_t;
+/**
+ * @brief Represents Media Element Types.
+ */
+typedef enum _BTRMGR_MediaElementType_t {
+    BTRMGR_MEDIA_ELEMENT_TYPE_UNKNOWN,
+    BTRMGR_MEDIA_ELEMENT_TYPE_ALBUM,
+    BTRMGR_MEDIA_ELEMENT_TYPE_ARTIST,
+    BTRMGR_MEDIA_ELEMENT_TYPE_GENRE,
+    BTRMGR_MEDIA_ELEMENT_TYPE_COMPILATIONS,
+    BTRMGR_MEDIA_ELEMENT_TYPE_PLAYLIST,
+    BTRMGR_MEDIA_ELEMENT_TYPE_TRACKLIST,
+    BTRMGR_MEDIA_ELEMENT_TYPE_TRACK
+} BTRMGR_MediaElementType_t;
+typedef enum _eBTRMGRDevMediaType_t {
+    BTRMGR_DEV_MEDIA_TYPE_PCM,
+    BTRMGR_DEV_MEDIA_TYPE_SBC,
+    BTRMGR_DEV_MEDIA_TYPE_MPEG,
+    BTRMGR_DEV_MEDIA_TYPE_AAC,
+    BTRMGR_DEV_MEDIA_TYPE_Unknown
+} eBTRMGRDevMediaType_t;
+typedef enum _eBTRMGRDevMediaAChan_t {
+    BTRMGR_DEV_MEDIA_CHANNEL_MONO,
+    BTRMGR_DEV_MEDIA_CHANNEL_DUAL,
+    BTRMGR_DEV_MEDIA_CHANNEL_STEREO,
+    BTRMGR_DEV_MEDIA_CHANNEL_JOINT_STEREO,
+    BTRMGR_DEV_MEDIA_CHANNEL_5_1,
+    BTRMGR_DEV_MEDIA_CHANNEL_7_1,
+    BTRMGR_DEV_MEDIA_CHANNEL_UNKNOWN
+} eBTRMGRDevMediaAChan_t;
+/**
+ * @brief Represents the media track info.
+ */
+typedef struct _BTRMGR_MediaTrackInfo_t {
+    char            pcAlbum[BTRMGR_MAX_STR_LEN];
+    char            pcGenre[BTRMGR_MAX_STR_LEN];
+    char            pcTitle[BTRMGR_MAX_STR_LEN];
+    char            pcArtist[BTRMGR_MAX_STR_LEN];
+    unsigned int    ui32TrackNumber;
+    unsigned int    ui32Duration;
+    unsigned int    ui32NumberOfTracks;
+} BTRMGR_MediaTrackInfo_t;
+/**
+ * @brief Represents the media position info.
+ */
+typedef struct _BTRMGR_MediaPositionInfo_t {
+    unsigned int          m_mediaDuration;
+    unsigned int          m_mediaPosition;
+} BTRMGR_MediaPositionInfo_t;
+typedef struct _BTRMGR_LeUUID_t {
+    unsigned short  flags;
+    char            m_uuid[BTRMGR_NAME_LEN_MAX];
+} BTRMGR_LeUUID_t;
+/**
+ * @brief Represents the supported service of the device.
+ */
+typedef struct _BTRMGR_DeviceService_t {
+    unsigned short  m_uuid;
+    char            m_profile[BTRMGR_NAME_LEN_MAX];
+} BTRMGR_DeviceService_t;
+/**
+ * @brief Represents device services list.
+ */
+typedef struct _BTRMGR_DeviceServiceList_t {
+    unsigned short          m_numOfService;
+    union { /* have introduced BTRMGR_LeUUID_t inorder that the usage of BTRMGR_DeviceService_t shouldn't be confused
+               if BTRMGR_DeviceService_t  alone is sufficient, then lets change in the next commit */
+        BTRMGR_DeviceService_t  m_profileInfo[BTRMGR_MAX_DEVICE_PROFILE];
+        BTRMGR_LeUUID_t         m_uuidInfo[BTRMGR_MAX_DEVICE_PROFILE];
+    };
+} BTRMGR_DeviceServiceList_t;
+typedef struct _BTRMGR_DeviceAdServiceData_t {
+    char            m_UUIDs[BTRMGR_UUID_STR_LEN_MAX];;
+    unsigned char   m_ServiceData[BTRMGR_SERVICE_DATA_LEN_MAX];
+    unsigned int    m_len;
+} BTRMGR_DeviceAdServiceData_t;
+/**
+ * @brief Represents the property of the device.
+ */
+typedef struct _BTRMGR_DevicesProperty_t {
+    BTRMgrDeviceHandle          m_deviceHandle;
+    BTRMGR_DeviceType_t         m_deviceType;
+    char                        m_name [BTRMGR_NAME_LEN_MAX];
+    char                        m_deviceAddress [BTRMGR_NAME_LEN_MAX];
+    int                         m_rssi;
+    BTRMGR_RSSIValue_t          m_signalLevel;
+    unsigned short              m_vendorID;
+    unsigned char               m_isPaired;
+    unsigned char               m_isConnected; /* This must be used only when m_isPaired is TRUE */
+    unsigned char               m_isLowEnergyDevice;
+    unsigned char               m_batteryLevel;
+    BTRMGR_DeviceServiceList_t  m_serviceInfo;
+    BTRMGR_DeviceAdServiceData_t m_adServiceData[BTRMGR_MAX_DEVICE_PROFILE];
+    char                        m_modalias[BTRMGR_NAME_LEN_MAX/2];
+    char                        m_firmwareRevision[BTRMGR_NAME_LEN_MAX/2];
+} BTRMGR_DevicesProperty_t;
+/**
+ * @brief Represents the details of device connected.
+ */
+typedef struct _BTRMGR_ConnectedDevice_t {
+    BTRMgrDeviceHandle          m_deviceHandle;
+    BTRMGR_DeviceType_t         m_deviceType;
+    char                        m_name [BTRMGR_NAME_LEN_MAX];
+    char                        m_deviceAddress [BTRMGR_NAME_LEN_MAX];
+    BTRMGR_DeviceServiceList_t  m_serviceInfo;
+    unsigned short              m_vendorID;
+    unsigned char               m_isLowEnergyDevice;
+    unsigned char               m_isConnected; /* This must be used only when m_isPaired is TRUE */
+    BTRMGR_DevicePower_t        m_powerStatus;
+    unsigned int                m_ui32DevClassBtSpec;
+    unsigned short              m_ui16DevAppearanceBleSpec;
+} BTRMGR_ConnectedDevice_t;
+/**
+ * @brief Represents the paired devices information.
+ */
+typedef struct _BTRMGR_PairedDevices_t {
+    BTRMgrDeviceHandle          m_deviceHandle;
+    BTRMGR_DeviceType_t         m_deviceType;
+    char                        m_name [BTRMGR_NAME_LEN_MAX];
+    char                        m_deviceAddress [BTRMGR_NAME_LEN_MAX];
+    BTRMGR_DeviceServiceList_t  m_serviceInfo;
+    unsigned short              m_vendorID;
+    unsigned char               m_isLowEnergyDevice;
+    unsigned char               m_isConnected; /* This must be used only when m_isPaired is TRUE */
+    unsigned char               m_isLastConnectedDevice;
+    unsigned int                m_ui32DevClassBtSpec;
+    unsigned short              m_ui16DevAppearanceBleSpec;
+} BTRMGR_PairedDevices_t;
+/**
+ * @brief Represents the discovered device's details.
+ */
+typedef struct _BTRMGR_DiscoveredDevices_t {
+    BTRMgrDeviceHandle  m_deviceHandle;
+    BTRMGR_DeviceType_t m_deviceType;
+    char                m_name [BTRMGR_NAME_LEN_MAX];
+    char                m_deviceAddress [BTRMGR_NAME_LEN_MAX];
+    unsigned short      m_vendorID;
+    unsigned char       m_isPairedDevice;
+    unsigned char       m_isConnected; /* This must be used only when m_isPaired is TRUE */
+    unsigned char       m_isLowEnergyDevice;
+    int                 m_rssi;
+    BTRMGR_RSSIValue_t  m_signalLevel;
+    unsigned char       m_isDiscovered;
+    unsigned char       m_isLastConnectedDevice;
+    unsigned int        m_ui32DevClassBtSpec;
+    unsigned short      m_ui16DevAppearanceBleSpec;
+} BTRMGR_DiscoveredDevices_t;
+/**
+ * @brief Represents the connected devices list.
+ */
+typedef struct _BTRMGR_ConnectedDevicesList_t {
+    unsigned short              m_numOfDevices;
+    BTRMGR_ConnectedDevice_t    m_deviceProperty[BTRMGR_DEVICE_COUNT_MAX];
+} BTRMGR_ConnectedDevicesList_t;
+/**
+ * @brief Represents the list of paired devices.
+ */
+typedef struct _BTRMGR_PairedDevicesList_t {
+    unsigned short          m_numOfDevices;
+    BTRMGR_PairedDevices_t  m_deviceProperty[BTRMGR_DEVICE_COUNT_MAX];
+} BTRMGR_PairedDevicesList_t;
+/**
+ * @brief Represents the list of scanned devices.
+ */
+typedef struct _BTRMGR_DiscoveredDevicesList_t {
+    unsigned short              m_numOfDevices;
+    BTRMGR_DiscoveredDevices_t  m_deviceProperty[BTRMGR_DISCOVERED_DEVICE_COUNT_MAX];
+} BTRMGR_DiscoveredDevicesList_t;
+/**
+ * @brief Represents the details of external devices connected.
+ */
+typedef struct _BTRMGR_ExternalDevice_t {
+    BTRMgrDeviceHandle          m_deviceHandle;
+    BTRMGR_DeviceType_t         m_deviceType;
+    char                        m_name [BTRMGR_NAME_LEN_MAX];
+    char                        m_deviceAddress [BTRMGR_NAME_LEN_MAX];
+    BTRMGR_DeviceServiceList_t  m_serviceInfo;
+    unsigned short              m_vendorID;
+    unsigned char               m_isLowEnergyDevice;
+    unsigned int                m_externalDevicePIN;
+    unsigned char               m_requestConfirmation;
+} BTRMGR_ExternalDevice_t;
+/**
+ * @brief Represents Media Element details.
+ */
+typedef struct _BTRMGR_MediaElementInfo_t {
+    BTRMgrMediaElementHandle    m_mediaElementHdl;
+    unsigned char               m_IsPlayable;
+    char                        m_mediaElementName[BTRMGR_MAX_STR_LEN];
+    BTRMGR_MediaTrackInfo_t     m_mediaTrackInfo;
+} BTRMGR_MediaElementInfo_t;
+/**
+  * @brief Represents Media Element List.
+ */
+typedef struct _BTRMGR_MediaElementListInfo_t {
+    unsigned short              m_numberOfElements;
+    BTRMGR_MediaElementInfo_t   m_mediaElementInfo[BTRMGR_MEDIA_ELEMENT_COUNT_MAX];
+} BTRMGR_MediaElementListInfo_t;
+/**
+  * @brief Represents Media Element List.
+ */
+typedef struct _BTRMGR_MediaDeviceStatus_t {
+    unsigned char                   m_ui8mediaDevVolume;
+    unsigned char                   m_ui8mediaDevMute;
+    BTRMGR_MediaControlCommand_t    m_enmediaCtrlCmd;
+} BTRMGR_MediaDeviceStatus_t;
+/**
+ * @brief Represents the media info.
+ */
+typedef struct _BTRMGR_MediaInfo_t {
+    BTRMgrDeviceHandle     m_deviceHandle;
+    BTRMGR_DeviceType_t    m_deviceType;
+    char                   m_name [BTRMGR_NAME_LEN_MAX];
+    union {
+        BTRMGR_MediaTrackInfo_t         m_mediaTrackInfo;
+        BTRMGR_MediaPositionInfo_t      m_mediaPositionInfo;
+        BTRMGR_MediaElementListInfo_t   m_mediaAlbumListInfo;
+        BTRMGR_MediaElementListInfo_t   m_mediaArtistListInfo;
+        BTRMGR_MediaElementListInfo_t   m_mediaGenreListInfo;
+        BTRMGR_MediaElementListInfo_t   m_mediaCompilationInfo;
+        BTRMGR_MediaElementListInfo_t   m_mediaPlayListInfo;
+        BTRMGR_MediaElementListInfo_t   m_mediaTrackListInfo;
+        char                            m_mediaPlayerName[BTRMGR_MAX_STR_LEN];
+        unsigned char                   m_mediaPlayerVolume;
+        unsigned short                  m_mediaPlayerDelay;
+        BTRMGR_MediaDeviceStatus_t      m_mediaDevStatus;
+    };
+} BTRMGR_MediaInfo_t;
+/**
+ * @brief Represents the configuration for a PCM stream.
+ */
+typedef struct _BTRMGR_MediaPCMInfo_t {
+    eBTRMGRDevMediaAChan_t  m_channelMode;
+    unsigned int            m_freq;
+    unsigned int            m_format;
+} BTRMGR_MediaPCMInfo_t;
+/**
+ * @brief Represents the configuration for a SBC stream.
+ */
+typedef struct _BTRMGR_MediaSBCInfo_t {
+    eBTRMGRDevMediaAChan_t  m_channelMode;
+    unsigned int            m_freq;
+    unsigned char           m_allocMethod;
+    unsigned char           m_subbands;
+    unsigned char           m_blockLength;
+    unsigned char           m_minBitpool;
+    unsigned char           m_maxBitpool;
+    unsigned short          m_frameLen;
+    unsigned short          m_bitrate;
+} BTRMGR_MediaSBCInfo_t;
+/**
+ * @brief Represents the configuration for a Mpeg stream.
+ */
+typedef struct _BTRMGR_MediaMPEGInfo_t {
+    eBTRMGRDevMediaAChan_t  m_channelMode;
+    unsigned int            m_freq;
+    unsigned char           m_crc;
+    unsigned char           m_layer;
+    unsigned char           m_mpf;
+    unsigned char           m_rfa;
+    unsigned short          m_frameLen;
+    unsigned short          m_bitrate;
+} BTRMGR_MediaMPEGInfo_t;
+/**
+ * @brief Represents the codec configuration for a stream.
+ */
+typedef struct _BTRMGR_MediaStreamInfo_t {
+    eBTRMGRDevMediaType_t m_codec;
+    union{
+        BTRMGR_MediaSBCInfo_t    m_sbcInfo;
+        BTRMGR_MediaMPEGInfo_t   m_mpegInfo;
+        BTRMGR_MediaPCMInfo_t    m_pcmInfo;
+    };
+} BTRMGR_MediaStreamInfo_t;
+/**
+ * @brief Represents the battery info.
+ */
+typedef struct _BTRMGR_BatteryInfo_t {
+        BTRMGR_DeviceType_t    m_deviceType;
+        char                   m_name [BTRMGR_NAME_LEN_MAX];
+        char                   m_uuid [BTRMGR_UUID_STR_LEN_MAX];
+        BTRMgrDeviceHandle     m_deviceHandle;
+        union {
+            char               m_notifyData[BTRMGR_MAX_DEV_OP_DATA_LEN];
+        };
+} BTRMGR_BatteryInfo_t;
+/**
+    * @brief Represents the notification data
+ */
+typedef struct _BTRMGR_DeviceOpInfo_t {
+    BTRMgrDeviceHandle              m_deviceHandle;
+    BTRMGR_DeviceType_t             m_deviceType;
+    BTRMGR_DeviceOperationType_t    m_deviceOpType;
+    char                            m_deviceAddress[BTRMGR_NAME_LEN_MAX];
+    char                            m_name[BTRMGR_NAME_LEN_MAX];
+    char                            m_uuid[BTRMGR_MAX_STR_LEN];
+    BTRMGR_LeOp_t                   m_leOpType;
+    union {
+        char                        m_readData[BTRMGR_MAX_DEV_OP_DATA_LEN];
+        char                        m_writeData[BTRMGR_MAX_DEV_OP_DATA_LEN];
+        char                        m_notifyData[BTRMGR_MAX_DEV_OP_DATA_LEN];
+    };
+} BTRMGR_DeviceOpInfo_t;
+/**
+ * @brief Represents the event message info.
+ */
+typedef struct _BTRMGR_EventMessage_t {
+    unsigned char   m_adapterIndex;
+    BTRMGR_Events_t m_eventType;
+    union {
+        BTRMGR_DiscoveredDevices_t  m_discoveredDevice;
+        BTRMGR_ExternalDevice_t     m_externalDevice;
+        BTRMGR_PairedDevices_t      m_pairedDevice;
+        BTRMGR_MediaInfo_t          m_mediaInfo;
+        BTRMGR_DeviceOpInfo_t       m_deviceOpInfo;
+	BTRMGR_BatteryInfo_t        m_batteryInfo;
+    };
+} BTRMGR_EventMessage_t;
+/**
+ * @brief Represents the event response.
+ */
+typedef struct _BTRMGR_EventResponse_t {
+    BTRMGR_Events_t     m_eventType;
+    BTRMgrDeviceHandle  m_deviceHandle;
+    char                m_writeData[BTRMGR_MAX_DEV_OP_DATA_LEN];
+    union {
+        unsigned char   m_eventResp;
+    };
+} BTRMGR_EventResponse_t;
+typedef struct _BTRMGR_UUID_t {
+    char**  m_uuid;
+    short   m_uuidCount;
+} BTRMGR_UUID_t;
+typedef struct _BTRMGR_DiscoveryFilterHandle_t {
+    
+    BTRMGR_UUID_t               m_btuuid;
+    int                         m_rssi;
+    int                         m_pathloss;
+    //BTRMGR_DeviceScanType_t     m_scanType;
+} BTRMGR_DiscoveryFilterHandle_t;
+/**
+ * @brief Structure for the custom advertisement payload
+ */
+typedef struct _BTRMGR_LeCustomAdvertisement_t {
+    unsigned char len_flags;
+    unsigned char type_flags;
+    unsigned char val_flags;
+    unsigned char len_comcastflags;
+    unsigned char type_comcastflags;
+    unsigned char deviceInfo_UUID_LO;
+    unsigned char deviceInfo_UUID_HI;
+    unsigned char rdk_diag_UUID_LO;
+    unsigned char rdk_diag_UUID_HI;
+    unsigned char len_manuf;
+    unsigned char type_manuf;
+    /* First two bytes must contain the manufacturer ID (little-endian order) */
+    unsigned char company_LO;
+    unsigned char company_HI;
+    unsigned short device_model;
+    unsigned char serial_number[BTRMGR_SERIAL_NUM_LEN];
+    unsigned char device_mac[BTRMGR_DEVICE_MAC_LEN];
+} BTRMGR_LeCustomAdvertisement_t;
+/* Fptr Callbacks types */
+typedef BTRMGR_Result_t (*BTRMGR_EventCallback)(BTRMGR_EventMessage_t astEventMessage);
+/* Interfaces */
+/**
+ * @brief  This API initializes the bluetooth manager.
+ *
+ * This API performs the following operations:
+ *
+ * - Initializes the bluetooth core layer.
+ * - Initialize the Paired Device List for Default adapter.
+ * - Register for callback to get the status of connected Devices.
+ * - Register for callback to get the Discovered Devices.
+ * - Register for callback to process incoming pairing requests.
+ * - Register for callback to process incoming connection requests.
+ * - Register for callback to process incoming media events.
+ * - Activates the default agent.
+ * - Initializes the persistant interface and saves all bluetooth profiles to the database.
+ *
+ * @return Returns the status of the operation.
+ * @retval BTRMGR_RESULT_SUCCESS on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_Init(void);
+/**
+ * @brief  This API invokes the deinit function of bluetooth core and persistant interface module.
+ *
+ * @return Returns the status of the operation.
+ * @retval BTRMGR_RESULT_SUCCESS on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_DeInit(void);
+/**
+ * @brief This API registers all the IARM call backs for BTRMGR and Third party Clients.
+ * 
+ * @return Returns the status of the operation.
+ * @retval BTRMGR_RESULT_SUCCESS on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_RegisterForCallbacks(const char* apcProcessName);
+/**
+ * @brief This API Unregisters all the IARM call backs for BTRMGR and Third party Clients.
+ *
+ * @return Returns the status of the operation.
+ * @retval BTRMGR_RESULT_SUCCESS on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_UnRegisterFromCallbacks(const char* apcProcessName);
+/**
+ * @brief  This API returns the number of bluetooth adapters available.
+ *
+ * @param[out] pNumOfAdapters    Indicates the number of adapters available.
+ *
+ * @return Returns the status of the operation.
+ * @retval eBTRMgrSuccess on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_GetNumberOfAdapters(unsigned char *pNumOfAdapters);
+/**
+ * @brief  This API is designed to reset the bluetooth adapter.
+ *
+ * As of now, HAL implementation is not available for this API.
+ *
+ * @param[in] aui8AdapterIdx     Index of bluetooth adapter.
+ *
+ * @return Returns the status of the operation.
+ * @retval eBTRMgrSuccess on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_ResetAdapter(unsigned char aui8AdapterIdx);
+/**
+ * @brief  This API is used to set the new name to the bluetooth adapter
+ *
+ * @param[in] aui8AdapterIdx     Index of bluetooth adapter.
+ * @param[in] pNameOfAdapter     The name to set.
+ *
+ * @return Returns the status of the operation.
+ * @retval eBTRMgrSuccess on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_SetAdapterName(unsigned char aui8AdapterIdx, const char* pNameOfAdapter);
+/**
+ * @brief  This API fetches the bluetooth adapter name.
+ *
+ * @param[in]  aui8AdapterIdx     Index of bluetooth adapter.
+ * @param[out] pNameOfAdapter     Bluetooth adapter name.
+ *
+ * @return Returns the status of the operation.
+ * @retval eBTRMgrSuccess on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_GetAdapterName(unsigned char aui8AdapterIdx, char* pNameOfAdapter);
+/**
+ * @brief  This API sets the bluetooth adapter power to ON/OFF.
+ *
+ * @param[in] aui8AdapterIdx     Index of bluetooth adapter.
+ * @param[in] power_status        Value to set the  power. 0 to OFF & 1 to ON.
+ *
+ * @return Returns the status of the operation.
+ * @retval eBTRMgrSuccess on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_SetAdapterPowerStatus(unsigned char aui8AdapterIdx, unsigned char power_status);
+/**
+ * @brief  This API fetches the power status, either 0 or 1.
+ *
+ * @param[in]  aui8AdapterIdx  Index of bluetooth adapter.
+ * @param[out] pPowerStatus    Indicates the power status.
+ *
+ * @return Returns the status of the operation.
+ * @retval eBTRMgrSuccess on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_GetAdapterPowerStatus(unsigned char aui8AdapterIdx, unsigned char *pPowerStatus);
+/**
+ * @brief  This API is to make the adapter discoverable until the given timeout.
+ *
+ * @param[in]  aui8AdapterIdx  Index of bluetooth adapter.
+ * @param[in]  discoverable    Value to turn on or off the discovery.
+ * @param[in]  timeout         Timeout to turn on discovery.
+ *
+ * @return Returns the status of the operation.
+ * @retval eBTRMgrSuccess on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_SetAdapterDiscoverable(unsigned char aui8AdapterIdx, unsigned char discoverable, int timeout);
+/**
+ * @brief  This API checks the adapter is discoverable or not.
+ *
+ * @param[in]   aui8AdapterIdx  Index of bluetooth adapter.
+ * @param[out]  pDiscoverable   Indicates discoverable or not.
+ *
+ * @return Returns the status of the operation.
+ * @retval eBTRMgrSuccess on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_IsAdapterDiscoverable(unsigned char aui8AdapterIdx, unsigned char *pDiscoverable);
+/**
+ * @brief  This API initiates the scanning process.
+ *
+ * @param[in]   aui8AdapterIdx  Index of bluetooth adapter.
+ * @param[in]   aenBTRMgrDevOpT Device operation type.
+ *
+ * @return Returns the status of the operation.
+ * @retval eBTRMgrSuccess on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_StartDeviceDiscovery(unsigned char aui8AdapterIdx, BTRMGR_DeviceOperationType_t aenBTRMgrDevOpT);
+/**
+ * @brief  This API terminates the scanning process.
+ *
+ * @param[in]   aui8AdapterIdx  Index of bluetooth adapter.
+ * @param[in]   aenBTRMgrDevOpT Device operation type.
+ *
+ * @return Returns the status of the operation.
+ * @retval eBTRMgrSuccess on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_StopDeviceDiscovery(unsigned char aui8AdapterIdx, BTRMGR_DeviceOperationType_t aenBTRMgrDevOpT);
+/**
+ * @brief  This API gives the discovery status.
+ *
+ * @param[in]   aui8AdapterIdx  Index of bluetooth adapter.
+ * @param[out]  aeDiscoveryStatus Device discovery status.
+ * @param[out]  aenBTRMgrDevOpT  Device operation type.
+ *
+ * @return Returns the status of the operation.
+ * @retval eBTRMgrSuccess on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_GetDiscoveryStatus (unsigned char aui8AdapterIdx, BTRMGR_DiscoveryStatus_t *aeDiscoveryStatus, BTRMGR_DeviceOperationType_t *aenBTRMgrDevOpT);
+/**
+ * @brief  This API fetches the list of devices scanned.
+ *
+ * @param[in]   aui8AdapterIdx        Index of bluetooth adapter.
+ * @param[out]  pDiscoveredDevices    Structure which holds the details of device scanned.
+ *
+ * @return Returns the status of the operation.
+ * @retval eBTRMgrSuccess on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_GetDiscoveredDevices(unsigned char aui8AdapterIdx, BTRMGR_DiscoveredDevicesList_t *pDiscoveredDevices);
+/**
+ * @brief  This API is used to pair the device that you wish to pair.
+ *
+ * @param[in] aui8AdapterIdx  Index of bluetooth adapter.
+ * @param[in] ahBTRMgrDevHdl  Indicates the device handle.
+ *
+ * @return Returns the status of the operation.
+ * @retval eBTRMgrSuccess on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_PairDevice(unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl);
+/**
+ * @brief  This API is used to remove the pairing information of the device selected.
+ *
+ * @param[in]   aui8AdapterIdx       Index of bluetooth adapter.
+ * @param[in]   ahBTRMgrDevHdl       Device handle.
+ *
+ * @return Returns the status of the operation.
+ * @retval eBTRMgrSuccess on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_UnpairDevice(unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl);
+/**
+ * @brief  This API returns the list of devices paired.
+ *
+ * @param[in] aui8AdapterIdx  Index of bluetooth adapter.
+ * @param[in] pPairedDevices  Structure which holds the paired devices information.
+ *
+ * @return Returns the status of the operation.
+ * @retval eBTRMgrSuccess on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_GetPairedDevices(unsigned char aui8AdapterIdx, BTRMGR_PairedDevicesList_t *pPairedDevices);
+/**
+ * @brief  This API connects the device as audio sink/headset/audio src based on the device type specified.
+ *
+ * @param[in] aui8AdapterIdx       Index of bluetooth adapter.
+ * @param[in] ahBTRMgrDevHdl        Indicates device handle.
+ * @param[in] connectAs            Device operation type.
+ *
+ * @return Returns the status of the operation.
+ * @retval eBTRMgrSuccess on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_ConnectToDevice(unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl, BTRMGR_DeviceOperationType_t connectAs);
+/**
+ * @brief  This API terminates the current connection.
+ *
+ * @param[in] aui8AdapterIdx       Index of bluetooth adapter.
+ * @param[in] ahBTRMgrDevHdl        Indicates device handle.
+ *
+ * @return Returns the status of the operation.
+ * @retval eBTRMgrSuccess on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_DisconnectFromDevice(unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl);
+/**
+ * @brief  This API returns the list of devices connected.
+ *
+ * @param[in]  aui8AdapterIdx       Index of bluetooth adapter.
+ * @param[out] pConnectedDevices    List of connected devices.
+ *
+ * @return Returns the status of the operation.
+ * @retval eBTRMgrSuccess on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_GetConnectedDevices(unsigned char aui8AdapterIdx, BTRMGR_ConnectedDevicesList_t *pConnectedDevices);
+/**
+ * @brief  This API returns the device information that includes the device name, mac address, RSSI value, battery level etc.
+ *
+ * @param[in]  aui8AdapterIdx       Index of bluetooth adapter.
+ * @param[in]  ahBTRMgrDevHdl       Indicates device handle.
+ * @param[out] pDeviceProperty      Device property information.
+ *
+ * @return Returns the status of the operation.
+ * @retval eBTRMgrSuccess on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_GetDeviceProperties(unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl, BTRMGR_DevicesProperty_t *pDeviceProperty);
+/**
+ * @brief  This API returns the device battery level
+ *
+ * @param[in]  aui8AdapterIdx       Index of bluetooth adapter.
+ * @param[in]  ahBTRMgrDevHdl       Indicates device handle.
+ * @param[out] pDeviceBatteryLevel  Holds battery level, is 0 if battery level can't be found
+ *
+ * @return Returns the status of the operation.
+ * @retval eBTRMgrSuccess on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_GetDeviceBatteryLevel (unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl,unsigned char * pDeviceBatteryLevel);
+/**
+ * @brief  This API initates the streaming from the device with default operation type.
+ *
+ * @param[in]  aui8AdapterIdx       Index of bluetooth adapter.
+ * @param[in]  aenBTRMgrDevConT     Device opeartion type.
+ *
+ * @return Returns the status of the operation.
+ * @retval eBTRMgrSuccess on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_StartAudioStreamingOut_StartUp(unsigned char aui8AdapterIdx, BTRMGR_DeviceOperationType_t aenBTRMgrDevConT);
+/**
+ * @brief  This API initates the streaming from the device with the selected operation type.
+ *
+ * @param[in]  aui8AdapterIdx       Index of bluetooth adapter.
+ * @param[in]  ahBTRMgrDevHdl       Indicates device Handle.
+ * @param[in]  connectAs            Device operation type.
+ *
+ * @return Returns the status of the operation.
+ * @retval eBTRMgrSuccess on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_StartAudioStreamingOut(unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl, BTRMGR_DeviceOperationType_t connectAs);
+/**
+ * @brief  This API terminates the streaming from the device.
+ *
+ * @param[in]  aui8AdapterIdx       Index of bluetooth adapter.
+ * @param[in]  ahBTRMgrDevHdl       Indicates device Handle.
+ *
+ * @return Returns the status of the operation.
+ * @retval eBTRMgrSuccess on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_StopAudioStreamingOut(unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl);
+/**
+ * @brief  This API returns the stream out status.
+ *
+ * @param[in]  aui8AdapterIdx       Index of bluetooth adapter.
+ * @param[out] pStreamingStatus     Streaming status.
+ *
+ * @return Returns the status of the operation.
+ * @retval eBTRMgrSuccess on success, appropriate error code otherwise.
+ */
+//TODO: Return deviceHandle if we are streaming out
+BTRMGR_Result_t BTRMGR_IsAudioStreamingOut(unsigned char aui8AdapterIdx, unsigned char *pStreamingStatus);
+/**
+ * @brief  This API is to set the audio type as primary or secondary.
+ *
+ * Secondary audio support is not implemented yet. Always primary audio is played for now.
+ *
+ * @param[in]  aui8AdapterIdx       Index of bluetooth adapter.
+ * @param[in]  type                 Streaming type primary/secondary
+ *
+ * @return Returns the status of the operation.
+ * @retval eBTRMgrSuccess on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_SetAudioStreamingOutType(unsigned char aui8AdapterIdx, BTRMGR_StreamOut_Type_t type);
+/**
+ * @brief  This API starts the audio streaming.
+ *
+ * @param[in]  aui8AdapterIdx       Index of bluetooth adapter.
+ * @param[in]  ahBTRMgrDevHdl       Device handle.
+ * @param[in]  connectAs            Device opeartion type.
+ *
+ * @return Returns the status of the operation.
+ * @retval eBTRMgrSuccess on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_StartAudioStreamingIn(unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl, BTRMGR_DeviceOperationType_t connectAs);
+/**
+ * @brief  This API termines the audio streaming.
+ *
+ * @param[in]  aui8AdapterIdx       Index of bluetooth adapter.
+ * @param[in]  ahBTRMgrDevHdl       Device handle.
+ *
+ * @return Returns the status of the operation.
+ * @retval eBTRMgrSuccess on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_StopAudioStreamingIn(unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl);
+/**
+ * @brief  This API returns the audio streaming status.
+ *
+ * @param[in]  aui8AdapterIdx       Index of bluetooth adapter.
+ * @param[out] pStreamingStatus     Streaming status.
+ *
+ * @return Returns the status of the operation.
+ * @retval eBTRMgrSuccess on success, appropriate error code otherwise.
+ */
+//TODO: Return  deviceHandle if we are streaming in
+BTRMGR_Result_t BTRMGR_IsAudioStreamingIn(unsigned char aui8AdapterIdx, unsigned char *pStreamingStatus);
+/**
+ * @brief  This API handles the events received.
+ *
+ * @param[in]  aui8AdapterIdx       Index of bluetooth adapter.
+ * @param[in]  apstBTRMgrEvtRsp     Structure which holds the event response.
+ *
+ * @return Returns the status of the operation.
+ * @retval eBTRMgrSuccess on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_SetEventResponse(unsigned char aui8AdapterIdx, BTRMGR_EventResponse_t* apstBTRMgrEvtRsp);
+/**
+ * @brief  This API is used to perform the media control operations.
+ *
+ * @param[in]  aui8AdapterIdx       Index of bluetooth adapter.
+ * @param[in]  ahBTRMgrDevHdl       Device handle.
+ * @param[in]  mediaCtrlCmd         Indicates the play, pause, resume etc.
+ *
+ * @return Returns the status of the operation.
+ * @retval eBTRMgrSuccess on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_MediaControl(unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl, BTRMGR_MediaControlCommand_t mediaCtrlCmd);
+/**
+ * @brief  This API is used to fetch the data path and configuration of a streaming out device.
+ *
+ * @param[in]  aui8AdapterIdx       Index of bluetooth adapter.
+ * @param[in]  ahBTRMgrDevHdl       Device handle.
+ * @param[out]  pi32dataPath        Device data path.
+ * @param[out]  pi32Readmtu         Read mtu size.
+ * @param[out]  pi32Writemtu        Write mtu size.
+ * @param[out]  pi32Delay           Device delay needed.
+ * @param[out]  pstBtrMgrDevStreamInfo Codec information.
+ *
+ * @return Returns the status of the operation.
+ * @retval eBTRMgrSuccess on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_GetDataPathAndConfigurationForStreamOut( unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl, int* pi32dataPath, int* pi32Readmtu, int* pi32Writemtu, unsigned int* pi32Delay, BTRMGR_MediaStreamInfo_t* pstBtrMgrDevStreamInfo);
+/**
+ * @brief  This API is used to release the data path of a streaming out device.
+ *
+ * @param[in]  aui8AdapterIdx       Index of bluetooth adapter.
+ * @param[in]  ahBTRMgrDevHdl       Device handle.
+ *
+ * @return Returns the status of the operation.
+ * @retval eBTRMgrSuccess on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_ReleaseDataPathForStreamOut( unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl);
+/**
+ * @brief  This API is used to start streaming audio to a bluetooth device from a socket described by pcAudioInputFilePath.
+ *
+ * @param[in]  aui8AdapterIdx       Index of bluetooth adapter.
+ * @param[in]  ahBTRMgrDevHdl       Device handle.
+ * @param[in]  pstMediaAudioOutInfo The audio information of the stream output.
+ * @param[in]  pstMediaAudioInInfo  The audio information of the stream input.
+ * @param[in]  i32OutFd             The output file descriptor of the bluetooth device.
+ * @param[in]  outMTUSize           The output MTU size.
+ * @param[in]  outDevDelay          The output device delay.
+ * @param[in]  pcAudioInputFilePath The path to the socket from which audio will be consumed.
+ *
+ * @return Returns the status of the operation.
+ * @retval eBTRMgrSuccess on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_StartSendingAudioFromFile(unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl, BTRMGR_MediaStreamInfo_t* pstMediaAudioOutInfo, BTRMGR_MediaStreamInfo_t* pstMediaAudioInInfo, int i32OutFd, int outMTUSize,  unsigned int outDevDelay, char * pcAudioInputFilePath);
+/**
+ * @brief  This API is used to stop streaming to a bluetooth device when the stream was started with BTRMGR_StartSendingAudioFromFile.
+ *
+ * @return Returns the status of the operation.
+ * @retval eBTRMgrSuccess on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_StopSendingAudioFromFile (void);
+/**
+ * @brief  This API is used to fetch the media volume and mute data.
+ *
+ * @param[in]  aui8AdapterIdx       Index of bluetooth adapter.
+ * @param[in]  ahBTRMgrDevHdl       Device handle.
+ * @param[in]  deviceOpType         device operation type audio out or in etc.
+ * @param[out]  pui8Volume          Media volume value.
+ * @param[out]  pui8Mute            Media mute set or not.
+ *
+ * @return Returns the status of the operation.
+ * @retval eBTRMgrSuccess on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_GetDeviceVolumeMute(unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl, BTRMGR_DeviceOperationType_t deviceOpType, unsigned char *pui8Volume, unsigned char *pui8Mute);
+/**
+ * @brief  This API is used to set the media volume and mute data.
+ *
+ * @param[in]  aui8AdapterIdx       Index of bluetooth adapter.
+ * @param[in]  ahBTRMgrDevHdl       Device handle.
+ * @param[in]  deviceOpType         device operation type audio out or in etc.
+ * @param[out]  ui8Volume          Media volume value.
+ * @param[out]  ui8Mute            Media mute set or not.
+ *
+ * @return Returns the status of the operation.
+ * @retval eBTRMgrSuccess on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_SetDeviceVolumeMute(unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl, BTRMGR_DeviceOperationType_t deviceOpType, unsigned char ui8Volume, unsigned char ui8Mute);
+/**
+ * @brief  This API is used to get the delay on the gstreamer pipeline.
+ *
+ * @param[in]  aui8AdapterIdx       Index of bluetooth adapter.
+ * @param[in]  ahBTRMgrDevHdl       Device handle.
+ * @param[in]  deviceOpType         device operation type audio out or in etc.
+ * @param[out]  pui16Delay          Media delay value.
+ * @param[out]  pui16MsInBuffer     Media mute set or not.
+ *
+ * @return Returns the status of the operation.
+ * @retval eBTRMgrSuccess on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_GetDeviceDelay (unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl,BTRMGR_DeviceOperationType_t deviceOpType,unsigned int* pui16Delay,unsigned int* pui16MsInBuffer);
+/**
+ * @brief  This API is used to set the delay on the gstreamer pipeline.
+ *
+ * @param[in]  aui8AdapterIdx       Index of bluetooth adapter.
+ * @param[in]  ahBTRMgrDevHdl       Device handle.
+ * @param[in]  deviceOpType         device operation type audio out or in etc.
+ * @param[out]  ui16Delay          Media volume delay.
+ *
+ * @return Returns the status of the operation.
+ * @retval eBTRMgrSuccess on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_SetDeviceDelay ( unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl,BTRMGR_DeviceOperationType_t deviceOpType,unsigned int ui16Delay);
+/**
+ * @brief  This API fetches the media track info like title, genre, duration, number of tracks, current track number.
+ *
+ * @param[in]  aui8AdapterIdx       Index of bluetooth adapter.
+ * @param[in]  ahBTRMgrDevHdl       Device handle.
+ * @param[out]  mediaTrackInfo       Track info like title, genre, duration etc.
+ *
+ * @return Returns the status of the operation.
+ * @retval eBTRMgrSuccess on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_GetMediaTrackInfo(unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl, BTRMGR_MediaTrackInfo_t *mediaTrackInfo);
+/**
+ * @brief  This API fetches the media track info like title, genre, duration, number of tracks, current track number.
+ *
+ * @param[in]  aui8AdapterIdx       Index of bluetooth adapter.
+ * @param[in]  ahBTRMgrDevHdl       Device handle.
+ * @param[in]  ahBTRMgrMedElementHdl     Media Element handle .
+ * @param[out]  mediaTrackInfo       Track info like title, genre, duration etc.
+ *
+ * @return Returns the status of the operation.
+ * @retval eBTRMgrSuccess on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_GetMediaElementTrackInfo(unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl, BTRMgrMediaElementHandle ahBTRMgrMedElementHdl, BTRMGR_MediaTrackInfo_t *mediaTrackInfo);
+/**
+ * @brief  This API fetches the current position and total duration of the media.
+ *
+ * @param[in]  aui8AdapterIdx       Index of bluetooth adapter.
+ * @param[in]  ahBTRMgrDevHdl       Device handle.
+ * @param[out] mediaPositionInfo    Media position info.
+ *
+ * @return Returns the status of the operation.
+ * @retval BTRMGR_RESULT_SUCCESS on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_GetMediaCurrentPosition(unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl, BTRMGR_MediaPositionInfo_t*  mediaPositionInfo);
+/**
+ * @brief  This API sets the mentioned media element list active/in_scope for further operations on it.
+ *
+ * @param[in]  aui8AdapterIdx            Index of bluetooth adapter.
+ * @param[in]  ahBTRMgrDevHdl            Device handle.
+ * @param[in]  ahBTRMgrMedElementHdl     Media Element handle
+ * @param[in]  aui16MediaElementStartIdx Starting index of the list.
+ * @param[in]  aui16MediaElementEndIdx   Ending index of the list
+ * @param[in]  aMediaElementType         Media Element Type.
+ *
+ * @return Returns the status of the operation.
+ * @retval BTRMGR_RESULT_SUCCESS on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_SetMediaElementActive (unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl, BTRMgrMediaElementHandle ahBTRMgrMedElementHdl, 
+                                                                                                            BTRMGR_MediaElementType_t aMediaElementType);
+/**
+ * @brief  This API gets the media element list.
+ * @param[in]  aui8AdapterIdx            Index of bluetooth adapter.
+ * @param[in]  ahBTRMgrDevHdl            Device handle.
+ * @param[in]  ahBTRMgrMedElementHdl     Media Element handle
+ * @param[in]  aui16MediaElementStartIdx Starting index of the list.
+ * @param[in]  aui16MediaElementEndIdx   Ending index of the list
+ * @param[in]  aMediaElementType         Media Element Type.
+ * @param[out] aMediaElementListInfo     Media Element List.
+ *
+ * @return Returns the status of the operation.
+ * @retval BTRMGR_RESULT_SUCCESS on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_GetMediaElementList (unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl, BTRMgrMediaElementHandle ahBTRMgrMedElementHdl, unsigned short aui16MediaElementStartIdx,
+                unsigned short aui16MediaElementEndIdx, unsigned char abMediaElementListDepth, BTRMGR_MediaElementType_t aMediaElementType, BTRMGR_MediaElementListInfo_t* aMediaElementListInfo);
+/**
+ * @brief  This API performs operation based on the element type selected.
+ * @param[in]  aui8AdapterIdx            Index of bluetooth adapter.
+ * @param[in]  ahBTRMgrDevHdl            Device handle.
+ * @param[in]  ahBTRMgrMedElementHdl     Media Element handle
+ * @param[in]  aMediaElementType         Media Element Type.
+ *
+ * @return Returns the status of the operation.
+ * @retval BTRMGR_RESULT_SUCCESS on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_SelectMediaElement (unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl, BTRMgrMediaElementHandle ahBTRMgrMedElementHdl, BTRMGR_MediaElementType_t aMediaElementType);
+/**
+ * @brief  This API fetches the Device name of the media.
+ *
+ * @param[in]  type     Device type.
+ *
+ * @return Returns the device name.
+ */
+const char* BTRMGR_GetDeviceTypeAsString(BTRMGR_DeviceType_t type);
+/**
+ * @brief  This API Enable/Disables Audio-In on the specified bluetooth adapter.
+ *
+ * @param[in]  aui8AdapterIdx       Index of bluetooth adapter.
+ * @param[in]  aui8State            0/1- Enable or Disable AudioIn service.
+ *
+ * @return Returns the status of the operation.
+ * @retval BTRMGR_RESULT_SUCCESS on success.
+ */
+BTRMGR_Result_t BTRMGR_SetAudioInServiceState (unsigned char aui8AdapterIdx, unsigned char aui8State);
+/**
+ * @brief  This API Enable/Disables Hid GamePad on the specified bluetooth adapter.
+ *
+ * @param[in]  aui8AdapterIdx       Index of bluetooth adapter.
+ * @param[in]  aui8State            0/1- Enable or Disable AudioIn service.
+ *
+ * @return Returns the status of the operation.
+ * @retval BTRMGR_RESULT_SUCCESS on success.
+ */
+BTRMGR_Result_t BTRMGR_SetHidGamePadServiceState (unsigned char aui8AdapterIdx, unsigned char aui8State);
+/**
+ * @brief  This API Enable/Disables Debug Mode for the btrMgrBus process.
+ *
+ * @param[in]  aui8State            0/1- Enable or Disable Debug Mode.
+ *
+ * @return Returns the status of the operation.
+ * @retval BTRMGR_RESULT_SUCCESS on success.
+ */
+BTRMGR_Result_t BTRMGR_SetBtmgrDebugModeState (unsigned char aui8State);
+/**
+ * @brief  This API Enable/Disables Broadcast feature.
+ *
+ * @param[in]  aui8AdapterIdx       Index of bluetooth adapter.
+ * @param[in]  aui8State            0/1- Enable or Disable AudioIn service.
+ *
+ * @return Returns the status of the operation.
+ * @retval BTRMGR_RESULT_SUCCESS on success.
+ */
+BTRMGR_Result_t BTRMGR_SetBroadcastState (unsigned char aui8AdapterIdx, unsigned char aui8State);
+/**
+ * @brief  This API Gets Beacon Detection status on the specified bluetooth adapter.
+ *
+ * @param[in]  aui8AdapterIdx       Index of bluetooth adapter.
+ * @param[out] isLimited            Current Beacon Detection Status.
+ *
+ * @return Returns the status of the operation.
+ * @retval BTRMGR_RESULT_SUCCESS on success.
+ */
+BTRMGR_Result_t BTRMGR_GetLimitBeaconDetection(unsigned char aui8AdapterIdx, unsigned char *isLimited);
+/**
+ * @brief  This API Sets Beacon Detection status on the specified bluetooth adapter.
+ *
+ * @param[in]  aui8AdapterIdx       Index of bluetooth adapter.
+ * @param[in]   isLimited            Current Beacon Detection Status.
+ *
+ * @return Returns the status of the operation.
+ * @retval BTRMGR_RESULT_SUCCESS on success.
+ */
+BTRMGR_Result_t BTRMGR_SetLimitBeaconDetection(unsigned char aui8AdapterIdx, unsigned char isLimited);
+BTRMGR_Result_t BTRMGR_GetLeProperty (unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl, const char* apBtrPropUuid, BTRMGR_LeProperty_t aenLeProperty, void* vpPropValue);
+/**
+ * @brief  This API fetches the characteristic uuid of Le device.
+ *
+ * @param[in]  aui8AdapterIdx       Index of bluetooth adapter.
+ * @param[in]  ahBTRMgrDevHdl       Device handle.
+ * @param[in]  apBtrServiceUuid     service UUID.
+ * @param[out] apBtrCharUuidList    uuid list.
+ *
+ * @return Returns the status of the operation.
+ * @retval BTRMGR_RESULT_SUCCESS on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_GetLeCharacteristicUUID (unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl, const char* apBtrServiceUuid, char* apBtrCharUuidList);
+/**
+ * @brief  This API performs LE operations on the specified bluetooth adapter.
+ *
+ * @param[in]  aui8AdapterIdx       Index of bluetooth adapter.
+ * @param[in]  ahBTRMgrDevHdl       Device handle.
+ * @param[in]  aBtrLeUuid           LE device uuid.
+ * @param[in]  aLeOpType            LE device operation type.
+ * @param[out] rOpResult            LE device operation result.
+ *
+ * @return Returns the status of the operation.
+ * @retval BTRMGR_RESULT_SUCCESS on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_PerformLeOp (unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl, const char* aBtrLeUuid, BTRMGR_LeOp_t aLeOpType, char* aLeOpArg, char* rOpResult);
+BTRMGR_Result_t BTRMGR_LE_StartAdvertisement(unsigned char aui8AdapterIdx, BTRMGR_LeCustomAdvertisement_t *pstBTMGR_LeCustomAdvt);
+BTRMGR_Result_t BTRMGR_LE_StopAdvertisement(unsigned char aui8AdapterIdx);
+BTRMGR_Result_t BTRMGR_LE_GetPropertyValue(unsigned char aui8AdapterIdx, char* lUUID, char *aValue, BTRMGR_LeProperty_t aElement);
+BTRMGR_Result_t BTRMGR_LE_SetServiceUUIDs(unsigned char aui8AdapterIdx, char *aUUID);
+BTRMGR_Result_t BTRMGR_LE_SetServiceInfo(unsigned char aui8AdapterIdx, char *aUUID, unsigned char aServiceType);
+BTRMGR_Result_t BTRMGR_LE_SetGattInfo(unsigned char aui8AdapterIdx, char *aParentUUID, char *aCharUUID, unsigned short aFlags, char *aValue, BTRMGR_LeProperty_t aElement);
+BTRMGR_Result_t BTRMGR_LE_SetGattPropertyValue(unsigned char aui8AdapterIdx, char* aUUID, char *aValue, BTRMGR_LeProperty_t aElement);
+BTRMGR_Result_t BTRMGR_SysDiagInfo(unsigned char aui8AdapterIdx, char *apDiagElement, char *apValue, BTRMGR_LeOp_t aOpType);
+BTRMGR_Result_t BTRMGR_ConnectToWifi(unsigned char aui8AdapterIdx, char *apSSID, char *apPassword, int aSecMode);
+BTRMGR_Result_t BTRMGR_StartLEDeviceActivation(void);
+BTRMGR_Result_t BTRMGR_SetBatteryOpsState(unsigned char aui8AdapterIdx, unsigned char aui8State);
+BTRMGR_Result_t BTRMGR_LEDeviceActivation(void);
+BTRMGR_Result_t BTRMGR_SetLTEServiceState(unsigned char aui8AdapterIdx, unsigned char aui8State);
+// Outgoing callbacks Registration Interfaces
+BTRMGR_Result_t BTRMGR_RegisterEventCallback(BTRMGR_EventCallback afpcBBTRMgrEventOut);
+/** @} */
+#ifdef __cplusplus
+}
+#endif
+#endif /* __BTR_MGR_H__ */

--- a/Tests/mocks/BluetoothMocks.cpp
+++ b/Tests/mocks/BluetoothMocks.cpp
@@ -1,0 +1,140 @@
+#include "BluetoothMocks.h"
+
+// Define the mock functions for Bluetooth Manager C API
+extern "C" {
+
+BTRMGR_Result_t BTRMGR_GetNumberOfAdapters(unsigned char* pNumOfAdapters) {
+    return mockBluetoothManagerInstance->BTRMGR_GetNumberOfAdapters(pNumOfAdapters);
+}
+
+BTRMGR_Result_t BTRMGR_StartDeviceDiscovery(unsigned char aui8AdapterIdx, BTRMGR_DeviceOperationType_t aenBTRMgrDevOpT) {
+    return mockBluetoothManagerInstance->BTRMGR_StartDeviceDiscovery(aui8AdapterIdx, aenBTRMgrDevOpT);
+}
+
+BTRMGR_Result_t BTRMGR_StopDeviceDiscovery(unsigned char aui8AdapterIdx, BTRMGR_DeviceOperationType_t aenBTRMgrDevOpT) {
+    return mockBluetoothManagerInstance->BTRMGR_StopDeviceDiscovery(aui8AdapterIdx, aenBTRMgrDevOpT);
+}
+
+BTRMGR_Result_t BTRMGR_SetAdapterPowerStatus(unsigned char aui8AdapterIdx, unsigned char power_status) {
+    return mockBluetoothManagerInstance->BTRMGR_SetAdapterPowerStatus(aui8AdapterIdx, power_status);
+}
+
+BTRMGR_Result_t BTRMGR_IsAdapterDiscoverable(unsigned char aui8AdapterIdx, unsigned char* pDiscoverable) {
+    return mockBluetoothManagerInstance->BTRMGR_IsAdapterDiscoverable(aui8AdapterIdx, pDiscoverable);
+}
+
+BTRMGR_Result_t BTRMGR_GetAdapterName(unsigned char aui8AdapterIdx, char* pNameOfAdapter) {
+    return mockBluetoothManagerInstance->BTRMGR_GetAdapterName(aui8AdapterIdx, pNameOfAdapter);
+}
+
+BTRMGR_Result_t BTRMGR_SetDeviceVolumeMute(unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl, BTRMGR_DeviceOperationType_t deviceOpType, unsigned char ui8Volume, unsigned char ui8Mute) {
+    return mockBluetoothManagerInstance->BTRMGR_SetDeviceVolumeMute(aui8AdapterIdx, ahBTRMgrDevHdl, deviceOpType, ui8Volume, ui8Mute);
+}
+
+BTRMGR_Result_t BTRMGR_SetEventResponse(unsigned char aui8AdapterIdx, BTRMGR_EventResponse_t* apstBTRMgrEvtRsp) {
+    return mockBluetoothManagerInstance->BTRMGR_SetEventResponse(aui8AdapterIdx, apstBTRMgrEvtRsp);
+}
+
+const char* BTRMGR_GetDeviceTypeAsString(BTRMGR_DeviceType_t type) {
+    return mockBluetoothManagerInstance->BTRMGR_GetDeviceTypeAsString(type);
+}
+
+BTRMGR_Result_t BTRMGR_StopAudioStreamingIn(unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl) {
+    return mockBluetoothManagerInstance->BTRMGR_StopAudioStreamingIn(aui8AdapterIdx, ahBTRMgrDevHdl);
+}
+
+BTRMGR_Result_t BTRMGR_StopAudioStreamingOut(unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl) {
+    return mockBluetoothManagerInstance->BTRMGR_StopAudioStreamingOut(aui8AdapterIdx, ahBTRMgrDevHdl);
+}
+
+// BTRMGR_UnRegisterFromCallbacks method not required to be mocked
+BTRMGR_Result_t BTRMGR_UnRegisterFromCallbacks(const char* apcProcessName) {
+    return BTRMGR_RESULT_SUCCESS;
+}
+
+BTRMGR_Result_t BTRMGR_StartAudioStreamingOut(unsigned char adapterIndex, BTRMgrDeviceHandle deviceHandle, BTRMGR_DeviceOperationType_t connectAs) {
+    return mockBluetoothManagerInstance->BTRMGR_StartAudioStreamingOut(adapterIndex, deviceHandle, connectAs);
+}
+
+BTRMGR_Result_t BTRMGR_StartAudioStreamingOut_StartUp(unsigned char aui8AdapterIdx, BTRMGR_DeviceOperationType_t aenBTRMgrDevConT) {
+    return mockBluetoothManagerInstance->BTRMGR_StartAudioStreamingOut_StartUp(aui8AdapterIdx, aenBTRMgrDevConT);
+}
+
+BTRMGR_Result_t BTRMGR_GetPairedDevices(unsigned char aui8AdapterIdx, BTRMGR_PairedDevicesList_t* pPairedDevices) {
+    return mockBluetoothManagerInstance->BTRMGR_GetPairedDevices(aui8AdapterIdx, pPairedDevices);
+}
+
+BTRMGR_Result_t BTRMGR_GetDiscoveredDevices(unsigned char aui8AdapterIdx, BTRMGR_DiscoveredDevicesList_t* pDiscoveredDevices) {
+    return mockBluetoothManagerInstance->BTRMGR_GetDiscoveredDevices(aui8AdapterIdx, pDiscoveredDevices);
+}
+
+BTRMGR_Result_t BTRMGR_ConnectToDevice(unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl, BTRMGR_DeviceOperationType_t connectAs) {
+    return mockBluetoothManagerInstance->BTRMGR_ConnectToDevice(aui8AdapterIdx, ahBTRMgrDevHdl, connectAs);
+}
+
+BTRMGR_Result_t BTRMGR_SetAudioStreamingOutType(unsigned char aui8AdapterIdx, BTRMGR_StreamOut_Type_t type) {
+    return mockBluetoothManagerInstance->BTRMGR_SetAudioStreamingOutType(aui8AdapterIdx, type);
+}
+
+BTRMGR_Result_t BTRMGR_GetAdapterPowerStatus(unsigned char aui8AdapterIdx, unsigned char* pPowerStatus) {
+    return mockBluetoothManagerInstance->BTRMGR_GetAdapterPowerStatus(aui8AdapterIdx, pPowerStatus);
+}
+
+BTRMGR_Result_t BTRMGR_MediaControl(unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl, BTRMGR_MediaControlCommand_t mediaCtrlCmd) {
+    return mockBluetoothManagerInstance->BTRMGR_MediaControl(aui8AdapterIdx, ahBTRMgrDevHdl, mediaCtrlCmd);
+}
+
+BTRMGR_Result_t BTRMGR_SetAdapterDiscoverable(unsigned char aui8AdapterIdx, unsigned char discoverable, int timeout) {
+    return mockBluetoothManagerInstance->BTRMGR_SetAdapterDiscoverable(aui8AdapterIdx, discoverable, timeout);
+}
+
+BTRMGR_Result_t BTRMGR_StartAudioStreamingIn(unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl, BTRMGR_DeviceOperationType_t connectAs) {
+    return mockBluetoothManagerInstance->BTRMGR_StartAudioStreamingIn(aui8AdapterIdx, ahBTRMgrDevHdl, connectAs);
+}
+
+BTRMGR_Result_t BTRMGR_GetMediaTrackInfo(unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl, BTRMGR_MediaTrackInfo_t* mediaTrackInfo) {
+    return mockBluetoothManagerInstance->BTRMGR_GetMediaTrackInfo(aui8AdapterIdx, ahBTRMgrDevHdl, mediaTrackInfo);
+}
+
+BTRMGR_Result_t BTRMGR_UnpairDevice(unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl) {
+    return mockBluetoothManagerInstance->BTRMGR_UnpairDevice(aui8AdapterIdx, ahBTRMgrDevHdl);
+}
+
+BTRMGR_Result_t BTRMGR_RegisterEventCallback(BTRMGR_EventCallback afpcBBTRMgrEventOut) {
+    if(mockBluetoothManagerInstance != nullptr) {
+        mockBluetoothManagerInstance->evBluetoothHandler = afpcBBTRMgrEventOut;
+    }
+    //return mockBluetoothManagerInstance->BTRMGR_RegisterEventCallback(afpcBBTRMgrEventOut);
+    return BTRMGR_RESULT_SUCCESS;
+}
+
+//BTRMGR_RegisterForCallbacks method not required to be mocked
+BTRMGR_Result_t BTRMGR_RegisterForCallbacks(const char* apcProcessName) {
+    return BTRMGR_RESULT_SUCCESS;
+}
+
+BTRMGR_Result_t BTRMGR_GetConnectedDevices(unsigned char aui8AdapterIdx, BTRMGR_ConnectedDevicesList_t* pConnectedDevices) {
+    return mockBluetoothManagerInstance->BTRMGR_GetConnectedDevices(aui8AdapterIdx, pConnectedDevices);
+}
+
+BTRMGR_Result_t BTRMGR_DisconnectFromDevice(unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl) {
+    return mockBluetoothManagerInstance->BTRMGR_DisconnectFromDevice(aui8AdapterIdx, ahBTRMgrDevHdl);
+}
+
+BTRMGR_Result_t BTRMGR_GetDeviceVolumeMute(unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl, BTRMGR_DeviceOperationType_t deviceOpType, unsigned char* pui8Volume, unsigned char* pui8Mute) {
+    return mockBluetoothManagerInstance->BTRMGR_GetDeviceVolumeMute(aui8AdapterIdx, ahBTRMgrDevHdl, deviceOpType, pui8Volume, pui8Mute);
+}
+
+BTRMGR_Result_t BTRMGR_GetDeviceProperties(unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl, BTRMGR_DevicesProperty_t* pDeviceProperty) {
+    return mockBluetoothManagerInstance->BTRMGR_GetDeviceProperties(aui8AdapterIdx, ahBTRMgrDevHdl, pDeviceProperty);
+}
+
+BTRMGR_Result_t BTRMGR_PairDevice(unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl) {
+    return mockBluetoothManagerInstance->BTRMGR_PairDevice(aui8AdapterIdx, ahBTRMgrDevHdl);
+}
+
+BTRMGR_Result_t BTRMGR_SetAdapterName(unsigned char adapterIndex, const char* adapterName) {
+    return mockBluetoothManagerInstance->BTRMGR_SetAdapterName(adapterIndex, adapterName);
+}
+
+}

--- a/Tests/mocks/BluetoothMocks.h
+++ b/Tests/mocks/BluetoothMocks.h
@@ -1,0 +1,51 @@
+//#pragma once
+#ifndef BLUETOOTH_MOCKS_H
+#define BLUETOOTH_MOCKS_H
+
+#include <gmock/gmock.h>
+#include "BluetoothMgr.h"
+#include "Bluetooth.h"
+
+// Mock class for Bluetooth Manager functions
+class MockBluetoothManager {
+public:
+    BTRMGR_EventCallback evBluetoothHandler;
+
+    MOCK_METHOD(BTRMGR_Result_t, BTRMGR_GetNumberOfAdapters, (unsigned char* pNumOfAdapters));
+    MOCK_METHOD(BTRMGR_Result_t, BTRMGR_StartDeviceDiscovery, (unsigned char aui8AdapterIdx, BTRMGR_DeviceOperationType_t aenBTRMgrDevOpT));
+    MOCK_METHOD(BTRMGR_Result_t, BTRMGR_StopDeviceDiscovery, (unsigned char aui8AdapterIdx, BTRMGR_DeviceOperationType_t aenBTRMgrDevOpT));
+    MOCK_METHOD(BTRMGR_Result_t, BTRMGR_SetAdapterPowerStatus, (unsigned char aui8AdapterIdx, unsigned char power_status));
+    MOCK_METHOD(BTRMGR_Result_t, BTRMGR_IsAdapterDiscoverable, (unsigned char aui8AdapterIdx, unsigned char* pDiscoverable));
+    MOCK_METHOD(BTRMGR_Result_t, BTRMGR_GetAdapterName, (unsigned char aui8AdapterIdx, char* pNameOfAdapter));
+    MOCK_METHOD(BTRMGR_Result_t, BTRMGR_SetDeviceVolumeMute, (unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl, BTRMGR_DeviceOperationType_t deviceOpType, unsigned char ui8Volume, unsigned char ui8Mute));
+    MOCK_METHOD(BTRMGR_Result_t, BTRMGR_SetEventResponse, (unsigned char aui8AdapterIdx, BTRMGR_EventResponse_t* apstBTRMgrEvtRsp));
+    MOCK_METHOD(const char*, BTRMGR_GetDeviceTypeAsString, (BTRMGR_DeviceType_t type));
+    MOCK_METHOD(BTRMGR_Result_t, BTRMGR_StopAudioStreamingIn, (unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl));
+    MOCK_METHOD(BTRMGR_Result_t, BTRMGR_StopAudioStreamingOut, (unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl));
+    MOCK_METHOD(BTRMGR_Result_t, BTRMGR_UnRegisterFromCallbacks, (const char* apcProcessName));
+    MOCK_METHOD(BTRMGR_Result_t, BTRMGR_StartAudioStreamingOut, (unsigned char adapterIndex, BTRMgrDeviceHandle deviceHandle, BTRMGR_DeviceOperationType_t connectAs));
+    MOCK_METHOD(BTRMGR_Result_t, BTRMGR_StartAudioStreamingOut_StartUp, (unsigned char aui8AdapterIdx, BTRMGR_DeviceOperationType_t aenBTRMgrDevConT));
+    MOCK_METHOD(BTRMGR_Result_t, BTRMGR_GetPairedDevices, (unsigned char aui8AdapterIdx, BTRMGR_PairedDevicesList_t* pPairedDevices));
+    MOCK_METHOD(BTRMGR_Result_t, BTRMGR_GetDiscoveredDevices, (unsigned char aui8AdapterIdx, BTRMGR_DiscoveredDevicesList_t* pDiscoveredDevices));
+    MOCK_METHOD(BTRMGR_Result_t, BTRMGR_ConnectToDevice, (unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl, BTRMGR_DeviceOperationType_t connectAs));
+    MOCK_METHOD(BTRMGR_Result_t, BTRMGR_SetAudioStreamingOutType, (unsigned char aui8AdapterIdx, BTRMGR_StreamOut_Type_t type));
+    MOCK_METHOD(BTRMGR_Result_t, BTRMGR_GetAdapterPowerStatus, (unsigned char aui8AdapterIdx, unsigned char* pPowerStatus));
+    MOCK_METHOD(BTRMGR_Result_t, BTRMGR_MediaControl, (unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl, BTRMGR_MediaControlCommand_t mediaCtrlCmd));
+    MOCK_METHOD(BTRMGR_Result_t, BTRMGR_SetAdapterDiscoverable, (unsigned char aui8AdapterIdx, unsigned char discoverable, int timeout));
+    MOCK_METHOD(BTRMGR_Result_t, BTRMGR_StartAudioStreamingIn, (unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl, BTRMGR_DeviceOperationType_t connectAs));
+    MOCK_METHOD(BTRMGR_Result_t, BTRMGR_GetMediaTrackInfo, (unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl, BTRMGR_MediaTrackInfo_t* mediaTrackInfo));
+    MOCK_METHOD(BTRMGR_Result_t, BTRMGR_UnpairDevice, (unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl));
+    MOCK_METHOD(BTRMGR_Result_t, BTRMGR_RegisterEventCallback, (BTRMGR_EventCallback afpcBBTRMgrEventOut));
+    MOCK_METHOD(BTRMGR_Result_t, BTRMGR_RegisterForCallbacks, (const char* apcProcessName));
+    MOCK_METHOD(BTRMGR_Result_t, BTRMGR_GetConnectedDevices, (unsigned char aui8AdapterIdx, BTRMGR_ConnectedDevicesList_t* pConnectedDevices));
+    MOCK_METHOD(BTRMGR_Result_t, BTRMGR_DisconnectFromDevice, (unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl));
+    MOCK_METHOD(BTRMGR_Result_t, BTRMGR_GetDeviceVolumeMute, (unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl, BTRMGR_DeviceOperationType_t deviceOpType, unsigned char* pui8Volume, unsigned char* pui8Mute));
+    MOCK_METHOD(BTRMGR_Result_t, BTRMGR_GetDeviceProperties, (unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl, BTRMGR_DevicesProperty_t* pDeviceProperty));
+    MOCK_METHOD(BTRMGR_Result_t, BTRMGR_PairDevice, (unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl));
+    MOCK_METHOD(BTRMGR_Result_t, BTRMGR_SetAdapterName, (unsigned char adapterIndex, const char* adapterName));
+};
+
+// Global pointer to access mock instance in C functions
+extern MockBluetoothManager* mockBluetoothManagerInstance;
+
+#endif // BLUETOOTH_MOCKS_H

--- a/l1tests.cmake
+++ b/l1tests.cmake
@@ -100,6 +100,7 @@ set(EMPTY_HEADERS
         ${BASEDIR}/rtNotifier.h
 	${BASEDIR}/dsRpc.h
 	${BASEDIR}/websocket/URL.h
+	${BASEDIR}/btmgr.h
         ${BASEDIR}/rdk/iarmmgrs/comcastIrKeyCodes.h
 	    ${BASEDIR}/rdk_logger_milestone.h
 	    ${BASEDIR}/opkg/opkg.h
@@ -137,6 +138,7 @@ set(FAKE_HEADERS
         ${BASEDIR}/rdkshell.h
 	${BASEDIR}/RdkLoggerMilestone.h
         ${BASEDIR}/secure_wrappermock.h
+	${BASEDIR}/BluetoothMgr.h
         )
 
 foreach (file ${FAKE_HEADERS})


### PR DESCRIPTION
Reason for change: Implement Gunit test cases for RDK Bluetooth service
Test Procedure: Test case report and code coverage

Risks: Low
Priority: P1