### PR TITLE
DELIA-66586: WPEFramework crash with signature "WPEFramework::Plugin:Packager::Deinitialize"

### DIFF
--- a/Packager/Packager.cpp
+++ b/Packager/Packager.cpp
@@ -57,7 +57,7 @@ namespace {
         _service->Register(&_notification);
 
          string result;
-        _implementation = _service->Root<Exchange::IPackager>(_connectionId, 2000, _T("PackagerImplementation"));
+        _implementation = _service->Root<Exchange::IPackager>(_connectionId, 5000, _T("PackagerImplementation"));
         if (_implementation == nullptr) {
             result = _T("Couldn't create package instance");
             _service->Unregister(&_notification);
@@ -73,9 +73,12 @@ namespace {
     {
         ASSERT(_service == service);
 
-        _service->Unregister(&_notification);
+        if(_service != nullptr) 
+        {
+           _service->Unregister(&_notification);
+        }
 
-        if (_implementation->Release() != Core::ERROR_DESTRUCTION_SUCCEEDED) {
+        if (_implementation != nullptr && _implementation->Release() != Core::ERROR_DESTRUCTION_SUCCEEDED) {
 
             ASSERT(_connectionId != 0);
 


### PR DESCRIPTION
Reason for Change: Fixed the packager plugin failed crash issue.
Test Procedure: Refer the ticket
Priority: P