### PR TITLE
DELIA-67506 : Monitor Change to include ILifeTime based deinitialize  actions

### DIFF
--- a/Monitor/CHANGELOG.md
+++ b/Monitor/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [2.0.2] - 2025-02-28
+### Changed
+ MonitorObjects inherit from PluginHost::IPlugin::ILifeTime and relaunching apps in Deinitialized() instead of Deactivated().
+
 ## [2.0.1] - 2025-02-06
 ### Changed
 - Thread Restart Logic removed due to recent Monitor Sync up. Bring back the Delay changes in Thread Restart Logic

--- a/Monitor/Monitor.cpp
+++ b/Monitor/Monitor.cpp
@@ -21,7 +21,7 @@
 
 #define API_VERSION_NUMBER_MAJOR 2
 #define API_VERSION_NUMBER_MINOR 0
-#define API_VERSION_NUMBER_PATCH 1
+#define API_VERSION_NUMBER_PATCH 2
 
 namespace WPEFramework {
 namespace Plugin {


### PR DESCRIPTION
Reason for change: PR-6052 - This change involves having MonitorObjects inherit from PluginHost::IPlugin::ILifeTime and relaunching apps in Deinitialized() instead of Deactivated(). Test Procedure: please referred ticket descriptions Risks: High
Priority: P0
Signed-off-by: Thamim Razith tabbas651@cable.comcast.com