### PR TITLE
RDKTV-34129: [WebKitBrowser] Use SIGHUP for suspended web process

### DIFF
--- a/WebKitBrowser/WebKitImplementation.cpp
+++ b/WebKitBrowser/WebKitImplementation.cpp
@@ -2713,8 +2713,9 @@ namespace Plugin {
                 if (_unresponsiveReplyNum <= kWebProcessUnresponsiveReplyDefaultLimit) {
                     _unresponsiveReplyNum = kWebProcessUnresponsiveReplyDefaultLimit;
                     Logging::DumpSystemFiles(webprocessPID);
-                    if (syscall(__NR_tgkill, webprocessPID, webprocessPID, SIGFPE) == -1) {
-                        SYSLOG(Logging::Error, (_T("tgkill failed, signal=%d process=%u errno=%d (%s)"), SIGFPE, webprocessPID, errno, strerror(errno)));
+                    // Kill with SIGHUP with no coredump/minidump
+                    if (syscall(__NR_tgkill, webprocessPID, webprocessPID, SIGHUP) == -1) {
+                        SYSLOG(Logging::Error, (_T("tgkill failed, signal=%d process=%u errno=%d (%s)"), SIGHUP, webprocessPID, errno, strerror(errno)));
                     }
                 } else {
                     DeactivateBrowser(PluginHost::IShell::FAILURE);


### PR DESCRIPTION
For suspended callsing use SIGHUP to kill unresponsive WebProcess (instead of SIGFPE) to skip minidump report.

In suspended state webkit browser plugin kills web process immediately on the very first unresponsiveness that produces false crash reports.

Reason for change: Fix crash report on browser shutdown
Test Procedure: Webapps smoke testing (launch and exit)
Priority: P1
Risks: Low