### PR TITLE
RDKTV-32644: Remove ODM APIs - Phase 1

### DIFF
--- a/AVOutput/AVOutputTV.h
+++ b/AVOutput/AVOutputTV.h
@@ -22,6 +22,8 @@
 
 #include "string.h"
 #include <set>
+#include <boost/filesystem.hpp>
+#include <boost/property_tree/ini_parser.hpp>
 
 #include "tvTypes.h"
 #include "tvSettings.h"
@@ -67,6 +69,49 @@
 #define STRING_DEFAULT  "Default"
 #define STRING_SOURCE    "Source."
 #define CREATE_DIRTY(__X__) (__X__+=STRING_DIRTY)
+#define CAPABLITY_FILE_NAME    "pq_capabilities.ini"
+
+
+class CIniFile
+{
+	std::string m_path;
+	std::string opt_path;
+	boost::property_tree::ptree m_data;
+
+public:
+	CIniFile(const std::string & filename, const std::string & filepath = "/etc/" )
+	{
+		opt_path = "/opt/panel/";
+		m_path = filepath;
+		m_path.append(filename);
+		opt_path.append(filename);
+
+		if(!boost::filesystem::exists( opt_path)) {
+			std::cout << "AVOutput : Using " << m_path <<std::endl;
+			boost::property_tree::ini_parser::read_ini(m_path, m_data);
+		}
+		else {
+			std::cout << "AVOutput : Using " << opt_path << std::endl;
+			boost::property_tree::ini_parser::read_ini(opt_path, m_data);
+	        }
+	}
+
+	~CIniFile()
+	{
+	}
+
+	template <typename T>
+	T Get(const std::string & key)
+	{
+		return m_data.get<T>(key);
+	}
+
+	template <typename T>
+	void Set(const std::string & key, const T & value){
+		//TODO DD: Not required currently
+		//m_data.put(key, value);
+	}
+};
 
 namespace WPEFramework {
 namespace Plugin {
@@ -217,10 +262,14 @@ class AVOutputTV : public AVOutputBase {
 		tvError_t getParamsCaps(std::vector<std::string> &range, std::vector<std::string> &pqmode, std::vector<std::string> &source,
 		                        std::vector<std::string> &format,std::string param , std::string & isPlatformSupport,
 				std::vector<std::string> & index);
+		int GetPanelID(char *panelid);
+		int ConvertHDRFormatToContentFormat(tvhdr_type_t hdrFormat);
+		int ReadCapablitiesFromConf(std::string &rangeInfo,std::string &pqmodeInfo,std::string &formatInfo,std::string &sourceInfo,std::string param, std::string & isPlatformSupport, std::string & indexInfo);
 		void getDimmingModeStringFromEnum(int value, std::string &toStore);
 		void getColorTempStringFromEnum(int value, std::string &toStore);
 		int getCurrentPictureMode(char *picMode);
 		int getDolbyParamToSync(int sourceIndex, int formatIndex, int& value);
+		tvDolbyMode_t GetDolbyVisionEnumFromModeString(const char* modeString);
 		std::string getDolbyModeStringFromEnum( tvDolbyMode_t mode);
 		JsonArray getSupportedVideoSource(void);
 		int getAvailableCapabilityModesWrapper(std::string param, std::string & outparam);

--- a/AVOutput/AVOutputTVHelper.cpp
+++ b/AVOutput/AVOutputTVHelper.cpp
@@ -192,7 +192,7 @@ namespace Plugin {
 
         if( source.compare("none") == 0 || source.compare("Current") == 0 ) {
             tvVideoSrcType_t currentSource = VIDEO_SOURCE_IP;
-            GetCurrentSource(&currentSource);
+            GetCurrentVideoSource(&currentSource);
             sourceIndex = (int)currentSource;
         }
         else {
@@ -237,14 +237,18 @@ namespace Plugin {
     int AVOutputTV::getDolbyModeIndex(const char * dolbyMode)
     {
         int mode = 0;
-        pic_modes_t *dolbyModes     ;
+        tvDolbyMode_t dolbyModes[tvMode_Max];
+        tvDolbyMode_t *dolbyModesPtr = dolbyModes; // Pointer to statically allocated tvDolbyMode_t array
         unsigned short totalAvailable = 0;
 
-        tvError_t ret = GetTVSupportedDolbyVisionModesODM(&dolbyModes,&totalAvailable);
-        if(ret == tvERROR_NONE) {
-            for(int count = 0;count <totalAvailable;count++ ) {
-                if(strncasecmp(dolbyMode, dolbyModes[count].name, strlen(dolbyMode))==0) {
-                    mode = dolbyModes[count].value;
+        // Set an initial value to indicate the mode type
+        dolbyModes[0] = tvDolbyMode_Dark;
+
+        tvError_t ret = GetTVSupportedDolbyVisionModes(&dolbyModesPtr, &totalAvailable);
+        if (ret == tvERROR_NONE) {
+            for (int count = 0; count < totalAvailable; count++) {
+		        if(strncasecmp(dolbyMode, getDolbyModeStringFromEnum(dolbyModes[count]).c_str(), strlen(dolbyMode))==0) {
+                    mode = dolbyModes[count];
                     break;
                 }
 
@@ -304,10 +308,10 @@ namespace Plugin {
 
         currentPicMode = picMode; //Convert to string
 
-        //GetCurrentSource
-        retVal = GetCurrentSource(&sourceIndex);
+        //GetCurrentVideoSource
+        retVal = GetCurrentVideoSource(&sourceIndex);
         if(retVal != tvERROR_NONE) {
-            LOGERR("%s : GetCurrentSource( ) Failed\n",__FUNCTION__);
+            LOGERR("%s : GetCurrentVideoSource( ) Failed\n",__FUNCTION__);
             return false;
         }
         currentSource = convertSourceIndexToString(sourceIndex);
@@ -408,7 +412,7 @@ namespace Plugin {
         std::set<string> formatInputSet;
         std::set<string> sourceInputSet;
 
-        if( ReadCapablitiesFromConfODM( rangeCapInfo, pqmodeCapInfo, formatCapInfo, sourceCapInfo,param, isPlatformSupport, indexInfo) ) {
+        if( ReadCapablitiesFromConf( rangeCapInfo, pqmodeCapInfo, formatCapInfo, sourceCapInfo,param, isPlatformSupport, indexInfo) ) {
             LOGINFO( "%s: readCapablitiesFromConf Failed !!!\n",__FUNCTION__);
             return false;
         }
@@ -635,7 +639,7 @@ namespace Plugin {
             PQFileName = std::string(AVOUTPUT_RFC_CALLERID_OVERRIDE);
         }
         else {
-            int val=GetPanelIDODM(panelId);
+            int val=GetPanelID(panelId);
             if(val==0) {
                 LOGINFO("%s : panel id read is : %s\n",__FUNCTION__,panelId);
                 if(strncmp(panelId,AVOUTPUT_CONVERTERBOARD_PANELID,strlen(AVOUTPUT_CONVERTERBOARD_PANELID))!=0) {
@@ -671,7 +675,7 @@ namespace Plugin {
 	    current_format  = VIDEO_FORMAT_SDR;
 	}
         // get current source
-        GetCurrentSource(&current_source);
+        GetCurrentVideoSource(&current_source);
 
         tr181_param_name += std::string(AVOUTPUT_SOURCE_PICTUREMODE_STRING_RFC_PARAM);
         tr181_param_name += "."+convertSourceIndexToString(current_source)+"."+"Format."+convertVideoFormatToString(current_format)+"."+"PictureModeString";
@@ -748,10 +752,10 @@ namespace Plugin {
         }
         else if (source == "Current") {
             tvVideoSrcType_t currentSource = VIDEO_SOURCE_IP;
-            tvError_t ret = GetCurrentSource(&currentSource);
+            tvError_t ret = GetCurrentVideoSource(&currentSource);
 
             if(ret != tvERROR_NONE) {
-                LOGWARN("%s: GetCurrentSource( ) Failed \n",__FUNCTION__);
+                LOGWARN("%s: GetCurrentVideoSource( ) Failed \n",__FUNCTION__);
                 return -1;
             }
             source = convertSourceIndexToString(currentSource);
@@ -1280,7 +1284,7 @@ namespace Plugin {
             sourceIndex = (tvVideoSrcType_t)getSourceIndex(source);
         }
         else {
-            GetCurrentSource(&sourceIndex);
+            GetCurrentVideoSource(&sourceIndex);
         }
 
         char picMode[PIC_MODE_NAME_MAX]={0};
@@ -1303,7 +1307,7 @@ namespace Plugin {
         tr181ErrorCode_t err = getLocalParam(rfc_caller_id, rfc_param.c_str(), &param);
         if ( tr181Success != err) {
             tvError_t retVal = GetDefaultPQParams(pqmodeIndex,(tvVideoSrcType_t)sourceIndex,
-                                                 (tvVideoFormatType_t)ConvertHDRFormatToContentFormatODM((tvhdr_type_t)format),
+                                                 (tvVideoFormatType_t)ConvertHDRFormatToContentFormat((tvhdr_type_t)format),
                                                  PQ_PARAM_DOLBY_MODE,&dolby_mode_value);
             if( retVal != tvERROR_NONE ) {
                 LOGERR("%s : failed\n",__FUNCTION__);
@@ -1333,7 +1337,7 @@ namespace Plugin {
         std::string indexInfo;
         std::vector<std::string> localIndex;
 
-        if( ReadCapablitiesFromConfODM( rangeInfo, pqmodeInfo, formatInfo ,sourceInfo,param, platformsupport, indexInfo)) {
+        if( ReadCapablitiesFromConf( rangeInfo, pqmodeInfo, formatInfo ,sourceInfo,param, platformsupport, indexInfo)) {
             LOGERR( "%s: ReadCapablitiesFromConf Failed !!!\n",__FUNCTION__);
             return tvERROR_GENERAL;
         }
@@ -1356,7 +1360,7 @@ namespace Plugin {
         std::string pqmodeInfo;
         std::string indexInfo;
 
-        if( ReadCapablitiesFromConfODM( rangeInfo, pqmodeInfo, formatInfo ,sourceInfo,param, isPlatformSupport, indexInfo)) {
+        if( ReadCapablitiesFromConf( rangeInfo, pqmodeInfo, formatInfo ,sourceInfo,param, isPlatformSupport, indexInfo)) {
             LOGERR( "%s: ReadCapablitiesFromConf Failed !!!\n",__FUNCTION__);
             return tvERROR_GENERAL;
         }
@@ -1364,6 +1368,119 @@ namespace Plugin {
             spliltCapablities( range, pqmode, format, source, index,rangeInfo, pqmodeInfo, formatInfo, sourceInfo, indexInfo);
         }
 
+        return ret;
+    }
+
+    int AVOutputTV::GetPanelID(char *panelId)
+    {
+        if (panelId == NULL) {
+            printf("Invalid buffer provided for panel ID\n");
+            return -1;
+        }
+
+        const char *command = "/usr/bin/panelIDConfig -i";
+        FILE *fp;
+
+        // Execute the binary
+        fp = popen(command, "r");
+        if (fp == NULL) {
+            printf("Failed to execute command: %s\n", command);
+            return -1;
+        }
+
+        // Read the panel ID from the binary's output
+        if (fgets(panelId, 20, fp) != NULL) {
+            size_t len = strlen(panelId);
+            if (len > 0 && panelId[len - 1] == '\n') {
+                panelId[len - 1] = '\0';
+            }
+        } else {
+            printf("Failed to read panel ID from panelIDConfig binary\n");
+            pclose(fp);
+            return -1;
+        }
+
+        pclose(fp);
+        return 0;
+    }
+
+    int AVOutputTV::ConvertHDRFormatToContentFormat(tvhdr_type_t hdrFormat)
+    {
+        int ret=tvContentFormatType_SDR;
+        switch(hdrFormat)
+        {
+            case HDR_TYPE_SDR:
+                ret=tvContentFormatType_SDR;
+                break;
+            case HDR_TYPE_HDR10:
+                ret=tvContentFormatType_HDR10;
+                break;
+            case HDR_TYPE_HDR10PLUS:
+                ret=tvContentFormatType_HDR10PLUS;
+                break;
+            case HDR_TYPE_DOVI:
+                ret=tvContentFormatType_DOVI;
+                break;
+            case HDR_TYPE_HLG:
+                ret=tvContentFormatType_HLG;
+                break;
+            default:
+                break;
+        }
+        return ret;
+    }
+
+
+    int AVOutputTV::ReadCapablitiesFromConf(std::string &rangeInfo,std::string &pqmodeInfo,std::string &formatInfo,std::string &sourceInfo,
+                           std::string param, std::string & isPlatformSupport, std::string & indexInfo)
+    {
+        int ret = 0;
+
+        try {
+            CIniFile inFile(CAPABLITY_FILE_NAME);
+            std::string configString;
+            if ((param == "DolbyVisionMode") || (param == "Backlight") ) {
+                configString = param + ".platformsupport";
+                isPlatformSupport = inFile.Get<std::string>(configString);
+                printf(" platfromsupport : %s\n",isPlatformSupport.c_str() );
+            }
+
+            if ( (param == "ColorTemperature") || (param == "DimmingMode") ||
+                ( param == "AutoBacklightControl") || (param == "DolbyVisionMode") ||
+                (param == "HDR10Mode") || (param == "HLGMode") || (param == "AspectRatio") ||
+                (param == "PictureMode") || (param == "VideoSource") || (param == "VideoFormat") ||
+                (param == "VideoFrameRate") ) {
+                configString =  param + ".range";
+                rangeInfo = inFile.Get<std::string>(configString);
+                printf(" String Range info : %s\n",rangeInfo.c_str() );
+            } else {
+                configString = param + ".range_from";
+                rangeInfo = inFile.Get<std::string>(configString);
+                configString = param + ".range_to";
+                rangeInfo += ","+inFile.Get<std::string>(configString);
+                printf(" Integer Range Info : %s\n",rangeInfo.c_str() );
+            }
+
+            if ((param == "VideoSource") || (param == "PictureMode") || (param == "VideoFormat") ) {
+                configString.clear();
+                configString = param + ".index";
+                indexInfo = inFile.Get<std::string>(configString);
+                printf("Index value %s\n", indexInfo.c_str());
+            }
+
+            configString.clear();
+            configString = param + ".pqmode";
+            pqmodeInfo = inFile.Get<std::string>(configString);
+            configString = param + ".format";
+            formatInfo = inFile.Get<std::string>(configString);
+            configString = param + ".source";
+            sourceInfo = inFile.Get<std::string>(configString);
+            ret = 0;
+        }
+        catch(const boost::property_tree::ptree_error &e) {
+            printf("%s: error %s::config table entry not found in ini file\n",__FUNCTION__,e.what());
+            ret = -1;
+        }
         return ret;
     }
 
@@ -1397,9 +1514,9 @@ namespace Plugin {
         std::string tr181_param_name;
         tvVideoSrcType_t currentSource = VIDEO_SOURCE_IP;
 
-        ret = GetCurrentSource(&currentSource);
+        ret = GetCurrentVideoSource(&currentSource);
         if(ret != tvERROR_NONE) {
-            LOGERR("GetCurrentSource() Failed set source to default\n");
+            LOGERR("GetCurrentVideoSource() Failed set source to default\n");
             return 0;
         }
 
@@ -1458,6 +1575,32 @@ namespace Plugin {
         }
 
         return ret;
+    }
+    tvDolbyMode_t AVOutputTV::GetDolbyVisionEnumFromModeString(const char* modeString)
+    {
+        if (strcmp(modeString, "Invalid") == 0) {
+            return tvDolbyMode_Invalid;
+        } else if (strcmp(modeString, "Dark") == 0) {
+            return tvDolbyMode_Dark;
+        } else if (strcmp(modeString, "Bright") == 0) {
+            return tvDolbyMode_Bright;
+        } else if (strcmp(modeString, "Game") == 0) {
+            return tvDolbyMode_Game;
+        } else if (strcmp(modeString, "HDR10 Dark") == 0) {
+            return tvHDR10Mode_Dark;
+        } else if (strcmp(modeString, "HDR10 Bright") == 0) {
+            return tvHDR10Mode_Bright;
+        } else if (strcmp(modeString, "HDR10 Game") == 0) {
+            return tvHDR10Mode_Game;
+        } else if (strcmp(modeString, "HLG Dark") == 0) {
+            return tvHLGMode_Dark;
+        } else if (strcmp(modeString, "HLG Bright") == 0) {
+            return tvHLGMode_Bright;
+        } else if (strcmp(modeString, "HLG Game") == 0) {
+            return tvHLGMode_Game;
+        }
+
+        return tvDolbyMode_Invalid; // Default case for invalid input
     }
 
     std::string AVOutputTV::getDolbyModeStringFromEnum( tvDolbyMode_t mode)

--- a/AVOutput/CHANGELOG.md
+++ b/AVOutput/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to this RDK Service will be documented in this file.
 * Changes in CHANGELOG should be updated when commits are added to the main or release branches. There should be one CHANGELOG entry per JIRA Ticket. This is not enforced on sprint branches since there could be multiple changes for the same JIRA ticket during development. 
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
+## [1.0.10] - 2024-12-23
+### Added
+- ODM API removal changes phase 1
+
 ## [1.0.9] - 2024-10-04
 ### Fixed
 - PQMode Camel Case issue


### PR DESCRIPTION
Reason for change: Eliminate the usage of ODM APIs that are scheduled for deprecation.
Test Procedure: as per jira
Priority: P1
Risks: None
Signed-off-by: Arjun Binu <arjun.binu@sky.uk>