### PR TITLE
SERXIONE-7826: [ES1 BCM] [BCM XOE][Flex2 BCM] [SDK24] Voice Guidance …

### DIFF
--- a/SystemAudioPlayer/impl/AudioPlayer.cpp
+++ b/SystemAudioPlayer/impl/AudioPlayer.cpp
@@ -263,7 +263,9 @@ void AudioPlayer::createPipeline(bool smartVolumeEnable)
     g_object_set(G_OBJECT(m_audioSink), "media-tunnel",  FALSE, NULL);
     g_object_set(G_OBJECT(m_audioSink), "audio-service",  TRUE, NULL);
 #elif defined(PLATFORM_BROADCOM)
-    m_audioSink = gst_element_factory_make("brcmpcmsink", NULL);
+    GstElement *convert = gst_element_factory_make("audioconvert", NULL);
+    GstElement *resample = gst_element_factory_make("audioresample", NULL);
+    m_audioSink = gst_element_factory_make("brcmaudiosink", NULL);
     m_audioVolume = m_audioSink;
 #else
     m_audioSink = gst_element_factory_make("autoaudiosink", NULL); 
@@ -443,9 +445,9 @@ void AudioPlayer::createPipeline(bool smartVolumeEnable)
         gst_element_link_many (m_source, parser, decodebin, convert, resample, audiofilter, m_audioVolume, m_audioSink, NULL);
         #elif defined(PLATFORM_BROADCOM)
         GstElement *parser = gst_element_factory_make("mpegaudioparse", NULL);
-        GstElement *decodebin = gst_element_factory_make("brcmmp3decoder", NULL);
-        gst_bin_add_many(GST_BIN(m_pipeline), m_source, parser, decodebin, m_audioSink, NULL);
-        gst_element_link_many (m_source, parser, decodebin, m_audioSink, NULL);
+        GstElement *decodebin = gst_element_factory_make("mpg123audiodec", NULL);
+        gst_bin_add_many(GST_BIN(m_pipeline), m_source, parser, decodebin, convert, resample, m_audioSink, NULL);
+        gst_element_link_many (m_source, parser, decodebin, convert, resample, m_audioSink, NULL);
         #endif
     }
 

--- a/TextToSpeech/impl/TTSSpeaker.cpp
+++ b/TextToSpeech/impl/TTSSpeaker.cpp
@@ -768,7 +768,7 @@ void TTSSpeaker::createPipeline(PipelineType type) {
     // create soc specific elements
 #if defined(PLATFORM_BROADCOM)
     m_source = gst_element_factory_make("souphttpsrc", NULL);
-    m_audioSink = gst_element_factory_make("brcmpcmsink", NULL);
+    m_audioSink = gst_element_factory_make("brcmaudiosink", NULL);
     m_audioVolume = m_audioSink;
 #elif defined(PLATFORM_AMLOGIC)
     GstElement *convert = gst_element_factory_make("audioconvert", NULL);
@@ -863,10 +863,12 @@ void TTSSpeaker::createPipeline(PipelineType type) {
     bool result = TRUE;
 #if defined(PLATFORM_BROADCOM)
     if(!m_pcmAudioEnabled){
-        GstElement *decodebin = gst_element_factory_make("brcmmp3decoder", NULL);
-        gst_bin_add_many(GST_BIN(m_pipeline), m_source, decodebin, m_audioSink, NULL);
-        result &= gst_element_link (m_source, decodebin);
-        result &= gst_element_link (decodebin, m_audioSink);
+        GstElement *parser = gst_element_factory_make("mpegaudioparse", NULL);
+        GstElement *decodebin = gst_element_factory_make("mpg123audiodec", NULL);
+        GstElement *convert = gst_element_factory_make("audioconvert", NULL);
+        GstElement *resample = gst_element_factory_make("audioresample", NULL);
+        gst_bin_add_many(GST_BIN(m_pipeline), m_source, parser, decodebin, convert, resample, m_audioSink, NULL);
+        result = gst_element_link_many (m_source, parser, decodebin, convert, resample, m_audioSink, NULL);
     }
     else {
         TTSLOG_INFO("PCM audio capsfilter added to sink");


### PR DESCRIPTION
…Feature is not working

Reason for change: gstreamer plugin change for audio playback.
Test Procedure: Mentioned in ticket
Risks: Low