### PR TITLE
RDKEMW-1817 : fix callsign

### DIFF
--- a/ContentProtection/ContentProtection.cpp
+++ b/ContentProtection/ContentProtection.cpp
@@ -69,9 +69,9 @@ namespace Plugin {
         Core::SystemInfo::SetEnvironment(_T("THUNDER_ACCESS"),
             (_T("127.0.0.1:9998")));
         _secManager = Core::ProxyType<JSONRPCLink>::Create(
-            _T("SecManager"), _T(""), "token=" + token);
+            _T("org.rdk.SecManager"), _T(""), "token=" + token);
         _watermark = Core::ProxyType<JSONRPCLink>::Create(
-            _T("Watermark"), _T(""), "token=" + token);
+            _T("org.rdk.Watermark"), _T(""), "token=" + token);
         Subscribe();
 
         return result;


### PR DESCRIPTION
Reason for change: "org.rdk." missing.
Test Procedure: None
Risks: None
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>