### PR TITLE
RDKTV-35827: To list AV1 codec from PlayerInfo

### DIFF
--- a/ContentProtection/CHANGELOG.md
+++ b/ContentProtection/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [2.0.0] - 2025-06-12
+### Changed
+- Parameters initData, openSessionResponse, updateSessionResponse to be stringified json instead of json
+
 ## [1.1.1] - 2025-05-26
 ### Fixed
 - Increase secmanager timeout

--- a/ContentProtection/ContentProtection.cpp
+++ b/ContentProtection/ContentProtection.cpp
@@ -19,9 +19,9 @@
 
 #include "ContentProtection.h"
 
-#define API_VERSION_NUMBER_MAJOR 1
-#define API_VERSION_NUMBER_MINOR 1
-#define API_VERSION_NUMBER_PATCH 1
+#define API_VERSION_NUMBER_MAJOR 2
+#define API_VERSION_NUMBER_MINOR 0
+#define API_VERSION_NUMBER_PATCH 0
 
 namespace WPEFramework {
 namespace Plugin {

--- a/ContentProtection/ContentProtection.h
+++ b/ContentProtection/ContentProtection.h
@@ -348,8 +348,10 @@ namespace Plugin {
                 override
             {
                 uint32_t result;
+                Core::JSON::String jsonString;
+                jsonString.FromString(initData);
                 JsonObject out;
-                out.FromString(initData);
+                out.FromString(jsonString);
                 out["clientId"] = clientId;
                 out["keySystem"] = Core::JSON::EnumType<KeySystem>(keySystem)
                                        .Data();
@@ -362,7 +364,9 @@ namespace Plugin {
                         result = Core::ERROR_GENERAL;
                     } else {
                         sessionId = in["sessionId"].Number();
-                        in.ToString(response);
+                        string inStr;
+                        in.ToString(inStr);
+                        response = Core::ToQuotedString('\"', inStr);
 
                         _parent._sessionStorage.Set(sessionId,
                             { clientId, appId, keySystem });
@@ -406,8 +410,10 @@ namespace Plugin {
                 }
 
                 uint32_t result;
+                Core::JSON::String jsonString;
+                jsonString.FromString(initData);
                 JsonObject out;
-                out.FromString(initData);
+                out.FromString(jsonString);
                 out["clientId"] = session.Value().ClientId;
                 out["sessionId"] = sessionId;
                 out["keySystem"] = Core::JSON::EnumType<KeySystem>(
@@ -422,7 +428,9 @@ namespace Plugin {
                     if (!in["success"].Boolean()) {
                         result = Core::ERROR_GENERAL;
                     } else {
-                        in.ToString(response);
+                        string inStr;
+                        in.ToString(inStr);
+                        response = Core::ToQuotedString('\"', inStr);
                     }
                 }
                 return result;

--- a/PlayerInfo/DeviceSettings/PlatformImplementation.cpp
+++ b/PlayerInfo/DeviceSettings/PlatformImplementation.cpp
@@ -475,7 +475,8 @@ private:
             {"video/mpeg, mpegversion=(int)4, systemstream=(boolean)false", Exchange::IPlayerProperties::VideoCodec::VIDEO_MPEG4},
             {"video/x-vp8", Exchange::IPlayerProperties::VideoCodec::VIDEO_VP8},
             {"video/x-vp9", Exchange::IPlayerProperties::VideoCodec::VIDEO_VP9},
-            {"video/x-vp10", Exchange::IPlayerProperties::VideoCodec::VIDEO_VP10}
+            {"video/x-vp10", Exchange::IPlayerProperties::VideoCodec::VIDEO_VP10},
+	     {"video/x-av1", Exchange::IPlayerProperties::VideoCodec::VIDEO_AV1}
         };
         if (GstUtils::GstRegistryCheckElementsForMediaTypes(videoCaps, _videoCodecs) != true) {
             TRACE(Trace::Warning, (_T("There is no Video Codec support available")));

--- a/PlayerInfo/PlayerInfo.json
+++ b/PlayerInfo/PlayerInfo.json
@@ -58,7 +58,8 @@
                 "MPEG4",
                 "VP8",
                 "VP9",
-                "VP10"
+                "VP10",
+		 "AV1"
             ],
             "enumvalues": [
                 0,
@@ -71,7 +72,8 @@
                 7,
                 8,
                 9,
-                10
+                10,
+		 11
             ],
             "example": "VideoH264"
         },
@@ -137,7 +139,8 @@
                         "VideoMpeg",
                         "VideoVp8",
                         "VideoVp9",
-                        "VideoVp10"
+                        "VideoVp10",
+			 "VideoAV1"
                     ],
                     "example": "VideoUndefined"
                 }


### PR DESCRIPTION
Reason For Change: PlayerInfo service doesn't report AV1 codec though platform supports
Test procedure: Mentioned in the ticket RDKTV-35827
Risks: Low
Signed-off-by: vidhathri_joshi@comcast.com