### PR TITLE
matchMedia("(dynamic-range: high)") implementation for hot plugin sce…

### DIFF
--- a/WebKitBrowser/CMakeLists.txt
+++ b/WebKitBrowser/CMakeLists.txt
@@ -270,6 +270,20 @@ add_library(${PLUGIN_WEBKITBROWSER_IMPLEMENTATION} SHARED
     Tags.cpp
     )
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../cmake")
+find_package(DS REQUIRED)
+find_package(IARMBus REQUIRED)
+target_include_directories(${PLUGIN_WEBKITBROWSER_IMPLEMENTATION}
+    PRIVATE
+    ${IARMBUS_INCLUDE_DIRS}
+    ${DS_INCLUDE_DIRS}
+    ../helpers)
+
+target_link_libraries(${PLUGIN_WEBKITBROWSER_IMPLEMENTATION}
+    PRIVATE
+    ${IARMBUS_LIBRARIES}
+    ${DS_LIBRARIES})
+
 if(NOT WEBKIT_GLIB_API)
     target_sources(${PLUGIN_WEBKITBROWSER_IMPLEMENTATION} PRIVATE InjectedBundle/Utils.cpp)
 endif()


### PR DESCRIPTION
…nario

This PR includes modifications in the webkitbrowser-plugin for the issue: https://github.com/WebPlatformForEmbedded/WPEWebKit/issues/1430. The fix in the WPEWebKit is already merged in https://github.com/WebPlatformForEmbedded/WPEWebKit repository as part of the PR: https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1448

**Note:**
In meta-rdk directory, below modifications are required to include dependency for webkitbrowser-plugin with devicesettings and iarmmgrs component.

git diff recipes-extended/webkitbrowser-plugin/webkitbrowser-plugin_git.bb
diff --git a/recipes-extended/webkitbrowser-plugin/webkitbrowser-plugin_git.bb b/recipes-extended/webkitbrowser-plugin/webkitbrowser-plugin_git.bb
index a4e00e8..4a6508f 100644
--- a/recipes-extended/webkitbrowser-plugin/webkitbrowser-plugin_git.bb
+++ b/recipes-extended/webkitbrowser-plugin/webkitbrowser-plugin_git.bb
@@ -27,6 +27,8 @@ TOOLCHAIN = "gcc"
 
 DEPENDS += "wpeframework wpeframework-tools-native ${WPEWEBKIT}"
 DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES', 'enable_libsoup3', 'libsoup', 'libsoup-2.4', d)}"
+DEPENDS += "devicesettings iarmmgrs"
+RDEPENDS_${PN} += "devicesettings"
 RRECOMMENDS_${PN} += "webkitbrowser-cache-cleanup"
 
 PACKAGECONFIG ??= "residentapp searchanddiscoveryapp htmlapp lightningapp aampjsbindings badgerbridge customprocessinfo"