### PR TITLE
RDKTV-37015: platfromSupport is missing from dimmingMode capabilities

### DIFF
--- a/AVOutput/AVOutputTV.cpp
+++ b/AVOutput/AVOutputTV.cpp
@@ -2175,6 +2175,7 @@ namespace Plugin {
                 supportedDimmingModeArray.Add(info.rangeVector[index]);
             }
 
+	    response["platformSupport"] = true;
             response["options"]=supportedDimmingModeArray;
 
             if (((info.pqmodeVector.front()).compare("none") != 0)) {


### PR DESCRIPTION
Reason For Change: platfromSupport is missing from getBacklightDimmingModeCaps
Test procedure: Mentioned in the ticket RDKTV-35827
Risks: Low
Signed-off-by: anju.raveendran@sky.uk