### PR TITLE
RDKTV-37015: platfromSupport is missing from dimmingMode capabilities

### DIFF
--- a/AVOutput/AVOutputTV.cpp
+++ b/AVOutput/AVOutputTV.cpp
@@ -2176,6 +2176,7 @@ namespace Plugin {
             }
 
             response["options"]=supportedDimmingModeArray;
+	    response["platformSupport"] = true;
 
             if (((info.pqmodeVector.front()).compare("none") != 0)) {
                 for (index = 0; index < info.pqmodeVector.size(); index++) {


### PR DESCRIPTION
Reason For Change: platfromSupport is missing from getBacklightDimmingModeCaps
Test procedure: Mentioned in the ticket RDKTV-37015
Risks: Low
Signed-off-by: anju.raveendran@sky.uk