### PR TITLE
LLAMA-17455: HDR10+ not returning

### DIFF
--- a/DisplayInfo/DeviceSettings/PlatformImplementation.cpp
+++ b/DisplayInfo/DeviceSettings/PlatformImplementation.cpp
@@ -677,6 +677,7 @@ public:
         }
         if(!capabilities) hdrCapabilities.push_back(HDR_OFF);
         if(capabilities & dsHDRSTANDARD_HDR10) hdrCapabilities.push_back(HDR_10);
+        if(capabilities & dsHDRSTANDARD_HDR10PLUS) hdrCapabilities.push_back(HDR_10PLUS);
         if(capabilities & dsHDRSTANDARD_HLG) hdrCapabilities.push_back(HDR_HLG);
         if(capabilities & dsHDRSTANDARD_DolbyVision) hdrCapabilities.push_back(HDR_DOLBYVISION);
         if(capabilities & dsHDRSTANDARD_TechnicolorPrime) hdrCapabilities.push_back(HDR_TECHNICOLOR);
@@ -705,6 +706,7 @@ public:
         }
         if(!capabilities) hdrCapabilities.push_back(HDR_OFF);
         if(capabilities & dsHDRSTANDARD_HDR10) hdrCapabilities.push_back(HDR_10);
+        if(capabilities & dsHDRSTANDARD_HDR10PLUS) hdrCapabilities.pushback(HDR_10PLUS);
         if(capabilities & dsHDRSTANDARD_HLG) hdrCapabilities.push_back(HDR_HLG);
         if(capabilities & dsHDRSTANDARD_DolbyVision) hdrCapabilities.push_back(HDR_DOLBYVISION);
         if(capabilities & dsHDRSTANDARD_TechnicolorPrime) hdrCapabilities.push_back(HDR_TECHNICOLOR);

--- a/DisplayInfo/DeviceSettings/PlatformImplementation.cpp
+++ b/DisplayInfo/DeviceSettings/PlatformImplementation.cpp
@@ -706,7 +706,7 @@ public:
         }
         if(!capabilities) hdrCapabilities.push_back(HDR_OFF);
         if(capabilities & dsHDRSTANDARD_HDR10) hdrCapabilities.push_back(HDR_10);
-        if(capabilities & dsHDRSTANDARD_HDR10PLUS) hdrCapabilities.pushback(HDR_10PLUS);
+        if(capabilities & dsHDRSTANDARD_HDR10PLUS) hdrCapabilities.push_back(HDR_10PLUS);
         if(capabilities & dsHDRSTANDARD_HLG) hdrCapabilities.push_back(HDR_HLG);
         if(capabilities & dsHDRSTANDARD_DolbyVision) hdrCapabilities.push_back(HDR_DOLBYVISION);
         if(capabilities & dsHDRSTANDARD_TechnicolorPrime) hdrCapabilities.push_back(HDR_TECHNICOLOR);


### PR DESCRIPTION
Reason for change: Ensuring that HDR10+ returns when applicable Test Procedure:
Risks: low
Priority: P1

Signed-off-by:Hayden Gfeller <Hayden_Gfeller@comcast.com>