### PR TITLE
SERXIONE-6196: DeviceIdentification activation fail

### DIFF
--- a/DeviceIdentification/CHANGELOG.md
+++ b/DeviceIdentification/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.0.6] - 2024-12-30
+### Fixed
+- Added method for retrieving Serial number if existing implementation fails to retrive the serial number.
+
 ## [1.0.6] - 2024-05-28
 ### Fixed
 - Added methods for retrieving Serial number, Chip Id and Firmware version for Broadcom Devices.

--- a/DeviceIdentification/CMakeLists.txt
+++ b/DeviceIdentification/CMakeLists.txt
@@ -126,4 +126,5 @@ target_include_directories(${MODULE_NAME}
 install(TARGETS ${MODULE_NAME} 
     DESTINATION lib/${STORAGE_DIRECTORY}/plugins)
 
+target_include_directories(${MODULE_NAME} PRIVATE ../helpers)
 write_config(${PLUGIN_NAME})

--- a/DeviceIdentification/DeviceIdentification.cpp
+++ b/DeviceIdentification/DeviceIdentification.cpp
@@ -20,10 +20,18 @@
 #include "DeviceIdentification.h"
 #include "IdentityProvider.h"
 #include <interfaces/IConfiguration.h>
+#include "tracing/Logging.h"
+#include "UtilsJsonRpc.h"
+#include "UtilsController.h"
+#ifdef USE_THUNDER_R4
+#include <interfaces/IDeviceInfo.h>
+#else
+#include <interfaces/IDeviceInfo2.h>
+#endif /* USE_THUNDER_R4 */
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 6
+#define API_VERSION_NUMBER_PATCH 7
 
 namespace WPEFramework {
 namespace {
@@ -154,6 +162,7 @@ namespace Plugin {
     string DeviceIdentification::GetDeviceId() const
     {
         string result;
+        string serial;
 #ifndef DISABLE_DEVICEID_CONTROL
         ASSERT(_identifier != nullptr);
 
@@ -165,6 +174,25 @@ namespace Plugin {
             if (myBuffer[0] != 0) {
                 result = Core::SystemInfo::Instance().Id(myBuffer, ~0);
             }
+            else
+            {
+                serial = RetrieveSerialNumberThroughCOMRPC();
+
+                if (!serial.empty()) {
+                    uint8_t ret = serial.length();
+
+                    if (ret > (sizeof(myBuffer) - 1)){
+                        ret = sizeof(myBuffer) - 1;
+                    }
+                    myBuffer[0] = ret;
+                    ::memcpy(&(myBuffer[1]), serial.c_str(), ret);
+
+                    if(myBuffer[0] != 0){
+                        result = Core::SystemInfo::Instance().Id(myBuffer, ~0);
+                    }
+                }
+            }
+            
         }
 #else
         // extract DeviceId set by Thunder
@@ -184,7 +212,34 @@ namespace Plugin {
 #endif
         return result;
     }
+    string DeviceIdentification::RetrieveSerialNumberThroughCOMRPC() const
+    {
+        std::string Number;
+        if (_service)
+        {
+            PluginHost::IShell::state state;
 
+        if ((Utils::getServiceState(_service, "DeviceInfo", state) == Core::ERROR_NONE) && (state != PluginHost::IShell::state::ACTIVATED))
+        {
+            Utils::activatePlugin(_service, "DeviceInfo");
+        }
+        if ((Utils::getServiceState(_service, "DeviceInfo", state) == Core::ERROR_NONE) && (state == PluginHost::IShell::state::ACTIVATED))
+        {
+            auto _remoteDeviceInfoObject = _service->QueryInterfaceByCallsign<Exchange::IDeviceInfo>("DeviceInfo");
+
+        if(_remoteDeviceInfoObject)
+                {
+                    _remoteDeviceInfoObject->SerialNumber(Number);
+                    _remoteDeviceInfoObject->Release();
+                }
+        }
+        else
+        {
+            LOGERR("Failed to create DeviceInfo object\n");
+        }
+        }
+        return Number;
+    }
     void DeviceIdentification::Info(JsonData::DeviceIdentification::DeviceidentificationData& deviceInfo) const
     {
         deviceInfo.Firmwareversion = _identifier->FirmwareVersion();

--- a/DeviceIdentification/DeviceIdentification.h
+++ b/DeviceIdentification/DeviceIdentification.h
@@ -94,6 +94,7 @@ namespace Plugin {
         uint32_t get_deviceidentification(JsonData::DeviceIdentification::DeviceidentificationData& response) const;
 
         string GetDeviceId() const;
+        string RetrieveSerialNumberThroughCOMRPC() const;
         void Info(JsonData::DeviceIdentification::DeviceidentificationData&) const;
 
         void Deactivated(RPC::IRemoteConnection* connection);


### PR DESCRIPTION
Reason for change: DeviceIdentification plugin activation fail
Test Procedure:Check DeviceIdentification plugin activation. 
Risks: Low
Signed-off-by:AkshayKumar_Gampa AkshayKumar_Gampa@comcast.com