### PR TITLE
RDKTV-35368: Failed to verify getApplication method

### DIFF
--- a/ContinueWatching/ContinueWatching.cpp
+++ b/ContinueWatching/ContinueWatching.cpp
@@ -139,7 +139,7 @@ namespace WPEFramework {
 				LOGERR("getApplicationToken Error \n");
 			}
 			appToken.Add(JsonValue(token));
-			response["application_token"]=appToken;
+			//response["application_token"]=appToken;
 			returnResponse(ret);
 		}
 


### PR DESCRIPTION
Reason for change: Adding debugs
Test Procedure: Debugging

Risks: Low
DO NOT MERGE