### PR TITLE
RDKEMW-18711:  VG is not working in Xione Dhruv build

### DIFF
--- a/TextToSpeech/impl/SatToken.cpp
+++ b/TextToSpeech/impl/SatToken.cpp
@@ -50,10 +50,9 @@ string SatToken::getSecurityToken() {
         if(file.Open(true)) {
             JsonObject config;
             if(config.IElement::FromFile(file)) {
-                Core::JSON::String port = config.Get("port");
-                Core::JSON::String binding = config.Get("binding");
-                if(!binding.Value().empty() && !port.Value().empty())
-                    endpoint = binding.Value() + ":" + port.Value();
+                Core::JSON::DecUInt32 port = config.Get("port");
+                if(port.Value() != 0)
+                    endpoint = std::string("127.0.0.1:") + std::to_string(port.Value());
             }
             file.Close();
         }


### PR DESCRIPTION
Read THUNDER_ACCESS port as JSON number and use loopback host

Reason for change:
- TTS OOP plugin /etc/WPEFramework/config.json fallback read "port" and "binding" as Core::JSON::String
- Core::JSON::String::Value() returns the quoted form for JSON string fields, so "binding":"0.0.0.0" yields an endpoint of "0.0.0.0":9998 (literal quotes) which Core::NodeId cannot parse
- An OOP child connects back to main on the same host; the listen binding is not the right connect target. Read port as DecUInt32 and use loopback.

Test Procedure: described in the ticket
Implements: code changes in TextToSpeech/impl
Risks: Low
Source: COMCAST
License: Apache-2.0
Upstream-Status: Pending

Version: patch