### PR TITLE
DELIA-67605 : RDKServices L1 Test with Valgrind failed dueto Signal 11 crash in Bluetooth plugin

### DIFF
--- a/.github/workflows/L1-tests.yml
+++ b/.github/workflows/L1-tests.yml
@@ -57,7 +57,7 @@ jobs:
             !install/usr/lib/wpeframework/plugins
           key: ${{ runner.os }}-${{ env.THUNDER_REF }}-${{ env.INTERFACES_REF }}-4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v3
         with:
           python-version: '3.x'
       - run: pip install jsonref
@@ -71,7 +71,7 @@ jobs:
         run: >
           sudo apt update
           &&
-          sudo apt install -y libsqlite3-dev libcurl4-openssl-dev valgrind lcov clang libsystemd-dev libboost-all-dev libwebsocketpp-dev meson libcunit1 libcunit1-dev
+          sudo apt install -y libsqlite3-dev libcurl4-openssl-dev valgrind lcov clang libsystemd-dev libboost-all-dev libwebsocketpp-dev meson libcunit1 libcunit1-dev gdb
 
       - name: Install GStreamer
         run: |
@@ -140,7 +140,9 @@ jobs:
       - name: Apply patches ThunderInterfaces
         run: |
           cd ThunderInterfaces
-          patch -p1 < ${{github.workspace}}/rdkservices/Tests/L2Tests/patches/DeviceInfo_brand_R2_L1tests.patch
+          patch -p1 < ${{github.workspace}}/rdkservices/Tests/L2Tests/patches/0001-DELIA-66976-SystemAudioPlayer-interface.patch 
+          patch -p1 < ${{github.workspace}}/rdkservices/Tests/L2Tests/patches/0002-DELIA-66976-specially-for-comcast-bring-back-the-old.patch
+          patch -p1 < ${{github.workspace}}/rdkservices/Tests/L2Tests/patches/DeviceInfo_brand.patch
           cd ..
 
       - name: Build ThunderInterfaces
@@ -169,6 +171,7 @@ jobs:
           headers/rdk/iarmbus
           headers/rdk/iarmmgrs-hal
           headers/ccec/drivers
+          headers/network
           &&
           cd headers
           &&
@@ -200,6 +203,8 @@ jobs:
           rdk/iarmmgrs-hal/mfrMgr.h
           rdk/iarmmgrs-hal/pwrMgr.h
           rdk/iarmmgrs-hal/sysMgr.h
+          network/wifiSrvMgrIarmIf.h
+          network/netsrvmgrIarm.h
           libudev.h
           rfcapi.h
           rbus.h
@@ -238,6 +243,7 @@ jobs:
           -I ${{github.workspace}}/rdkservices/Tests/headers/rdk/iarmbus
           -I ${{github.workspace}}/rdkservices/Tests/headers/rdk/iarmmgrs-hal
           -I ${{github.workspace}}/rdkservices/Tests/headers/ccec/drivers
+          -I ${{github.workspace}}/rdkservices/Tests/headers/network
           -include ${{github.workspace}}/rdkservices/Tests/mocks/devicesettings.h
           -include ${{github.workspace}}/rdkservices/Tests/mocks/maintenanceMGR.h
           -include ${{github.workspace}}/rdkservices/Tests/mocks/pkg.h
@@ -282,6 +288,8 @@ jobs:
           -DRDK_SERVICES_L1_TEST=ON
           -DPLUGIN_HDMIINPUT=ON
           -DPLUGIN_HDCPPROFILE=ON
+          -DPLUGIN_NETWORK=ON
+          -DPLUGIN_WIFIMANAGER=ON
           -DPLUGIN_TRACECONTROL=ON
           -DPLUGIN_WAREHOUSE=ON
           -DPLUGIN_ACTIVITYMONITOR=ON

--- a/Tests/L1Tests/CMakeLists.txt
+++ b/Tests/L1Tests/CMakeLists.txt
@@ -45,7 +45,7 @@ add_executable(${PROJECT_NAME}
         ../mocks/rdkshell.cpp
 	../mocks/opkgMock.cpp
 	../mocks/WpaCtrl.cpp
-	../mocks/BluetoothMocks.cpp
+        ../mocks/BluetoothMocks.cpp
         )
 
 set_source_files_properties(
@@ -79,6 +79,8 @@ include_directories(../../LocationSync
         ../../SystemServices
         ../../HdmiInput
         ../../HdcpProfile
+        ../../Network
+        ../../WifiManager
         ../../TraceControl
         ../../Warehouse
         ../../ActivityMonitor
@@ -120,6 +122,8 @@ link_directories(../../LocationSync
         ../../DeviceInfo
         ../../HdmiInput
         ../../HdcpProfile
+        ../../Network
+        ../../WifiManager
         ../../TraceControl
         ../../Warehouse
         ../../ActivityMonitor
@@ -161,6 +165,8 @@ target_link_libraries(${PROJECT_NAME}
         ${NAMESPACE}DeviceInfo
         ${NAMESPACE}HdmiInput
         ${NAMESPACE}HdcpProfile
+        ${NAMESPACE}Network
+        ${NAMESPACE}WifiManager
         ${NAMESPACE}TraceControl
         ${NAMESPACE}Warehouse
         ${NAMESPACE}ActivityMonitor
@@ -178,7 +184,7 @@ target_link_libraries(${PROJECT_NAME}
         ${NAMESPACE}TextToSpeech
 	${NAMESPACE}MiracastService
 	${NAMESPACE}MiracastPlayer
-	${NAMESPACE}Bluetooth
+        ${NAMESPACE}Bluetooth
         )
 
 target_include_directories(${PROJECT_NAME}

--- a/Tests/L1Tests/tests/test_Bluetooth.cpp
+++ b/Tests/L1Tests/tests/test_Bluetooth.cpp
@@ -31,7 +31,7 @@ protected:
     static void SetUpTestCase() {
         std::cout << "Setup once before start test" << std::endl;
 
-	if(mockBluetoothManagerInstance == nullptr) {
+	if(p_iarmBusImplMock == nullptr) {
             p_iarmBusImplMock  = new NiceMock <IarmBusImplMock>;
             IarmBus::setImpl(p_iarmBusImplMock);
 	}
@@ -45,15 +45,17 @@ protected:
         // Called once after all test cases have run
         std::cout << "Tearing down after all tests are run." << std::endl;
         // Clean up tasks such as releasing resources or resetting state
-	if (p_iarmBusImplMock != nullptr) {
-	    delete p_iarmBusImplMock;
-	    p_iarmBusImplMock = nullptr;
-	}
-
 	if(mockBluetoothManagerInstance != nullptr) {
 	    delete mockBluetoothManagerInstance;
 	    mockBluetoothManagerInstance = nullptr;
 	}
+
+	IarmBus::setImpl(nullptr);
+        if (p_iarmBusImplMock != nullptr) {
+            delete p_iarmBusImplMock;
+            p_iarmBusImplMock = nullptr;
+        }
+
     }
 
     void SetUp() override {
@@ -120,6 +122,15 @@ TEST_F(BluetoothTest, StartScanWrapper_SuccessWithAdapters) {
     // Invoke the startScan method and check the response
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("startScan"), _T("{\"timeout\":30}"), response));
     EXPECT_EQ(response, "{\"status\":\"AVAILABLE\",\"success\":true}");
+
+    // Mock successful stop
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_StopDeviceDiscovery(::testing::Eq(0), ::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Return(BTRMGR_RESULT_SUCCESS));
+
+    // Stop discovery
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("stopScan"), _T("{}"), response));
+    EXPECT_EQ(response, "{\"success\":true}");
 }
 
 // Test Case: StartScanWrapper when no adapters are available
@@ -183,6 +194,16 @@ TEST_F(BluetoothTest, StartScanWrapper_DiscoveryFailed) {
 
     // Verify the response matches the actual implementation
     EXPECT_EQ(response, "{\"status\":\"AVAILABLE\",\"success\":true}");
+
+    // Mock successful stop
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_StopDeviceDiscovery(::testing::Eq(0), ::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Return(BTRMGR_RESULT_SUCCESS));
+
+    // Stop discovery
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("stopScan"), _T("{}"), response));
+    EXPECT_EQ(response, "{\"success\":true}");
+
 }
 
 TEST_F(BluetoothTest, StartScanWrapper_ProfileParsingWithReset) {
@@ -251,6 +272,15 @@ TEST_F(BluetoothTest, StartScanWrapper_DiscoveryInProgress) {
     EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("startScan"),
         _T("{\"timeout\":30, \"profile\":\"HEADPHONES\"}"), response));
     EXPECT_EQ(response, "{\"status\":\"AVAILABLE\",\"success\":true}");
+
+    // Mock successful stop
+    EXPECT_CALL(*mockBluetoothManagerInstance, BTRMGR_StopDeviceDiscovery(::testing::Eq(0), ::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Return(BTRMGR_RESULT_SUCCESS));
+
+    // Stop discovery
+    EXPECT_EQ(Core::ERROR_NONE, handler.Invoke(connection, _T("stopScan"), _T("{}"), response));
+    EXPECT_EQ(response, "{\"success\":true}");
 }
 
 TEST_F(BluetoothTest, StartScanWrapper_MissingParameters) {


### PR DESCRIPTION
Reason for change: Fixed Crash issue from test_bluetooth.cpp
Test Procedure: Run the Gunit test cases.
Risks: Low
Priority: P1
Signed-off-by: Darshan Desale [darshan_desale@comcast.com](mailto:darshan_desale@comcast.com)