### PR TITLE
RDK-56377: Add Text View On CEC message during OTP

### DIFF
--- a/HdmiCecSource/HdmiCecSource.cpp
+++ b/HdmiCecSource/HdmiCecSource.cpp
@@ -1477,8 +1477,11 @@ namespace WPEFramework
                 if (smConnection)  {
                     try
                     {
-                        LOGINFO("Command: sending ImageViewOn TV \r\n");
+                        /*LOGINFO("Command: sending ImageViewOn TV \r\n");
                         smConnection->sendTo(LogicalAddress::TV, MessageEncoder().encode(ImageViewOn()));
+                        usleep(10000);*/
+                        LOGINFO("Command: sending TextViewOn TV \r\n");
+                        smConnection->sendTo(LogicalAddress::TV, MessageEncoder().encode(TextViewOn()));
                         usleep(10000);
                         LOGINFO("Command: sending ActiveSource  physical_addr :%s \r\n",physical_addr.toString().c_str());
                         smConnection->sendTo(LogicalAddress::BROADCAST, MessageEncoder().encode(ActiveSource(physical_addr)));


### PR DESCRIPTION
Reason for change: Add Text View On CEC message during OTP

Test Procedure: build and verify
Risks: Medium
Priority: P1
Signed-off-by: Srigayathry Pugazhenthi <srigayathry.pugazhenthi@sky.uk>