### PR TITLE
RDK-56367, RDK-57841: ALLM AVI info frames

### DIFF
--- a/DisplaySettings/CHANGELOG.md
+++ b/DisplaySettings/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [2.0.7] - 2025-06-02
+### Added
+- Set AVI content type & scan info frames during the ALLM Game mode and reset on video mode
+
 ## [2.0.6] - 2025-05-08
 ### Fixed
 - Return correct enum member for the HDR modes

--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -6114,7 +6114,14 @@ void DisplaySettings::sendMsgThread()
 				if (isDisplayConnected(strVideoPort))
 				{
 					bool enable = (newState == "GAME") ? true : false;
-					vPort.setAllmEnabled(enable);
+					vPort.getDisplay().setAllmEnabled(enable);
+					if(enable){ // Game mode
+					    vPort.getDisplay().setAVIContentType(dsAVICONTENT_TYPE_GAME);
+					    vPort.getDisplay().setAVIScanInformation(dsAVI_SCAN_TYPE_UNDERSCAN);
+					}else{ // video mode
+					    vPort.getDisplay().setAVIContentType(dsAVICONTENT_TYPE_NOT_SIGNALLED);
+					    vPort.getDisplay().setAVIScanInformation(dsAVI_SCAN_TYPE_NO_DATA);
+					}
 				}
 				else
 				{


### PR DESCRIPTION
Reason for change: Moving ALLM APIs from dsVideoPort to dsDisplay So, invoke the ALLM API using getDisplay() Set AVI content type & scan info frames during the ALLM Game mode and reset on video mode

Test Procedure: build and verify
Risks: Medium
Priority: P1
Signed-off-by: Srigayathry Pugazhenthi srigayathry.pugazhenthi@sky.uk