### PR TITLE
RDKDEV-1110 RTD131X-1512 AMLS905X4-1915: Observing Xcast crash with l…

### DIFF
--- a/XCast/XCast.conf.in
+++ b/XCast/XCast.conf.in
@@ -2,8 +2,3 @@ precondition = ["Platform"]
 callsign = "org.rdk.Xcast"
 autostart = "@PLUGIN_XCAST_AUTOSTART@"
 startuporder = "@PLUGIN_XCAST_STARTUPORDER@"
-configuration = JSON()
-
-rootobject = JSON()
-rootobject.add("mode", "@PLUGIN_XCAST_MODE@")
-configuration.add("root", rootobject)

--- a/XCast/XCast.config
+++ b/XCast/XCast.config
@@ -5,8 +5,3 @@ set (callsign "org.rdk.Xcast")
 if(PLUGIN_XCAST_STARTUPORDER)
 set (startuporder ${PLUGIN_XCAST_STARTUPORDER})
 endif()
-
-map()
-    kv(mode ${PLUGIN_XCAST_MODE})
-end()
-ans(rootobject)


### PR DESCRIPTION
RDKDEV-1110 RTD131X-1512 AMLS905X4-1915: Observing Xcast crash with latest changes

Reason for change: Removed root configuration to resolve Xcast crash 

Test Procedure: Build and verify

Risks: Low

Signed-off-by: Arikrishnan G <arikrishnan_g@comcast.com>