### PR TITLE
DELIA-67219:getDevicePowerState returns correct power state

### DIFF
--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -273,7 +273,7 @@ bool setPowerState(std::string powerState)
     } else if (powerState == "DEEP_SLEEP") {
         param.newState = IARM_BUS_PWRMGR_POWERSTATE_STANDBY_DEEP_SLEEP;
     } else if (powerState == "LIGHT_SLEEP") {
-        param.newState = IARM_BUS_PWRMGR_POWERSTATE_STANDBY;
+        param.newState = IARM_BUS_PWRMGR_POWERSTATE_STANDBY_LIGHT_SLEEP;
     } else {
         return false;
     }
@@ -3631,8 +3631,10 @@ namespace WPEFramework {
                 if (res == IARM_RESULT_SUCCESS) {
                     if (param.curState == IARM_BUS_PWRMGR_POWERSTATE_ON)
                         currentState = "ON";
-                    else if ((param.curState == IARM_BUS_PWRMGR_POWERSTATE_STANDBY) || (param.curState == IARM_BUS_PWRMGR_POWERSTATE_STANDBY_LIGHT_SLEEP) )
+                    else if (param.curState == IARM_BUS_PWRMGR_POWERSTATE_STANDBY)
                         currentState = "STANDBY";
+                    else if (param.curState == IARM_BUS_PWRMGR_POWERSTATE_STANDBY_LIGHT_SLEEP)
+                        currentState = "LIGHT_SLEEP";
                     else if ( param.curState == IARM_BUS_PWRMGR_POWERSTATE_STANDBY_DEEP_SLEEP)
                         currentState = "DEEP_SLEEP";
                 }
@@ -4185,14 +4187,14 @@ namespace WPEFramework {
                     {
                         IARM_Bus_PWRMgr_EventData_t *eventData = (IARM_Bus_PWRMgr_EventData_t *)data;
 			std::string curState,newState = "";
-
 			if(eventData->data.state.curState == IARM_BUS_PWRMGR_POWERSTATE_ON) {
 				curState = "ON";
-            } else if (eventData->data.state.curState == IARM_BUS_PWRMGR_POWERSTATE_OFF) {
-                curState = "OFF";
-			} else if ((eventData->data.state.curState == IARM_BUS_PWRMGR_POWERSTATE_STANDBY)||
-				   (eventData->data.state.curState == IARM_BUS_PWRMGR_POWERSTATE_STANDBY_LIGHT_SLEEP)) {
+                        } else if (eventData->data.state.curState == IARM_BUS_PWRMGR_POWERSTATE_OFF) {
+                                 curState = "OFF";
+			} else if (eventData->data.state.curState == IARM_BUS_PWRMGR_POWERSTATE_STANDBY_LIGHT_SLEEP){
 				curState = "LIGHT_SLEEP";
+			} else if (eventData->data.state.curState == IARM_BUS_PWRMGR_POWERSTATE_STANDBY) {
+				curState = "STANDBY";
 			} else if (eventData->data.state.curState == IARM_BUS_PWRMGR_POWERSTATE_STANDBY_DEEP_SLEEP) {
 				curState = "DEEP_SLEEP";
 			} else if (eventData->data.state.curState == IARM_BUS_PWRMGR_POWERSTATE_OFF) {
@@ -4201,11 +4203,12 @@ namespace WPEFramework {
 
 			if(eventData->data.state.newState == IARM_BUS_PWRMGR_POWERSTATE_ON) {
 				newState = "ON";
-            } else if(eventData->data.state.newState == IARM_BUS_PWRMGR_POWERSTATE_OFF) {
-                newState = "OFF";
-			} else if((eventData->data.state.newState == IARM_BUS_PWRMGR_POWERSTATE_STANDBY)||
-				  (eventData->data.state.newState == IARM_BUS_PWRMGR_POWERSTATE_STANDBY_LIGHT_SLEEP)) {
+                        } else if(eventData->data.state.newState == IARM_BUS_PWRMGR_POWERSTATE_OFF) {
+                                newState = "OFF";
+                        } else if (eventData->data.state.newState == IARM_BUS_PWRMGR_POWERSTATE_STANDBY_LIGHT_SLEEP){
                                 newState = "LIGHT_SLEEP";
+                        } else if (eventData->data.state.newState == IARM_BUS_PWRMGR_POWERSTATE_STANDBY) {
+                                newState = "STANDBY";
 			} else if(eventData->data.state.newState == IARM_BUS_PWRMGR_POWERSTATE_STANDBY_DEEP_SLEEP) {
                                 newState = "DEEP_SLEEP";
 			}

--- a/Tests/L1Tests/tests/test_SystemServices.cpp
+++ b/Tests/L1Tests/tests/test_SystemServices.cpp
@@ -2211,7 +2211,7 @@ TEST_F(SystemServicesTest, setPowerStateSuccess_when_powerstate_Light_sleep)
                 EXPECT_EQ(string(ownerName), string(_T(IARM_BUS_PWRMGR_NAME)));
                 EXPECT_EQ(string(methodName), string(_T(IARM_BUS_PWRMGR_API_SetPowerState)));
                 auto param = static_cast<IARM_Bus_PWRMgr_SetPowerState_Param_t*>(arg);
-                EXPECT_EQ(param->newState, IARM_BUS_PWRMGR_POWERSTATE_STANDBY);
+                EXPECT_EQ(param->newState, IARM_BUS_PWRMGR_POWERSTATE_STANDBY_LIGHT_SLEEP);
                 return IARM_RESULT_SUCCESS;
             });
 
@@ -2547,7 +2547,7 @@ TEST_F(SystemServicesEventIarmTest, onSystemPowerStateChanged_PowerState_STANDBY
                                                              "\"params\":"
                                                              "\\{"
                                                              "\"powerState\":\"LIGHT_SLEEP\","
-                                                             "\"currentPowerState\":\"LIGHT_SLEEP\""
+                                                             "\"currentPowerState\":\"STANDBY\""
                                                              "\\}"
                                                              "\\}")));
 


### PR DESCRIPTION
DELIA-67219:getDevicePowerState returns correct power state
Reason for change: Report correct power state
Test Procedure: Refer jira
Risks: Medium
Priority: P1