### PR TITLE
RDK-56526: setForceHDRMode - allow only subset of HDR modes

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -6090,9 +6090,9 @@ void DisplaySettings::sendMsgThread()
             else if(strcmp(strFormat,"DV")== 0)
                     mode = dsHDRSTANDARD_DolbyVision;
             else if(strcmp(strFormat,"HLG")== 0)
-                    mode = dsHDRSTANDARD_TechnicolorPrime;
+                    mode = dsHDRSTANDARD_HLG;
             else if(strcmp(strFormat,"TechnicolorPrime")== 0)
-                    mode = dsHDRSTANDARD_NONE;
+                    mode = dsHDRSTANDARD_TechnicolorPrime;
 	    else
 		    mode = dsHDRSTANDARD_Invalid;
 


### PR DESCRIPTION
Reason for change: Return correct hdr modes from getVideoFormatTypeFromString func 
Un-used hdr modes will not be forced by HAL and returns not supported

Test Procedure: build and verify
Risks: Medium
Priority: P1
Signed-off-by: Srigayathry Pugazhenthi srigayathry.pugazhenthi@sky.uk