### PR TITLE
RDKTV-35060 : Friendly name change causes pairing loss with phone

### DIFF
--- a/XCast/XCast.cpp
+++ b/XCast/XCast.cpp
@@ -128,6 +128,11 @@ XCast::~XCast()
         delete m_SystemPluginObj;
         m_SystemPluginObj = nullptr;
     }
+    if (m_FriendlyNameUpdateTimerID)
+    {
+        g_source_remove(m_FriendlyNameUpdateTimerID);
+        m_FriendlyNameUpdateTimerID = 0;
+    }
     _service = nullptr;
 }
 
@@ -631,11 +636,29 @@ void XCast::onFriendlyNameUpdateHandler(const JsonObject& parameters)
         {
             m_friendlyName = value;
             LOGINFO("onFriendlyNameUpdateHandler  :%s",m_friendlyName.c_str());
-            if (m_xcastEnable && ( (m_standbyBehavior == true) || ((m_standbyBehavior == false)&&(m_powerState == IARM_BUS_PWRMGR_POWERSTATE_ON)) ) ) {
-                _xcast->enableCastService(m_friendlyName,true);
+            if (m_FriendlyNameUpdateTimerID)
+            {
+                g_source_remove(m_FriendlyNameUpdateTimerID);
+                m_FriendlyNameUpdateTimerID = 0;
             }
-            else { 
-                _xcast->enableCastService(m_friendlyName,false);
+            m_FriendlyNameUpdateTimerID = g_timeout_add(50, XCast::update_friendly_name_timercallback, this);
+            if (0 == m_FriendlyNameUpdateTimerID)
+            {
+                bool enabledStatus = false;
+                LOGWARN("Failed to create the timer. Setting friendlyName immediately");
+                if (m_xcastEnable && ( (m_standbyBehavior == true) || ((m_standbyBehavior == false)&&(m_powerState == IARM_BUS_PWRMGR_POWERSTATE_ON)) ) )
+                {
+                    enabledStatus = true;
+                }
+                if (_xcast)
+                {
+                    LOGINFO("Updating FriendlyName [%s] status[%x]",m_friendlyName.c_str(),enabledStatus);
+                    _xcast->enableCastService(m_friendlyName,enabledStatus);
+                }
+            }
+            else
+            {
+                LOGINFO("Timer triggered to update friendlyName");
             }
         }
     }
@@ -656,6 +679,28 @@ uint32_t XCast::getProtocolVersion(const JsonObject& parameters, JsonObject& res
         }
     }
     returnResponse(returnStatus);
+}
+
+gboolean XCast::update_friendly_name_timercallback(gpointer userdata)
+{
+    XCast *self = (XCast *)userdata;
+    bool enabledStatus = false;
+
+    if (m_xcastEnable && ( (m_standbyBehavior == true) || ((m_standbyBehavior == false)&&(m_powerState == IARM_BUS_PWRMGR_POWERSTATE_ON)) ) )
+    {
+        enabledStatus = true;
+    }
+
+    if (self && self->_xcast)
+    {
+        LOGINFO("Updating FriendlyName from Timer [%s] status[%x]",m_friendlyName.c_str(),enabledStatus);
+        self->_xcast->enableCastService(m_friendlyName,enabledStatus);
+    }
+    else
+    {
+        LOGERR("instance NULL [%p]",self);
+    }
+    return G_SOURCE_REMOVE;
 }
 
 bool XCast::getEntryFromAppLaunchParamList (const char* appName, DynamicAppConfig& retAppConfig)

--- a/XCast/XCast.h
+++ b/XCast/XCast.h
@@ -42,6 +42,7 @@
 #include "XCastCommon.h"
 #include <mutex>
 #include <map>
+#include <glib.h>
 #include "UtilsLogging.h"
 
 namespace WPEFramework {
@@ -168,6 +169,7 @@ namespace Plugin {
         std::vector<DynamicAppConfig*> m_appConfigCache;
         static string m_friendlyName;
         static bool m_standbyBehavior;
+        guint m_FriendlyNameUpdateTimerID{0};
         //Timer related variables and functions
         TpTimer m_locateCastTimer;
         void InitializeIARM();
@@ -182,6 +184,7 @@ namespace Plugin {
         void updateDynamicAppCache(JsonArray applications);
         void getSystemPlugin();
         int updateSystemFriendlyName();
+        static gboolean update_friendly_name_timercallback(gpointer userdata);
         void onFriendlyNameUpdateHandler(const JsonObject& parameters);
         bool setPowerState(std::string powerState);
 


### PR DESCRIPTION
RDKTV-35060 : Friendly name change causes pairing loss with phone

Reason for change: FriendlyName updation between inprocess and outofprocess takes 20sec
Test Procedure: FriendlyName updation should take less than 1sec
Risks: Low

Signed-off-by: yuvaramachandran_gurusamy [yuvaramachandran_gurusamy@comcast.com]