### PR TITLE
SERXIONE-6655: Xumo Content Store - Age Ratings

### DIFF
--- a/UserSettings/CHANGELOG.md
+++ b/UserSettings/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [2.0.0] - 2025-01-08
+### Updated
+- Updated input param names for pinControl, liveWatershed, playbackWatershed, blockNotRatedContent, pinOnPurchase properties.
+
 ## [1.2.0] - 2024-09-17
 ### Added
 - Added ParentalControl new properties in Usersetttings.

--- a/UserSettings/UserSettings.cpp
+++ b/UserSettings/UserSettings.cpp
@@ -19,9 +19,9 @@
 
 #include "UserSettings.h"
 
-#define API_VERSION_NUMBER_MAJOR 1
-#define API_VERSION_NUMBER_MINOR 1
-#define API_VERSION_NUMBER_PATCH 2
+#define API_VERSION_NUMBER_MAJOR 2
+#define API_VERSION_NUMBER_MINOR 0
+#define API_VERSION_NUMBER_PATCH 0
 
 namespace WPEFramework
 {


### PR DESCRIPTION
SERXIONE-6655: Xumo Content Store - Age Ratings - Failure in get/setBlockNotRatedContent Thunder API call. Fixed versions

Reason for Change: Matching curl calls to spec.
Test Procedure: Run usersettings curl commands on box.
Risks: HIGH
Priority: P0