### PR TITLE
SERXIONE-6620: Unable to wakeup TV after wakeup

### DIFF
--- a/HdmiCecSource/CHANGELOG.md
+++ b/HdmiCecSource/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.1.4] - 2025-05-08
+### Changed
+- Added retry timeout for the CEC OTP messages
+
 ## [1.1.3] - 2025-02-11
 ### Changed
 - Fixed cec handler to get right LA and update source initiator

--- a/HdmiCecSource/HdmiCecSource.cpp
+++ b/HdmiCecSource/HdmiCecSource.cpp
@@ -1478,10 +1478,10 @@ namespace WPEFramework
                     try
                     {
                         LOGINFO("Command: sending ImageViewOn TV \r\n");
-                        smConnection->sendTo(LogicalAddress::TV, MessageEncoder().encode(ImageViewOn()));
+                        smConnection->sendTo(LogicalAddress::TV, MessageEncoder().encode(ImageViewOn()),500);
                         usleep(10000);
                         LOGINFO("Command: sending ActiveSource  physical_addr :%s \r\n",physical_addr.toString().c_str());
-                        smConnection->sendTo(LogicalAddress::BROADCAST, MessageEncoder().encode(ActiveSource(physical_addr)));
+                        smConnection->sendTo(LogicalAddress::BROADCAST, MessageEncoder().encode(ActiveSource(physical_addr)),500);
                         usleep(10000);
                         isDeviceActiveSource = true;
                         LOGINFO("Command: sending GiveDevicePowerStatus \r\n");


### PR DESCRIPTION
Reason for change: Add retry timeout for OTP

Test Procedure: build and verify with wakeup test cases
Risks: Medium
Priority: P1
Signed-off-by: Srigayathry Pugazhenthi srigayathry.pugazhenthi@sky.uk