### PR TITLE
RDKTV-35867: WPEframework crash fingerprint 41002687 at Cobalt::set_state

### DIFF
--- a/RDKShell/CHANGELOG.md
+++ b/RDKShell/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.6.8] - 2025-05-30
+### Fixed
+- RDKTV-35867: WPEframework crash fingerprint 41002687 at Cobalt::set_state
+
 ## [1.6.7] - 2025-02-27
 ### Fixed
 - Increase Hibernation delay to 30sec and get from RFC

--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -718,6 +718,10 @@ namespace WPEFramework {
 	    {
 		return Core::ERROR_GENERAL;
 	    }
+            if(message->Error.IsSet()) {
+        	std::cout << "Call failed: " << message->Designator.Value() << " error: " <<  message->Error.Code.Value() << "\n";
+            	return message->Error.Code.Value();
+             }
 #elif (THUNDER_VERSION == 2)
             auto resp =  dispatcher_->Invoke(sThunderSecurityToken, channelId, *message);
 #else


### PR DESCRIPTION
Reason for change: add error return in RDKShell JSONRPCDirectLink::Invoke method  
Test Procedure: as metioned in Ticket
Risks: Low
Priority: P1
Signed-off-by:Boopathi Vanavarayan <boopathi_vanavarayan@comcast.com>