### PR TITLE
RDKTV-35867: WPEframework crash fingerprint 41002687 at Cobalt::set_state

### DIFF
--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -718,6 +718,10 @@ namespace WPEFramework {
 	    {
 		return Core::ERROR_GENERAL;
 	    }
+            if(message->Error.IsSet()) {
+        	std::cout << "Call failed: " << message->Designator.Value() << " error: " <<  message->Error.Code.Value() << "\n";
+            	return message->Error.Code.Value();
+             }
 #elif (THUNDER_VERSION == 2)
             auto resp =  dispatcher_->Invoke(sThunderSecurityToken, channelId, *message);
 #else


### PR DESCRIPTION

Reason for change: add error return in RDKShell JSONRPCDirectLink::Invoke method   Test Procedure: as metioned in Ticket
Risks: Low
Priority: P1
Signed-off-by:Boopathi Vanavarayan <boopathi_vanavarayan@comcast.com>