### PR TITLE
 RDKEMW-495: [RDKE][XUMO] - Observed failed to start the Home app

### DIFF
--- a/UserSettings/UserSettings.cpp
+++ b/UserSettings/UserSettings.cpp
@@ -19,7 +19,7 @@
 
 #include "UserSettings.h"
 
-#define API_VERSION_NUMBER_MAJOR 2
+#define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 0
 #define API_VERSION_NUMBER_PATCH 0
 
@@ -76,6 +76,20 @@ namespace WPEFramework
 
         if(nullptr != _userSetting)
         {
+            configure = _userSetting->QueryInterface<Exchange::IConfiguration>();
+            if (configure != nullptr)
+            {
+                uint32_t result = configure->Configure(_service);
+                if(result != Core::ERROR_NONE)
+                {
+                    message = _T("UserSettings could not be configured");
+                }
+            }
+            else
+            {
+                message = _T("UserSettings implementation did not provide a configuration interface");
+            }
+
             // Register for notifications
             _userSetting->Register(&_usersettingsNotification);
             // Invoking Plugin API register to wpeframework
@@ -108,6 +122,8 @@ namespace WPEFramework
         {
             _userSetting->Unregister(&_usersettingsNotification);
             Exchange::JUserSettings::Unregister(*this);
+
+            configure->Release();
 
             // Stop processing:
             RPC::IRemoteConnection* connection = service->RemoteConnection(_connectionId);

--- a/UserSettings/UserSettings.cpp
+++ b/UserSettings/UserSettings.cpp
@@ -19,7 +19,7 @@
 
 #include "UserSettings.h"
 
-#define API_VERSION_NUMBER_MAJOR 1
+#define API_VERSION_NUMBER_MAJOR 2
 #define API_VERSION_NUMBER_MINOR 0
 #define API_VERSION_NUMBER_PATCH 0
 

--- a/UserSettings/UserSettings.h
+++ b/UserSettings/UserSettings.h
@@ -23,6 +23,7 @@
 #include <interfaces/json/JsonData_UserSettings.h>
 #include <interfaces/json/JUserSettings.h>
 #include <interfaces/IUserSettings.h>
+#include <interfaces/IConfiguration.h>
 #include "UtilsLogging.h"
 #include "tracing/Logging.h"
 #include <mutex>
@@ -104,12 +105,6 @@ namespace Plugin {
                     Exchange::JUserSettings::Event::OnPreferredClosedCaptionServiceChanged(_parent, service);
                 }
 
-                void OnPrivacyModeChanged(const string &privacyMode) override
-                {
-                    LOGINFO("PrivacyModeChanged: %s\n", privacyMode.c_str());
-                    Exchange::JUserSettings::Event::OnPrivacyModeChanged(_parent, privacyMode);
-                }
-
                 void OnPinControlChanged(const bool pinControl) override
                 {
                     LOGINFO("PinControlChanged: %d\n", pinControl);
@@ -184,6 +179,7 @@ namespace Plugin {
             uint32_t _connectionId{};
             Exchange::IUserSettings* _userSetting{};
             Core::Sink<Notification> _usersettingsNotification;
+            Exchange::IConfiguration* configure;
     };
 
 } // namespace Plugin

--- a/UserSettings/UserSettings.h
+++ b/UserSettings/UserSettings.h
@@ -105,6 +105,11 @@ namespace Plugin {
                     Exchange::JUserSettings::Event::OnPreferredClosedCaptionServiceChanged(_parent, service);
                 }
 
+                void OnPrivacyModeChanged(const string &privacyMode) override
+                {
+                    LOGINFO("PrivacyModeChanged: %s\n", privacyMode.c_str());
+                    Exchange::JUserSettings::Event::OnPrivacyModeChanged(_parent, privacyMode);
+                }
                 void OnPinControlChanged(const bool pinControl) override
                 {
                     LOGINFO("PinControlChanged: %d\n", pinControl);

--- a/UserSettings/UserSettingsImplementation.cpp
+++ b/UserSettings/UserSettingsImplementation.cpp
@@ -23,11 +23,6 @@
 #include <mutex>
 #include "tracing/Logging.h"
 
-#ifdef HAS_RBUS
-#define RBUS_COMPONENT_NAME "UserSettingsThunderPlugin"
-#define RBUS_PRIVACY_MODE_EVENT_NAME "Device.X_RDKCENTRAL-COM_UserSettings.PrivacyModeChanged"
-#endif
-
 namespace WPEFramework {
 namespace Plugin {
 
@@ -49,50 +44,41 @@ SERVICE_REGISTRATION(UserSettingsImplementation, 1, 0);
 
 UserSettingsImplementation::UserSettingsImplementation()
 : _adminLock()
-, _engine(Core::ProxyType<RPC::InvokeServerType<1, 0, 4>>::Create())
-, _communicatorClient(Core::ProxyType<RPC::CommunicatorClient>::Create(Core::NodeId("/tmp/communicator"), Core::ProxyType<Core::IIPCServer>(_engine)))
-, _controller(nullptr)
 , _remotStoreObject(nullptr)
 , _storeNotification(*this)
 , _registeredEventHandlers(false)
-#ifdef HAS_RBUS
-, _rbusHandleStatus(RBUS_ERROR_NOT_INITIALIZED)
-#endif
+, _service(nullptr)
 {
     LOGINFO("Create UserSettingsImplementation Instance");
-
     UserSettingsImplementation::instance(this);
+}
 
-     if (!_communicatorClient.IsValid())
-     {
-         LOGWARN("Invalid _communicatorClient\n");
-    }
-    else
+uint32_t UserSettingsImplementation::Configure(PluginHost::IShell* service)
+{
+    uint32_t result = Core::ERROR_GENERAL;
+
+    if (service != nullptr && _service == nullptr)
     {
+        _service = service;
+        _service->AddRef();
+        result = Core::ERROR_NONE;
 
-#if ((THUNDER_VERSION == 2) || ((THUNDER_VERSION == 4) && (THUNDER_VERSION_MINOR == 2)))
-        _engine->Announcements(_communicatorClient->Announcement());
-#endif
-
-        LOGINFO("Connect the COM-RPC socket\n");
-        _controller = _communicatorClient->Open<PluginHost::IShell>(_T("org.rdk.PersistentStore"), ~0, 3000);
-
-        if (_controller)
+        _remotStoreObject = _service->QueryInterfaceByCallsign<WPEFramework::Exchange::IStore2>("org.rdk.PersistentStore");
+        if (_remotStoreObject != nullptr)
         {
-             _remotStoreObject = _controller->QueryInterface<Exchange::IStore2>();
-
-             if(_remotStoreObject)
-             {
-                 _remotStoreObject->AddRef();
-             }
+            registerEventHandlers();
         }
         else
         {
-            LOGERR("Failed to create PersistentStore Controller\n");
+            LOGERR("_remotStoreObject is null \n");
         }
-
-        registerEventHandlers();
     }
+    else
+    {
+        LOGERR("service is null \n");
+    }
+
+    return result;
 }
 
 UserSettingsImplementation* UserSettingsImplementation::instance(UserSettingsImplementation *UserSettingsImpl)
@@ -111,48 +97,28 @@ UserSettingsImplementation* UserSettingsImplementation::instance(UserSettingsImp
 
 UserSettingsImplementation::~UserSettingsImplementation()
 {
-    if (_controller)
-    {
-        _controller->Release();
-        _controller = nullptr;
-    }
-
-    LOGINFO("Disconnect from the COM-RPC socket\n");
-    // Disconnect from the COM-RPC socket
-    _communicatorClient->Close(RPC::CommunicationTimeOut);
-    if (_communicatorClient.IsValid())
-    {
-        _communicatorClient.Release();
-    }
-
-    if(_engine.IsValid())
-    {
-        _engine.Release();
-    }
-
     if(_remotStoreObject)
     {
         _remotStoreObject->Release();
     }
-    _registeredEventHandlers = false;
-    
-#ifdef HAS_RBUS
-    if (RBUS_ERROR_SUCCESS == _rbusHandleStatus)
+    if (_service != nullptr)
     {
-        rbus_close(_rbusHandle);
-        _rbusHandleStatus = RBUS_ERROR_NOT_INITIALIZED;
+       _service->Release();
     }
 
-#endif
+    _registeredEventHandlers = false;
 }
 
 void UserSettingsImplementation::registerEventHandlers()
 {
-    ASSERT (nullptr != _remotStoreObject);
-
-    if(!_registeredEventHandlers && _remotStoreObject) {
+    if (!_registeredEventHandlers && _remotStoreObject)
+    {
         _registeredEventHandlers = true;
         _remotStoreObject->Register(&_storeNotification);
+    }
+    else
+    {
+        LOGERR("_remotStoreObject is null or _registeredEventHandlers is true");
     }
 }
 
@@ -268,14 +234,6 @@ void UserSettingsImplementation::Dispatch(Event event, const JsonValue params)
              }
          break;
 
-         case PRIVACY_MODE_CHANGED:
-             while (index != _userSettingNotification.end())
-             {
-                 (*index)->OnPrivacyModeChanged(params.String());
-                 ++index;
-             }
-         break;
-
          case PIN_CONTROL_CHANGED:
               while (index != _userSettingNotification.end())
               {
@@ -367,10 +325,6 @@ void UserSettingsImplementation::ValueChanged(const Exchange::IStore2::ScopeType
     {
         dispatchEvent(PREFERRED_CLOSED_CAPTIONS_SERVICE_CHANGED, JsonValue((string)value));
     }
-    else if((ns.compare(USERSETTINGS_NAMESPACE) == 0) && (key.compare(USERSETTINGS_PRIVACY_MODE_KEY) == 0))
-    {
-        dispatchEvent(PRIVACY_MODE_CHANGED, JsonValue((string)value));
-    }
     else if((ns.compare(USERSETTINGS_NAMESPACE) == 0) && (key.compare(USERSETTINGS_PIN_CONTROL_KEY) == 0))
     {
         dispatchEvent(PIN_CONTROL_CHANGED, JsonValue((bool)(value.compare("true")==0)?true:false));
@@ -410,12 +364,14 @@ uint32_t UserSettingsImplementation::SetUserSettingsValue(const string& key, con
     uint32_t status = Core::ERROR_GENERAL;
     _adminLock.Lock();
 
-    ASSERT (nullptr != _remotStoreObject);
     if (nullptr != _remotStoreObject)
     {
         status = _remotStoreObject->SetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, key, value, 0);
     }
-
+    else
+    {
+        LOGERR("_remotStoreObject is null");
+    }
     _adminLock.Unlock();
     return status;
 }
@@ -426,12 +382,10 @@ uint32_t UserSettingsImplementation::GetUserSettingsValue(const string& key, str
     uint32_t ttl = 0;
     _adminLock.Lock();
 
-    ASSERT (nullptr != _remotStoreObject);
+    LOGINFO("Key[%s] value[%s]", key.c_str(), value.c_str());
     if (nullptr != _remotStoreObject)
     {
         status = _remotStoreObject->GetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, key, value, ttl);
-
-        LOGINFO("Key[%s] value[%s] status[%d]", key.c_str(), value.c_str(), status);
         if(Core::ERROR_UNKNOWN_KEY == status || Core::ERROR_NOT_EXIST == status)
         {
             if(usersettingsDefaultMap.find(key)!=usersettingsDefaultMap.end())
@@ -445,6 +399,11 @@ uint32_t UserSettingsImplementation::GetUserSettingsValue(const string& key, str
             }
         }
     }
+    else
+    {
+        LOGERR("_remotStoreObject is null");
+    }
+
     _adminLock.Unlock();
 
     return status;
@@ -579,99 +538,6 @@ uint32_t UserSettingsImplementation::GetPreferredClosedCaptionService(string &se
     std::string value = "";
 
     status = GetUserSettingsValue(USERSETTINGS_PREFERRED_CLOSED_CAPTIONS_SERVICE_KEY, service);
-    return status;
-}
-
-uint32_t UserSettingsImplementation::SetPrivacyMode(const string& privacyMode)
-{
-    uint32_t status = Core::ERROR_GENERAL;
-
-    LOGINFO("privacyMode: %s", privacyMode.c_str());
-
-    if (privacyMode != "SHARE" && privacyMode != "DO_NOT_SHARE")
-    {
-        LOGERR("Wrong privacyMode value: '%s', returning default", privacyMode.c_str());
-        return status;
-    }
-
-    _adminLock.Lock();
-
-    ASSERT (nullptr != _remotStoreObject);
-
-    if (nullptr != _remotStoreObject)
-    {
-        uint32_t ttl = 0;
-        string oldPrivacyMode;
-        status = _remotStoreObject->GetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_PRIVACY_MODE_KEY, oldPrivacyMode, ttl);
-        LOGINFO("oldPrivacyMode: %s", oldPrivacyMode.c_str());
-
-        if (privacyMode != oldPrivacyMode)
-        {
-#ifdef HAS_RBUS
-            if (Core::ERROR_NONE == status)
-            {
-                if (RBUS_ERROR_SUCCESS != _rbusHandleStatus)
-                {
-                    _rbusHandleStatus = rbus_open(&_rbusHandle, RBUS_COMPONENT_NAME);
-                }
-
-                if (RBUS_ERROR_SUCCESS == _rbusHandleStatus)
-                {
-                    rbusValue_t value;
-                    rbusSetOptions_t opts = {true, 0};
-
-                    rbusValue_Init(&value);
-                    rbusValue_SetString(value, privacyMode.c_str());
-                    int rc = rbus_set(_rbusHandle, RBUS_PRIVACY_MODE_EVENT_NAME, value, &opts);
-                    if (rc != RBUS_ERROR_SUCCESS)
-                    {
-                        std::stringstream str;
-                        str << "Failed to set property " << RBUS_PRIVACY_MODE_EVENT_NAME << ": " << rc;
-                        LOGERR("%s", str.str().c_str());
-                    }
-                    rbusValue_Release(value);
-                }
-                else
-                {
-                    std::stringstream str;
-                    str << "rbus_open failed with error code " << _rbusHandleStatus;
-                    LOGERR("%s", str.str().c_str());
-                }
-            }
-#endif
-            status = _remotStoreObject->SetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_PRIVACY_MODE_KEY, privacyMode, 0);
-        }
-    }
-
-    _adminLock.Unlock();
-
-    return status;
-}
-
-uint32_t UserSettingsImplementation::GetPrivacyMode(string &privacyMode) const
-{
-    uint32_t status = Core::ERROR_NONE;
-    std::string value = "";
-    uint32_t ttl = 0;
-    privacyMode = "";
-
-    _adminLock.Lock();
-
-    ASSERT (nullptr != _remotStoreObject);
-
-    if (nullptr != _remotStoreObject)
-    {
-        _remotStoreObject->GetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_PRIVACY_MODE_KEY, privacyMode, ttl);
-    }
-
-    _adminLock.Unlock();
-    
-    if (privacyMode != "SHARE" && privacyMode != "DO_NOT_SHARE") 
-    {
-        LOGWARN("Wrong privacyMode value: '%s', returning default", privacyMode.c_str());
-        privacyMode = "SHARE";
-    }
-
     return status;
 }
 
@@ -852,6 +718,7 @@ uint32_t UserSettingsImplementation::GetPinOnPurchase(bool &pinOnPurchase) const
 
     if(Core::ERROR_NONE == status)
     {
+
         if (0 == value.compare("true"))
         {
             pinOnPurchase = true;

--- a/UserSettings/UserSettingsImplementation.cpp
+++ b/UserSettings/UserSettingsImplementation.cpp
@@ -23,6 +23,10 @@
 #include <mutex>
 #include "tracing/Logging.h"
 
+#ifdef HAS_RBUS
+#define RBUS_COMPONENT_NAME "UserSettingsThunderPlugin"
+#define RBUS_PRIVACY_MODE_EVENT_NAME "Device.X_RDKCENTRAL-COM_UserSettings.PrivacyModeChanged"
+#endif
 namespace WPEFramework {
 namespace Plugin {
 
@@ -47,7 +51,9 @@ UserSettingsImplementation::UserSettingsImplementation()
 , _remotStoreObject(nullptr)
 , _storeNotification(*this)
 , _registeredEventHandlers(false)
-, _service(nullptr)
+#ifdef HAS_RBUS
+, _rbusHandleStatus(RBUS_ERROR_NOT_INITIALIZED)
+#endif
 {
     LOGINFO("Create UserSettingsImplementation Instance");
     UserSettingsImplementation::instance(this);
@@ -107,6 +113,14 @@ UserSettingsImplementation::~UserSettingsImplementation()
     }
 
     _registeredEventHandlers = false;
+#ifdef HAS_RBUS
+    if (RBUS_ERROR_SUCCESS == _rbusHandleStatus)
+    {
+        rbus_close(_rbusHandle);
+        _rbusHandleStatus = RBUS_ERROR_NOT_INITIALIZED;
+    }
+
+#endif
 }
 
 void UserSettingsImplementation::registerEventHandlers()
@@ -234,6 +248,13 @@ void UserSettingsImplementation::Dispatch(Event event, const JsonValue params)
              }
          break;
 
+         case PRIVACY_MODE_CHANGED:
+             while (index != _userSettingNotification.end())
+             {
+                 (*index)->OnPrivacyModeChanged(params.String());
+                 ++index;
+             }
+         break;
          case PIN_CONTROL_CHANGED:
               while (index != _userSettingNotification.end())
               {
@@ -324,6 +345,10 @@ void UserSettingsImplementation::ValueChanged(const Exchange::IStore2::ScopeType
     else if((ns.compare(USERSETTINGS_NAMESPACE) == 0) && (key.compare(USERSETTINGS_PREFERRED_CLOSED_CAPTIONS_SERVICE_KEY) == 0))
     {
         dispatchEvent(PREFERRED_CLOSED_CAPTIONS_SERVICE_CHANGED, JsonValue((string)value));
+    }
+    else if((ns.compare(USERSETTINGS_NAMESPACE) == 0) && (key.compare(USERSETTINGS_PRIVACY_MODE_KEY) == 0))
+    {
+        dispatchEvent(PRIVACY_MODE_CHANGED, JsonValue((string)value));
     }
     else if((ns.compare(USERSETTINGS_NAMESPACE) == 0) && (key.compare(USERSETTINGS_PIN_CONTROL_KEY) == 0))
     {
@@ -538,6 +563,99 @@ uint32_t UserSettingsImplementation::GetPreferredClosedCaptionService(string &se
     std::string value = "";
 
     status = GetUserSettingsValue(USERSETTINGS_PREFERRED_CLOSED_CAPTIONS_SERVICE_KEY, service);
+    return status;
+}
+
+uint32_t UserSettingsImplementation::SetPrivacyMode(const string& privacyMode)
+{
+    uint32_t status = Core::ERROR_GENERAL;
+
+    LOGINFO("privacyMode: %s", privacyMode.c_str());
+
+    if (privacyMode != "SHARE" && privacyMode != "DO_NOT_SHARE")
+    {
+        LOGERR("Wrong privacyMode value: '%s', returning default", privacyMode.c_str());
+        return status;
+    }
+
+    _adminLock.Lock();
+
+    ASSERT (nullptr != _remotStoreObject);
+
+    if (nullptr != _remotStoreObject)
+    {
+        uint32_t ttl = 0;
+        string oldPrivacyMode;
+        status = _remotStoreObject->GetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_PRIVACY_MODE_KEY, oldPrivacyMode, ttl);
+        LOGINFO("oldPrivacyMode: %s", oldPrivacyMode.c_str());
+
+        if (privacyMode != oldPrivacyMode)
+        {
+#ifdef HAS_RBUS
+            if (Core::ERROR_NONE == status)
+            {
+                if (RBUS_ERROR_SUCCESS != _rbusHandleStatus)
+                {
+                    _rbusHandleStatus = rbus_open(&_rbusHandle, RBUS_COMPONENT_NAME);
+                }
+
+                if (RBUS_ERROR_SUCCESS == _rbusHandleStatus)
+                {
+                    rbusValue_t value;
+                    rbusSetOptions_t opts = {true, 0};
+
+                    rbusValue_Init(&value);
+                    rbusValue_SetString(value, privacyMode.c_str());
+                    int rc = rbus_set(_rbusHandle, RBUS_PRIVACY_MODE_EVENT_NAME, value, &opts);
+                    if (rc != RBUS_ERROR_SUCCESS)
+                    {
+                        std::stringstream str;
+                        str << "Failed to set property " << RBUS_PRIVACY_MODE_EVENT_NAME << ": " << rc;
+                        LOGERR("%s", str.str().c_str());
+                    }
+                    rbusValue_Release(value);
+                }
+                else
+                {
+                    std::stringstream str;
+                    str << "rbus_open failed with error code " << _rbusHandleStatus;
+                    LOGERR("%s", str.str().c_str());
+                }
+            }
+#endif
+            status = _remotStoreObject->SetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_PRIVACY_MODE_KEY, privacyMode, 0);
+        }
+    }
+
+    _adminLock.Unlock();
+
+    return status;
+}
+
+uint32_t UserSettingsImplementation::GetPrivacyMode(string &privacyMode) const
+{
+    uint32_t status = Core::ERROR_NONE;
+    std::string value = "";
+    uint32_t ttl = 0;
+    privacyMode = "";
+
+    _adminLock.Lock();
+
+    ASSERT (nullptr != _remotStoreObject);
+
+    if (nullptr != _remotStoreObject)
+    {
+        _remotStoreObject->GetValue(Exchange::IStore2::ScopeType::DEVICE, USERSETTINGS_NAMESPACE, USERSETTINGS_PRIVACY_MODE_KEY, privacyMode, ttl);
+    }
+
+    _adminLock.Unlock();
+    
+    if (privacyMode != "SHARE" && privacyMode != "DO_NOT_SHARE") 
+    {
+        LOGWARN("Wrong privacyMode value: '%s', returning default", privacyMode.c_str());
+        privacyMode = "SHARE";
+    }
+
     return status;
 }
 

--- a/UserSettings/UserSettingsImplementation.h
+++ b/UserSettings/UserSettingsImplementation.h
@@ -31,6 +31,10 @@
 #include <core/core.h>
 #include <plugins/plugins.h>
 
+#ifdef HAS_RBUS
+#include "rbus.h"
+#endif
+
 #define USERSETTINGS_NAMESPACE "UserSettings"
 
 #define USERSETTINGS_AUDIO_DESCRIPTION_KEY                    "audioDescription"
@@ -39,6 +43,7 @@
 #define USERSETTINGS_CAPTIONS_KEY                             "captions"
 #define USERSETTINGS_PREFERRED_CAPTIONS_LANGUAGES_KEY         "preferredCaptionsLanguages"
 #define USERSETTINGS_PREFERRED_CLOSED_CAPTIONS_SERVICE_KEY    "preferredClosedCaptionsService"
+#define USERSETTINGS_PRIVACY_MODE_KEY                         "privacyMode"
 #define USERSETTINGS_PIN_CONTROL_KEY                          "pinControl"
 #define USERSETTINGS_VIEWING_RESTRICTIONS_KEY                 "viewingRestrictions"
 #define USERSETTINGS_VIEWING_RESTRICTIONS_WINDOW_KEY          "viewingRestrictionsWindow"
@@ -106,6 +111,7 @@ namespace Plugin {
                 CAPTIONS_CHANGED,
                 PREFERRED_CAPTIONS_LANGUAGE_CHANGED,
                 PREFERRED_CLOSED_CAPTIONS_SERVICE_CHANGED,
+                PRIVACY_MODE_CHANGED,
                 PIN_CONTROL_CHANGED,
                 VIEWING_RESTRICTIONS_CHANGED,
                 VIEWING_RESTRICTIONS_WINDOW_CHANGED,
@@ -169,6 +175,8 @@ namespace Plugin {
         uint32_t GetPreferredCaptionsLanguages(string &preferredLanguages) const override;
         uint32_t SetPreferredClosedCaptionService(const string& service) override;
         uint32_t GetPreferredClosedCaptionService(string &service) const override;
+        uint32_t SetPrivacyMode(const string& privacyMode) override;
+        uint32_t GetPrivacyMode(string &privacyMode) const override;
         uint32_t SetPinControl(const bool pinControl) override;
         uint32_t GetPinControl(bool &pinControl) const override;
         uint32_t SetViewingRestrictions(const string& viewingRestrictions) override;
@@ -202,6 +210,10 @@ namespace Plugin {
         bool _registeredEventHandlers;
         PluginHost::IShell* _service;
 
+#ifdef HAS_RBUS
+        rbusError_t _rbusHandleStatus;
+        rbusHandle_t _rbusHandle;
+#endif
         void dispatchEvent(Event, const JsonValue &params);
         void Dispatch(Event event, const JsonValue params);
 


### PR DESCRIPTION
Reason for change:
QueryInterfaceByCallsign used in UserSettings to get persistentStore(IStore2) interface.

 Test Procedure:
 Run L2 workflows. Create full stack build and verify all the curl commands of UserSettings.

 Risks: High
 Priority: P0
