### PR TITLE
RDKEMW-2565 Add deviceIdentification plugin details into deviceinfo (…

### DIFF
--- a/.github/workflows/L1-tests.yml
+++ b/.github/workflows/L1-tests.yml
@@ -141,6 +141,7 @@ jobs:
         run: |
           cd ThunderInterfaces
           patch -p1 < ${{github.workspace}}/rdkservices/Tests/L2Tests/patches/DeviceInfo_brand_R2_L1tests.patch
+          patch -p1 < ${{github.workspace}}/rdkservices/Tests/L2Tests/patches/0001-RDKEMW-2565-Add-deviceIdentification-plugin-details-.patch
           cd ..
 
       - name: Build ThunderInterfaces

--- a/DeviceInfo/DeviceInfo.h
+++ b/DeviceInfo/DeviceInfo.h
@@ -120,6 +120,8 @@ namespace Plugin {
         uint32_t get_brandname(JsonData::DeviceInfo::BrandnameData& response) const;
         uint32_t get_devicetype(JsonData::DeviceInfo::DevicetypeData& response) const;
         uint32_t get_distributorid(JsonData::DeviceInfo::DistributoridData& response) const;
+        uint32_t get_releaseversion(JsonData::DeviceInfo::ReleaseversionData& response) const;
+        uint32_t get_chipset(JsonData::DeviceInfo::ChipsetData& response) const;
         uint32_t get_supportedaudioports(JsonData::DeviceInfo::SupportedaudioportsData& response) const;
         uint32_t get_supportedvideodisplays(JsonData::DeviceInfo::SupportedvideodisplaysData& response) const;
         uint32_t get_hostedid(JsonData::DeviceInfo::HostedidData& response) const;

--- a/DeviceInfo/DeviceInfo.json
+++ b/DeviceInfo/DeviceInfo.json
@@ -595,6 +595,50 @@
         }
       ]
     },
+    "releaseversion": {
+        "summary": "Release version of Image . If unable to find the Release version default value is 99.99.0.0",
+        "readonly": true,
+        "params": {
+            "type": "object",
+            "properties": {
+                "releaseversion": {
+                    "type": "string",
+                    "example": "8.2.0.0"
+                }
+            },
+            "required": [
+                "releaseversion"
+            ]
+        },
+        "errors": [
+            {
+                "description": "General error",
+                "$ref": "#/common/errors/general"
+            }
+        ]
+    },
+    "chipset": {
+        "summary": "Chipset used for this device",
+        "readonly": true,
+        "params": {
+            "type": "object",
+            "properties": {
+                "chipset": {
+                    "type": "string",
+                    "example": "T962X3"
+                }
+            },
+            "required": [
+                "chipset"
+            ]
+        },
+        "errors": [
+            {
+                "description": "General error",
+                "$ref": "#/common/errors/general"
+            }
+        ]
+    },
     "distributorid": {
       "summary": "Partner ID or distributor ID for device",
       "readonly": true,

--- a/DeviceInfo/DeviceInfoJsonRpc.cpp
+++ b/DeviceInfo/DeviceInfoJsonRpc.cpp
@@ -42,6 +42,8 @@ namespace Plugin {
         Property<BrandnameData>(_T("brandname"), &DeviceInfo::get_brandname, nullptr, this);
         Property<DevicetypeData>(_T("devicetype"), &DeviceInfo::get_devicetype, nullptr, this);
         Property<DistributoridData>(_T("distributorid"), &DeviceInfo::get_distributorid, nullptr, this);
+        Property<ReleaseversionData>(_T("releaseversion"), &DeviceInfo::get_releaseversion, nullptr, this);
+        Property<ChipsetData>(_T("chipset"), &DeviceInfo::get_chipset, nullptr, this);
         Property<SupportedaudioportsData>(_T("supportedaudioports"), &DeviceInfo::get_supportedaudioports, nullptr, this);
         Property<SupportedvideodisplaysData>(_T("supportedvideodisplays"), &DeviceInfo::get_supportedvideodisplays, nullptr, this);
         Property<HostedidData>(_T("hostedid"), &DeviceInfo::get_hostedid, nullptr, this);
@@ -66,6 +68,8 @@ namespace Plugin {
         Unregister(_T("brandname"));
         Unregister(_T("devicetype"));
         Unregister(_T("distributorid"));
+        Unregister(_T("releaseversion"));
+        Unregister(_T("chipset"));
         Unregister(_T("supportedaudioports"));
         Unregister(_T("supportedvideodisplays"));
         Unregister(_T("hostedid"));
@@ -281,6 +285,52 @@ namespace Plugin {
         }
 
         return result;
+    }
+
+    // Property: releaseversion - ReleaseVersion of the Image 
+    // Return codes:
+    //  - ERROR_NONE: Success
+    //  - ERROR_GENERAL: General error
+    uint32_t DeviceInfo::get_releaseversion(ReleaseversionData& response) const
+    {
+
+        string releaseversion = "";
+
+        auto result = _deviceInfo->ReleaseVersion(releaseversion);
+        if (result == Core::ERROR_NONE) {
+            response.Releaseversion = releaseversion;
+            LOGINFO("ReleaseVersion of the Image: %s\n", releaseversion.c_str());
+            return Core::ERROR_NONE;
+        }
+        else
+        {
+            LOGERR("Unable to get releaseVersion of the Image:\n");
+            return Core::ERROR_GENERAL;
+        }
+
+    }
+
+    // Property: chipset - chipset of the device
+    // Return codes:
+    //  - ERROR_NONE: Success
+    //  - ERROR_GENERAL: General error
+    uint32_t DeviceInfo::get_chipset(ChipsetData& response) const
+    {
+
+        string chipset  = "";
+
+        auto result = _deviceInfo->ChipSet(chipset);
+        if (result == Core::ERROR_NONE) {
+            response.Chipset = chipset;
+            LOGINFO("Chipset of the device: %s\n", chipset.c_str());
+            return Core::ERROR_NONE;
+        }
+        else
+        {
+            LOGERR("Unable to get Chipset of the device \n");
+            return Core::ERROR_GENERAL;
+        }
+
     }
 
     // Property: supportedaudioports - Audio ports supported on the device (all ports that are physically present)

--- a/DeviceInfo/Implementation/DeviceInfo.cpp
+++ b/DeviceInfo/Implementation/DeviceInfo.cpp
@@ -155,5 +155,42 @@ namespace Plugin {
             ? Core::ERROR_NONE
             : GetRFCData(_T("Device.DeviceInfo.X_RDKCENTRAL-COM_Syndication.PartnerId"), distributorId);
     }
+
+
+    Core::hresult DeviceInfoImplementation::ReleaseVersion(string& releaseVersion ) const
+    {
+        const std::string defaultVersion = "99.99.0.0";
+        std::regex pattern(R"((\d+)\.(\d+)[sp])");
+        std::smatch match;
+        std::string imagename = "";
+        if(Core::ERROR_NONE == GetFileRegex(_T("/version.txt"), std::regex("^imagename:([^\\n]+)$"), imagename))
+        {
+            if (std::regex_search(imagename, match, pattern)) {
+                std::string major = match[1];
+                std::string minor = match[2];
+                releaseVersion = major + "." + minor + ".0.0";
+            }
+            else
+            {
+                releaseVersion = defaultVersion ;
+                LOGERR("Unable to get releaseVersion of the Image:%s.So default releaseVersion is: %s ",imagename.c_str(),releaseVersion.c_str());
+            }
+        }
+        else
+        {
+                releaseVersion = defaultVersion ;
+                LOGERR("Unable to read from /version.txt.  So default releaseVersion is: %s ",releaseVersion.c_str());
+
+        }
+
+        return Core::ERROR_NONE; 
+    }
+
+    uint32_t DeviceInfoImplementation::ChipSet(string& chipset) const
+    {
+        auto result = GetFileRegex(_T("/etc/device.properties"),std::regex("^CHIPSET_NAME(?:\\s*)=(?:\\s*)(?:\"{0,1})([^\"\\n]+)(?:\"{0,1})(?:\\s*)$"), chipset);
+        return result; 
+    }
+
 }
 }

--- a/DeviceInfo/Implementation/DeviceInfo.h
+++ b/DeviceInfo/Implementation/DeviceInfo.h
@@ -30,6 +30,8 @@ namespace Plugin {
         uint32_t DeviceType(string& deviceType) const override;
         uint32_t DistributorId(string& distributorId) const override;
         uint32_t Brand(string& brand) const override;
+        Core::hresult ReleaseVersion(string& releaseVersion ) const override;
+        Core::hresult ChipSet(string& chipSet ) const override;
     };
 }
 }

--- a/Tests/L2Tests/patches/0001-RDKEMW-2565-Add-deviceIdentification-plugin-details-.patch
+++ b/Tests/L2Tests/patches/0001-RDKEMW-2565-Add-deviceIdentification-plugin-details-.patch
@@ -1,0 +1,87 @@
+From 63ee428b1ec6585c8cf4b7bf30b1b3ecb052abdc Mon Sep 17 00:00:00 2001
+From: ramkumarpraba <Ramkumar_Prabaharan@comcast.com>
+Date: Fri, 13 Jun 2025 13:39:27 +0000
+Subject: [PATCH] RDKEMW-2565 Add deviceIdentification plugin details into
+ deviceinfo
+
+Reason for change: Add chipset and ReleaseVersion  property to DeviceInfo Plugin
+Test Procedure: verify build success and basic test
+Risks: Low
+Priority: P1
+Signed-off-by: ramkumar_prabaharan@comcast.com
+---
+ interfaces/IDeviceInfo2.h |  2 ++
+ jsonrpc/DeviceInfo.json   | 44 +++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 46 insertions(+)
+
+diff --git a/interfaces/IDeviceInfo2.h b/interfaces/IDeviceInfo2.h
+index 0e56da9..1ebdc9a 100644
+--- a/interfaces/IDeviceInfo2.h
++++ b/interfaces/IDeviceInfo2.h
+@@ -19,6 +19,8 @@ namespace Exchange {
+         virtual uint32_t DeviceType(string& deviceType /* @out */) const = 0;
+         virtual uint32_t DistributorId(string& distributorId /* @out */) const = 0;
+ 	virtual uint32_t Brand(string& brand /* @out */) const = 0;
++    virtual Core::hresult ReleaseVersion(string& releaseVersion /* @out */) const = 0;
++    virtual Core::hresult ChipSet(string& chipSet /* @out */) const = 0;
+     };
+ 
+     struct EXTERNAL IDeviceAudioCapabilities : virtual public Core::IUnknown {
+diff --git a/jsonrpc/DeviceInfo.json b/jsonrpc/DeviceInfo.json
+index 1f7997e..d90879c 100644
+--- a/jsonrpc/DeviceInfo.json
++++ b/jsonrpc/DeviceInfo.json
+@@ -524,6 +524,50 @@
+         }
+       ]
+     },
++    "releaseversion": {
++      "summary": "Release version of Image",
++      "readonly": true,
++      "params": {
++        "type": "object",
++        "properties": {
++          "releaseversion": {
++            "type": "string",
++            "example": "8.2.0.0"
++          }
++        },
++        "required": [
++          "releaseversion"
++        ]
++      },
++      "errors": [
++        {
++          "description": "General error",
++          "$ref": "#/common/errors/general"
++        }
++      ]
++    },
++    "chipset": {
++        "summary": "Chipset used for this device",
++        "readonly": true,
++        "params": {
++            "type": "object",
++            "properties": {
++                "chipset": {
++                    "type": "string",
++                    "example": "T962X3"
++                }
++            },
++            "required": [
++                "chipset"
++            ]
++        },
++        "errors": [
++            {
++                "description": "General error",
++                "$ref": "#/common/errors/general"
++            }
++        ]
++    },
+     "make": {
+       "summary": "Device manufacturer",
+       "readonly": true,
+-- 
+2.25.1
+

--- a/docs/api/DeviceInfoPlugin.md
+++ b/docs/api/DeviceInfoPlugin.md
@@ -2,7 +2,7 @@
 <a name="DeviceInfo_Plugin"></a>
 # DeviceInfo Plugin
 
-**Version: [1.0.15](https://github.com/rdkcentral/rdkservices/blob/main/DeviceInfo/CHANGELOG.md)**
+**Version: [1.1.0](https://github.com/rdkcentral/rdkservices/blob/main/DeviceInfo/CHANGELOG.md)**
 
 A DeviceInfo plugin for Thunder framework.
 
@@ -418,9 +418,12 @@ DeviceInfo interface properties:
 | [firmwareversion](#firmwareversion) <sup>RO</sup> | Versions maintained in version |
 | [serialnumber](#serialnumber) <sup>RO</sup> | Serial number set by manufacturer |
 | [modelid](#modelid) <sup>RO</sup> | Device model number or SKU |
+| [brandname](#brandname) <sup>RO</sup> | Device brand name |
 | [make](#make) <sup>RO</sup> | Device manufacturer |
 | [modelname](#modelname) <sup>RO</sup> | Friendly device model name |
 | [devicetype](#devicetype) <sup>RO</sup> | Device type |
+| [releaseversion](#releaseversion) <sup>RO</sup> | Release version of Image  |
+| [chipset](#chipset) <sup>RO</sup> | Chipset used for this device |
 | [distributorid](#distributorid) <sup>RO</sup> | Partner ID or distributor ID for device |
 | [supportedaudioports](#supportedaudioports) <sup>RO</sup> | Audio ports supported on the device (all ports that are physically present) |
 | [supportedvideodisplays](#supportedvideodisplays) <sup>RO</sup> | Video ports supported on the device (all ports that are physically present) |
@@ -740,6 +743,54 @@ No Events
 }
 ```
 
+<a name="brandname"></a>
+## *brandname*
+
+Provides access to the device brand name.
+
+> This property is **read-only**.
+
+### Events
+
+No Events
+
+### Value
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| (property) | object | Device brand name |
+| (property)?.brandname | string | <sup>*(optional)*</sup>  |
+
+### Errors
+
+| Code | Message | Description |
+| :-------- | :-------- | :-------- |
+| 1 | ```ERROR_GENERAL``` | General error |
+
+### Example
+
+#### Get Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "DeviceInfo.brandname"
+}
+```
+
+#### Get Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "brandname": "Comcast"
+    }
+}
+```
+
 <a name="make"></a>
 ## *make*
 
@@ -852,7 +903,7 @@ No Events
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
 | (property) | object | Device type |
-| (property).devicetype | string | Device type (must be one of the following: *tv*, *IpStb*, *QamIpStb*) |
+| (property).devicetype | string | Device type (must be one of the following: *IpTv*, *IpStb*, *QamIpStb*) |
 
 ### Errors
 
@@ -880,6 +931,102 @@ No Events
     "id": 42,
     "result": {
         "devicetype": "IpStb"
+    }
+}
+```
+
+<a name="releaseversion"></a>
+## *releaseversion*
+
+Provides access to the release version of Image . If unable to find the Release version default value is 99.99.0.0.
+
+> This property is **read-only**.
+
+### Events
+
+No Events
+
+### Value
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| (property) | object | Release version of Image . If unable to find the Release version default value is 99.99.0.0 |
+| (property).releaseversion | string |  |
+
+### Errors
+
+| Code | Message | Description |
+| :-------- | :-------- | :-------- |
+| 1 | ```ERROR_GENERAL``` | General error |
+
+### Example
+
+#### Get Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "DeviceInfo.releaseversion"
+}
+```
+
+#### Get Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "releaseversion": "8.2.0.0"
+    }
+}
+```
+
+<a name="chipset"></a>
+## *chipset*
+
+Provides access to the chipset used for this device.
+
+> This property is **read-only**.
+
+### Events
+
+No Events
+
+### Value
+
+| Name | Type | Description |
+| :-------- | :-------- | :-------- |
+| (property) | object | Chipset used for this device |
+| (property).chipset | string |  |
+
+### Errors
+
+| Code | Message | Description |
+| :-------- | :-------- | :-------- |
+| 1 | ```ERROR_GENERAL``` | General error |
+
+### Example
+
+#### Get Request
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "DeviceInfo.chipset"
+}
+```
+
+#### Get Response
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+        "chipset": "T962X3"
     }
 }
 ```


### PR DESCRIPTION
…#6285)

* RDKEMW-2565 Add deviceIdentification plugin details into deviceinfo

Reason for change: Add chipset and ReleaseVersion  property to DeviceInfo Plugin
Test Procedure: verify build success and basic test
Risks: Low
Priority: P1
Signed-off-by: ramkumar_prabaharan@comcast.com

* RDKEMW-2565 Add deviceIdentification plugin details into deviceinfo

Reason for change: Add chipset and ReleaseVersion  property to DeviceInfo Plugin
Test Procedure: verify build success and basic test
Risks: Low
Priority: P1
Signed-off-by: ramkumar_prabaharan@comcast.com

* RDKEMW-2565 Add deviceIdentification plugin details into deviceinfo

Reason for change: Add chipset and ReleaseVersion  property to DeviceInfo Plugin
Test Procedure: verify build success and basic test
Risks: Low
Priority: P1
Signed-off-by: ramkumar_prabaharan@comcast.com

* RDKEMW-2565 Add deviceIdentification plugin details into deviceinfo

Reason for change: Add chipset and ReleaseVersion property to DeviceInfo Plugin
Test Procedure: verify build success and basic test
Risks: Low
Priority: P1
Signed-off-by: ramkumar_prabaharan@comcast.com

* RDKEMW-2565 Add deviceIdentification plugin details into deviceinfo

Reason for change: Add chipset and ReleaseVersion property to DeviceInfo Plugin
Test Procedure: verify build success and basic test
Risks: Low
Priority: P1
Signed-off-by: ramkumar_prabaharan@comcast.com

---------

Signed-off-by: ramkumar_prabaharan@comcast.com