### PR TITLE
DELIA-67689 : Increase secmanager timeout

### DIFF
--- a/ContentProtection/ContentProtection.h
+++ b/ContentProtection/ContentProtection.h
@@ -285,6 +285,7 @@ namespace Plugin {
 
     private:
         enum { Timeout = 1000 };
+        enum { OpenSessionTimeout = 5000 };
 
     private:
         using JSONRPCLink = WPEFramework::JSONRPC::SmartLinkType<
@@ -355,7 +356,7 @@ namespace Plugin {
                 out["licenseRequest"] = licenseRequest;
                 JsonObject in;
                 result = _parent._secManager->Invoke<JsonObject, JsonObject>(
-                    Timeout, _T("openPlaybackSession"), out, in);
+                    OpenSessionTimeout, _T("openPlaybackSession"), out, in);
                 if (result == Core::ERROR_NONE) {
                     if (!in["success"].Boolean()) {
                         result = Core::ERROR_GENERAL;
@@ -416,7 +417,7 @@ namespace Plugin {
                 JsonObject in;
                 result = _parent._secManager->Invoke<
                     JsonObject, JsonObject>(
-                    Timeout, _T("updatePlaybackSession"), out, in);
+                    OpenSessionTimeout, _T("updatePlaybackSession"), out, in);
                 if (result == Core::ERROR_NONE) {
                     if (!in["success"].Boolean()) {
                         result = Core::ERROR_GENERAL;


### PR DESCRIPTION
Reason for change: depending on the server response time and network time the call can take 1-3 seconds normally and sometimes even a little more.
Test Procedure: None
Risks: None
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>