### PR TITLE
RDK-56377: Add Text View On CEC message during OTP

### DIFF
--- a/HdmiCecSource/HdmiCecSource.cpp
+++ b/HdmiCecSource/HdmiCecSource.cpp
@@ -1478,7 +1478,7 @@ namespace WPEFramework
                     try
                     {
                         /*LOGINFO("Command: sending ImageViewOn TV \r\n");
-                        smConnection->sendTo(LogicalAddress::TV, MessageEncoder().encode(ImageViewOn()));*/
+                        smConnection->sendTo(LogicalAddress::TV, MessageEncoder().encode(ImageViewOn())); */
                         LOGINFO("Command: sending TextViewOn TV \r\n");
                         smConnection->sendTo(LogicalAddress::TV, MessageEncoder().encode(TextViewOn()));
                         usleep(10000);


### PR DESCRIPTION
Reason for change: Add Text View On CEC message during OTP

Test Procedure: build and verify
Risks: Medium
Priority: P1
Signed-off-by: Srigayathry Pugazhenthi <srigayathry.pugazhenthi@sky.uk>