### PR TITLE
RDKTV-33096: Wpeframework crash with signature RDKShell::subscribeForSystemEvent

### DIFF
--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -891,9 +891,7 @@ namespace WPEFramework {
                 }
 		else if (requestName.compare("susbscribeSystemEvent") == 0)
                 {
-                   gSubscribeMutex.lock();
 		   subscribeForSystemEvent("onSystemPowerStateChanged");
-		   gSubscribeMutex.unlock();
                    std::cout << "subscribed system event " << std::endl;
                    JsonObject joGetParams;
                     JsonObject joGetResult;
@@ -7885,6 +7883,7 @@ namespace WPEFramework {
 
         int32_t RDKShell::subscribeForSystemEvent(std::string event)
         {
+	    gSubscribeMutex.lock();
             int32_t status = Core::ERROR_GENERAL;
 
             PluginHost::IShell::state state;
@@ -7924,7 +7923,7 @@ namespace WPEFramework {
             }
             else
                 std::cout << "No Connection to SystemServices" << std::endl;
-
+	    gSubscribeMutex.unlock();
             return status;
         }
         


### PR DESCRIPTION
Reason for change: adding lock-unlock in RDKShell::subscribeForSystemEvent() for proper synchronization Test Procedure: as specified in RDKTV-33096
Risks: Low
Priority: P1
Signed-off-by:Boopathi Vanavarayan <boopathi_vanavarayan@comcast.com>

Change-Id: I5a88ff61e351d3fd537bfe5906edea485bff9967