### PR TITLE
XIONE-17974 - Dolby Atmos logo NOT seen on Netflix

### DIFF
--- a/PlayerInfo/DeviceSettings/PlatformImplementation.cpp
+++ b/PlayerInfo/DeviceSettings/PlatformImplementation.cpp
@@ -393,6 +393,8 @@ public:
                 else if(soundmode == device::AudioStereoMode::kStereo) mode = STEREO;
                 else if(soundmode == device::AudioStereoMode::kMono) mode = MONO;
                 else if(soundmode == device::AudioStereoMode::kPassThru) mode = PASSTHRU;
+				else if(soundmode == device::AudioStereoMode::kDD) mode = DOLBYDIGITAL;
+                else if(soundmode == device::AudioStereoMode::kDDPlus) mode = DOLBYDIGITALPLUS;
                 else mode = UNKNOWN;
 
                 /* Auto mode applicable for HDMI Arc and SPDIF */


### PR DESCRIPTION
Reason for change: Add missing audio modes to playerinfo list
Test Procedure: None
Risks: Low
Priority: P1

Signed-off-by:Hayden Gfeller <Hayden_Gfeller@comcast.com>