### PR TITLE
LLAMA-16238: Static audio heard while navigating after enabling VG

### DIFF
--- a/SystemAudioPlayer/impl/AudioPlayer.cpp
+++ b/SystemAudioPlayer/impl/AudioPlayer.cpp
@@ -49,18 +49,8 @@ AudioPlayer::AudioPlayer(AudioType audioType,SourceType sourceType,PlayMode play
     {
         m_PCMFormat = "S16LE";
         m_Layout = "interleaved";
-        if(playMode == SYSTEM)
-        {
-            m_Rate = 44100;
-            m_Channels = 2;
-        }
-        else
-        {
-            // tts-mode for local tts
-            m_Rate = 22050;
-            m_Channels = 1;
-        }
-
+        m_Rate = 22050;
+        m_Channels = 1;
     }
 
     createPipeline(false);


### PR DESCRIPTION
Reason for change: Fix audio glitch  
Test Procedure: Mentioned in ticket
Risks: Low