### PR TITLE
DELIA-67605 : RDKServices L1 Test with Valgrind failed dueto Signal 11 crash in Bluetooth plugin

### DIFF
--- a/.github/workflows/L1-tests.yml
+++ b/.github/workflows/L1-tests.yml
@@ -296,6 +296,7 @@ jobs:
           -DDS_FOUND=ON
           -DPLUGIN_TEXTTOSPEECH=ON
           -DPLUGIN_MIRACAST=ON
+          -DPLUGIN_BLUETOOTH=ON
           -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
           &&
           cmake --build build/rdkservices -j8

--- a/Tests/L1Tests/CMakeLists.txt
+++ b/Tests/L1Tests/CMakeLists.txt
@@ -45,6 +45,7 @@ add_executable(${PROJECT_NAME}
         ../mocks/rdkshell.cpp
 	../mocks/opkgMock.cpp
 	../mocks/WpaCtrl.cpp
+        ../mocks/BluetoothMocks.cpp
         )
 
 set_source_files_properties(
@@ -183,6 +184,7 @@ target_link_libraries(${PROJECT_NAME}
         ${NAMESPACE}TextToSpeech
 	${NAMESPACE}MiracastService
 	${NAMESPACE}MiracastPlayer
+        ${NAMESPACE}Bluetooth
         )
 
 target_include_directories(${PROJECT_NAME}

--- a/Tests/L1Tests/tests/test_Bluetooth.cpp
+++ b/Tests/L1Tests/tests/test_Bluetooth.cpp
@@ -1,4 +1,3 @@
-#if 0
 #include <gtest/gtest.h>
 #include "Bluetooth.h"
 #include "BluetoothMocks.h"
@@ -32,7 +31,7 @@ protected:
     static void SetUpTestCase() {
         std::cout << "Setup once before start test" << std::endl;
 
-	if(mockBluetoothManagerInstance == nullptr) {
+	if(p_iarmBusImplMock == nullptr) {
             p_iarmBusImplMock  = new NiceMock <IarmBusImplMock>;
             IarmBus::setImpl(p_iarmBusImplMock);
 	}
@@ -46,16 +45,17 @@ protected:
         // Called once after all test cases have run
         std::cout << "Tearing down after all tests are run." << std::endl;
         // Clean up tasks such as releasing resources or resetting state
-	if (p_iarmBusImplMock != nullptr) {
-	    delete p_iarmBusImplMock;
-	    p_iarmBusImplMock = nullptr;
-	    IarmBus::setImpl(nullptr);
-	}
-
 	if(mockBluetoothManagerInstance != nullptr) {
 	    delete mockBluetoothManagerInstance;
 	    mockBluetoothManagerInstance = nullptr;
 	}
+
+	IarmBus::setImpl(nullptr);
+        if (p_iarmBusImplMock != nullptr) {
+            delete p_iarmBusImplMock;
+            p_iarmBusImplMock = nullptr;
+        }
+
     }
 
     void SetUp() override {
@@ -122,6 +122,15 @@ TEST_F(BluetoothTest, StartScanWrapper_SuccessWithAdapters) {
     // Invoke the startScan method and check the response
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("startScan"), _T("{\"timeout\":30}"), response));
     EXPECT_EQ(response, "{\"status\":\"AVAILABLE\",\"success\":true}");
+
+    // Mock successful stop
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_StopDeviceDiscovery(::testing::Eq(0), ::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Return(BTRMGR_RESULT_SUCCESS));
+
+    // Stop discovery
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("stopScan"), _T("{}"), response));
+    EXPECT_EQ(response, "{\"success\":true}");
 }
 
 // Test Case: StartScanWrapper when no adapters are available
@@ -185,6 +194,16 @@ TEST_F(BluetoothTest, StartScanWrapper_DiscoveryFailed) {
 
     // Verify the response matches the actual implementation
     EXPECT_EQ(response, "{\"status\":\"AVAILABLE\",\"success\":true}");
+
+    // Mock successful stop
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_StopDeviceDiscovery(::testing::Eq(0), ::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Return(BTRMGR_RESULT_SUCCESS));
+
+    // Stop discovery
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("stopScan"), _T("{}"), response));
+    EXPECT_EQ(response, "{\"success\":true}");
+
 }
 
 TEST_F(BluetoothTest, StartScanWrapper_ProfileParsingWithReset) {
@@ -253,6 +272,15 @@ TEST_F(BluetoothTest, StartScanWrapper_DiscoveryInProgress) {
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("startScan"),
         _T("{\"timeout\":30, \"profile\":\"HEADPHONES\"}"), response));
     EXPECT_EQ(response, "{\"status\":\"AVAILABLE\",\"success\":true}");
+
+    // Mock successful stop
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_StopDeviceDiscovery(::testing::Eq(0), ::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Return(BTRMGR_RESULT_SUCCESS));
+
+    // Stop discovery
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("stopScan"), _T("{}"), response));
+    EXPECT_EQ(response, "{\"success\":true}");
 }
 
 TEST_F(BluetoothTest, StartScanWrapper_MissingParameters) {
@@ -2413,4 +2441,3 @@ TEST_F(BluetoothTest, EventCallbackTest) {
         ASSERT_EQ(BTRMGR_RESULT_SUCCESS, mockBluetoothManagerInstance->evBluetoothHandler(eventMsg));
     }
 }
-#endif


### PR DESCRIPTION
Reason for change: Fixed Crash issue from test_bluetooth.cpp
Test Procedure: Run the Gunit test cases.
Risks: Low
Priority: P1
Signed-off-by: Darshan Desale darshan_desale@comcast.com