### PR TITLE
RDKEMW-4795 : Account the case when ASSERT is no-op

### DIFF
--- a/PersistentStore/sqlite/Store2.h
+++ b/PersistentStore/sqlite/Store2.h
@@ -124,7 +124,9 @@ namespace Plugin {
                     sqlite3_close_v2(_data);
                     if ((rc == SQLITE_CORRUPT) || (rc == SQLITE_NOTADB)) {
                         OnError(__FUNCTION__, rc);
-                        ASSERT(file.Destroy());
+                        if (!file.Destroy()) {
+                            perror("remove failed");
+                        }
                         _corrupt = true;
                     }
                 }


### PR DESCRIPTION
Reason for change: Code in ASSERT seemingly did not run
Test Procedure: Corrupt store is removed
Risks: None