### PR TITLE
RDKDEV-1108: Potential bug CWE-197 - Numeric Truncation Error found during static …

### DIFF
--- a/WebKitBrowser/WebKitBrowser.cpp
+++ b/WebKitBrowser/WebKitBrowser.cpp
@@ -210,7 +210,7 @@ namespace Plugin {
 
         Core::ProxyType<Web::Response> result(PluginHost::IFactories::Instance().Response());
         Core::TextSegmentIterator index(
-            Core::TextFragment(request.Path, _skipURL, request.Path.length() - _skipURL), false, '/');
+            Core::TextFragment(request.Path, static_cast<uint32_t>(_skipURL), static_cast<uint32_t>(request.Path.length() - _skipURL)), false, '/');
 
         result->ErrorCode = Web::STATUS_BAD_REQUEST;
         result->Message = "Unknown error";

--- a/WebKitBrowser/WebKitBrowser.h
+++ b/WebKitBrowser/WebKitBrowser.h
@@ -274,7 +274,7 @@ namespace Plugin {
         void event_statechange(const bool& suspended); // StateControl
 
     private:
-        uint8_t _skipURL;
+        size_t _skipURL;
         uint32_t _connectionId;
         PluginHost::IShell* _service;
         Exchange::IWebBrowser* _browser;


### PR DESCRIPTION
…code analysis in webkitbrowser-plugin

Below warning is raised during Static Code Analysis (SCA) using PVS-Studio in webkitbrowser-plugin component at
https://github.com/rdkcentral/rdkservices/blob/sprint/25Q2/WebKitBrowser/WebKitBrowser.cpp#L57

_skipURL = _service->WebPrefix().length();

[CWE-197] V1029: Numeric Truncation Error. Return value of the 'length' function is written to the 8-bit variable.

In https://github.com/rdkcentral/rdkservices/blob/sprint/25Q2/WebKitBrowser/WebKitBrowser.h#L277 _skipURL is declared as uint8_t datatype which is an unsigned int of 8 bits that can store a value ranging from 0 to 255.

uint8_t _skipURL;

_skipURL value is received from the length of the string returned by _service->WebPrefix() method:

_skipURL = _service->WebPrefix().length();

As per the code, WebPrefix contains the string "/Service/WebKitBrowser" and the values of _skipURL and WebPrefix().length are 22 which is within the range value of uint8_t.

Probably we would never reach more than 255 value here but in theory service->WebPrefix().length() could return something higher when length() is size_t . If the string length exceeds 255 in the future, it could lead to truncation or unexpected behaviour.

So wanted to address this warning with fix.