### PR TITLE
RDKTV-37696: Sync low latency for AVOutput initialization

### DIFF
--- a/AVOutput/AVOutputTVHelper.cpp
+++ b/AVOutput/AVOutputTVHelper.cpp
@@ -1209,6 +1209,13 @@ namespace Plugin {
             LOGERR("Backlight Sync to cache Failed !!!\n");
         }
 
+        if( !updateAVoutputTVParam("sync","LowLatencyState",info,PQ_PARAM_LOWLATENCY_STATE,level) ) {
+            LOGINFO("LowLatencyState Successfully Synced to Drive Cache\n");
+        }
+        else {
+            LOGERR("LowLatencyState Sync to cache Failed !!!\n");
+        }
+
         syncCMSParams(); //sync CMS 
         
         syncWBParams();

--- a/AVOutput/CHANGELOG.md
+++ b/AVOutput/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.1.3] - 2025-08-21
+### Fixed
+- Sync low latency for AVOutput initialization
+
 ## [1.1.2] - 2025-05-14
 ### Fixed
 - Set backlight dimming mode failure


### PR DESCRIPTION
This fix is required for a proper sync to ensure lowlatency values are persistent across reboots.