### PR TITLE
RDKTV-37015: platfromSupport is missing from dimmingMode capabilities

### DIFF
--- a/AVOutput/AVOutputTV.cpp
+++ b/AVOutput/AVOutputTV.cpp
@@ -2016,6 +2016,10 @@ namespace Plugin {
             returnResponse(false);
         }
 
+	if (isPlatformSupport("DimmingMode") != 0) {
+            returnResponse(false);
+        }
+
         if (getParamIndex("DimmingMode",inputInfo,indexInfo) == -1) {
             LOGERR("%s: getParamIndex failed to get \n", __FUNCTION__);
             returnResponse(false);
@@ -2072,6 +2076,10 @@ namespace Plugin {
             returnResponse(false);
         }
 
+	if (isPlatformSupport("DimmingMode") != 0) {
+            returnResponse(false);
+        }
+
         if( !isCapablityCheckPassed( "DimmingMode" , inputInfo )) {
             LOGERR("%s: CapablityCheck failed for DimmingMode\n", __FUNCTION__);
             returnResponse(false);
@@ -2115,6 +2123,10 @@ namespace Plugin {
 
         if( !isCapablityCheckPassed( "DimmingMode" , inputInfo )) {
             LOGERR("%s: CapablityCheck failed for DimmingMode\n", __FUNCTION__);
+            returnResponse(false);
+        }
+
+	if (isPlatformSupport("DimmingMode") != 0) {
             returnResponse(false);
         }
 
@@ -2171,6 +2183,8 @@ namespace Plugin {
             returnResponse(false);
         }
         else {
+            response["platformSupport"] = (info.isPlatformSupportVector[0].compare("true") == 0)  ? true : false;
+
             for (index = 0; index < info.rangeVector.size(); index++) {
                 supportedDimmingModeArray.Add(info.rangeVector[index]);
             }

--- a/AVOutput/AVOutputTVHelper.cpp
+++ b/AVOutput/AVOutputTVHelper.cpp
@@ -2302,7 +2302,7 @@ namespace Plugin {
 
             }
 
-            if ((param == "DolbyVisionMode") || (param == "Backlight") || (param == "CMS") || (param == "CustomWhiteBalance") || (param == "HDRMode") || (param == "BacklightControl")) {
+            if ((param == "DolbyVisionMode") || (param == "Backlight") || (param == "CMS") || (param == "CustomWhiteBalance") || (param == "HDRMode") || (param == "BacklightControl") || (param == "DimmingMode")) {
                 configString = param + ".platformsupport";
                 info.isPlatformSupport = inFile.Get<std::string>(configString);
                 printf(" platformsupport : %s\n",info.isPlatformSupport.c_str() );


### PR DESCRIPTION
Reason For Change: platfromSupport is missing from getBacklightDimmingModeCaps
Test procedure: Mentioned in the ticket RDKTV-37015
Risks: Low
Signed-off-by: anju.raveendran@sky.uk