### PR TITLE
RDKTV-36064: getDolbyVisionMode api fails to return "Dark/Bright" in …

### DIFF
--- a/AVOutput/AVOutputTV.cpp
+++ b/AVOutput/AVOutputTV.cpp
@@ -2252,6 +2252,7 @@ namespace Plugin {
         paramIndex_t indexInfo;
         int dolbyMode = 0;
         int err = 0;
+        tvVideoFormatType_t video_type = VIDEO_FORMAT_NONE;
 
         if (parsingGetInputArgument(parameters, "DolbyVisionMode",inputInfo) != 0) {
             LOGINFO("%s: Failed to parse argument\n", __FUNCTION__);
@@ -2262,6 +2263,12 @@ namespace Plugin {
 	    returnResponse(false);
 	}
 
+        GetCurrentVideoFormat(&video_type);
+        if(video_type != VIDEO_FORMAT_DV)
+        {
+            LOGERR("%s: Invalid video format: %d \n", __FUNCTION__,video_type);
+            returnResponse(false);
+        }
 
         if (getParamIndex("DolbyVisionMode",inputInfo,indexInfo) == -1) {
             LOGERR("%s: getParamIndex failed to get \n", __FUNCTION__);

--- a/AVOutput/CHANGELOG.md
+++ b/AVOutput/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.1.4] - 2025-08-26
+### Fixed
+- Fixed getDolbyVisionMode() for non DV content
+
 ## [1.1.3] - 2025-08-04
 ### Fixed
 - platformSupport is not present in getDimmingModeCaps API


### PR DESCRIPTION
…response for AVOutput plugins.

Reason for change: Added condition in getDolbyVisionMode() to return error for non DV content.
Test Procedure: as per JIRA
Risks: None
Priority: P2