### PR TITLE
RDKTV-35412 : ResidentApp is not restarted automatically when it was crashed

### DIFF
--- a/Monitor/CHANGELOG.md
+++ b/Monitor/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [2.0.1] - 2025-02-04
+### Changed
+- Bring back the Delay changes in Thread Restart Logic
+
 ## [2.0.0] - 2024-12-12
 ### Changed
 - Synced Monitor Plugin with WebPlatformForEmbedded/ThunderNanoServicesRDK/tree/R4_4/Monitor

--- a/Monitor/Monitor.cpp
+++ b/Monitor/Monitor.cpp
@@ -21,7 +21,7 @@
 
 #define API_VERSION_NUMBER_MAJOR 2
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 0
+#define API_VERSION_NUMBER_PATCH 1
 
 namespace WPEFramework {
 namespace Plugin {

--- a/Monitor/Monitor.h
+++ b/Monitor/Monitor.h
@@ -787,7 +787,7 @@ POP_WARNING()
                             _service->Notify(message);
                             _parent.event_action(callsign, "Activate", "Automatic");
                             TRACE(Trace::Error, (_T("Restarting %s again because we detected it misbehaved."), callsign.c_str()));
-                            Core::IWorkerPool::Instance().Submit(PluginHost::IShell::Job::Create(service, PluginHost::IShell::ACTIVATED, PluginHost::IShell::AUTOMATIC));
+                            Core::IWorkerPool::Instance().Schedule(Core::Time::Now().Add(5000), PluginHost::IShell::Job::Create(service, PluginHost::IShell::ACTIVATED, PluginHost::IShell::AUTOMATIC));
                         }
                     } 
                 }


### PR DESCRIPTION
Reason for change: Thread Restart Logic due to recent Monitor plugin sync with ThunderNanoServices. Bring back the Thread Restart Logic.
Test Procedure: Verified in Jenkins Build
Risks: High
Signed-off-by: Thamim  Razith <tabbas651@cable.comcast.com>