### PR TITLE
RDKTV-37015

### DIFF
--- a/AVOutput/AVOutputTV.cpp
+++ b/AVOutput/AVOutputTV.cpp
@@ -2175,6 +2175,7 @@ namespace Plugin {
                 supportedDimmingModeArray.Add(info.rangeVector[index]);
             }
 
+	    response["platformSupport"] = true;
             response["options"]=supportedDimmingModeArray;
 
             if (((info.pqmodeVector.front()).compare("none") != 0)) {

--- a/PersistentStore/sqlite/Store2.h
+++ b/PersistentStore/sqlite/Store2.h
@@ -124,7 +124,9 @@ namespace Plugin {
                     sqlite3_close_v2(_data);
                     if ((rc == SQLITE_CORRUPT) || (rc == SQLITE_NOTADB)) {
                         OnError(__FUNCTION__, rc);
-                        ASSERT(file.Destroy());
+                        if (!file.Destroy()) {
+                            perror("remove failed");
+                        }
                         _corrupt = true;
                     }
                 }


### PR DESCRIPTION
RDKTV-37015: platfromSupport is missing from dimmingMode capabilities

Reason For Change: platfromSupport is missing from getBacklightDimmingModeCaps
Test procedure: Mentioned in the ticket RDKTV-35827
Risks: Low
Signed-off-by: anju.raveendran@sky.uk