### PR TITLE
SERXIONE-8115: Screen Cutoff Regression

### DIFF
--- a/DisplaySettings/DisplaySettings.cpp
+++ b/DisplaySettings/DisplaySettings.cpp
@@ -6160,7 +6160,6 @@ void DisplaySettings::sendMsgThread()
 				if (isDisplayConnected(strVideoPort))
 				{
 					bool enable = (newState == "GAME") ? true : false;
-					vPort.getDisplay().setAllmEnabled(enable);
 					if(enable){ // Game mode
 					    vPort.getDisplay().setAVIContentType(dsAVICONTENT_TYPE_GAME);
 					    vPort.getDisplay().setAVIScanInformation(dsAVI_SCAN_TYPE_UNDERSCAN);
@@ -6168,6 +6167,7 @@ void DisplaySettings::sendMsgThread()
 					    vPort.getDisplay().setAVIContentType(dsAVICONTENT_TYPE_NOT_SIGNALLED);
 					    vPort.getDisplay().setAVIScanInformation(dsAVI_SCAN_TYPE_NO_DATA);
 					}
+					vPort.getDisplay().setAllmEnabled(enable);
 				}
 				else
 				{


### PR DESCRIPTION
SERXIONE-8115: Screen Cutoff Regression

Reason for change: Fix exception handling in DisplaySettings::Request()
Test Procedure: see Jira ticket
Priority: P1
Risks: None

Signed-off-by: yuvaramachandran_gurusamy <yuvaramachandran_gurusamy@comcast.com>