### PR TITLE
RDK-56367: Disable allm during power mode change

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -4671,6 +4671,19 @@ namespace WPEFramework {
             DisplaySettings::_instance->InitAudioPorts();
             audioPortInitActive = false;
         }
+	void DisplaySettings::resetToVideoMode(void)
+	{
+            if(!DisplaySettings::_instance)
+                 return;
+	    try{
+	        std::string mode = "VIDEO";
+	        DisplaySettings::_instance->Request(mode); //reset to video mode
+	        Utils::String::updateSystemModeFile("DEVICE_OPTIMIZE","currentstate",mode,"add");
+	    }catch (...)
+	    {
+		LOGWARN("Exception occurred during video mode reset...");
+	    }
+	}
 
         void DisplaySettings::powerEventHandler(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
         {
@@ -4704,6 +4717,8 @@ namespace WPEFramework {
                     {
                         LOGERR("exception in thread creation : %s", e.what());
                     }
+                    // Reset video mode or disable allm during power mode change.
+	            DisplaySettings::_instance->resetToVideoMode();
                 }
 
 		else {

--- a/DisplaySettings/DisplaySettings.h
+++ b/DisplaySettings/DisplaySettings.h
@@ -182,6 +182,7 @@ namespace WPEFramework {
 	    void onCecEnabledEventHandler(const JsonObject& parameters);
             void onAudioDevicePowerStatusEventHandler(const JsonObject& parameters);
 	    bool isDisplayConnected (std::string port);
+	    void resetToVideoMode();
             //End events
         public:
             DisplaySettings();


### PR DESCRIPTION
Reason for change: ALLM should be disabled after deepsleep/standby mode

Test Procedure: build and verify
Risks: Medium
Priority: P1
Signed-off-by: Srigayathry Pugazhenthi srigayathry.pugazhenthi@sky.uk