### PR TITLE
CPESP-6366: Fixing compilation issue

### DIFF
--- a/UserSettings/UserSettingsImplementation.cpp
+++ b/UserSettings/UserSettingsImplementation.cpp
@@ -403,7 +403,7 @@ void UserSettingsImplementation::ValueChanged(const Exchange::IStore2::ScopeType
     {
         dispatchEvent(PREFERRED_CLOSED_CAPTIONS_SERVICE_CHANGED, JsonValue((string)value));
     }
-    else if((ns.compare(USERSETTINGS_NAMESPACE) == 0) && (key.compare(USERSETTINGS_PRIVACY_MODE_KEY) == 0))
+    else if(0 == (ns.compare(USERSETTINGS_NAMESPACE)) && (0 == key.compare(USERSETTINGS_PRIVACY_MODE_KEY)))
     {
         dispatchEvent(PRIVACY_MODE_CHANGED, JsonValue((string)value));
     }

--- a/UserSettings/UserSettingsImplementation.h
+++ b/UserSettings/UserSettingsImplementation.h
@@ -121,6 +121,7 @@ namespace Plugin {
             CAPTIONS_CHANGED,
             PREFERRED_CAPTIONS_LANGUAGE_CHANGED,
             PREFERRED_CLOSED_CAPTIONS_SERVICE_CHANGED,
+            PRIVACY_MODE_CHANGED,
             PIN_CONTROL_CHANGED,
             VIEWING_RESTRICTIONS_CHANGED,
             VIEWING_RESTRICTIONS_WINDOW_CHANGED,
@@ -188,6 +189,8 @@ namespace Plugin {
         Core::hresult GetPreferredCaptionsLanguages(string &preferredLanguages) const override;
         Core::hresult SetPreferredClosedCaptionService(const string& service) override;
         Core::hresult GetPreferredClosedCaptionService(string &service) const override;
+        Core::hresult SetPrivacyMode(const string& privacyMode) override;
+        Core::hresult GetPrivacyMode(string &privacyMode) const override;
         Core::hresult SetPinControl(const bool pinControl) override;
         Core::hresult GetPinControl(bool &pinControl) const override;
         Core::hresult SetViewingRestrictions(const string& viewingRestrictions) override;


### PR DESCRIPTION
Reason for change: Added user settings accessibility settings and inspector interface to user settings plugin. Test Procedure: Make full stack build and verify user settings inspector interface. https://etwiki.sys.comcast.net/display/RDKV/User+Settings+Inspector Risks: Low
Priority: P1