### PR TITLE
RDK-56526: setForceHDRMode - allow only subset of HDR modes

### DIFF
--- a/DisplaySettings/CHANGELOG.md
+++ b/DisplaySettings/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [2.0.6] - 2025-05-08
+### Fixed
+- Return correct enum member for the HDR modes
+
 ## [2.0.5] - 2025-02-07
 ### Fixed
 - Fixed Assert failure

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -6092,9 +6092,9 @@ void DisplaySettings::sendMsgThread()
             else if(strcmp(strFormat,"DV")== 0)
                     mode = dsHDRSTANDARD_DolbyVision;
             else if(strcmp(strFormat,"HLG")== 0)
-                    mode = dsHDRSTANDARD_TechnicolorPrime;
+                    mode = dsHDRSTANDARD_HLG;
             else if(strcmp(strFormat,"TechnicolorPrime")== 0)
-                    mode = dsHDRSTANDARD_NONE;
+                    mode = dsHDRSTANDARD_TechnicolorPrime;
 	    else
 		    mode = dsHDRSTANDARD_Invalid;
 


### PR DESCRIPTION
Reason for change: Return correct hdr modes from getVideoFormatTypeFromString func Un-used hdr modes will not be forced by HAL and returns not supported

Test Procedure: build and verify
Risks: Medium
Priority: P1
Signed-off-by: Srigayathry Pugazhenthi srigayathry.pugazhenthi@sky.uk