### PR TITLE
SERXIONE-6874 - Safety checks to avoid crash on systemservices

### DIFF
--- a/SystemServices/SystemServices.cpp
+++ b/SystemServices/SystemServices.cpp
@@ -2627,6 +2627,7 @@ namespace WPEFramework {
 	uint32_t SystemServices::setTerritory(const JsonObject& parameters, JsonObject& response)
 	{
 		bool resp = false;
+		const std::lock_guard<std::mutex> lock(m_territoryMutex);
 		if(parameters.HasLabel("territory")){
 			makePersistentDir();
 			string regionStr = "";
@@ -2704,12 +2705,23 @@ namespace WPEFramework {
 	uint32_t SystemServices::getTerritory(const JsonObject& parameters, JsonObject& response)
 	{
 		bool resp = true;
+		const std::lock_guard<std::mutex> lock(m_territoryMutex);
 		m_strTerritory = "";
 		m_strRegion = "";
 		resp = readTerritoryFromFile();
 		response["territory"] = m_strTerritory;
 		response["region"] = m_strRegion;
 		returnResponse(resp);
+	}
+
+    string SystemServices::safeExtractAfterColon(const std::string& inputLine) {
+             size_t pos = inputLine.find(':');
+             if ((pos != std::string::npos) && (pos + 1 < inputLine.length())) {
+                 return inputLine.substr(pos + 1);
+             } else {
+                  LOGERR("Territory file corrupted");  
+             }
+             return "";
 	}
 
 	bool SystemServices::readTerritoryFromFile()
@@ -2722,12 +2734,12 @@ namespace WPEFramework {
 			getline (inFile, str);
 			if(str.length() > 0){
 				retValue = true;
-				m_strTerritory = str.substr(str.find(":")+1,str.length());
+				m_strTerritory =  safeExtractAfterColon(str);
 				int index = m_strStandardTerritoryList.find(m_strTerritory);
 				if((m_strTerritory.length() == 3) && (index >=0 && index <= 1100) ){
 					getline (inFile, str);
 					if(str.length() > 0){
-					    m_strRegion = str.substr(str.find(":")+1,str.length());
+					    m_strRegion =  safeExtractAfterColon(str);
 					    if(!isRegionValid(m_strRegion))
 					    {
 						    m_strTerritory = "";

--- a/SystemServices/SystemServices.h
+++ b/SystemServices/SystemServices.h
@@ -161,6 +161,7 @@ namespace WPEFramework {
 #endif
                 pid_t m_uploadLogsPid;
                 std::mutex m_uploadLogsMutex;
+                std::mutex m_territoryMutex;
 
             public:
                 SystemServices();
@@ -184,6 +185,7 @@ namespace WPEFramework {
                 std::string getStbTimestampString();
 		std::string getStbBranchString();
                 bool makePersistentDir();
+                std::string safeExtractAfterColon(const std::string& inputLine);
 
 #if defined(USE_IARMBUS) || defined(USE_IARM_BUS)
                 void InitializeIARM();


### PR DESCRIPTION
Reason for change: Added mutex lock around setTerritory/GetTerritory
Test Procedure:
Risks: low
Priority: P1
Version: Minor