### PR TITLE
RDKTV-36064: getDolbyVisionMode api fails to return "Dark/Bright" in …

### DIFF
--- a/AVOutput/AVOutputTV.cpp
+++ b/AVOutput/AVOutputTV.cpp
@@ -2252,6 +2252,7 @@ namespace Plugin {
         paramIndex_t indexInfo;
         int dolbyMode = 0;
         int err = 0;
+        tvVideoFormatType_t video_type = VIDEO_FORMAT_NONE;
 
         if (parsingGetInputArgument(parameters, "DolbyVisionMode",inputInfo) != 0) {
             LOGINFO("%s: Failed to parse argument\n", __FUNCTION__);
@@ -2262,6 +2263,12 @@ namespace Plugin {
 	    returnResponse(false);
 	}
 
+        GetCurrentVideoFormat(&video_type);
+        if(video_type != VIDEO_FORMAT_DV)
+        {
+            LOGERR("%s: Invalid video format: %d \n", __FUNCTION__,video_type);
+            returnResponse(false);
+        }
 
         if (getParamIndex("DolbyVisionMode",inputInfo,indexInfo) == -1) {
             LOGERR("%s: getParamIndex failed to get \n", __FUNCTION__);


### PR DESCRIPTION
Reason for change: Added condition in getDolbyVisionMode() to return error for non DV content.
Test Procedure: as per JIRA
Risks: None
Priority: P2
Signed-off-by: Anbarasan R <anbarasan.r@sky.uk>