### PR TITLE
RDKDEV-1028 - Ensure getDevicePowerState returns the correct power state for LIGHT_SLEEP

### DIFF
--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -274,7 +274,7 @@ bool setPowerState(std::string powerState)
     } else if (powerState == "DEEP_SLEEP") {
         param.newState = IARM_BUS_PWRMGR_POWERSTATE_STANDBY_DEEP_SLEEP;
     } else if (powerState == "LIGHT_SLEEP") {
-        param.newState = IARM_BUS_PWRMGR_POWERSTATE_STANDBY;
+        param.newState = IARM_BUS_PWRMGR_POWERSTATE_STANDBY_LIGHT_SLEEP;
     } else {
         return false;
     }
@@ -3625,8 +3625,10 @@ namespace WPEFramework {
                 if (res == IARM_RESULT_SUCCESS) {
                     if (param.curState == IARM_BUS_PWRMGR_POWERSTATE_ON)
                         currentState = "ON";
-                    else if ((param.curState == IARM_BUS_PWRMGR_POWERSTATE_STANDBY) || (param.curState == IARM_BUS_PWRMGR_POWERSTATE_STANDBY_LIGHT_SLEEP) )
+                    else if (param.curState == IARM_BUS_PWRMGR_POWERSTATE_STANDBY) 
                         currentState = "STANDBY";
+                    else if ( param.curState == IARM_BUS_PWRMGR_POWERSTATE_STANDBY_LIGHT_SLEEP)
+                        currentState = "LIGHT_SLEEP";
                     else if ( param.curState == IARM_BUS_PWRMGR_POWERSTATE_STANDBY_DEEP_SLEEP)
                         currentState = "DEEP_SLEEP";
                 }


### PR DESCRIPTION
RDKDEV-1028 - Ensure getDevicePowerState returns the correct power state for LIGHT_SLEEP

Reason for change: For LIGHT_SLEEP its returning power state as STANDBY, to overcome this modified the corresponding power state for all modes.

Test Procedure: Build and verify. Verify power state is set and get correctly as per state mode.

Risks: Low