### PR TITLE
RDKTV-32538: The HDMI volume Icon is not smooth

### DIFF
--- a/HdmiCecSink/HdmiCecSink.cpp
+++ b/HdmiCecSink/HdmiCecSink.cpp
@@ -3511,11 +3511,6 @@ namespace WPEFramework
                             _instance->sendKeyReleaseEvent(keyInfo.logicalAddr);
                     }
 
-		    if((_instance->m_SendKeyQueue.size()<=1 || (_instance->m_SendKeyQueue.size() % 2 == 0)) && ((keyInfo.keyCode == VOLUME_UP) || (keyInfo.keyCode == VOLUME_DOWN) || (keyInfo.keyCode == MUTE)) )
-		    {
-		        _instance->sendGiveAudioStatusMsg();
-		    }
-
             }//while(!_instance->m_sendKeyEventThreadExit)
         }//threadSendKeyEvent
 


### PR DESCRIPTION
Reason for change: Not requesting the Audio status upon the volume key press.
Test Procedure: refer the ticket
Risks: None
Signed-off-by: Neethu A S neethu.arambilsunny@sky.uk