### PR TITLE
RDK-54413: Correct the usage of array of pointers param in GetTVSupportedAPIs

### DIFF
--- a/AVOutput/AVOutputTV.cpp
+++ b/AVOutput/AVOutputTV.cpp
@@ -2276,13 +2276,16 @@ namespace Plugin {
 
         LOGINFO("Entry\n");
         tvDolbyMode_t dvModes[tvMode_Max];
-        tvDolbyMode_t *dvModesPtr = dvModes; // Pointer to statically allocated tvDolbyMode_t array 
+        tvDolbyMode_t *dvModesPtr[tvMode_Max];
         unsigned short totalAvailable = 0;
-
+        for (int i = 0; i < tvMode_Max; i++)
+        {
+            dvModesPtr[i] = &dvModes[i];
+        }
         // Set an initial value to indicate the mode type
         dvModes[0] = tvDolbyMode_Dark;
 
-        tvError_t ret = GetTVSupportedDolbyVisionModes(&dvModesPtr, &totalAvailable);
+        tvError_t ret = GetTVSupportedDolbyVisionModes(dvModesPtr, &totalAvailable);
         if(ret != tvERROR_NONE) {
             returnResponse(false);
         }
@@ -2510,9 +2513,14 @@ namespace Plugin {
     uint32_t AVOutputTV::getSupportedPictureModes(const JsonObject& parameters, JsonObject& response)
     {
         LOGINFO("Entry\n");
-        pic_modes_t *pictureModes;
+        pic_modes_t pictureModes[PIC_MODES_SUPPORTED_MAX];
+        pic_modes_t *pictureModesPtr[PIC_MODES_SUPPORTED_MAX];
         unsigned short totalAvailable = 0;
-        tvError_t ret = GetTVSupportedPictureModes(&pictureModes,&totalAvailable);
+        for (int i = 0; i < PIC_MODES_SUPPORTED_MAX; i++)
+        {
+            pictureModesPtr[i] = &pictureModes[i];
+        }
+        tvError_t ret = GetTVSupportedPictureModes(pictureModesPtr,&totalAvailable);
         if(ret != tvERROR_NONE) {
             returnResponse(false);
         }

--- a/AVOutput/AVOutputTVHelper.cpp
+++ b/AVOutput/AVOutputTVHelper.cpp
@@ -238,13 +238,18 @@ namespace Plugin {
     {
         int mode = 0;
         tvDolbyMode_t dolbyModes[tvMode_Max];
-        tvDolbyMode_t *dolbyModesPtr = dolbyModes; // Pointer to statically allocated tvDolbyMode_t array
+        tvDolbyMode_t *dolbyModesPtr[tvMode_Max];
         unsigned short totalAvailable = 0;
+
+        for (int i = 0; i < tvMode_Max; i++)
+        {
+            dolbyModesPtr[i] = &dolbyModes[i];
+        }
 
         // Set an initial value to indicate the mode type
         dolbyModes[0] = tvDolbyMode_Dark;
 
-        tvError_t ret = GetTVSupportedDolbyVisionModes(&dolbyModesPtr, &totalAvailable);
+        tvError_t ret = GetTVSupportedDolbyVisionModes(dolbyModesPtr, &totalAvailable);
         if (ret == tvERROR_NONE) {
             for (int count = 0; count < totalAvailable; count++) {
 		        if(strncasecmp(dolbyMode, getDolbyModeStringFromEnum(dolbyModes[count]).c_str(), strlen(dolbyMode))==0) {


### PR DESCRIPTION
GetTVSupportedPictureModes, GetTVSupportedVideoFormats, GetTVSupportedVideoSources, GetTVSupportedVideoSources, GetTVSupportedDolbyVisionModes does not properly use the array of pointers parameter in the HAL. Additionally, to match the current HAL code, the VTS code has been implemented, which is not the correct approach. The parameters must be passed according to the interface requirements. Changes are required in these APIs across the VTS L1/L2/L3 code.