### PR TITLE
RDKTV-35827: To list AV1 codec from PlayerInfo

### DIFF
--- a/PlayerInfo/DeviceSettings/PlatformImplementation.cpp
+++ b/PlayerInfo/DeviceSettings/PlatformImplementation.cpp
@@ -475,7 +475,8 @@ private:
             {"video/mpeg, mpegversion=(int)4, systemstream=(boolean)false", Exchange::IPlayerProperties::VideoCodec::VIDEO_MPEG4},
             {"video/x-vp8", Exchange::IPlayerProperties::VideoCodec::VIDEO_VP8},
             {"video/x-vp9", Exchange::IPlayerProperties::VideoCodec::VIDEO_VP9},
-            {"video/x-vp10", Exchange::IPlayerProperties::VideoCodec::VIDEO_VP10}
+            {"video/x-vp10", Exchange::IPlayerProperties::VideoCodec::VIDEO_VP10},
+	    {"video/x-av1", Exchange::IPlayerProperties::VideoCodec::VIDEO_AV1}
         };
         if (GstUtils::GstRegistryCheckElementsForMediaTypes(videoCaps, _videoCodecs) != true) {
             TRACE(Trace::Warning, (_T("There is no Video Codec support available")));

--- a/PlayerInfo/PlayerInfo.json
+++ b/PlayerInfo/PlayerInfo.json
@@ -58,7 +58,8 @@
                 "MPEG4",
                 "VP8",
                 "VP9",
-                "VP10"
+                "VP10",
+                "AV1"
             ],
             "enumvalues": [
                 0,
@@ -71,7 +72,8 @@
                 7,
                 8,
                 9,
-                10
+                10,
+                11
             ],
             "example": "VideoH264"
         },
@@ -137,7 +139,8 @@
                         "VideoMpeg",
                         "VideoVp8",
                         "VideoVp9",
-                        "VideoVp10"
+                        "VideoVp10",
+                        "VideoAV1"
                     ],
                     "example": "VideoUndefined"
                 }


### PR DESCRIPTION
Reason For Change: PlayerInfo service doesn't report AV1 codec though platform supports
Test procedure: Mentioned in the ticket RDKTV-35827
Risks: Low
Signed-off-by: vidhathri_joshi@comcast.com