### PR TITLE
RDKCOM-5265: RDKDEV-1109: Potential bug CWE-670 - virtual function was overridden incorrectly E…

### DIFF
--- a/WebKitBrowser/WebKitImplementation.cpp
+++ b/WebKitBrowser/WebKitImplementation.cpp
@@ -2183,7 +2183,7 @@ namespace Plugin {
         {
             struct ExitJob : public Core::IDispatch
             {
-                virtual void Dispatch() { exit(1); }
+                void Dispatch() override { exit(1); }
             };
 
             Core::IWorkerPool::Instance().Submit(Core::ProxyType<Core::IDispatch>(Core::ProxyType<ExitJob>::Create()));


### PR DESCRIPTION
…rror found during static code analysis in webkitbrowser-plugin.

Below warning is raised during Static Code Analysis (SCA) using PVS-Studio in webkitbrowser-plugin component at
https://github.com/rdkcentral/rdkservices/blob/sprint/25Q2/WebKitBrowser/WebKitImplementation.cpp#L2717

struct ExitJob : public Core::IDispatch
{
virtual void Dispatch() { exit(1); }
};

[CWE-670] V762: It is possible a virtual function was overridden incorrectly. See first argument of function 'Dispatch' in derived class 'ExitJob' and base class 'IDispatchType'.
 
The warning is raised in https://github.com/rdkcentral/rdkservices/blob/sprint/25Q2/WebKitBrowser/WebKitImplementation.cpp#L2717
virtual void Dispatch() { exit(1); }

This warning suggests a mismatch between the Dispatch() function signature in ExitJob and the virtual function it is intended to override.

From Thunder Interface code(https://github.com/rdkcentral/Thunder/blob/R4/Source/core/IAction.h) I could see struct IDispatch is inherited from IDispatchType template.
Here there are two templates IDispatchType which includes Dispatch virtual function - one with argument and other without any argument.

Seems this issue arises because the Dispatch() method in ExitJob does not use the override keyword, making a chance of mismtach with the the virtual function from the base class.

By marking the Dispatch() method in ExitJob as an override of the virtual Dispatch() method in the base class I could see the warning is getting resolved.

So wanted to address this warning with fix.